### PR TITLE
[codex] Document West Virginia data coverage

### DIFF
--- a/data/admin-source-packages.json
+++ b/data/admin-source-packages.json
@@ -1576,16 +1576,25 @@
         "expectedJurisdictions": 55
       },
       "audit": {
-        "status": "needs_data",
-        "why": "West Virginia 2024 post-election audit artifacts have not been inventoried or normalized into this administration context registry yet."
+        "status": "candidate",
+        "reportingLevel": "statewide_policy",
+        "sourceDocumentId": "wv-sos-election-security-hand-count-audit",
+        "sourceUrl": "https://sos.wv.gov/elections/Pages/ElectionSecurity.aspx",
+        "why": "West Virginia Secretary of State election-security materials document a hand-count audit requirement and related voting-system security context, but 2024 county audit selection/outcome artifacts have not been collected or normalized.",
+        "caveat": "Candidate source inventory only; no 2024 post-election audit result rows are loaded for West Virginia."
       },
       "cvr": {
         "status": "needs_data",
-        "why": "West Virginia 2024 CVR artifacts have not been inventoried or normalized into this administration context registry yet."
+        "why": "West Virginia 2024 cast-vote-record availability and request paths have not been inventoried or normalized into this administration context registry yet.",
+        "caveat": "No CVR dataset or county CVR availability table is loaded."
       },
       "incidents": {
-        "status": "needs_data",
-        "why": "West Virginia 2024 incident, correction, and litigation artifacts have not been inventoried or normalized into this administration context registry yet."
+        "status": "candidate",
+        "reportingLevel": "statewide_reporting_path",
+        "sourceDocumentId": "wv-sos-election-security-complaint-reporting",
+        "sourceUrl": "https://sos.wv.gov/elections/Pages/ElectionSecurity.aspx",
+        "why": "West Virginia Secretary of State election-security materials identify official complaint/reporting paths for election-law violations, but 2024 incident, correction, recount, and litigation records have not been normalized.",
+        "caveat": "Candidate source inventory only; not a loaded incident, correction, recount, or litigation dataset."
       }
     },
     {

--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -776,18 +776,60 @@
       "state": "WV",
       "name": "West Virginia",
       "priority": 12,
-      "currentStatus": "official_precinct_review_package_collected",
+      "currentStatus": "official_precinct_review_turnout_package_collected_admin_context_partial",
       "officialSourcePages": [
         "https://results.enr.clarityelections.com/WV/122766/web.345435/",
-        "https://results.enr.clarityelections.com/WV/122766/current_ver.txt"
+        "https://results.enr.clarityelections.com/WV/122766/current_ver.txt",
+        "https://sos.wv.gov/elections/Pages/ElectionSecurity.aspx",
+        "https://sos.wv.gov/elections/Pages/VoteRegTotals.aspx"
       ],
       "requiredArtifacts": [
         "official county detailxml.zip reports for all 55 counties",
-        "precinct boundary geometry if subcounty map overlays are required"
+        "precinct boundary geometry if subcounty map overlays are required",
+        "official 2024 post-election audit selection/outcome artifacts if published or obtainable",
+        "CVR availability/request-path inventory",
+        "incident, correction, recount, and litigation source inventory"
       ],
       "preferredComparisonContest": "U.S. Senate; loaded from official county detail XML reports as precinct-level President-vs-U.S.-Senate review rows.",
-      "parserNeeded": "westVirginiaClarityCountyDetailXmlDirectory loaded for 55 county result rows, 1,648 precinct review rows, and 1,649 precinct turnout rows.",
-      "blocker": "West Virginia now has official county detailxml.zip reports collected from the Secretary of State Clarity results app. The parser loads precinct-level President-versus-U.S.-Senate review rows. Remaining optional gap: precinct boundary geometry for subcounty map overlays."
+      "parserNeeded": "westVirginiaClarityCountyDetailXmlDirectory loaded for 55 county result rows, 1,648 precinct review rows, and 1,649 precinct turnout rows. Equipment context is loaded separately from Verified Voting county context; audit/CVR/incident records remain source-inventory tasks.",
+      "blocker": "West Virginia has official county detailxml.zip reports collected from the Secretary of State Clarity results app. The parser loads precinct-level President-versus-U.S.-Senate review rows and state-native precinct turnout denominators from VoterTurnout totalVoters/ballotsCast. Remaining gaps are official statewide precinct boundary geometry for subcounty overlays and normalized administration context for audit outcomes, CVR availability, incidents, corrections, recounts, and litigation.",
+      "availableArtifacts": {
+        "presidentialCountyResults": {
+          "sourceTitle": "West Virginia SOS official county detail XML reports",
+          "sourceUrl": "https://results.enr.clarityelections.com/WV/122766/web.345435/",
+          "localFile": "data/wv-2024-county-detailxml-reports",
+          "parserHint": "Aggregate U.S. PRESIDENT precinct Choice/VoteType rows by county."
+        },
+        "localReviewRows": {
+          "sourceTitle": "West Virginia SOS official county detail XML reports",
+          "sourceUrl": "https://results.enr.clarityelections.com/WV/122766/web.345435/",
+          "localFile": "data/wv-2024-county-detailxml-reports",
+          "level": "precinct",
+          "comparisonContest": "U.S. Senate",
+          "parserHint": "Pair U.S. PRESIDENT and U.S. SENATOR precinct Choice/VoteType rows by county and precinct name."
+        },
+        "turnout": {
+          "sourceTitle": "West Virginia SOS county detail XML VoterTurnout rows",
+          "sourceUrl": "https://results.enr.clarityelections.com/WV/122766/web.345435/",
+          "localFile": "data/wv-2024-county-detailxml-reports",
+          "level": "precinct",
+          "denominator": "VoterTurnout Precinct totalVoters",
+          "ballotsCast": "VoterTurnout Precinct ballotsCast"
+        },
+        "countyBoundary": {
+          "sourceTitle": "U.S. Census TIGERweb county geography",
+          "sourceUrl": "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE%3D%2754%27&outFields=NAME,BASENAME,GEOID,STATE,COUNTY&returnGeometry=true&outSR=4326&f=geojson",
+          "localFile": "data/wv-counties.geojson",
+          "nameProperty": "NAME",
+          "codeProperty": "COUNTY"
+        },
+        "equipmentContext": {
+          "sourceTitle": "Verified Voting Verifier West Virginia 2024 equipment context",
+          "sourceUrl": "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/54",
+          "localFile": "data/wv-2024-equipment-context.csv",
+          "parserHint": "Context only; do not use for votes or turnout."
+        }
+      }
     }
   ]
 }

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -1717,7 +1717,7 @@
       "stateName": "West Virginia",
       "jurisdictionName": "Statewide",
       "scope": "statewide",
