### PR TITLE
[codex] Document Wisconsin data coverage gaps

### DIFF
--- a/data/turnout-source-packages.json
+++ b/data/turnout-source-packages.json
@@ -147,7 +147,7 @@
         "registeredVoterDenominatorFile": "data/wi-2024-registered-voter-denominator-eac.json",
         "registeredVoters": 3933068,
         "ballotsCast": 3434185,
-        "warningRows": 0
+        "warningRows": 2
       },
       "statusNote": "Promoted 2024 turnout rows are available from the configured official turnout source.",
       "nextAction": "Keep source link and denominator caveats visible in the app."

--- a/data/wi-2024-admin-context-sources.json
+++ b/data/wi-2024-admin-context-sources.json
@@ -2,8 +2,19 @@
   "state": "WI",
   "stateName": "Wisconsin",
   "electionYear": 2024,
-  "generatedAt": "2026-06-24",
+  "generatedAt": "2026-06-30",
   "caveat": "This is a source inventory for app readiness. It records official or candidate source locations and collection status; it is not a normalized row-level audit, CVR, or incident dataset.",
+  "equipment": {
+    "status": "loaded_context",
+    "sourceTitle": "Verified Voting Verifier Wisconsin 2024 equipment context plus WEC audited-equipment context",
+    "sourceUrl": "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/55",
+    "officialAuditSourceUrl": "https://elections.wi.gov/resources/reports/2024-post-election-voting-equipment-audit-report",
+    "localArtifact": "data/verifiedvoting-wi-2024-equipment.json",
+    "normalizedArtifact": "data/wi-2024-equipment-context.csv",
+    "officialAuditArtifact": "data/wi-2024-audit/2024-post-election-voting-equipment-audit-final-report.pdf",
+    "scopeNote": "Verifier rows are jurisdiction-level equipment context, not vote or turnout data. The WEC audit report provides official audited-equipment context for selected reporting units, but does not replace a statewide official equipment inventory.",
+    "nextAction": "Use equipment rows as context only; cite the WEC audit report when discussing audited selected units and keep the Verifier source caveat visible."
+  },
   "audit": {
     "status": "partial",
     "sourceTitle": "Wisconsin 2024 Post-Election Voting Equipment Audit Report",
@@ -12,20 +23,26 @@
     "localArtifact": "data/wi-2024-audit/2024-post-election-voting-equipment-audit-final-report.pdf",
     "normalizedArtifact": "data/wi-2024-audit-selections.csv",
     "summaryArtifact": "data/wi-2024-audit-summary.json",
-    "nextAction": "If per-reporting-unit discrepancy outcomes are needed, request or collect the submitted local audit materials; the published report provides selected reporting units, equipment, ballots audited, and statewide findings."
+    "nextAction": "If per-reporting-unit discrepancy outcomes are needed, request or collect the submitted local audit materials; the published report provides selected reporting units, equipment, ballots audited, and statewide findings.",
+    "scopeNote": "Loaded audit rows cover Appendix B selected reporting units and aggregate statewide findings. The published report does not include a per-reporting-unit discrepancy outcome table.",
+    "recordsRequestNeed": "Submitted local audit materials or per-reporting-unit outcome/discrepancy tables, preferably keyed by county, municipality, reporting unit, contest, equipment, machine total, hand total, discrepancy, explanation, and outcome category."
   },
   "cvr": {
-    "status": "candidate",
+    "status": "partial",
     "sourceTitle": "Wisconsin county cast vote record availability inventory",
     "sourceUrl": "https://elections.wi.gov/about/records-request",
     "localArtifact": "data/wi-2024-cvr-availability.csv",
-    "nextAction": "Confirm county-by-county CVR availability or public-record request path. Current artifact is a 72-county inventory scaffold, not a loaded CVR dataset."
+    "nextAction": "Confirm county-by-county CVR availability or public-record request path. Current artifact is a 72-county inventory scaffold, not a loaded CVR dataset.",
+    "scopeNote": "The current artifact is a 72-county availability scaffold. It does not confirm county CVR publication or custody and is not a loaded CVR dataset.",
+    "recordsRequestNeed": "County-by-county CVR availability, custodian, request URL/email, file format, ballot-mode fields, and whether public CVR release is blocked, partial, or available for the November 5, 2024 general election."
   },
   "incidents": {
     "status": "candidate",
     "sourceTitle": "Wisconsin Elections Commission 2024 general election and public meeting materials",
     "sourceUrl": "https://elections.wi.gov/elections/election-results/2024/november-5-general-election",
     "localArtifact": "data/wi-2024-incident-context.csv",
-    "nextAction": "Inventory official incident, correction, recount, and litigation records from WEC and county sources; normalize source-linked rows when found."
+    "nextAction": "Inventory official incident, correction, recount, and litigation records from WEC and county sources; normalize source-linked rows when found.",
+    "scopeNote": "Candidate source inventory only; not a normalized incident, correction, recount, or litigation dataset.",
+    "recordsRequestNeed": "Official source-linked records for incidents, tabulation corrections, amended canvasses, recount filings/outcomes, and election-related litigation, with event date, jurisdiction, status, source URL, and local artifact path."
   }
 }

