### PR TITLE
Document New Hampshire coverage inventory leads

### DIFF
--- a/data/admin-source-packages.json
+++ b/data/admin-source-packages.json
@@ -1036,22 +1036,22 @@
       },
       "audit": {
         "status": "needs_data",
-        "why": "New Hampshire 2024 post-election audit artifacts have not been normalized. The NH source inventory artifact records this as an official-source request item.",
+        "why": "New Hampshire 2024 post-election audit artifacts have not been normalized. The expanded NH source inventory records audit/CVR request authorities and keeps this as an official-source request item, not a loaded audit dataset.",
         "localArtifact": "data/nh-2024-admin-source-inventory.json",
         "caveat": "Source inventory only; no audit result rows are loaded."
       },
       "cvr": {
         "status": "needs_data",
-        "why": "New Hampshire 2024 CVR availability artifacts or request paths have not been normalized. The NH source inventory artifact records this as an official-source request item.",
+        "why": "New Hampshire 2024 CVR availability artifacts or request paths have not been normalized. The expanded NH source inventory records state and local request paths for CVR, tabulator-log, custody, and ward-specific records if public.",
         "localArtifact": "data/nh-2024-admin-source-inventory.json",
         "caveat": "Source inventory only; no CVR data is loaded."
       },
       "incidents": {
         "status": "partial",
-        "why": "Archived official 2024 general-election recount result sheet filenames were identified, but recount, incident, correction, and litigation rows are not normalized.",
+        "why": "The NH source inventory now identifies archived official 2024 legislative-district recount sheet filenames and request paths, but recount, incident, correction, and litigation rows are not normalized.",
         "sourceUrl": "https://www.sos.nh.gov/2024-general-election-results",
         "localArtifact": "data/nh-2024-admin-source-inventory.json",
-        "caveat": "Partial source inventory only; not a loaded incident/recount dataset."
+        "caveat": "Partial source inventory only; not a loaded incident/recount/litigation dataset and not evidence of an administration issue."
       }
     },
     {

--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -1259,7 +1259,7 @@
       "state": "NH",
       "name": "New Hampshire",
       "priority": 9,
-      "currentStatus": "official_town_ward_review_turnout_package_collected",
+      "currentStatus": "official_town_ward_review_turnout_package_collected_historical_admin_inventory_expanded",
       "officialSourcePages": [
         "https://www.sos.nh.gov/2024-general-election-results",
         "https://web.archive.org/web/20260130123951id_/https://www.sos.nh.gov/2024-general-election-results",
@@ -1268,16 +1268,21 @@
         "https://web.archive.org/web/20250311214424id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2024-ge-congressional-district-1_3.xlsx",
         "https://web.archive.org/web/20250201102742id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2024-ge-congressional-district-2_4.xlsx",
         "https://web.archive.org/web/20250611055417id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2024-ge-ballots-cast_14.xls",
-        "https://web.archive.org/web/20250611055423id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2024-ge-names-on-checklist_7.xlsx"
+        "https://web.archive.org/web/20250611055423id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2024-ge-names-on-checklist_7.xlsx",
+        "https://web.archive.org/cdx?url=www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2016-ge-president*&output=json&fl=timestamp,original,statuscode,mimetype&filter=statuscode:200&collapse=urlkey",
+        "https://web.archive.org/web/20240720085749id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2016-ge-governor.xls",
+        "https://web.archive.org/web/20240720085753id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2016-ge-congressional-district-1.xlsx",
+        "https://web.archive.org/web/20240720085755id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2016-ge-congressional-district-2.xlsx"
       ],
       "requiredArtifacts": [
-        "historical President-versus-U.S. House and President-versus-Governor ticket-splitting baseline",
-        "town/ward boundary geometry if map overlays below county level are required",
+        "downloaded official 2016 President, Governor, and U.S. House workbook artifacts plus a historical normalizer before loading 2016 baseline rows",
+        "targeted official archive or records-request path for 2020 and 2012 President-versus-U.S. House/Governor baseline artifacts",
+        "town/ward boundary geometry or official reporting-unit crosswalk if map overlays below county level are required",
         "normalized post-election audit, recount, CVR availability, incident/correction, and litigation artifacts"
       ],
       "preferredComparisonContest": "U.S. House, loaded from official Congressional District 1 and 2 town/ward workbooks; keep district-based comparison caveat visible.",
-      "parserNeeded": "newHampshireTownWardCsv loaded for 10 county result rows, 304 town/ward President-versus-U.S.-House review rows, and 304 state-native town/ward turnout rows from official ballots-cast and names-on-checklist workbooks.",
-      "blocker": "New Hampshire now has official town/ward President-versus-U.S. House review rows and state-native town/ward turnout denominators from archived Secretary of State workbooks. The live SOS page still returns access denied from this environment, so retained archive URLs and local artifacts are the reproducible source path. Remaining blockers are historical split-ticket baselines, town/ward geometry, and normalized audit/recount/CVR/incident/correction/litigation records."
+      "parserNeeded": "newHampshireTownWardCsv loaded for 10 county result rows, 304 town/ward President-versus-U.S.-House review rows, and 304 state-native town/ward turnout rows from official ballots-cast and names-on-checklist workbooks. A historical sibling normalizer is needed for the identified 2016 official archive workbook leads before historical baseline rows can be loaded.",
+      "blocker": "New Hampshire now has official town/ward President-versus-U.S. House review rows and state-native town/ward turnout denominators from archived Secretary of State workbooks. The July 1, 2026 inventory adds official 2016 archive leads for President, Governor, and U.S. House baseline feasibility, but no historical rows are loaded. The live SOS page still returns access denied from this environment, 2020 and 2012 remain targeted archive/records-request items, and town/ward geometry plus normalized audit/recount/CVR/incident/correction/litigation records remain uncollected."
     },
     {
       "state": "NY",

--- a/data/nh-2024-admin-source-inventory.json
+++ b/data/nh-2024-admin-source-inventory.json
@@ -2,8 +2,35 @@
   "state": "NH",
   "stateName": "New Hampshire",
   "electionYear": 2024,
-  "checkedAt": "2026-06-30",
+  "checkedAt": "2026-07-01",
   "authority": "New Hampshire Secretary of State and official public records/GIS source paths",
+  "artifactRole": "source inventory only",
+  "localArtifact": "data/nh-2024-admin-source-inventory.json",
+  "reportingGrain": "town_ward",
+  "parserOrNormalizationPath": "scripts/normalize-nh-general-workbooks.mjs for loaded 2024 result, review, and turnout rows; no admin-row parser is loaded from this inventory.",
+  "loadedPackageSummary": {
+    "status": "loaded",
+    "sourceUrl": "https://www.sos.nh.gov/2024-general-election-results",
+    "localArtifacts": [
+      "data/nh-2024-ge-president.xls",
+      "data/nh-2024-ge-governor.xls",
+      "data/nh-2024-ge-congressional-district-1.xlsx",
+      "data/nh-2024-ge-congressional-district-2.xlsx",
+      "data/nh-2024-ge-ballots-cast.xls",
+      "data/nh-2024-ge-names-on-checklist.xlsx",
+      "data/nh-2024-town-ward-president-governor.csv"
+    ],
+    "expectedRowsOrTotals": {
+      "countyResultRows": 10,
+      "townWardReviewRows": 304,
+      "townWardTurnoutRows": 304,
+      "presidentialVotes": 826189,
+      "ballotsCastDetailTotal": 831468,
+      "namesOnChecklistTotal": 1013075,
+      "sameDayRegistrationTotal": 96623
+    },
+    "caveat": "The live SOS page remains access-limited from this environment, so archived official workbook URLs and committed local artifacts are the reproducible source path. Detailed town/ward ballots-cast rows sum to 831,468 while the workbook county summary totals 831,467 after the source correction note."
+  },
   "sameGrainComparison": {
     "status": "loaded",
     "reportingGrain": "town_ward",
@@ -18,6 +45,7 @@
       "data/nh-2024-town-ward-president-governor.csv"
     ],
     "parser": "scripts/normalize-nh-general-workbooks.mjs",
+    "expectedRows": 304,
     "caveat": "U.S. House rows are same town/ward grain but district-based, not a single statewide contest. Use as a cleaner same-grain comparison than Governor, with district-contest caveats visible."
   },
   "turnoutDenominators": {
@@ -36,19 +64,92 @@
     "ballotsCastDetailTotal": 831468,
     "namesOnChecklistTotal": 1013075,
     "sameDayRegistrationTotal": 96623,
-    "caveat": "The ballots-cast workbook county summary totals 831,467 while detailed town/ward rows sum to 831,468 after the source's Strafford County correction note. The normalized rows retain detailed town/ward values and keep this reconciliation caveat."
+    "caveat": "The normalized rows retain detailed town/ward values and keep the one-vote ballots-cast summary/detail reconciliation caveat."
   },
