### PR TITLE
Validate ETL source status enum

### DIFF
--- a/civic_etl/pipeline.py
+++ b/civic_etl/pipeline.py
@@ -18,6 +18,7 @@ REQUIRED_CAPABILITIES = {
 }
 
 PRODUCTION_WRITE_STATUSES = {"promoted"}
+SOURCE_STATUSES = {"loaded", "candidate", "needs_data", "superseded", "documented_exclusion"}
 
 
 def artifact_metadata(local_file: str) -> dict[str, Any]:
@@ -145,6 +146,11 @@ def validate_config(config: EtlConfig) -> ValidationReport:
             errors.append(f"source {source.id} must use an https URL")
         if not source.parser:
             errors.append(f"source {source.id} is missing parser metadata")
+        if source.status not in SOURCE_STATUSES:
+            errors.append(
+                f"source {source.id} has invalid source status {source.status}; "
+                f"expected one of {', '.join(sorted(SOURCE_STATUSES))}"
+            )
         if source.status in PRODUCTION_WRITE_STATUSES:
             errors.append(f"source {source.id} cannot request production promotion from config")
         if source.status != "loaded":

--- a/etl/state-configs/wi.json
+++ b/etl/state-configs/wi.json
@@ -102,7 +102,7 @@
       "authority": "Wisconsin Elections Commission and Wisconsin county clerks",
       "timestampBasis": "County inventory scaffold generated for 2024 general-election records requests.",
       "confidence": "Scaffold only. It tracks county-by-county CVR availability/request follow-up and does not confirm public CVR release or load CVR records.",
-      "status": "partial"
+      "status": "candidate"
     },
     {
       "id": "wi-2024-incident-context",

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -1,4 +1,5 @@
 import unittest
+from dataclasses import replace
 import zipfile
 import json
 from pathlib import Path
@@ -159,6 +160,21 @@ class PipelineTests(unittest.TestCase):
         path = Path(".etl-test") / name
         path.mkdir(parents=True, exist_ok=True)
         return path
+
+    def test_config_rejects_source_statuses_outside_production_enum(self):
+        config = load_config("etl/state-configs/wi.json")
+        config = replace(
+            config,
+            sources=[replace(config.sources[0], status="partial"), *config.sources[1:]],
+        )
+
+        report = validate_config(config)
+
+        self.assertFalse(report.passed)
+        self.assertIn(
+            "source wi-2024-ward-by-ward-federal-state-xlsx has invalid source status partial",
+            report.errors[0],
+        )
 
     def test_wisconsin_config_validates(self):
         config = load_config("etl/state-configs/wi.json")


### PR DESCRIPTION
## Summary
- Enforce production-safe source status values during ETL config validation.
- Move Wisconsin CVR scaffold context from non-production enum value partial to candidate in the native ETL config.
- Add a Python regression test so invalid config source statuses fail before promotion.

## Validation
- python -m civic_etl.cli validate --config etl/state-configs/wi.json
- python -m civic_etl.cli validate-all --config-dir etl/state-configs --out .etl/validate-all
- python -m unittest tests.python.test_pipeline.PipelineTests.test_config_rejects_source_statuses_outside_production_enum tests.python.test_pipeline.PipelineTests.test_wisconsin_config_validates
- npm test
- npm run validate:source-packages
- npm run validate:provenance
- python -m civic_etl.cli import --config etl/state-configs/wi.json --out .etl/staging

## Production impact
- Prevents invalid source_status enum values from reaching native promotion, unblocking Wisconsin Wave 6 promotion from main.