### PR TITLE
[codex] Document Mississippi OCR coverage status

### DIFF
--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -562,11 +562,12 @@
       "requiredArtifacts": [
         "OCR text generated from official county recapitulation PDFs with npm run etl:ocr:ms if precinct-level review is pursued; the default renderer/OCR path is Node-based and rotates the sideways recapitulation sheets before OCR, with optional external Poppler/Tesseract mode",
         "reviewed structured precinct-level President-versus-U.S. Senate CSV promoted from scripts/extract-ms-recap-grid-cells.mjs output",
-        "state-native turnout denominator artifact if replacing EAC turnout fallback"
+        "state-native turnout denominator artifact if replacing EAC turnout fallback",
+        "official 2020, 2016, and 2012 Mississippi SOS county presidential artifacts before enabling historical baselines"
       ],
       "preferredComparisonContest": "U.S. Senate",
-      "parserNeeded": "mississippiElectionRecapCsv is loaded for county review. For precinct-level rows, run scripts/ocr-ms-county-result-pdfs.mjs, run scripts/extract-ms-recap-grid-cells.mjs to produce review-gated cell candidates, reconcile/review the candidate CSV, then promote a structured precinct review artifact.",
-      "blocker": "Mississippi county-level President-versus-U.S. Senate review rows are live from the Secretary of State statewide recap CSV. Precinct-level advisory flags remain blocked until the image-only county recapitulation PDFs are OCRed, reviewed, and parsed into structured rows."
+      "parserNeeded": "mississippiElectionRecapCsv is loaded for county review. For precinct-level rows, run scripts/ocr-ms-county-result-pdfs.mjs or reuse checked-in OCR text, run scripts/extract-ms-recap-ocr-text-rows.mjs and scripts/reconcile-ms-ocr-grid-cells.mjs, apply reviewed corrections with npm run etl:verify:ms:ocr:reviewed for partial-review status, then promote only a fully reviewed structured precinct artifact.",
+      "blocker": "Mississippi county-level President-versus-U.S. Senate review rows are live from the Secretary of State statewide recap CSV. On 2026-06-30, the reviewed partial OCR path reported 11 import-ready counties, 61 review-required counties, and 10 missing-OCR counties; precinct-level advisory flags remain blocked until all county recapitulation PDFs are OCRed or manually reviewed, reconciled to the official recap totals, and parsed into structured rows. Historical baselines remain blocked until official SOS county presidential artifacts for 2020, 2016, and 2012 are collected and source-cited."
     },
     {
       "state": "MO",

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -864,13 +864,14 @@
       ],
       "missingFields": [
         "precinct rows",
-        "state-native turnout denominator"
+        "state-native turnout denominator",
+        "2020/2016/2012 source-cited historical baseline artifacts"
       ],
-      "parserStatus": "mississippiElectionRecapCsv loaded for county review",
+      "parserStatus": "mississippiElectionRecapCsv loaded for county review; historical baselines remain blocked pending official SOS county artifacts",
       "manualReviewBurden": "low",
       "confidence": "loaded",
       "caveats": "County-level review is useful but not a precinct-level scatter plot.",
-      "nextAction": "Keep loaded county package; use county PDFs only for precinct-level upgrade."
+      "nextAction": "Keep loaded county package; collect official Mississippi SOS 2020, 2016, and 2012 county presidential artifacts before enabling historicalBaseline."
     },
     {
       "state": "MS",
@@ -894,14 +895,14 @@
       ],
       "missingFields": [
         "reviewed structured precinct CSV",
-        "total-column exclusion",
+        "complete correction-reviewed OCR coverage for all counties",
         "fully reconciled OCR output"
       ],
-      "parserStatus": "OCR scripts and reconciliation gate exist; output remains review-gated",
+      "parserStatus": "OCR scripts and reconciliation gate exist; 2026-06-30 reviewed partial verification reported 11 import-ready counties, 61 review-required counties, and 10 missing-OCR counties",
       "manualReviewBurden": "high",
       "confidence": "partial",