-  "geometry": {
-    "status": "blocked",
+  "historicalBaselineFeasibility": {
+    "status": "candidate_2016_official_archive_lead",
+    "target": "President-versus-U.S. House and President-versus-Governor split-ticket baselines for 2012, 2016, and 2020, preferably at town/ward grain and county context if town/ward matching is blocked.",
+    "archiveCdxCheckedAt": "2026-07-01",
+    "availableOfficialArchiveLeads": [
+      {
+        "year": 2016,
+        "authority": "New Hampshire Secretary of State",
+        "sourceUrl": "https://web.archive.org/cdx?url=www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2016-ge-president*&output=json&fl=timestamp,original,statuscode,mimetype&filter=statuscode:200&collapse=urlkey",
+        "reportingGrain": "county workbook files with town/ward rows to be confirmed during parser work",
+        "artifactCandidates": [
+          "2016-ge-president-summary-and-belknap.xls",
+          "2016-ge-president-carroll.xls",
+          "2016-ge-president-cheshire.xls",
+          "2016-ge-president-coos.xls",
+          "2016-ge-president-grafton.xls",
+          "2016-ge-president-hillsborough.xls",
+          "2016-ge-president-merrimack.xls",
+          "2016-ge-president-rockingham.xls",
+          "2016-ge-president-strafford-and-sullivan.xls",
+          "2016-ge-governor.xls",
+          "2016-ge-congressional-district-1.xlsx",
+          "2016-ge-congressional-district-2.xlsx"
+        ],
+        "parserNeeded": "Extend scripts/normalize-nh-general-workbooks.mjs or add a sibling historical normalizer after downloading the archived official 2016 XLS/XLSX artifacts.",
+        "confidence": "official_archive_lead"
+      }
+    ],
+    "blockedOrUnresolvedLeads": [
+      {
+        "year": 2020,
+        "authority": "New Hampshire Secretary of State",
+        "sourceUrl": "https://www.sos.nh.gov/2020-general-election-results",
+        "status": "needs_targeted_archive_or_records_request",
+        "checkedPatterns": [
+          "2020-ge-president*",
+          "*2020*president*",
+          "*2020*governor*",
+          "*2020*congressional*"
+        ],
+        "caveat": "The tested Internet Archive CDX filename patterns returned no usable workbook candidates or transient 503 responses; do not treat secondary 2020 county summaries as replacements for official town/ward baselines."
+      },
+      {
+        "year": 2012,
+        "authority": "New Hampshire Secretary of State",
+        "sourceUrl": "https://www.sos.nh.gov/2012-general-election-results",
+        "status": "needs_targeted_archive_or_records_request",
+        "checkedPatterns": [
+          "2012-ge-president*"
+        ],
+        "caveat": "No official 2012 workbook candidates were confirmed in this pass."
+      }
+    ],
+    "caveat": "No historical baseline rows are loaded. The 2016 archive lead is a source-acquisition path only until official artifacts are downloaded, parsed, and reconciled."
+  },
+  "geometryAndCrosswalk": {
+    "status": "county_geometry_loaded_town_ward_geometry_blocked",
     "loadedArtifact": "data/nh-counties.geojson",
     "loadedLevel": "county",
-    "needed": "Official town/ward geometry or a reproducible town-to-ward boundary crosswalk for subcounty overlays.",
-    "requestPath": "Ask New Hampshire Secretary of State or the state GIS clearinghouse for 2024 general-election town/ward reporting-unit boundaries that match the SOS workbook labels.",
-    "caveat": "County geometry is loaded; town/ward geometry is not included and should not be inferred from result workbook names alone."
+    "loadedAuthority": "U.S. Census Bureau",
+    "needed": "Official town/ward geometry or a reproducible reporting-unit crosswalk for 2024 SOS town/ward labels.",
+    "candidateSourcePaths": [
+      {
+        "authority": "U.S. Census Bureau",
+        "sourceUrl": "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer",
+        "use": "County geometry only; already loaded for map joins."
+      },
+      {
+        "authority": "U.S. Census Bureau",
+        "sourceUrl": "https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html",
+        "use": "County subdivision/place geometry may help town-level context but will not by itself split cities into voting wards."
+      },
+      {
+        "authority": "New Hampshire Secretary of State or New Hampshire GIS clearinghouse/local city GIS offices",
+        "sourceUrl": "https://www.sos.nh.gov/2024-general-election-results",
+        "use": "Request 2024 general-election town/ward reporting-unit boundaries or an official crosswalk matching SOS workbook labels."
+      }
+    ],
+    "caveat": "Town/ward geometry is not included and should not be inferred from result workbook names alone. A town-only Census layer would still leave city wards unresolved."
   },
   "recountsCorrectionsIncidentsLitigation": {
     "status": "partial_inventory",
     "sourceUrl": "https://www.sos.nh.gov/2024-general-election-results",
+    "reportingGrain": "legislative district recount sheets, not presidential town/ward rows",
     "archivedRecountArtifactsIdentified": [
       "2024-ge-recount-results-sheet-election-results-grafton-dist-7-tot.xlsx",
       "2024-ge-recount-results-sheet-election-results-hills-dist-9-tot.xlsx",
@@ -58,11 +159,27 @@
       "2024-ge-recount-results-sheet-election-results-strafford-dist-4-tot.xlsx",
       "2024-ge-recount-results-sheet-election-results-sullivan-dist-5-tot.xlsx"
     ],
+    "parserNeeded": "A recount-sheet normalizer should be added only after the official XLSX recount artifacts are downloaded and their contest/district scope is reviewed.",
     "caveat": "Archived official recount result sheets were identified for legislative districts, but no normalized recount, incident, correction, or litigation row package is loaded in this PR."
   },
   "auditAndCvr": {
     "status": "needs_source_inventory",
     "needed": "Official 2024 post-election audit artifacts, CVR availability statements or request paths, and any tabulator-log or custody records that the state or local offices make public.",
+    "candidateRequestAuthorities": [
+      "New Hampshire Secretary of State",
+      "New Hampshire Attorney General election-law/civil-bureau public records path if litigation or complaint records are required",
+      "City and town clerks for ward-specific CVR, recount, correction, or incident records when state-level publication is absent"
+    ],
     "caveat": "No CVR dataset, post-election audit result table, or per-unit discrepancy artifact is loaded. Treat this as a source-request queue, not evidence of an administration issue."
+  },
+  "websiteAndApiDisplayPath": {
+    "status": "configuration_checked",
+    "displaySurfaces": [
+      "county map joins use data/nh-counties.geojson",
+      "review graphs use 304 town/ward President-versus-U.S.-House rows",
+      "turnout context uses 304 town/ward ballots-cast/names-on-checklist rows"
+    ],
+    "productionChecked": false,
+    "caveat": "Production promotion and production API checks were not authorized for this worker pass."
   }
 }

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -1135,13 +1135,15 @@
       "stateName": "New Hampshire",
       "jurisdictionName": "Statewide",
       "scope": "statewide",
