### PR TITLE
[codex] Improve Indiana source coverage provenance

### DIFF
--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -494,12 +494,17 @@
       ],
       "requiredArtifacts": [
         "official precinct-level or county-subdivision result rows for President, if Indiana publishes or provides them",
-        "official precinct-level or county-subdivision result rows for U.S. Senate, if Indiana publishes or provides them",
-        "supplemental MIT/OpenElections President and U.S. Senate local review rows are loaded for advisory flag calculation"
+        "official precinct-level or county-subdivision result rows for U.S. Senate at the same reporting-unit grain, if Indiana publishes or provides them",
+        "state-native turnout and registered-voter denominator rows by county or lower reporting unit",
+        "precinct or local reporting-unit boundary geometry, if subcounty map overlays are required",
+        "audit, recount, CVR availability, incident, correction, and certification records for 2024 administration context",
+        "2020, 2016, and 2012 historical presidential baselines with source provenance",
+        "supplemental MIT/OpenElections President and U.S. Senate local review rows are loaded for advisory flag calculation",
+        "Verified Voting county equipment context is loaded as secondary administration context only"
       ],
       "preferredComparisonContest": "U.S. Senate; official ENR supports certified county totals, and MIT/OpenElections supplemental rows support local President-vs-U.S.-Senate advisory review.",