-      "caveats": "OCR recovered sample/probe cells, but blanks, total columns, rotation, and grid issues prevent import until reconciled.",
-      "nextAction": "Continue OCR reconciliation and promote only reviewed, reconciled precinct rows."
+      "caveats": "OCR and reviewed corrections recover some counties, but most county outputs remain review-gated; correction additions can represent reviewed cells that are not present in the partial checked-in OCR text. Do not import precinct rows until all counties reconcile to the official SOS recap totals.",
+      "nextAction": "Continue OCR/manual review for the 61 review-required counties and 10 missing-OCR counties, rerun npm run etl:verify:ms:ocr:reviewed, then promote only fully reviewed precinct rows."
     },
     {
       "state": "MT",

--- a/docs/ms-2024-data-coverage.md
+++ b/docs/ms-2024-data-coverage.md
@@ -1,0 +1,41 @@
+# Mississippi 2024 Data Coverage
+
+Checked at: 2026-06-30
+
+This note is an internal source and review-path inventory for Mississippi. It does not replace the ETL config, source registries, or reviewed staging artifacts.
+
+## Loaded Official Coverage
+
+- Certified presidential county results: loaded from the Mississippi Secretary of State 2024 General Election statewide recap CSV at `data/ms-2024-election-recap-sheets.csv`.
+- Same-grain comparison contest: loaded from the same SOS recap CSV using county-level U.S. Senate rows.
+- Statewide reference PDF: retained at `data/ms-2024-official-statewide-results.pdf` for provenance next to the parsed CSV.
+- County geometry: loaded from Census TIGERweb county GeoJSON at `data/ms-counties.geojson`.
+- Turnout denominator: loaded from EAC 2024 V2 county/jurisdiction fallback rows at `data/eac-2024-state-turnout/ms-2024-eac-turnout.csv`; this remains a fallback until a Mississippi-native turnout or registration source is collected.
+- Equipment context: loaded separately in `data/admin-source-packages.json` from Verified Voting Verifier county-level context, normalized to `data/ms-2024-equipment-context.csv`. This is administration context only, not a turnout or vote-result source.
+
+## Precinct Review Path
+
+The official county recapitulation PDF package is present at `data/ms-2024-county-results-pdfs` with 84 PDFs for 82 counties because updated Coahoma and Pike files are retained with their originals. The OCR review path is intentionally gated and should not be promoted until reviewed county outputs reconcile to the official recap totals.
+
+Current checked-in OCR artifacts include partial text rows under `data/ms-2024-county-results-ocr-text` plus reviewed correction rows in `data/ms-2024-ocr-reviewed-corrections.csv`. Running:
+
+```powershell
+npm run etl:verify:ms:ocr:reviewed
+```
+
+on 2026-06-30 reported 11 import-ready counties, 61 counties still requiring review, and 10 counties still missing OCR after applying the broader reviewed correction file in partial-review mode. The import-ready counties were Adams, Alcorn, Amite, Benton, Bolivar, Calhoun, Chickasaw, Clarke, Clay, Coahoma, and George.
+
+Remaining precinct-review blocker: complete OCR or manual review for the other counties, reconcile candidate totals for Harris, Trump, Pinkins, and Wicker against the official SOS recap CSV, then promote only a reviewed structured precinct CSV through a parser.
+
+## Historical Baselines
+
+2020, 2016, and 2012 historical baselines were not added in this pass. No source-cited official historical Mississippi county presidential artifacts are present in the repo, and live direct checks against likely SOS historical recap URL patterns were blocked or rejected from this environment, including the known 2024 CSV path. That only documents an acquisition blocker from this environment; it is not evidence that the Secretary of State does not publish historical files.
+
+Next action: collect official Mississippi SOS historical county presidential artifacts for 2020, 2016, and 2012 from the SOS election results archive or request them from the SOS Elections Division. For each artifact, record source URL, local path, reporting grain, parser path, expected county count, candidate totals, caveats, and confidence before enabling `historicalBaseline` for Mississippi.
+
+## Remaining 2024 Source Gaps
+
+- Mississippi-native turnout or registration denominator rows to replace the EAC fallback.
+- Precinct-level structured President-versus-U.S. Senate review CSV promoted from reviewed county PDF OCR/manual review.
+- Precinct boundary geometry if subcounty map overlays are required.
+- Post-election audit, CVR availability, incident/correction/litigation, tabulator/EMS log, logic-and-accuracy, and custody records. These are tracked as `needs_data` administration context, not as findings.

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "etl:template:ms:ocr-corrections": "node scripts/create-ms-ocr-correction-template.mjs",
     "etl:template:ms:ocr-corrections:sample": "node scripts/create-ms-ocr-correction-template.mjs --cells .etl/ocr/ms-sample-text-row-candidates.csv --reconciliation .etl/ocr/ms-sample-text-row-reconciliation.csv --out .etl/ocr/ms-sample-ocr-correction-template.csv",
     "etl:verify:ms:ocr": "node scripts/verify-ms-ocr-pipeline.mjs",
+    "etl:verify:ms:ocr:reviewed": "node scripts/verify-ms-ocr-pipeline.mjs --skip-ocr --corrections data/ms-2024-ocr-reviewed-corrections.csv --allow-unused-corrections --report .etl/ocr/ms-reviewed-ocr-verification-report.csv --state .etl/ocr/ms-reviewed-ocr-verification-state.json",
     "etl:verify:ms:ocr:sample": "node scripts/verify-ms-ocr-pipeline.mjs --skip-ocr --pdf-dir data/ms-2024-county-results-pdfs --text-pages-dir .etl/ocr/ms-sample-text/pages --cells .etl/ocr/ms-sample-text-row-candidates.csv --reconciliation .etl/ocr/ms-sample-text-row-reconciliation.csv --correction-template .etl/ocr/ms-sample-ocr-correction-template.csv --report .etl/ocr/ms-sample-ocr-verification-report.csv --state .etl/ocr/ms-sample-ocr-verification-state.json --limit-counties 2 --limit-pages 2",
     "etl:extract:ms:pdf-text-layer": "node scripts/extract-ms-pdf-text-layer.mjs",
     "etl:promote:ms:ocr-recovery": "node scripts/promote-ms-ocr-recovery-text.mjs",

--- a/scripts/reconcile-ms-ocr-grid-cells.mjs
+++ b/scripts/reconcile-ms-ocr-grid-cells.mjs
@@ -8,6 +8,7 @@ const defaults = {
   sourceOverrides: "data/ms-2024-ocr-source-overrides.json",
   out: ".etl/ocr/ms-grid-reconciliation.csv",
   corrections: "",
+  allowUnusedCorrections: false,
 };
 
 const candidateAliases = [
@@ -30,6 +31,7 @@ function usage() {
     "  --source-overrides <file>  Optional source/reconciliation override JSON. Default: " + defaults.sourceOverrides,
     "  --out <file>    Reconciliation CSV output. Default: " + defaults.out,
     "  --corrections <file>  Optional human-reviewed correction CSV.",
+    "  --allow-unused-corrections  Permit correction rows that do not match this partial candidate-cell set.",
     "  --help          Show this help.",
   ].join("\n"));
 }
