### PR TITLE
[codex] Document Michigan historical baseline gap

### DIFF
--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -152,7 +152,8 @@
       "caveats": [
         "MVIC live download endpoints are browser-protected; local official export artifacts are already stored in the repo.",
         "Turnout is county-level, not precinct-level.",
-        "Precinct boundary GeoJSON is not present in this package."
+        "Precinct boundary GeoJSON is not present in this package.",
+        "Historical baseline rows for 2020, 2016, and 2012 are not committed or parsed yet, so Michigan historical baseline capability remains disabled."
       ]
     },
     {

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -745,13 +745,14 @@
         "county registration/turnout"
       ],
       "missingFields": [
-        "precinct boundary geometry"
+        "precinct boundary geometry",
+        "2020, 2016, and 2012 county historical presidential baselines"
       ],
       "parserStatus": "native precinct review package loaded",
       "manualReviewBurden": "low",
       "confidence": "loaded",
-      "caveats": "Turnout is county-level, not precinct-level.",
-      "nextAction": "Optional next step is precinct geometry and precinct-level turnout denominator if available."
+      "caveats": "Turnout is county-level, not precinct-level. Historical baseline capability remains disabled until official Michigan county presidential rows for 2020, 2016, and 2012 are committed and parsed.",
+      "nextAction": "Optional next steps are precinct geometry, a precinct-level turnout denominator if available, and official historical county presidential baseline exports for 2020, 2016, and 2012."
     },
     {
       "state": "MN",

--- a/docs/native-import-source-packages.md
+++ b/docs/native-import-source-packages.md
@@ -66,7 +66,7 @@ Expected validation:
 | Local review rows | 4,428 |
 | Turnout rows | 83 |
 
-Caveats: MVIC live download endpoints are browser-protected, but the official downloaded artifacts are present. Turnout is county-level. Precinct boundary GeoJSON is not included.
+Caveats: MVIC live download endpoints are browser-protected, but the official downloaded artifacts are present. Turnout is county-level. Precinct boundary GeoJSON is not included. Historical baseline rows for 2020, 2016, and 2012 are not committed or parsed yet, so the Michigan historical baseline capability remains disabled.
 
 ## Pennsylvania
 

--- a/etl/state-configs/mi.json
+++ b/etl/state-configs/mi.json
@@ -109,6 +109,6 @@
     "map": true,
     "reviewGraphs": true,
     "turnout": true,
-    "historicalBaseline": true
+    "historicalBaseline": false
   }
 }

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -216,6 +216,8 @@ class PipelineTests(unittest.TestCase):
         self.assertEqual(artifact["native"]["metrics"]["nativeReviewRows"], 4428)
         self.assertEqual(artifact["native"]["metrics"]["nativeComparisonRows"], 4416)
         self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutRows"], 83)
+        self.assertFalse(artifact["capabilities"]["historicalBaseline"])
+        self.assertEqual(artifact["native"].get("historicalRows", []), [])
         self.assertTrue(any(row["coverageMode"] == "voteShareOnly" for row in artifact["native"]["reviewRows"]))
 
     def test_north_carolina_native_staging_parses_precinct_zip(self):


### PR DESCRIPTION
## Summary

- Corrects Michigan's native ETL capability flags so historical baseline coverage is not advertised while the staging artifact has zero historical rows.
- Documents the remaining MI historical baseline gap in the source acquisition and native package inventories.
- Adds a focused Michigan pipeline assertion that historical rows remain empty while the capability is disabled.

## Michigan Sources Confirmed

- Official MVIC county result export: `data/mi-2024-general-election-results.txt`
- Official MVIC precinct result ZIP with President and U.S. Senate rows: `data/mi-2024-precinct-results.zip`
- Official MVIC county turnout export: `data/mi-2024-voter-turnout.txt`
- Official Michigan SOS registration denominator PDF extraction: `data/mi-2024-registered-voter-count.json`
- Census county geometry: `data/mi-counties.geojson`

## Validation

Passed:

- `npm run etl:prepare:mi`
- `npm run etl:validate:mi`
- `npm run etl:import:mi`
- `python -m unittest tests.python.test_pipeline.PipelineTests.test_michigan_native_staging_parses_mvic_package`
- `node tests/api/swing-state-parity.test.mjs`
- `node tests/api/electronic-integrity.test.mjs`
- `npm run validate:source-packages`
- `npm run validate:source-acquisition-tiers`
- `npm run validate:turnout-packages`
- `npm run typecheck`
- `npm run build`

Known unrelated validation blockers:

- `npm run validate:maps` fails on pre-existing RI/VT/WY production map-join gaps; MI reports 83 result rows, 83 boundaries, and zero unmatched/unmapped rows.
- `npm run validate:provenance` fails before MI due to a pre-existing UTF-8 BOM in `etl/state-configs/or.json`.

## Review

Self-review found no issues in the MI diff. Visible branch overlap checks show shared inventory/test file overlap with active IN/GA/NC/NV branches, but their diffs do not touch Michigan sections.

## Remaining Risk

- 2020, 2016, and 2012 Michigan county historical presidential baselines are not yet committed or parsed.
- Turnout remains county-level, not precinct-level.
- Precinct geometry is not included.
- Michigan audit/CVR/tabulator-log/incident/correction records remain request/inventory work, not loaded evidence.

This PR does not promote data to production and does not make fraud or misconduct claims.