-      "dataFamily": "results_review_turnout",
+      "dataFamily": "results_review_turnout_historical_admin_inventory",
       "tier": "tier_1_official_export_database",
       "reportingGrain": "town_ward",
       "exportFormats": [
         "XLS",
         "XLSX",
-        "normalized CSV"
+        "normalized CSV",
+        "archived official 2016 XLS/XLSX baseline leads",
+        "admin inventory JSON"
       ],
       "sourceUrls": [
         "https://www.sos.nh.gov/2024-general-election-results"
@@ -1149,7 +1151,10 @@
       "exampleUrls": [
         "https://web.archive.org/web/20241219172754id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2024-ge-president_3.xls",
         "https://web.archive.org/web/20250311214424id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2024-ge-congressional-district-1_3.xlsx",
-        "https://web.archive.org/web/20250611055423id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2024-ge-names-on-checklist_7.xlsx"
+        "https://web.archive.org/web/20250611055423id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2024-ge-names-on-checklist_7.xlsx",
+        "https://web.archive.org/cdx?url=www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2016-ge-president*&output=json&fl=timestamp,original,statuscode,mimetype&filter=statuscode:200&collapse=urlkey",
+        "https://web.archive.org/web/20240720085749id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2016-ge-governor.xls",
+        "https://web.archive.org/web/20240720085753id_/https://www.sos.nh.gov/sites/g/files/ehbemt561/files/inline-documents/sonh/2016-ge-congressional-district-1.xlsx"
       ],
       "availableFields": [
         "town/ward President rows",
@@ -1158,19 +1163,21 @@
         "town/ward ballots-cast rows",
         "town/ward names-on-checklist registered-voter denominator rows",
         "county geometry",
-        "county equipment context"
+        "county equipment context",
+        "official 2016 archive leads for President, Governor, and U.S. House historical baseline feasibility",
+        "NH administration/source inventory with recount, geometry, audit, CVR, incident, correction, and litigation request paths"
       ],
       "missingFields": [
-        "historical President-versus-U.S. House and President-versus-Governor ticket-splitting baseline",
+        "loaded 2012/2016/2020 historical President-versus-U.S. House and President-versus-Governor ticket-splitting baseline",
         "town/ward boundary geometry",
         "normalized post-election audit rows",
         "normalized recount, CVR availability, incident/correction, and litigation rows"
       ],
-      "parserStatus": "newHampshireTownWardCsv loaded with official President, Governor, U.S. House, ballots-cast, and names-on-checklist rows normalized by scripts/normalize-nh-general-workbooks.mjs",
+      "parserStatus": "newHampshireTownWardCsv loaded with official President, Governor, U.S. House, ballots-cast, and names-on-checklist rows normalized by scripts/normalize-nh-general-workbooks.mjs; data/nh-2024-admin-source-inventory.json now records official 2016 historical-baseline archive leads and remaining admin/geometry request paths",
       "manualReviewBurden": "medium",
       "confidence": "loaded_with_district_comparison_caveat",
-      "caveats": "Live SOS page is access-limited from this environment; archived official workbook artifacts are retained. U.S. House is same town/ward grain but district-based rather than a single statewide contest. State-native ballots-cast and names-on-checklist rows replace EAC fallback turnout, with a one-vote source summary/detail caveat in ballots-cast totals.",
-      "nextAction": "Add official historical baselines, request town/ward geometry, and normalize official audit/recount/CVR/incident/correction/litigation records."
+      "caveats": "Live SOS page is access-limited from this environment; archived official workbook artifacts are retained. U.S. House is same town/ward grain but district-based rather than a single statewide contest. State-native ballots-cast and names-on-checklist rows replace EAC fallback turnout, with a one-vote source summary/detail caveat in ballots-cast totals. The 2016 historical archive lead is not loaded until artifacts are downloaded, parsed, and reconciled; 2020 and 2012 remain targeted archive/records-request items.",
+      "nextAction": "Download and parse the official 2016 archived President, Governor, and U.S. House XLS/XLSX leads; continue targeted archive/records requests for 2020 and 2012; request town/ward geometry or a reporting-unit crosswalk; normalize official audit/recount/CVR/incident/correction/litigation records if obtained."
     },
     {
       "state": "NJ",

--- a/docs/native-import-source-packages.md
+++ b/docs/native-import-source-packages.md
@@ -223,8 +223,10 @@ Caveats: review rows are President-versus-U.S.-House rather than a single statew
 - Turnout source: `data/nh-2024-ge-ballots-cast.xls` plus `data/nh-2024-ge-names-on-checklist.xlsx`, normalized into the same town/ward CSV
 - Turnout denominator: names on checklist
 - County boundary: `data/nh-counties.geojson`
+- Administration/source inventory: `data/nh-2024-admin-source-inventory.json`
+- Historical baseline lead: official archived 2016 President county XLS files plus `2016-ge-governor.xls` and 2016 congressional district XLSX files were identified through Internet Archive CDX, but are not downloaded or loaded.
 
-Expected validation: 10 county rows, 304 town/ward review rows, 304 turnout rows, 831,468 detailed ballots cast, and 1,013,075 names-on-checklist registered-voter denominator rows. Remaining gaps: official town/ward geometry, historical split-ticket baselines, and normalized audit/recount/CVR/incident/correction/litigation records.
+Expected validation: 10 county rows, 304 town/ward review rows, 304 turnout rows, 831,468 detailed ballots cast, and 1,013,075 names-on-checklist registered-voter denominator rows. Remaining gaps: a 2016 historical normalizer and downloaded archive artifacts, targeted official archive/records-request paths for 2020 and 2012 historical baselines, official town/ward geometry, and normalized audit/recount/CVR/incident/correction/litigation records.
 
 ## Indiana Wave 5 Update
 

--- a/etl/state-configs/nh.json
+++ b/etl/state-configs/nh.json
@@ -100,8 +100,8 @@
       "localFile": "data/nh-2024-admin-source-inventory.json",
       "parser": "newHampshireAdminSourceInventoryJson",
       "authority": "New Hampshire Secretary of State; official public records and GIS request paths",
-      "timestampBasis": "Worker source pass and Internet Archive CDX enumeration on 2026-06-30.",
-      "confidence": "Inventory artifact documents loaded comparison/turnout artifacts, official recount sheet candidates, county-only geometry status, and audit/CVR/source-request blockers. It is context only, not a normalized incident or audit dataset.",
+      "timestampBasis": "Worker source pass and Internet Archive CDX enumeration refreshed on 2026-07-01.",
+      "confidence": "Inventory artifact documents loaded comparison/turnout artifacts, official 2016 historical-baseline archive leads, official recount sheet candidates, county-only geometry status, and audit/CVR/source-request blockers. It is context only, not a normalized incident, recount, CVR, litigation, historical, or audit dataset.",
       "status": "loaded"
     }
   ],