--- a/docs/turnout-collection-inventory.md
+++ b/docs/turnout-collection-inventory.md
@@ -7,8 +7,8 @@ This is an internal collection inventory. It is not rendered in the Civic Result
 ## Summary
 
 - States checked: 50
-- Turnout loaded in database or validated native staging: 8
-- Native config present but turnout missing: 2
+- Turnout loaded in database or validated native staging: 9
+- Loaded through official EAC fallback while state-native ward denominator remains missing: 1
 - Need native turnout package: 40
 
 ## Loaded Turnout
@@ -22,18 +22,18 @@ This is an internal collection inventory. It is not rendered in the Civic Result
 | PA Pennsylvania | 67 | county | registeredVoters | `data/pa-2024-voter-registration-vote-history-summary.xlsx` |
 | SC South Carolina | 46 | county | printedRegistrationListVoters | `data/sc-2024-vrems-turnout.csv` |
 | VA Virginia | 2,669 | precinct | registeredVoters | `data/va-2024-enr-election-turnout.csv` |
+| WI Wisconsin | 1,851 | local_jurisdiction | registeredVoters | `data/wi-2024-eac-turnout.csv` |
 | WV West Virginia | 1,649 | precinct | registeredVoters | `data/wv-2024-county-detailxml-reports` |
 
-## Native Config Present, Turnout Missing
+## Loaded Fallback, State-Native Denominator Still Missing
 
 | State | Current status | Needed |
 | --- | --- | --- |
-| WI Wisconsin | Native presidential and review ETL is loaded, but turnout rows are 0. | Official Wisconsin registered-voter denominator data. Prefer ward-level data that can join to the WEC ward workbook; county-level is usable with caveats. |
-| MO Missouri | Native presidential, review, and state-native turnout ETL config is loaded, but database turnout rows may remain 0 until staging is imported/promoted. | Run `npm run etl:prepare:mo` and `npm run etl:import:mo`; turnout source is the official Missouri SOS 2024 General Election voter turnout PDF normalized to `data/mo-2024-general-turnout.csv`. |
+| WI Wisconsin | Native presidential and review ETL is loaded, and official EAC 2024 EAVS V2 local-jurisdiction turnout rows are configured and loaded as fallback context. | Official Wisconsin registered-voter denominator data. Prefer ward-level data that can join to the WEC ward workbook; county- or municipality-level is usable only with caveats. |
 
-## States Needing Native Turnout Packages
+## States Needing Native Turnout Packages Or State-Native Replacements
 
-These states do not currently have native turnout ETL configs or database turnout rows.
+These states still need a state-native turnout package or review of whether fallback turnout coverage is sufficient for the current caveats.
 
 `AK`, `AL`, `AR`, `AZ`, `CA`, `CO`, `CT`, `DE`, `FL`, `GA`, `HI`, `IA`, `ID`, `IL`, `IN`, `KS`, `KY`, `LA`, `MA`, `MD`, `ME`, `MS`, `MT`, `NC`, `ND`, `NE`, `NJ`, `NM`, `NV`, `NY`, `OK`, `OR`, `RI`, `SD`, `TN`, `TX`, `UT`, `VT`, `WA`, `WY`
 
