### PR TITLE
[codex] Document Mississippi Wave 5 coverage caveats

### DIFF
--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -947,17 +947,22 @@
         "https://www.sos.ms.gov/elections-voting/election-results/2024/2024-general-election-results",
         "https://www.sos.ms.gov/elections/electionresults/2024ElectionRecapSheets.csv",
         "https://www.sos.ms.gov/elections/electionresults/2024%20Official%20Statewide%20Results.pdf",
-        "https://sos.ms.gov/elections/electionresults_aspx/elections_results_2024_county.aspx"
+        "https://sos.ms.gov/elections/electionresults_aspx/elections_results_2024_county.aspx",
+        "https://www.sos.ms.gov/elections-voting/election-results",
+        "https://www.sos.ms.gov/elections-voting/election-results/2020/2020-general-election",
+        "https://www.sos.ms.gov/elections-voting/election-results/2016/2016-general-election",
+        "https://www.sos.ms.gov/elections-voting/election-results/2012/2012-election-results",
+        "https://www.sos.ms.gov/elections-voting/active-voter-count-reports"
       ],
       "requiredArtifacts": [
         "OCR text generated from official county recapitulation PDFs with npm run etl:ocr:ms if precinct-level review is pursued; the default renderer/OCR path is Node-based and rotates the sideways recapitulation sheets before OCR, with optional external Poppler/Tesseract mode",
         "reviewed structured precinct-level President-versus-U.S. Senate CSV promoted from scripts/extract-ms-recap-grid-cells.mjs output",
-        "state-native turnout denominator artifact if replacing EAC turnout fallback",
-        "official 2020, 2016, and 2012 Mississippi SOS county presidential artifacts before enabling historical baselines"
+        "state-native turnout denominator artifact and official ballots-cast/voter-participation artifact if replacing EAC turnout fallback; SOS Active Voter Count Reports are a denominator lead only",
+        "official 2020, 2016, and 2012 Mississippi SOS county presidential artifacts from the SOS archive iframe targets, direct recap files, or SOS request path before enabling historical baselines"
       ],
       "preferredComparisonContest": "U.S. Senate",
-      "parserNeeded": "mississippiElectionRecapCsv is loaded for county review. For precinct-level rows, run scripts/ocr-ms-county-result-pdfs.mjs or reuse checked-in OCR text, run scripts/extract-ms-recap-ocr-text-rows.mjs and scripts/reconcile-ms-ocr-grid-cells.mjs, apply reviewed corrections with npm run etl:verify:ms:ocr:reviewed for partial-review status, then promote only a fully reviewed structured precinct artifact.",
-      "blocker": "Mississippi county-level President-versus-U.S. Senate review rows are live from the Secretary of State statewide recap CSV. On 2026-06-30, the reviewed partial OCR path reported 11 import-ready counties, 61 review-required counties, and 10 missing-OCR counties; precinct-level advisory flags remain blocked until all county recapitulation PDFs are OCRed or manually reviewed, reconciled to the official recap totals, and parsed into structured rows. Historical baselines remain blocked until official SOS county presidential artifacts for 2020, 2016, and 2012 are collected and source-cited."
+      "parserNeeded": "mississippiElectionRecapCsv is loaded for county review. For precinct-level rows, run scripts/ocr-ms-county-result-pdfs.mjs or reuse checked-in OCR text, run scripts/extract-ms-recap-ocr-text-rows.mjs and scripts/reconcile-ms-ocr-grid-cells.mjs, apply reviewed corrections with npm run etl:verify:ms:ocr:reviewed for partial-review status, then promote only a fully reviewed structured precinct artifact. For historical baselines, first collect source-cited official SOS county presidential artifacts from the 2020, 2016, and 2012 archive pages or request path; do not parse secondary tables as replacements.",
+      "blocker": "Mississippi county-level President-versus-U.S. Senate review rows are live from the Secretary of State statewide recap CSV. On 2026-06-30, the reviewed partial OCR path reported 11 import-ready counties, 61 review-required counties, and 10 missing-OCR counties; precinct-level advisory flags remain blocked until all county recapitulation PDFs are OCRed or manually reviewed, reconciled to the official recap totals, and parsed into structured rows. Historical baselines remain blocked until official SOS county presidential artifacts for 2020, 2016, and 2012 are collected from the archive iframe/direct file/request path and source-cited. Turnout remains EAC fallback until a Mississippi-native ballots-cast plus denominator package is collected; SOS Active Voter Count Reports are a denominator lead, not a complete turnout source by themselves."
     },
     {
       "state": "MO",

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -877,7 +877,11 @@
         "https://www.sos.ms.gov/elections/electionresults/2024ElectionRecapSheets.csv"
       ],
       "exampleUrls": [
-        "https://www.sos.ms.gov/elections-voting/election-results/2024/2024-general-election-results"
+        "https://www.sos.ms.gov/elections-voting/election-results/2024/2024-general-election-results",
+        "https://www.sos.ms.gov/elections-voting/election-results/2020/2020-general-election",
+        "https://www.sos.ms.gov/elections-voting/election-results/2016/2016-general-election",
+        "https://www.sos.ms.gov/elections-voting/election-results/2012/2012-election-results",
+        "https://www.sos.ms.gov/elections-voting/active-voter-count-reports"
       ],
       "availableFields": [
         "county President rows",
@@ -885,14 +889,14 @@
       ],
       "missingFields": [
         "precinct rows",
-        "state-native turnout denominator",
-        "2020/2016/2012 source-cited historical baseline artifacts"
+        "state-native ballots-cast turnout rows paired with a denominator artifact",
+        "2020/2016/2012 source-cited historical baseline artifacts from the SOS archive iframe/direct file/request path"
       ],