@@ -157,7 +157,7 @@
     "directionalScreenConfidence": "medium",
     "directionalScreenReason": "U.S. House district workbooks provide same town/ward-grain Democratic and Republican comparison rows for all loaded New Hampshire President rows. The comparison is cleaner than Governor, but still district-based rather than a single statewide contest.",
     "corroborationNeeded": [
-      "historical New Hampshire President-versus-U.S. House and President-versus-Governor split-ticket baselines",
+      "historical New Hampshire President-versus-U.S. House and President-versus-Governor split-ticket baselines; 2016 official archive leads identified but not loaded",
       "town/ward boundary geometry or an official reporting-unit crosswalk",
       "normalized post-election audit, recount, CVR availability, incident/correction, and litigation records"
     ],

--- a/tests/python/test_new_hampshire_coverage_inventory.py
+++ b/tests/python/test_new_hampshire_coverage_inventory.py
@@ -1,0 +1,52 @@
+import json
+import unittest
+from pathlib import Path
+
+
+class NewHampshireCoverageInventoryTest(unittest.TestCase):
+    def setUp(self):
+        self.inventory = json.loads(Path("data/nh-2024-admin-source-inventory.json").read_text(encoding="utf-8-sig"))
+
+    def test_loaded_package_counts_and_ballots_cast_caveat_are_preserved(self):
+        summary = self.inventory["loadedPackageSummary"]
+        expected = summary["expectedRowsOrTotals"]
+
+        self.assertEqual(self.inventory["state"], "NH")
+        self.assertEqual(self.inventory["reportingGrain"], "town_ward")
+        self.assertEqual(expected["countyResultRows"], 10)
+        self.assertEqual(expected["townWardReviewRows"], 304)
+        self.assertEqual(expected["townWardTurnoutRows"], 304)
+        self.assertEqual(expected["ballotsCastDetailTotal"], 831468)
+        self.assertIn("831,467", summary["caveat"])
+        self.assertIn("831,468", summary["caveat"])
+
+    def test_historical_inventory_records_only_confirmed_2016_archive_leads(self):
+        historical = self.inventory["historicalBaselineFeasibility"]
+        lead = historical["availableOfficialArchiveLeads"][0]
+        unresolved = {item["year"]: item for item in historical["blockedOrUnresolvedLeads"]}
+
+        self.assertEqual(historical["status"], "candidate_2016_official_archive_lead")
+        self.assertEqual(lead["year"], 2016)
+        self.assertIn("2016-ge-president-summary-and-belknap.xls", lead["artifactCandidates"])
+        self.assertIn("2016-ge-governor.xls", lead["artifactCandidates"])
+        self.assertIn("2016-ge-congressional-district-2.xlsx", lead["artifactCandidates"])
+        self.assertEqual(unresolved[2020]["status"], "needs_targeted_archive_or_records_request")
+        self.assertEqual(unresolved[2012]["status"], "needs_targeted_archive_or_records_request")
+        self.assertIn("No historical baseline rows are loaded", historical["caveat"])
+
+    def test_geometry_admin_and_display_paths_remain_inventory_only(self):
+        geometry = self.inventory["geometryAndCrosswalk"]
+        recounts = self.inventory["recountsCorrectionsIncidentsLitigation"]
+        audit_cvr = self.inventory["auditAndCvr"]
+        display = self.inventory["websiteAndApiDisplayPath"]
+
+        self.assertEqual(geometry["status"], "county_geometry_loaded_town_ward_geometry_blocked")
+        self.assertIn("city wards unresolved", geometry["caveat"])
+        self.assertEqual(recounts["status"], "partial_inventory")
+        self.assertGreaterEqual(len(recounts["archivedRecountArtifactsIdentified"]), 7)
+        self.assertEqual(audit_cvr["status"], "needs_source_inventory")
+        self.assertFalse(display["productionChecked"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## State and task scope

Wave 8 New Hampshire coverage inventory pass. This does not production-promote data and does not load historical/admin rows. It expands the NH source inventory beyond the loaded 2024 town/ward President-vs-U.S.-House and turnout package.

## Sources added or confirmed

- Preserved archived official NH SOS 2024 workbooks and the one-vote ballots-cast detail-vs-summary caveat.
- Added official archive leads for 2016 President county XLS files, `2016-ge-governor.xls`, and 2016 congressional district XLSX files as historical baseline feasibility sources.
- Documented 2020 and 2012 as targeted official archive/records-request items; no secondary historical rows substituted.
- Expanded town/ward geometry/crosswalk, recount, audit, CVR, incident/correction, and litigation request-path inventory.

## Scripts/configs changed

- Updated `data/nh-2024-admin-source-inventory.json`.
- Refreshed NH-scoped registry/docs entries in source-acquisition, native source packages, admin packages, native handoff docs, and `etl/state-configs/nh.json`.
- Added `tests/python/test_new_hampshire_coverage_inventory.py`.

## Validation commands run

- `npm install`
- `npm run etl:import:nh`
- `npm run native:report-indicators -- .etl/staging`
- `python -m civic_etl.cli validate --config etl/state-configs/nh.json`
- `python -m unittest tests.python.test_new_hampshire_coverage_inventory tests.python.test_pipeline.PipelineTests.test_new_hampshire_town_ward_csv_parser_builds_review_rows`
- `npm run validate:source-packages`
- `npm run validate:admin-packages`
- `npm run validate:turnout-packages`
- `npm run validate:source-acquisition-tiers`
- `npm run validate:maps`
- `npm run validate:provenance`
- `npm run typecheck`
- `npm run build`
- `npm test`

## Advisory indicator report

From `.etl/staging`:

- NH native review rows: 304
- Calculated advisory indicator rows: 14
- Flagged jurisdiction count: 9
- Flagged area count: 9
- Indicator types: `vote_share_pattern`, `average_down_ballot_difference`
- Production checked: no; promotion/API verification was not authorized.

## Website/API display path checked

- Staging artifact regenerated successfully.
- NH county map join path remains county geometry only.
- Review rows remain 304 town/ward President-vs-U.S.-House advisory rows.
- Turnout rows remain 304 town/ward ballots-cast/names-on-checklist rows.

## Caveats and remaining risks

- No historical baseline rows are loaded. The 2016 archive lead still needs downloaded official artifacts, parser work, and reconciliation.
- 2020 and 2012 official baseline artifacts remain targeted archive/records-request items.
- Town/ward boundary geometry or an official reporting-unit crosswalk remains missing.
- Audit, recount, CVR availability, incident/correction, and litigation rows remain source-inventory/request items only.
- `npm run validate:source-packages` passed with pre-existing warnings for missing legacy/app-ready bundles in other states.

## Review-subagent result

No review-subagent tool was available in this environment; only GitHub PR review tools were exposed. I performed a dedicated local review pass over the diff, JSON parsing, schema validators, generated-file status, and `git diff --check`; no actionable issues remained.