-      "dataFamily": "results_review_turnout",
+      "dataFamily": "results_review_turnout_equipment_admin_context",
       "tier": "tier_2_official_dashboard_endpoint",
       "reportingGrain": "precinct",
       "exportFormats": [
@@ -1731,16 +1731,20 @@
         "county results",
         "precinct President rows",
         "precinct U.S. Senate rows",
-        "precinct turnout rows"
+        "precinct turnout rows",
+        "county equipment context"
       ],
       "missingFields": [
-        "precinct boundary geometry"
+        "official statewide precinct boundary geometry",
+        "normalized 2024 post-election audit selection/outcome artifacts",
+        "CVR availability/request-path inventory",
+        "incident, correction, recount, and litigation records"
       ],
-      "parserStatus": "westVirginiaClarityCountyDetailXmlDirectory loaded",
+      "parserStatus": "westVirginiaClarityCountyDetailXmlDirectory loaded for results/review/turnout; Verified Voting county equipment context loaded",
       "manualReviewBurden": "low",
       "confidence": "loaded",
-      "caveats": "Rows are advisory review inputs, not confirmed findings.",
-      "nextAction": "Treat as an example Tier 2 goal state; optional next step is precinct geometry."
+      "caveats": "Rows are advisory review inputs, not confirmed findings. Equipment context is jurisdiction-level metadata only. County map geometry is loaded; no official statewide precinct boundary geometry package was identified in this pass.",
+      "nextAction": "Collect or document an official statewide precinct boundary source if one exists, then inventory official WV SOS/county audit, CVR, incident, correction, recount, and litigation artifacts."
     },
     {
       "state": "WY",

--- a/data/turnout-source-packages.json
+++ b/data/turnout-source-packages.json
@@ -1238,21 +1238,21 @@
       "year": 2024,
       "priority": 49,
       "status": "loaded",
-      "sourceLevel": "jurisdiction",
+      "sourceLevel": "precinct",
       "denominatorType": "registeredVoters",
-      "denominatorTiming": "eacReported",
-      "sourceTitle": "EAC fallback turnout rows",
-      "sourceUrl": "https://www.eac.gov/research-and-data/studies-and-reports",
-      "localFile": "data/eac-2024-state-turnout/wv-2024-eac-turnout.csv",
-      "parser": "eacTurnoutCsv",
-      "expectedTurnoutRows": 55,
-      "statusNote": "Official EAC 2024 EAVS fallback turnout rows are validated in ETL and promoted to the database; prefer state-native denominator artifacts when available.",
-      "nextAction": "Prefer official state election office turnout/registration artifact when available; keep the EAC fallback visibly caveated until then.",
+      "denominatorTiming": "officialCountyReport",
+      "sourceTitle": "West Virginia SOS official county detail XML turnout rows",
+      "sourceUrl": "https://results.enr.clarityelections.com/WV/122766/web.345435/",
+      "localFile": "data/wv-2024-county-detailxml-reports",
+      "parser": "westVirginiaClarityCountyDetailXmlDirectory",
+      "expectedTurnoutRows": 1649,
+      "statusNote": "Official West Virginia Secretary of State county detail XML reports are loaded through the WV native ETL config. Each county detail.xml VoterTurnout Precinct row provides ballotsCast and totalVoters fields at precinct grain.",
+      "nextAction": "Keep the Clarity detail XML source and precinct-geometry caveat visible; collect official precinct boundary geometry if subcounty map overlays are required.",
       "coverage": {
-        "jurisdictionRows": 55,
-        "registeredVoterDenominatorFile": "data/eac-2024-state-turnout/wv-2024-eac-registered-voter-denominator.json",
-        "registeredVoters": 1210415,
-        "ballotsCast": 769206,
+        "jurisdictionRows": 1649,
+        "registeredVoterDenominatorFile": "data/wv-2024-county-detailxml-reports",
+        "registeredVoters": 1187991,
+        "ballotsCast": 770587,
         "warningRows": 0
       }
     },