-      "parserStatus": "mississippiElectionRecapCsv loaded for county review; historical baselines remain blocked pending official SOS county artifacts",
+      "parserStatus": "mississippiElectionRecapCsv loaded for county review; historical baselines remain blocked pending official SOS county artifacts from the archive iframe/direct file/request path",
       "manualReviewBurden": "low",
       "confidence": "loaded",
-      "caveats": "County-level review is useful but not a precinct-level scatter plot.",
-      "nextAction": "Keep loaded county package; collect official Mississippi SOS 2020, 2016, and 2012 county presidential artifacts before enabling historicalBaseline."
+      "caveats": "County-level review is useful but not a precinct-level scatter plot. SOS Active Voter Count Reports are a denominator lead only and do not replace ballots-cast turnout rows by themselves.",
+      "nextAction": "Keep loaded county package; collect official Mississippi SOS 2020, 2016, and 2012 county presidential artifacts and a Mississippi-native ballots-cast plus denominator package before enabling historicalBaseline or replacing EAC turnout."
     },
     {
       "state": "MS",

--- a/data/turnout-source-packages.json
+++ b/data/turnout-source-packages.json
@@ -790,14 +790,16 @@
       "localFile": "data/eac-2024-state-turnout/ms-2024-eac-turnout.csv",
       "parser": "eacTurnoutCsv",
       "expectedTurnoutRows": 82,
-      "statusNote": "Official EAC 2024 EAVS fallback turnout rows are validated in ETL and promoted to the database; prefer state-native denominator artifacts when available.",
-      "nextAction": "Prefer official state election office turnout/registration artifact when available; keep the EAC fallback visibly caveated until then.",
+      "statusNote": "Official EAC 2024 EAVS fallback turnout rows are validated in ETL and promoted to the database. Mississippi SOS Active Voter Count Reports are an official denominator lead, but they need an official ballots-cast/voter-participation partner before replacing EAC fallback turnout.",
+      "nextAction": "Collect the November or December 2024 Mississippi SOS Active Voter Count Report as a denominator cross-check, then pair it with official Mississippi ballots-cast or voter-participation rows before replacing the EAC fallback.",
       "coverage": {
         "jurisdictionRows": 82,
         "registeredVoterDenominatorFile": "data/eac-2024-state-turnout/ms-2024-eac-registered-voter-denominator.json",
         "registeredVoters": 2131726,
         "ballotsCast": 1225176,
-        "warningRows": 0
+        "warningRows": 0,
+        "denominatorCandidateSourceUrl": "https://www.sos.ms.gov/elections-voting/active-voter-count-reports",
+        "denominatorCandidateCaveat": "Active voter counts are monthly registration denominators and do not by themselves provide ballots-cast turnout rows or election-day denominator timing."
       }
     },
     {

--- a/docs/ms-2024-data-coverage.md
+++ b/docs/ms-2024-data-coverage.md
@@ -1,6 +1,6 @@
 # Mississippi 2024 Data Coverage
 
-Checked at: 2026-06-30
+Checked at: 2026-07-01
 
 This note is an internal source and review-path inventory for Mississippi. It does not replace the ETL config, source registries, or reviewed staging artifacts.
 
@@ -29,9 +29,21 @@ Remaining precinct-review blocker: complete OCR or manual review for the other c
 
 ## Historical Baselines
 
-2020, 2016, and 2012 historical baselines were not added in this pass. No source-cited official historical Mississippi county presidential artifacts are present in the repo, and live direct checks against likely SOS historical recap URL patterns were blocked or rejected from this environment, including the known 2024 CSV path. That only documents an acquisition blocker from this environment; it is not evidence that the Secretary of State does not publish historical files.
+2020, 2016, and 2012 historical baselines were not added in this pass. No source-cited official historical Mississippi county presidential artifacts are present in the repo. The live Mississippi SOS election-results index confirms archive pages for the target elections:
 
-Next action: collect official Mississippi SOS historical county presidential artifacts for 2020, 2016, and 2012 from the SOS election results archive or request them from the SOS Elections Division. For each artifact, record source URL, local path, reporting grain, parser path, expected county count, candidate totals, caveats, and confidence before enabling `historicalBaseline` for Mississippi.
+- 2020 General Election: `https://www.sos.ms.gov/elections-voting/election-results/2020/2020-general-election`
+- 2016 General Election: `https://www.sos.ms.gov/elections-voting/election-results/2016/2016-general-election`
+- 2012 Election Results: `https://www.sos.ms.gov/elections-voting/election-results/2012/2012-election-results`
+
+Those archive pages render the result tables through an iframe in the current site. The text fetch used in this pass did not expose stable direct county presidential artifact URLs, so no historical parser or CSV was added. That documents an acquisition blocker from this environment; it is not evidence that the Secretary of State does not publish or retain the historical files.
+
+Next action: collect official Mississippi SOS historical county presidential artifacts for 2020, 2016, and 2012 from the archive iframe targets, from any linked official recap files, or by request to the SOS Elections Division/Public Records Request path. For each artifact, record source URL, local path, reporting grain, parser path, expected county count, candidate totals, caveats, and confidence before enabling `historicalBaseline` for Mississippi.
+
+## Turnout Denominator Follow-Up
+
+The Mississippi SOS Active Voter Count Reports page is an official denominator lead: `https://www.sos.ms.gov/elections-voting/active-voter-count-reports`. The page describes monthly county active-voter counts compared with Census voting-age population estimates. These reports are not a drop-in replacement for the current EAC turnout rows because they are monthly active-registration denominators and do not by themselves provide ballots-cast rows, election-day denominator timing, or a same-grain turnout calculation.
+
+Next action: collect the November or December 2024 active-voter report as a state-native denominator cross-check, then pair it only with an official Mississippi ballots-cast or voter-participation artifact before replacing the EAC turnout fallback.
 
 ## Remaining 2024 Source Gaps
 

--- a/docs/turnout-collection-inventory.md
+++ b/docs/turnout-collection-inventory.md
@@ -53,6 +53,10 @@ Ask the data team for:
 - Parser hints: sheet/table name, header row, join keys, county field, precinct/ward field.
 - Caveats: inactive-voter treatment, election-day registration, provisional/absentee handling, overseas/federal-only ballots, or reporting-unit mismatch.
 
+## Mississippi Update
+
+Mississippi currently uses official EAC 2024 V2 county/jurisdiction fallback rows at `data/eac-2024-state-turnout/ms-2024-eac-turnout.csv`, totaling 82 jurisdiction rows, 1,225,176 ballots cast, and 2,131,726 registered voters. The Mississippi SOS Active Voter Count Reports page (`https://www.sos.ms.gov/elections-voting/active-voter-count-reports`) is a state-native denominator lead because it publishes monthly county active-voter counts, but those reports are not a complete turnout replacement unless paired with official Mississippi ballots-cast or voter-participation rows and documented denominator timing.
+
 ## Nebraska Update
 
 Nebraska now retains three turnout-relevant source paths: EAC 2024 V2 county/jurisdiction fallback rows at `data/eac-2024-state-turnout/ne-2024-eac-turnout.csv`, the official Secretary of State 2024 General Canvass Book at `data/ne-2024-general-canvass-book.pdf`, and the official post-general eligible-voter registration report at `data/ne-2024-post-general-eligible-voter-report.pdf`. The current ETL still emits EAC fallback turnout rows: 93 rows, 965,145 ballots cast, and 1,263,487 registered voters. The canvass book's county voting-statistics section reports 1,263,487 registered voters and 965,236 total voting statewide, so a Nebraska canvass voting-statistics normalizer must reconcile that 91-vote source difference before replacing the EAC parser. The public inventory and request paths are documented in `data/ne-2024-admin-source-inventory.json`.

--- a/src/app/workspace-tabs.tsx
+++ b/src/app/workspace-tabs.tsx
@@ -1404,6 +1404,26 @@ const stateDataNoteOverrides: Record<string, StateDataNoteOverride[]> = {
       why: "Precinct review data is loaded, but precinct boundary overlays are not sourced yet, so graph outliers need source-row inspection.",
     },
   ],
