### PR TITLE
[codex] Document Missouri 2024 coverage blockers

### DIFF
--- a/data/mo-2024-admin-source-inventory.json
+++ b/data/mo-2024-admin-source-inventory.json
@@ -16,7 +16,13 @@
       "data/mo-historical-presidential-baseline.csv"
     ],
     "scopeNote": "Official county/reporting-jurisdiction President, U.S. Senate, turnout, and historical baseline rows are loaded. The SOS results page identifies precinct-level general-election result files as purchasable from the Elections Division, so precinct-level Missouri review rows remain blocked until that file is obtained.",
-    "requestNeed": "Purchase or request 2024 general election precinct-level result files for President and U.S. Senate, plus any reporting-unit definitions needed to distinguish Kansas City and county jurisdictions."
+    "requestNeed": "Purchase or request 2024 general election precinct-level result files for President and U.S. Senate, plus any reporting-unit definitions needed to distinguish Kansas City and county jurisdictions.",
+    "checkedPageEvidence": {
+      "checkedAt": "2026-07-01",
+      "officialStatement": "The Missouri SOS results page states that precinct-level election results are available for general November elections from 1996 to 2024 and directs purchasers/questions to the Elections Division.",
+      "resultFileRange": "1996-2024 general elections",
+      "contactPath": "Missouri SOS Elections Division email listed on the results page"
+    }
   },
   "equipment": {
     "status": "loaded_context",
@@ -39,7 +45,7 @@
       "https://www.sos.mo.gov/CMSImages/ElectionGoVoteMissouri/CurrentElectionLawBook.pdf"
     ],
     "reportingLevel": "local_election_authority",
-    "scopeNote": "Missouri rules describe post-election verification/manual recount procedures, including a public random selection of at least five percent of precincts, certificates filed with the Secretary of State and public records, and discrepancy investigation before certification when thresholds are exceeded. No 2024 statewide audit selection/outcome table is loaded.",
+    "scopeNote": "Missouri rules describe post-election verification/manual recount procedures, including a public random selection of at least five percent of precincts, certificates filed with the Secretary of State and public records, and discrepancy investigation before certification when thresholds are exceeded. The SOS election-security page also states that Missouri has 116 election jurisdictions, each with its own voting system, and that election results are audited by local election officials before certification. No 2024 statewide audit selection/outcome table is loaded.",
     "recordsRequestNeed": "Collect or request 2024 post-election verification certificates, selected precincts, selected contests, machine totals, hand totals, discrepancies, explanations, and final outcomes from the Secretary of State or local election authorities."
   },
   "cvr": {
@@ -63,5 +69,28 @@
     ],
     "scopeNote": "The SOS results page lists historical recount result links for some past elections but not a 2024 general-election recount link in the checked page. The Elections Integrity page identifies complaint paths and published HAVA determinations; the 2026 Kramer determination references 2022 and 2024 voter-registration/list and reconciliation allegations and related federal-court hearing-process orders. No normalized 2024 incident, correction, recount, or litigation rows are loaded.",
     "recordsRequestNeed": "Inventory official 2024 amended canvasses, correction notices, recount petitions/outcomes, HAVA determinations, court dockets/orders, and local incident reports before adding row-level administration context."