@@ -65,6 +65,8 @@ For Wisconsin, ask for:
 - Join keys that match the WEC ward-by-ward workbook, if ward-level data exists.
 - Expected row count and statewide denominator total.
 - Caveats for same-day registration, inactive voters, absentee ballots, provisional ballots, and reporting-unit changes.
+
+Current Wisconsin caveat: the WEC ward-by-ward federal/state results workbook does not include registered-voter denominator fields. The loaded EAC fallback uses A1a Total Reg and F1a Total Voters at EAC local-jurisdiction grain, totaling 1,851 rows, 3,933,068 registered voters, and 3,434,185 voters. It is official turnout context, but it is not same-grain WEC ward denominator data and is not used as an advisory flag input.
 
 ## West Virginia Update
 

--- a/docs/turnout-source-packages.md
+++ b/docs/turnout-source-packages.md
@@ -1,14 +1,26 @@
 # Turnout Source Packages
 
-Checked at: 2026-06-16
+Checked at: 2026-06-30
 
 This file summarizes turnout source packages that can be used by Civic Result Maps native ETL. The package is intentionally source-first: native importers should parse the listed official artifacts or normalized CSV files directly, not generated app bundles.
 
 ## Wisconsin
 
-Status: partial official local sources available
+Status: loaded official EAC statewide fallback; partial official local ward sources retained as supplemental provenance
 
-Wisconsin has native results/review data available, but a statewide ward-level turnout denominator source is not currently present. The legacy repo has a partial turnout package covering four counties:
+Wisconsin has native WEC ward result/review data available. A statewide WEC ward-level registered-voter denominator source is not currently present in public machine-readable artifacts, so the current statewide turnout package uses the official U.S. EAC 2024 EAVS V2 local-jurisdiction fallback:
+
+| Metric | Value |
+| --- | ---: |
+| Reporting grain | local_jurisdiction |
+| Rows | 1,851 |
+| Ballots cast / voters | 3,434,185 |
+| Registered voters | 3,933,068 |
+| Warning rows | 2 |
+| Turnout artifact | `data/wi-2024-eac-turnout.csv` |
+| Denominator artifact | `data/wi-2024-registered-voter-denominator-eac.json` |
+
+The legacy/local package remains useful supplemental provenance covering four counties:
 
 | County | Level | Rows | Denominator Timing | Warning Rows |
 | --- | --- | ---: | --- | ---: |
@@ -17,7 +29,7 @@ Wisconsin has native results/review data available, but a statewide ward-level t
 | Jefferson | ward | 34 | unknown | 34 |
 | Oneida | ward | 22 | preElectionDay | 22 |
 
-Expected package totals:
+Supplemental local package totals:
 
 | Metric | Value |
 | --- | ---: |
@@ -33,10 +45,15 @@ Expected package totals:
 Committed Civic Result Maps artifacts:
 
 - `data/wi-2024-turnout-source-package.json`
+- `data/wi-2024-eac-turnout.csv`
+- `data/wi-2024-registered-voter-denominator-eac.json`
+- `data/wi-2024-registered-voter-denominator-eac.csv`
 - `data/wi-2024-turnout-partial.csv`
 
 Source artifacts referenced by the manifest:
 
+- `data/eac-2024-eavs-v2-csv.zip`
+- `data/eac-2024-codebook.xlsx`
 - `data/milwaukee-city-turnout.csv`
 - `data/City of Milwaukee 2024 General Election Ward by Ward Results.pdf`
 - `data/dane-county-turnout.csv`
@@ -53,23 +70,31 @@ Reference generated output:
 
 Parser contract:
 
-- Primary native artifact: `data/wi-2024-turnout-partial.csv`
+- Primary statewide artifact: `data/wi-2024-eac-turnout.csv`
+- Primary registered-voter denominator artifact: `data/wi-2024-registered-voter-denominator-eac.json`
+- Supplemental local artifact: `data/wi-2024-turnout-partial.csv`
 - State-specific manifest: `data/wi-2024-turnout-source-package.json`