-      "parserNeeded": "indianaEnrCountyJson package loaded for official county results; indianaEnrJurisdictionDirectoryInventory collected for official county JurR inventory; localComparisonCsv loaded for MIT/OpenElections supplemental precinct President and U.S. Senate rows.",
-      "blocker": "Official Indiana ENR county category JSON is collected and parsed for certified county totals, and official JurR county jurisdiction JSON files are inventoried but do not contain President or U.S. Senate candidate result rows. Advisory flags can now be calculated from MIT/OpenElections supplemental local rows, with caveats that MIT flags Indiana Senate/Governor overreporting in some counties and non-unique precinct labels. Official precinct-level candidate rows remain preferred if available from the Indiana Election Division or county election offices.",
+      "parserNeeded": "indianaEnrCountyJson package loaded for official county results; indianaEnrJurisdictionDirectoryInventory collected for official county JurR inventory; localComparisonCsv loaded for MIT/OpenElections supplemental precinct President and U.S. Senate rows. A new parser remains needed if official precinct/subcounty Indiana candidate rows are obtained.",
+      "blocker": "Official Indiana ENR county category JSON is collected and parsed for certified county totals, and official JurR county jurisdiction JSON files are inventoried but do not contain President or U.S. Senate candidate result rows. Advisory flags can now be calculated from MIT/OpenElections supplemental local rows, with caveats that MIT flags Indiana Senate/Governor overreporting in some counties and non-unique precinct labels. Official precinct-level candidate rows, state-native turnout denominators, precinct geometry, historical baselines, and audit/recount/CVR/incident/correction records remain preferred if available from the Indiana Election Division or county election offices.",
       "supplementalSourcePages": [
         "https://doi.org/10.7910/DVN/NYTPDU",
         "https://github.com/openelections/openelections-data-in/tree/master/2024/counties"

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -488,31 +488,44 @@
       "stateName": "Indiana",
       "jurisdictionName": "Statewide",
       "scope": "statewide",
-      "dataFamily": "results_review_turnout",
+      "dataFamily": "results_review_turnout_equipment",
       "tier": "tier_2_official_dashboard_endpoint",
-      "reportingGrain": "county",
+      "reportingGrain": "county results plus supplemental precinct review",
       "exportFormats": [
-        "archived ENR JSON"
+        "archived ENR JSON",
+        "supplemental MIT/OpenElections CSV",
+        "EAC fallback turnout CSV",
+        "Verified Voting equipment CSV"
       ],
       "sourceUrls": [
-        "https://enr.indianavoters.in.gov/"
+        "https://enr.indianavoters.in.gov/",
+        "https://www.eac.gov/research-and-data/studies-and-reports",
+        "https://doi.org/10.7910/DVN/NYTPDU",
+        "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/18"
       ],
       "exampleUrls": [
         "https://web.archive.org/web/20241229230948id_/https://enr.indianavoters.in.gov/site/data/OffCatC_1019_A.json"
       ],
       "availableFields": [
-        "county President rows",
-        "county U.S. Senate rows",
-        "county turnout fallback"
+        "official county President rows",
+        "official county U.S. Senate rows",
+        "supplemental precinct President-versus-U.S.-Senate review rows",
+        "EAC county turnout fallback",
+        "county election equipment context"
       ],
       "missingFields": [
-        "precinct/subcounty result rows"
+        "official precinct/subcounty President rows",
+        "official precinct/subcounty U.S. Senate rows at the same grain",
+        "state-native turnout and registered-voter denominator rows",
+        "precinct boundary geometry",
+        "2020/2016/2012 historical baselines",
+        "audit, recount, CVR availability, incident, and correction records"
       ],
-      "parserStatus": "indianaEnrCountyJson package loaded",
+      "parserStatus": "indianaEnrCountyJson loaded for official county results; localComparisonCsv loaded for MIT/OpenElections supplemental precinct review rows; equipment context CSV present",
       "manualReviewBurden": "medium",
       "confidence": "loaded",
-      "caveats": "Archived ENR category files contain 92 county RegionSummary rows, not precinct rows.",
-      "nextAction": "Find whether Indiana exposes precinct/subcounty ENR exports elsewhere."
+      "caveats": "Archived ENR category files contain 92 county RegionSummary rows, not precinct rows. MIT/OpenElections review rows are supplemental advisory inputs with published Indiana caveats; certified totals remain official Indiana ENR. Equipment context is county-level administration context only.",
+      "nextAction": "Request official Indiana precinct/subcounty President and U.S. Senate rows, state-native turnout denominators, precinct geometry, historical baselines, and audit/recount/CVR/incident/correction records before upgrading beyond supplemental local review."
     },
     {
       "state": "KS",

--- a/data/source-records-request-packets/in-2024-precinct-results-request.md
+++ b/data/source-records-request-packets/in-2024-precinct-results-request.md
@@ -1,13 +1,28 @@
-# Indiana 2024 Precinct/County-Subdivision Result Rows Request
+# Indiana 2024 Official Source Gap Request
 
-This request seeks machine-readable official result rows for the November 5, 2024 Indiana General Election. The public ENR county category JSON files currently available in this repository contain county totals, and the archived `JurR_*_B.json` county jurisdiction files contain office/contact and reporting-region/referendum structures, not candidate result rows.
+This request seeks machine-readable official source records for the November 5, 2024 Indiana General Election. The public ENR county category JSON files currently available in this repository contain county totals, and the archived `JurR_*_B.json` county jurisdiction files contain office/contact and reporting-region/referendum structures, not candidate result rows.
 
-Requested records:
+Requested result records:
 - President and Vice President result rows by precinct, township, ward, vote center/reporting unit, or the lowest county-subdivision level maintained by the office.
 - U.S. Senator result rows at the same reporting-unit level and with the same local-unit identifiers.
 - Field definitions or export layout documentation for county, local unit, precinct/reporting-unit code, candidate, party, vote total, contest name, and ballot/reporting mode fields.
 - Any county-level file manifest that identifies whether a county reports consolidated vote-center totals, precinct totals, absentee/early/provisional rows, or other non-precinct reporting units.
 
-Preferred formats: original election-management-system export, CSV, XLSX, JSON, fixed-width text with layout, or database extract. Please preserve original filenames, timestamps, certification status, and export settings.
+Requested turnout and registration records:
+- State-native ballots-cast and registered-voter denominator rows by county or lower reporting unit.
+- Denominator timing and definitions, including whether inactive voters, election-day registrations, provisional ballots, absentee ballots, overseas/federal-only ballots, and same-day changes are included.
+- Expected statewide ballots-cast and registered-voter totals for reconciliation.
 
-If the Indiana Election Division does not maintain these records statewide, please identify the county election offices or other custodians most likely to maintain the files.
+Requested geography and baseline records:
+- Precinct, ward, township, vote-center/reporting-unit, or other local geometry/crosswalk files needed to join subcounty result rows.
+- Historical county or subcounty presidential result baselines for 2020, 2016, and 2012, with source URLs, certification status, and parser notes.
+
+Requested administration-context records:
+- Post-election audit reports, audit unit lists, discrepancy summaries, and statewide audit findings.
+- Recount records or confirmations of no applicable statewide recounts for President or U.S. Senate.
+- Cast vote record availability documentation, export rules, public-records limitations, or county custodian routing guidance.
+- Incident, correction, amended canvass, litigation, certification, and other post-election records that change or qualify published 2024 result data.
+
+Preferred formats: original election-management-system export, CSV, XLSX, JSON, fixed-width text with layout, shapefile/GeoJSON/geodatabase for geometry, PDF reports with source tables, or database extract. Please preserve original filenames, timestamps, certification status, and export settings.
+
+If the Indiana Election Division does not maintain any of these records statewide, please identify the county election offices or other custodians most likely to maintain them.

--- a/etl/state-configs/in.json
+++ b/etl/state-configs/in.json
@@ -70,6 +70,17 @@
       "timestampBasis": "Census TIGERweb county geography service artifact.",
       "confidence": "County geometry is used for Indiana county map joins; precinct boundary geometry is not included in this package.",
       "status": "loaded"
+    },
+    {
+      "id": "in-2024-equipment-context",
+      "category": "County election equipment context",
+      "url": "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/18",
+      "localFile": "data/in-2024-equipment-context.csv",
+      "parser": "verifiedVotingEquipmentContextCsv",
+      "authority": "Verified Voting Verifier",
+      "timestampBasis": "Verified Voting Verifier 2024 Indiana jurisdiction equipment context normalized for CivicResultMaps.",
+      "confidence": "County-level election-administration context only. This secondary source does not replace official Indiana result, turnout, audit, recount, CVR, or incident/correction records and does not prove or disprove advisory flags.",
+      "status": "loaded"
     }
   ],
   "turnout": {
@@ -89,7 +100,7 @@
   "expected": {
     "jurisdictions": 92,
     "resultRows": 92,
-    "sources": 6,
+    "sources": 7,
     "geometryFeatures": 92,
     "stateTotal": 2936677,
     "trump": 1720347,

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -373,6 +373,10 @@ class PipelineTests(unittest.TestCase):
 
         self.assertTrue(report.passed)
         self.assertEqual(artifact["native"]["parser"], "nativeIndianaEnrCountyJson")
+        self.assertEqual(len(artifact["sources"]), 7)
+        equipment_source = next(source for source in artifact["sources"] if source["id"] == "in-2024-equipment-context")
+        self.assertEqual(equipment_source["parser"], "verifiedVotingEquipmentContextCsv")
+        self.assertTrue(equipment_source["metadata"]["artifacts"][0]["exists"])
         self.assertEqual(artifact["native"]["metrics"]["nativeResultRows"], 92)
         self.assertEqual(artifact["native"]["metrics"]["nativeResultTotalVotes"], 2936677)
         self.assertEqual(artifact["native"]["metrics"]["nativeTrumpVotes"], 1720347)


### PR DESCRIPTION
## Summary

State: IN

This PR keeps Indiana scoped to source coverage/provenance improvements. It does not promote data to production.

Changes:
- Adds the existing `data/in-2024-equipment-context.csv` artifact to `etl/state-configs/in.json` as loaded county-level equipment context, with caveats that it is secondary administration context only.
- Updates Indiana source acquisition and native source package inventory rows to distinguish official county ENR totals, supplemental MIT/OpenElections precinct review rows, EAC fallback turnout, loaded equipment context, and remaining official gaps.
- Expands the Indiana records request packet to cover official precinct/subcounty President and U.S. Senate rows, state-native turnout/registration denominators, subcounty geometry, historical baselines, and audit/recount/CVR/incident/correction records.
- Adds a focused Indiana Python test assertion that staging exposes seven sources and includes the equipment context artifact.

## Sources Confirmed

- Indiana Election Division archived ENR county presidential and U.S. Senate JSON files remain the certified county result sources.
- Indiana archived `JurR_*_B.json` files remain inventoried as official county jurisdiction JSON with zero candidate race containers.
- MIT/OpenElections Indiana precinct rows remain supplemental advisory review inputs only.
- EAC 2024 V2 turnout rows remain the fallback turnout denominator source.
- Verified Voting Verifier Indiana 2024 county equipment context is now cited as secondary administration context.

## Validation

- `python -m civic_etl.cli validate --config etl/state-configs/in.json`
- `python -m civic_etl.cli import --config etl/state-configs/in.json --out .etl/staging`
- `python -m unittest tests.python.test_pipeline.PipelineTests.test_indiana_enr_county_json_parser_builds_county_rows`
- `node tests/api/swing-state-parity.test.mjs`
- `npm run validate:source-packages` (passes with pre-existing warnings for missing legacy/app-ready bundles in other states)
- `npm run validate:source-acquisition-tiers`
- `npm run typecheck`
- `npm run build`

## Review Pass

Self-review found one source-tier completeness issue: the Indiana tier row mentioned EAC, MIT, and Verified Voting artifacts while only listing the ENR dashboard URL. Addressed by adding the corresponding source URLs to the Indiana row. No further findings after rerunning the affected validator.

## Overlap Check

Visible Wave 2 overlap checked before PR creation. MI currently touches the same shared inventory/test files, but on adjacent Michigan rows/assertions; PA touches `civic_etl/native.py` and `etl/state-configs/pa.json`; IA and KY had no visible diffs. No direct Indiana-line conflicts found.

## Remaining Risk

Official Indiana precinct/subcounty candidate rows remain unavailable in the loaded artifacts. State-native turnout denominators, precinct geometry, 2020/2016/2012 historical baselines, audit/recount/CVR availability, incident/correction records, and official source-side clarification for supplemental review caveats remain open records/source-discovery gaps.