+  },
+  "precinctGeometryCrosswalks": {
+    "status": "blocked_no_statewide_geometry_identified",
+    "sourceTitle": "Missouri SOS local election authority directory and county/request path",
+    "sourceUrls": [
+      "https://www.sos.mo.gov/elections/goVoteMissouri/localelectionauthority",
+      "https://www.sos.mo.gov/elections/results"
+    ],
+    "loadedGeometry": {
+      "localArtifact": "data/mo-counties.geojson",
+      "authority": "U.S. Census Bureau TIGERweb",
+      "reportingLevel": "county",
+      "scopeNote": "Loaded map geometry supports county joins only. Kansas City is a separate SOS reporting jurisdiction and does not have a separate Census county polygon."
+    },
+    "scopeNote": "No official statewide precinct-boundary geometry or precinct-to-county/reporting-jurisdiction crosswalk was identified in this pass. Missouri precinct review rows should not be mapped or joined below county/reporting-jurisdiction grain until the purchasable precinct file is paired with an official boundary file or reporting-unit crosswalk.",
+    "requestNeed": "Request 2024 precinct boundary GIS, precinct identifiers, split precinct definitions, and crosswalk fields that join the purchasable precinct result file to county/Kansas City/St. Louis City reporting jurisdictions."
+  },
+  "displayApiCaveats": {
+    "status": "documented_county_reporting_jurisdiction_only",
+    "reviewLevel": "county_reporting_jurisdiction",
+    "mapLevel": "county_with_kansas_city_reporting_jurisdiction_caveat",
+    "advisoryUse": "Current Missouri advisory rows compare official President and U.S. Senate rows at county/reporting-jurisdiction grain only. They are screening inputs, not findings, and not precinct-level scatter plots.",
+    "productionPromotion": "No production promotion is authorized from this worker pass. Regenerate staging and run native:report-indicators before any later promotion."
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "npm run test:api && npm run test:etl",
-    "test:api": "node tests/api/api-contract.test.mjs && node tests/api/seed-script.test.mjs && node tests/api/legacy-import.test.mjs && node tests/api/native-import.test.mjs && node tests/api/turnout-normalizer.test.mjs && node tests/api/vote-method-normalizer.test.mjs && node tests/api/wi-audit-normalizer.test.mjs && node tests/api/wi-review-completion.test.mjs && node tests/api/wi-remaining-data-status.test.mjs && node tests/api/wi-remaining-collection.test.mjs && node tests/api/swing-state-parity.test.mjs && node tests/api/electronic-integrity.test.mjs",
+    "test:api": "node tests/api/api-contract.test.mjs && node tests/api/seed-script.test.mjs && node tests/api/legacy-import.test.mjs && node tests/api/native-import.test.mjs && node tests/api/turnout-normalizer.test.mjs && node tests/api/vote-method-normalizer.test.mjs && node tests/api/wi-audit-normalizer.test.mjs && node tests/api/wi-review-completion.test.mjs && node tests/api/wi-remaining-data-status.test.mjs && node tests/api/wi-remaining-collection.test.mjs && node tests/api/swing-state-parity.test.mjs && node tests/api/mo-source-coverage.test.mjs && node tests/api/electronic-integrity.test.mjs",
     "test:etl": "python -m unittest discover -s tests/python",
     "db:generate": "drizzle-kit generate",
     "db:push": "node --env-file=.env.local ./node_modules/drizzle-kit/bin.cjs push",

--- a/tests/api/mo-source-coverage.test.mjs
+++ b/tests/api/mo-source-coverage.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const adminInventory = JSON.parse(readFileSync("data/mo-2024-admin-source-inventory.json", "utf8"));
+const nativePackages = JSON.parse(readFileSync("data/native-import-source-packages.json", "utf8"));
+const acquisitionTiers = JSON.parse(readFileSync("data/source-acquisition-tiers.json", "utf8"));
+const adminPackages = JSON.parse(readFileSync("data/admin-source-packages.json", "utf8"));
+const moConfig = JSON.parse(readFileSync("etl/state-configs/mo.json", "utf8"));
+
+const nativeMo = nativePackages.states.find((entry) => entry.state === "MO");
+const tierMo = acquisitionTiers.states.find((entry) => entry.state === "MO");
+const adminMo = adminPackages.stateYearStatuses.find((entry) => entry.state === "MO" && entry.electionYear === 2024);
+
+test("Missouri source inventory keeps precinct purchase and geometry blockers explicit", () => {
+  assert.equal(adminInventory.precinctResults.status, "blocked_purchase_required");
+  assert.match(adminInventory.precinctResults.checkedPageEvidence.officialStatement, /1996 to 2024/);
+  assert.match(adminInventory.precinctResults.requestNeed, /President and U.S. Senate/);
+
+  assert.equal(adminInventory.precinctGeometryCrosswalks.status, "blocked_no_statewide_geometry_identified");
+  assert.equal(adminInventory.precinctGeometryCrosswalks.loadedGeometry.localArtifact, "data/mo-counties.geojson");
+  assert.match(adminInventory.precinctGeometryCrosswalks.scopeNote, /No official statewide precinct-boundary geometry/);
+  assert.ok(adminInventory.displayApiCaveats.advisoryUse.includes("county/reporting-jurisdiction grain only"));
+});
+
+test("Missouri registries preserve loaded turnout and historical baselines while caveating admin gaps", () => {
+  assert.equal(moConfig.turnout.sourceId, "mo-2024-general-turnout");
+  assert.equal(moConfig.historicalBaselines.sourceId, "mo-historical-presidential-baseline");
+  assert.equal(moConfig.expected.turnoutRows, 116);
+  assert.equal(moConfig.historicalBaselines.expected.rowCount, 348);
+
+  assert.ok(nativeMo, "MO native package entry is present");
+  assert.match(nativeMo.nativeReadiness, /precinct_file_purchase_blocker/);
+  assert.match(nativeMo.caveats.join("\n"), /Administration-source inventory/);
+
+  assert.ok(tierMo, "MO acquisition tier entry is present");
+  assert.match(tierMo.missingFields.join("\n"), /precinct boundary geometry/);
+  assert.match(tierMo.nextAction, /Purchase or request Missouri SOS precinct-level/);
+
+  assert.ok(adminMo, "MO admin source package entry is present");
+  assert.equal(adminMo.audit.status, "candidate");
+  assert.equal(adminMo.cvr.status, "candidate");
+  assert.equal(adminMo.incidents.status, "candidate");
+});


### PR DESCRIPTION
## Scope

Missouri Wave 8 focused source-coverage pass. This keeps the existing official 2024 county/reporting-jurisdiction results, U.S. Senate comparison rows, official turnout, and 2012/2016/2020 historical baselines intact while documenting remaining coverage blockers.

## Sources confirmed

- Missouri SOS results page: 2024 county/reporting-jurisdiction results are loaded, and precinct-level general-election files remain purchase/request-only through the Elections Division.
- Missouri SOS election security and current election law book: local-jurisdiction audit/manual recount context is documented as source inventory only.
- Missouri SOS local election authority directory: request path for precinct geometry/crosswalk and CVR availability follow-up.

## Changes

- Expanded `data/mo-2024-admin-source-inventory.json` with checked precinct-purchase evidence, precinct geometry/crosswalk request needs, and display/API caveats.
- Added `tests/api/mo-source-coverage.test.mjs` to lock Missouri purchase/geometry/admin caveats and preserve loaded turnout/historical baseline expectations.
- Wired the new focused test into `npm run test:api`.

## Validation

- `node tests/api/mo-source-coverage.test.mjs`
- `npm run etl:validate:mo`
- `npm run etl:import:mo`
- `npm run native:report-indicators -- .etl/staging`
- `npm run validate:admin-packages`
- `npm run validate:source-packages` (warnings only for pre-existing missing legacy/app-ready files in other states)
- `npm run validate:source-acquisition-tiers`
- `npm run validate:turnout-packages`
- `npm run test:api`
- `npm run typecheck`
- `npm run build`

## Missouri indicator report

From fresh `.etl/staging/mo-2024-staging.json` via `npm run native:report-indicators -- .etl/staging`:

- Native review rows: 116
- Calculated advisory indicator rows: 75
- Flagged jurisdiction count: 75
- Flagged county/jurisdiction count: 75
- Flagged area count: 75
- Indicator types: `county_down_ballot_distribution`
- Production/API DB counts checked: no. Production promotion and production verification were not authorized for this worker pass.

## Display/API path checked

Build completed successfully, and the new API test checks that Missouri remains county/reporting-jurisdiction only, with Kansas City geometry caveats and no precinct-level advisory presentation.

## Review result

No review subagent tool was available in this lane, so I performed a dedicated local review pass over the staged diff plus `git diff --cached --check`. No actionable issues found.

## Remaining Missouri risks

- Precinct-level President and U.S. Senate rows remain blocked until the Missouri SOS purchasable/requested precinct file is obtained.
- Official statewide precinct boundary geometry or a precinct/reporting-jurisdiction crosswalk was not identified or loaded.
- Normalized 2024 post-election audit selections/outcomes, CVR availability rows, incident/correction rows, recount records, and litigation rows are not loaded.
- Kansas City remains a separate SOS reporting jurisdiction without a separate Census county polygon.