+  MS: [
+    {
+      key: "review",
+      evidence: "Mississippi statewide recap CSV rows are loaded for county-level President-versus-U.S. Senate review.",
+      status: "partial",
+      why: "The current review rows are county-level advisory screening inputs, not precinct-level scatter plots. The reviewed OCR path still reports 11 import-ready Mississippi OCR counties, 61 review-required counties, and 10 missing-OCR counties before any precinct promotion.",
+    },
+    {
+      key: "turnout",
+      evidence: "EAC 2024 V2 county/jurisdiction fallback rows are loaded while Mississippi-native turnout remains pending.",
+      status: "partial",
+      why: "The SOS Active Voter Count Reports page is an official denominator lead, but active-voter counts still need an official ballots-cast or voter-participation partner before replacing the EAC turnout fallback.",
+    },
+    {
+      key: "history",
+      evidence: "The SOS election-results archive exposes 2020, 2016, and 2012 election result pages, but no source-cited county presidential artifacts are committed yet.",
+      status: "missing",
+      why: "Historical baseline charts stay disabled until official SOS county presidential artifacts are collected from archive iframe targets, direct recap files, or the SOS request path and parsed with provenance.",
+    },
+  ],
   NC: [
     {
       key: "map",

--- a/tests/api/api-contract.test.mjs
+++ b/tests/api/api-contract.test.mjs
@@ -244,6 +244,10 @@ test("review indicators explain advisory meaning", () => {
   assert.match(tabs, /17 zero-total precinct entries are omitted/);
   assert.match(tabs, /Nevada Secretary of State archived statewide general election results/);
   assert.match(tabs, /live NVSOS and Silver State hosts still return Incapsula/);
+  assert.match(tabs, /Mississippi statewide recap CSV rows are loaded/);
+  assert.match(tabs, /11 import-ready Mississippi OCR counties/);
+  assert.match(tabs, /SOS Active Voter Count Reports page is an official denominator lead/);
+  assert.match(tabs, /archive iframe targets, direct recap files, or the SOS request path/);
   assert.doesNotMatch(tabs, /Sources API/);
   assert.match(explorer, /Eli5/);
   assert.match(explorer, /clickable-row/);
@@ -451,6 +455,9 @@ test("native source package handoff is validated in CI", () => {
   assert.match(msCoverageDoc, /11 import-ready counties/);
   assert.match(msCoverageDoc, /EAC 2024 V2 county\/jurisdiction fallback/);
   assert.match(msCoverageDoc, /historical baselines were not added/);
+  assert.match(msCoverageDoc, /2020 General Election/);
+  assert.match(msCoverageDoc, /Active Voter Count Reports page is an official denominator lead/);
+  assert.match(msCoverageDoc, /do not by themselves provide ballots-cast rows/);
   assert.match(msReconciler, /precinctExtractedTotal/);
   assert.match(msReconciler, /detected_total_column_cells/);
   assert.match(msReconciler, /--corrections/);


### PR DESCRIPTION
## Summary

- Updates Mississippi 2024 coverage documentation with official SOS archive-page leads for 2020, 2016, and 2012 historical presidential baseline collection, without enabling historical baselines or adding unreviewed rows.
- Records the Mississippi SOS Active Voter Count Reports page as a denominator lead only, keeping EAC 2024 V2 turnout as the current fallback until an official ballots-cast/voter-participation partner is collected.
- Adds Mississippi-specific app Data Notes for county-level review rows, OCR-gated precinct status, EAC fallback turnout, and missing historical baselines.
- Updates source/turnout inventories and focused contract assertions so the caveats remain visible.

## Sources Confirmed

- Mississippi SOS 2024 General Election results page and recap CSV/PDF paths already loaded.
- Mississippi SOS county PDF result package path remains the OCR-gated precinct-review source.
- Mississippi SOS election-results archive pages for 2020 General Election, 2016 General Election, and 2012 Election Results are documented as official acquisition leads.
- Mississippi SOS Active Voter Count Reports page is documented as a denominator lead only.

## Validation

Passed:

- `python -m civic_etl.cli validate --config etl/state-configs/ms.json`
- `npm run etl:verify:ms:ocr:reviewed`
- `npm run etl:import:ms`
- `npm run native:report-indicators -- .etl/staging`
- `npm run validate:source-packages` (warnings only for existing missing legacy/app-ready bundles)
- `npm run validate:turnout-packages`
- `npm run validate:source-acquisition-tiers`
- `git diff --check`

Indicator report after staging:

- Native review rows: 82
- Calculated advisory indicator rows: 5
- Flagged county/jurisdiction count: 5
- Flagged area count: 5
- Indicator types: `county_down_ballot_distribution`
- Production API/DB reflection: not checked; no production promotion was authorized.

OCR reviewed verification:

- 11 import-ready counties
- 61 review-required counties
- 10 missing-OCR counties

Known validation caveats:

- `npm run etl:verify:ms:ocr:reviewed` initially failed under sandbox because `.etl/ocr` writes were denied; rerun with allowed worktree writes passed.
- `npm run test:api` currently fails before the new MS assertions on an existing Georgia assertion mismatch: expected `county presidential candidate rows sum 19 votes higher` is not present in `src/app/workspace-tabs.tsx` in this worktree.
- `npm run typecheck` cannot complete in this worktree because `node_modules` is absent; errors are dependency/module-resolution failures plus an initial denied `tsconfig.tsbuildinfo` write.

## Review

Review subagent tool was unavailable, so I performed a structured self-review of the diff. Result: no blocking issues found. The changes are Mississippi-scoped except for existing national inventory files where only the MS rows/status text were edited. No normalized outputs were hand-edited, and no production promotion was run.

## Remaining Risks

- Precinct-level Mississippi advisory flags remain blocked until all county PDFs are OCRed or manually reviewed, reconciled to official recap totals, and promoted through a reviewed structured artifact.
- Historical baselines remain blocked until official SOS county presidential artifacts for 2020, 2016, and 2012 are collected from archive iframe targets, direct recap files, or the SOS request path.
- Mississippi-native turnout remains pending; Active Voter Count Reports are denominator context only until paired with official ballots-cast/voter-participation rows.