@@ -44,6 +46,7 @@ function parseArgs(argv) {
     else if (arg === "--source-overrides") options.sourceOverrides = argv[++index];
     else if (arg === "--out") options.out = argv[++index];
     else if (arg === "--corrections") options.corrections = argv[++index];
+    else if (arg === "--allow-unused-corrections") options.allowUnusedCorrections = true;
     else throw new Error("Unknown option: " + arg);
   }
   return options;
@@ -197,10 +200,10 @@ function loadCorrections(correctionsPath) {
   return { additions, updates };
 }
 
-function applyCorrections(cells, corrections) {
+function applyCorrections(cells, corrections, options = {}) {
   const unusedUpdates = new Set(corrections.updates.keys());
   const correctedCells = [];
-  const metrics = { correctionAdditions: 0, correctionExclusions: 0, correctionUpdates: 0 };
+  const metrics = { correctionAdditions: 0, correctionExclusions: 0, correctionUpdates: 0, unusedCorrections: 0 };
 
   for (const cell of cells) {
     const key = correctionKey(cell);
@@ -223,9 +226,10 @@ function applyCorrections(cells, corrections) {
     metrics.correctionUpdates += 1;
   }
 
-  if (unusedUpdates.size) {
+  if (unusedUpdates.size && !options.allowUnusedCorrections) {
     throw new Error("Correction rows did not match candidate cells: " + [...unusedUpdates].join(", "));
   }
+  metrics.unusedCorrections = unusedUpdates.size;
 
   for (const correction of corrections.additions) {
     correctedCells.push({
@@ -386,7 +390,7 @@ async function main() {
 
   const inputCells = parseCsv(fs.readFileSync(options.cells, "utf8"));
   const corrections = loadCorrections(options.corrections);
-  const corrected = applyCorrections(inputCells, corrections);
+  const corrected = applyCorrections(inputCells, corrections, { allowUnusedCorrections: options.allowUnusedCorrections });
   const officialTotals = loadOfficialTotals(options.recap);
   const sourceOverrides = loadSourceOverrides(options.sourceOverrides);
   const report = summarize(corrected.cells, officialTotals, sourceOverrides);

--- a/scripts/verify-ms-ocr-pipeline.mjs
+++ b/scripts/verify-ms-ocr-pipeline.mjs
@@ -26,6 +26,7 @@ const defaults = {
   skipOcr: false,
   forceOcr: false,
   failOnReview: false,
+  allowUnusedCorrections: false,
 };
 
 const expectedCandidateKeys = ["harris", "trump", "pinkins", "wicker"];
@@ -60,6 +61,7 @@ function usage() {
     "  --skip-ocr                   Reuse existing OCR text and only extract/reconcile/report.",
     "  --force-ocr                  Re-OCR selected counties even when text exists.",
     "  --fail-on-review             Exit nonzero if any county is not import-ready.",
+    "  --allow-unused-corrections   Permit broader correction files during partial verification runs.",
     "  --help                       Show this help.",
   ].join("\n"));
 }
@@ -91,6 +93,7 @@ function parseArgs(argv) {
     else if (arg === "--skip-ocr") options.skipOcr = true;
     else if (arg === "--force-ocr") options.forceOcr = true;
     else if (arg === "--fail-on-review") options.failOnReview = true;
+    else if (arg === "--allow-unused-corrections") options.allowUnusedCorrections = true;
     else throw new Error("Unknown option: " + arg);
   }
   return options;
@@ -275,6 +278,7 @@ function runExtractor(options) {
 function runReconciler(options) {
   const args = ["scripts/reconcile-ms-ocr-grid-cells.mjs", "--cells", options.cells, "--source-overrides", options.sourceOverrides, "--out", options.reconciliation];
   if (options.corrections) args.push("--corrections", options.corrections);
+  if (options.allowUnusedCorrections) args.push("--allow-unused-corrections");
   runNode(args);
 }
 

--- a/tests/api/api-contract.test.mjs
+++ b/tests/api/api-contract.test.mjs
@@ -403,6 +403,7 @@ test("native source package handoff is validated in CI", () => {
   const msCombinedReviewScript = readFileSync("scripts/combine-ms-ocr-review-artifacts.mjs", "utf8");
   const msReviewedCorrections = readFileSync("data/ms-2024-ocr-reviewed-corrections.csv", "utf8");
   const msVerifier = readFileSync("scripts/verify-ms-ocr-pipeline.mjs", "utf8");
+  const msCoverageDoc = readFileSync("docs/ms-2024-data-coverage.md", "utf8");
   assert.match(packageScripts["etl:extract:ms:ocr-text-rows"], /extract-ms-recap-ocr-text-rows/);
   assert.match(packageScripts["etl:extract:ms:pdf-text-layer"], /extract-ms-pdf-text-layer/);
   assert.match(packageScripts["etl:promote:ms:ocr-recovery"], /promote-ms-ocr-recovery-text/);
@@ -411,6 +412,7 @@ test("native source package handoff is validated in CI", () => {
   assert.match(packageScripts["etl:template:ms:ocr-corrections"], /create-ms-ocr-correction-template/);
   assert.match(packageScripts["etl:template:ms:ocr-corrections:sample"], /ms-sample-ocr-correction-template/);
   assert.match(packageScripts["etl:verify:ms:ocr"], /verify-ms-ocr-pipeline/);
+  assert.match(packageScripts["etl:verify:ms:ocr:reviewed"], /--allow-unused-corrections/);
   assert.match(packageScripts["etl:verify:ms:ocr:sample"], /--skip-ocr/);
   assert.match(msTextExtractor, /text_row_fallback/);
   assert.match(msTextExtractor, /This is a fallback companion to grid-cell extraction/);
@@ -440,13 +442,18 @@ test("native source package handoff is validated in CI", () => {
   assert.match(msVerifier, /--rotate/);
   assert.match(msVerifier, /--psm/);
   assert.match(msVerifier, /failOnReview/);
+  assert.match(msVerifier, /allowUnusedCorrections/);
   assert.match(msVerifier, /import_ready/);
   assert.match(msVerifier, /missing_ocr/);
+  assert.match(msCoverageDoc, /11 import-ready counties/);
+  assert.match(msCoverageDoc, /EAC 2024 V2 county\/jurisdiction fallback/);
+  assert.match(msCoverageDoc, /historical baselines were not added/);
   assert.match(msReconciler, /precinctExtractedTotal/);
   assert.match(msReconciler, /detected_total_column_cells/);
   assert.match(msReconciler, /--corrections/);
   assert.match(msReconciler, /manual_correction/);
   assert.match(msReconciler, /manual_addition/);
+  assert.match(msReconciler, /unusedCorrections/);
   assert.match(msReconciler, /Correction rows did not match candidate cells/);
 });
 


### PR DESCRIPTION
## Summary

- Documents Mississippi 2024 source coverage, including loaded SOS county results, U.S. Senate comparison rows, EAC turnout fallback, county geometry, equipment context, and remaining source gaps.
- Adds an opt-in `--allow-unused-corrections` path for partial Mississippi OCR review runs while preserving strict correction matching by default.
- Adds `npm run etl:verify:ms:ocr:reviewed` and API contract coverage for the reviewed partial OCR status documentation.

## Mississippi sources confirmed

- Mississippi Secretary of State 2024 statewide recap CSV/PDF for county President and U.S. Senate rows.
- Official county recapitulation PDF package retained for precinct review work.
- Census county geometry GeoJSON.
- EAC 2024 V2 county/jurisdiction turnout fallback.
- Verified Voting equipment context recorded as administration context only.

## Validation

- `npm run validate:source-packages` passed with pre-existing unrelated warnings for legacy/reference bundles.
- `npm run validate:source-acquisition-tiers` passed.
- `node tests\api\api-contract.test.mjs` passed.
- `python -m civic_etl.cli validate --config etl/state-configs/ms.json` passed.
- `python -m civic_etl.cli import --config etl/state-configs/ms.json --out .etl/staging` passed.
- `npm run validate:maps` passed with existing equipment-geometry warnings; production result geometry joins passed.
- `npm run validate:provenance` passed.
- `npm run etl:verify:ms:ocr:reviewed` passed and reported 11 import-ready counties, 61 review-required counties, and 10 missing-OCR counties.
- `npm test` passed.
- `npm run typecheck` passed.
- `npm run build` passed.

## Review

Local self-review of the staged diff found no unsupported fraud/misconduct claims, no production data promotion, no unrelated file edits, and no conflict signal against `origin/codex/validator-config-fixes` before commit.

## Remaining risks

- Mississippi historical baselines for 2020, 2016, and 2012 are still blocked pending source-cited official SOS county presidential artifacts.
- Precinct review remains gated until all county recapitulation outputs are OCRed or manually reviewed and reconciled to official SOS recap totals.
- EAC turnout remains a fallback until a Mississippi-native turnout or registration denominator is collected.
- Audit/CVR availability, incident/correction/litigation, logs, logic-and-accuracy, custody records, and precinct geometry remain source gaps, not findings.