### PR TITLE
Guard Vercel preview job without secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,19 +75,37 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check Vercel preview secrets
+        id: vercel-secrets
+        shell: bash
+        run: |
+          if [[ -n "$VERCEL_TOKEN" && -n "$VERCEL_ORG_ID" && -n "$VERCEL_PROJECT_ID" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Vercel preview deploy skipped because preview secrets are not configured for this workflow context."
+          fi
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
       - name: Pull Vercel environment
+        if: steps.vercel-secrets.outputs.available == 'true'
         run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Build Vercel output
+        if: steps.vercel-secrets.outputs.available == 'true'
         run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Deploy preview
+        if: steps.vercel-secrets.outputs.available == 'true'
         run: npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary
- Skip Vercel preview pull/build/deploy steps when VERCEL_TOKEN, VERCEL_ORG_ID, or VERCEL_PROJECT_ID are unavailable in the workflow context.
- Keep the validate job authoritative while preventing empty --token invocations from failing otherwise-good PRs.

## Validation
- git diff --check

Shared coordinator fix for Wave 6 PR verification; no production data promotion.