@@ -1417,6 +1417,35 @@
       "caveats": [
         "EAC F1a Total Voters is not identical to WEC presidential contest total votes.",
         "WEC remains the official source for Wisconsin presidential result rows; EAC is the statewide turnout fallback."
+      ]
+    },
+    {
+      "state": "WV",
+      "name": "West Virginia",
+      "authority": "West Virginia Secretary of State",
+      "sourceLevel": "precinct",
+      "turnoutSource": {
+        "sourceTitle": "West Virginia SOS official county detail XML VoterTurnout rows",
+        "sourceUrl": "https://results.enr.clarityelections.com/WV/122766/web.345435/",
+        "localFile": "data/wv-2024-county-detailxml-reports",
+        "parser": "westVirginiaClarityCountyDetailXmlDirectory"
+      },
+      "denominatorSource": {
+        "sourceTitle": "West Virginia SOS county detail XML totalVoters field",
+        "sourceUrl": "https://results.enr.clarityelections.com/WV/122766/web.345435/",
+        "localFile": "data/wv-2024-county-detailxml-reports",
+        "parser": "westVirginiaClarityCountyDetailXmlDirectory",
+        "denominatorType": "registeredVoters",
+        "denominatorTiming": "officialCountyReport"
+      },
+      "expected": {
+        "turnoutRows": 1649,
+        "registeredVoters": 1187991,
+        "ballotsCast": 770587
+      },
+      "caveats": [
+        "Turnout rows are precinct-level VoterTurnout rows inside official county detail.xml reports.",
+        "The current map package includes county geometry only; official precinct boundary geometry was not identified in this package."
       ]
     }
   ],

--- a/docs/native-import-source-packages.md
+++ b/docs/native-import-source-packages.md
@@ -121,6 +121,20 @@ Expected validation:
 | Historical baseline rows | 279 |
 
 Caveats: review rows are county-level President-versus-U.S. Senate two-year special election comparisons, not precinct/subcounty scatter plots. The official public source pass did not identify statewide precinct/subcounty President and U.S. Senate result exports; request those rows and matching reporting-unit geometry before upgrading advisory coverage below county level.
+
+## West Virginia Wave 4 Update
+
+- Config: etl/state-configs/wv.json
+- Authority: West Virginia Secretary of State
+- County and precinct result source: data/wv-2024-county-detailxml-reports
+- Comparison contest: U.S. Senate, same precinct detail XML rows
+- Turnout source: official county detail XML VoterTurnout precinct rows
+- Turnout denominator: totalVoters registered-voter field; expected 1,649 rows, 770,587 ballots cast, and 1,187,991 registered voters
+- County boundary: data/wv-counties.geojson
+- Equipment context: data/wv-2024-equipment-context.csv from Verified Voting, context only
+
+Remaining gaps: official statewide precinct boundary geometry for subcounty overlays, 2024 audit selection/outcome artifacts, CVR availability/request paths, and incident/correction/recount/litigation inventories. The loaded review rows remain advisory screening inputs, not findings.
+
 ## Native ETL Acceptance Criteria
 
 For each state, the native importer should fail before promotion if:

--- a/docs/turnout-collection-inventory.md
+++ b/docs/turnout-collection-inventory.md
@@ -60,3 +60,7 @@ For Wisconsin, ask for:
 - Join keys that match the WEC ward-by-ward workbook, if ward-level data exists.
 - Expected row count and statewide denominator total.
 - Caveats for same-day registration, inactive voters, absentee ballots, provisional ballots, and reporting-unit changes.