-- Format: normalized turnout CSV
-- Required columns: `state`, `county`, `municipality`, `ward`, `source_level`, `ballots_cast`, `registered_voters`, `registration_denominator_timing`, `denominator_type`, `coverage_status`, `warning_required`, `source_url`
-- Optional columns: `notes`
-- Warning required when denominator timing is `preElectionDay` or `unknown`
-- Ward-level join keys: `county`, `municipality`, `ward`
-- Dane join key: `county`
+- Primary format: normalized EAC turnout CSV
+- Primary required columns: `state`, `election_year`, `jurisdiction_code`, `jurisdiction_name`, `level`, `ballots_cast`, `registered_voters`, `turnout_pct`, `denominator_type`, `denominator_timing`, `source_url`, `source_title`, `source_status`
+- Primary optional/context columns: `county`, `local_unit`, `denominator_note`, `warning_required`, `notes`
+- EAC fallback join keys: `state`, `jurisdiction_code`, `jurisdiction_name`
+- Supplemental local required columns: `state`, `county`, `municipality`, `ward`, `source_level`, `ballots_cast`, `registered_voters`, `registration_denominator_timing`, `denominator_type`, `coverage_status`, `warning_required`, `source_url`
+- Supplemental warning required when denominator timing is `preElectionDay` or `unknown`
+- Supplemental ward-level join keys: `county`, `municipality`, `ward`
+- Supplemental Dane join key: `county`
 
 Important caveats:
 
-- This package is not statewide Wisconsin turnout coverage.
+- The EAC fallback is statewide official turnout context, but it is not WEC ward-grain denominator data.
+- EAC F1a Total Voters is not identical to the WEC presidential contest vote total.
 - The WEC ward-by-ward federal/state results workbook does not include registered-voter denominators.
+- Two EAC Wisconsin jurisdiction rows have zero registered-voter denominators; normalized turnout percentages are blank and warning-gated.
 - Wisconsin same-day registration means pre-Election-Day denominators can understate final registered voters.
 - Jefferson denominator timing is not stated and must be warning-gated.
 - Dane is county-level only, not ward-level.
 - Ward labels need normalization before joining to WEC ward result rows.
+
+Native ETL should use the EAC fallback for statewide turnout context while keeping the partial local rows and missing ward-level WEC denominator need explicit.
 
 Native ETL should import these rows as partial Wisconsin turnout and expose missing counties explicitly.
 

--- a/tests/api/wi-remaining-data-status.test.mjs
+++ b/tests/api/wi-remaining-data-status.test.mjs
@@ -93,3 +93,15 @@ test("Wisconsin admin context scopes audit, CVR, incidents, and equipment eviden
   assert.match(adminContext.incidents.scopeNote, /not a normalized incident/);
   assert.match(adminContext.incidents.recordsRequestNeed, /recount filings\/outcomes/);
 });
+
+test("Wisconsin turnout source registry keeps EAC warning rows visible", () => {
+  const turnoutPackages = JSON.parse(readFileSync("data/turnout-source-packages.json", "utf8"));
+  const wisconsin = turnoutPackages.stateYearStatuses.find((entry) => entry.state === "WI" && entry.year === 2024);
+  const turnoutCsv = readFileSync(wisconsin.localFile, "utf8").trim().split(/\r?\n/);
+  const header = turnoutCsv[0].split(",");
+  const warningIndex = header.indexOf("warning_required");
+  const warningRows = turnoutCsv.slice(1).filter((line) => line.split(",")[warningIndex] === "true").length;
+
+  assert.equal(wisconsin.coverage.warningRows, warningRows);
+  assert.equal(wisconsin.coverage.warningRows, 2);
+});

--- a/tests/api/wi-remaining-data-status.test.mjs
+++ b/tests/api/wi-remaining-data-status.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import test from "node:test";
 
 const report = JSON.parse(readFileSync("data/wi-2024-remaining-data-status.json", "utf8"));