+
+## West Virginia Update
+
+West Virginia now has state-native precinct turnout rows configured from official Secretary of State county detail XML reports at data/wv-2024-county-detailxml-reports. The parser uses VoterTurnout precinct ballotsCast and totalVoters fields, with 1,649 turnout rows, 770,587 ballots cast, and 1,187,991 registered-voter denominator total. The remaining turnout-adjacent gap is official precinct boundary geometry for subcounty overlays, not turnout denominator provenance.

--- a/etl/state-configs/wv.json
+++ b/etl/state-configs/wv.json
@@ -35,7 +35,7 @@
       "parser": "westVirginiaClarityCountyDetailXmlDirectory",
       "authority": "West Virginia Secretary of State",
       "timestampBasis": "Official county detailxml.zip reports from the West Virginia Secretary of State Clarity results app for the November 5, 2024 General Election.",
-      "confidence": "Official county-level Clarity report ZIPs. Each detail.xml contains precinct-level President, U.S. Senate, and turnout rows for that county.",
+      "confidence": "Official county-level Clarity report ZIPs. Each detail.xml contains precinct-level President, U.S. Senate, and VoterTurnout rows for that county. The VoterTurnout Precinct totalVoters field is the state-native registered-voter denominator used by this config.",
       "status": "loaded"
     },
     {
@@ -59,7 +59,9 @@
     "notes": "West Virginia turnout rows come from official county detail XML reports with precinct totalVoters and ballotsCast fields.",
     "warningRequired": false,
     "expected": {
-      "rowCount": 1649
+      "rowCount": 1649,
+      "registeredVoters": 1187991,
+      "ballotsCast": 770587
     }
   },
   "expected": {

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -459,6 +459,8 @@ class PipelineTests(unittest.TestCase):
         self.assertEqual(artifact["native"]["metrics"]["nativeReviewRows"], 1648)
         self.assertEqual(artifact["native"]["metrics"]["nativeComparisonRows"], 1648)
         self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutRows"], 1649)
+        self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutBallotsCast"], 770587)
+        self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutRegisteredVoters"], 1187991)
         self.assertEqual(artifact["native"]["metrics"]["nativeComparisonContest"], "United States Senator")
         barbour = next(row for row in artifact["native"]["reviewRows"] if row["county"] == "Barbour County" and row["localUnit"] == "PRECINCT 1")
         self.assertEqual(barbour["coverageMode"], "presidentVsSenate")


### PR DESCRIPTION
## Summary

- Strengthens West Virginia turnout provenance around the official Secretary of State Clarity county detail XML package.
- Updates WV source-acquisition, native-import, turnout-source, and admin-source registries to reflect state-native precinct turnout, county equipment context, and remaining geometry/admin gaps.
- Adds focused ETL assertions for WV turnout ballots-cast and registered-voter denominator totals.

## Sources confirmed

- West Virginia Secretary of State Clarity 2024 General Election results package: https://results.enr.clarityelections.com/WV/122766/web.345435/
- West Virginia Clarity current version endpoint: https://results.enr.clarityelections.com/WV/122766/current_ver.txt
- West Virginia Secretary of State Election Security page: https://sos.wv.gov/elections/Pages/ElectionSecurity.aspx
- West Virginia voter-registration totals page: https://sos.wv.gov/elections/Pages/VoteRegTotals.aspx
- Verified Voting Verifier WV 2024 equipment context: https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/54

## Validation

- `npm run validate:source-packages` passed with existing warnings for missing legacy/app-ready files outside WV.
- `npm run validate:turnout-packages` passed.
- `npm run validate:source-acquisition-tiers` passed.
- `python -m civic_etl.cli validate --config etl/state-configs/wv.json` passed.
- `python -m civic_etl.cli import --config etl/state-configs/wv.json --out C:\tmp\CivicResultMaps-WV\tmp-staging` passed; temporary staging output was removed.
- `python -m unittest tests.python.test_pipeline.PipelineTests.test_west_virginia_clarity_detailxml_parser_builds_precinct_rows` passed.
- `node tests/api/api-contract.test.mjs` passed.
- `node tests/api/native-import.test.mjs` passed.
- `node tests/api/turnout-normalizer.test.mjs` passed.
- `npm run validate:maps` passed.
- `npm run validate:provenance` passed.

## Known blockers / not run

- `npm run validate:admin-packages` is blocked by pre-existing Missouri `needs_inventory` statuses outside this WV scope.
- `npm run typecheck` and `npm run build` were not completed because this fresh worktree has no `node_modules`; `typecheck` also could not write `tsconfig.tsbuildinfo` under the sandbox, and `build` could not find `next`.

## Remaining WV risk

- No official statewide precinct boundary geometry package was identified in this pass; WV still uses county geometry for map joins.
- Audit, CVR availability, incident/correction/recount, and litigation entries are source-inventory context only unless future official artifacts are collected and normalized.
- Review rows remain advisory screening inputs, not findings.