@@ -63,4 +63,33 @@ test("Wisconsin CVR availability scaffold uses clean county names", () => {
   const csv = readFileSync("data/wi-2024-cvr-availability.csv", "utf8");
   assert.match(csv, /Adams County,not_inventoried/);
   assert.doesNotMatch(csv, /County County/);
+});
+
+test("Wisconsin admin context scopes audit, CVR, incidents, and equipment evidence", () => {
+  const adminContext = JSON.parse(readFileSync("data/wi-2024-admin-context-sources.json", "utf8"));
+  const cvrCsv = readFileSync(adminContext.cvr.localArtifact, "utf8").trim().split(/\r?\n/);
+
+  assert.equal(adminContext.generatedAt, "2026-06-30");
+  assert.equal(adminContext.equipment.status, "loaded_context");
+  assert.equal(existsSync(adminContext.equipment.localArtifact), true);
+  assert.equal(existsSync(adminContext.equipment.normalizedArtifact), true);
+  assert.equal(existsSync(adminContext.equipment.officialAuditArtifact), true);
+  assert.match(adminContext.equipment.scopeNote, /not vote or turnout data/);
+  assert.match(adminContext.equipment.officialAuditSourceUrl, /post-election-voting-equipment-audit/);
+  assert.equal(adminContext.audit.status, "partial");
+  assert.equal(existsSync(adminContext.audit.localArtifact), true);
+  assert.equal(existsSync(adminContext.audit.normalizedArtifact), true);
+  assert.equal(existsSync(adminContext.audit.summaryArtifact), true);
+  assert.match(adminContext.audit.scopeNote, /does not include a per-reporting-unit discrepancy outcome table/);
+  assert.match(adminContext.audit.recordsRequestNeed, /Submitted local audit materials/);
+  assert.equal(adminContext.cvr.status, "partial");
+  assert.equal(existsSync(adminContext.cvr.localArtifact), true);
+  assert.equal(cvrCsv.length - 1, 72);
+  assert.equal(cvrCsv.every((line, index) => index === 0 || line.includes(",not_inventoried,")), true);
+  assert.match(adminContext.cvr.scopeNote, /not a loaded CVR dataset/);
+  assert.match(adminContext.cvr.recordsRequestNeed, /County-by-county CVR availability/);
+  assert.equal(adminContext.incidents.status, "candidate");
+  assert.equal(existsSync(adminContext.incidents.localArtifact), true);
+  assert.match(adminContext.incidents.scopeNote, /not a normalized incident/);
+  assert.match(adminContext.incidents.recordsRequestNeed, /recount filings\/outcomes/);
 });


### PR DESCRIPTION
## Summary

- Updates Wisconsin turnout inventories to reflect the loaded official EAC 2024 EAVS V2 local-jurisdiction fallback while keeping the missing WEC ward-level denominator request explicit.
- Expands Wisconsin admin context source inventory for equipment, audit, CVR availability, incident/correction/recount/litigation records, and records-request needs without promoting data.
- Strengthens the WI remaining-data test to verify context artifact paths, the 72-county CVR scaffold, source caveat scope, and EAC warning-row count.
- Wave 1 rerun fixed `data/turnout-source-packages.json` so WI EAC warning rows are exposed as `2`, matching the docs/source package.
- Branch history is clean: this PR contains only Wisconsin coverage changes, not coordinator docs.

## Sources Confirmed

- Wisconsin Elections Commission 2024 ward results page/workbook path and WEC records-request path remain the official Wisconsin source/request path; scripted WEC page checks are still Cloudflare-blocked from this environment.
- U.S. EAC 2024 EAVS V2 ZIP and codebook remain the official fallback for Wisconsin turnout/registered-voter denominator context.
- WEC 2024 post-election voting equipment audit report remains partial audit context; it does not publish per-reporting-unit discrepancy outcomes.
- Verified Voting Verifier remains equipment context only, not a turnout or vote-result source.

## Validation

- `node tests/api/wi-remaining-data-status.test.mjs`
- `node tests/api/wi-remaining-collection.test.mjs`
- `node tests/api/wi-audit-normalizer.test.mjs`
- `npm run validate:turnout-packages`
- `npm run validate:admin-packages`
- `python -m civic_etl.cli validate --config etl/state-configs/wi.json`
- `python -m civic_etl.cli import --config etl/state-configs/wi.json --out .etl/staging`
- `npm run test:api`
- `npm run build`

## Review

Initial review issues were addressed before PR creation. Wave 1 rerun found and fixed the stale WI `warningRows: 0` API/readiness value. No unresolved actionable findings remain.

## Remaining Risk

- No public statewide WEC ward-level registered-voter denominator source is confirmed; records requests remain needed.
- WEC final audit report provides selected units and aggregate findings, not per-unit discrepancy outcomes.
- CVR availability is still a 72-county scaffold and not a loaded CVR dataset.
- Incident/correction/recount/litigation rows remain candidate inventory only until official rows are collected and normalized.