### PR TITLE
[codex] Document West Virginia coverage inventory

### DIFF
--- a/data/admin-source-packages.json
+++ b/data/admin-source-packages.json
@@ -1705,17 +1705,32 @@
         "caveat": "Candidate source inventory only; no 2024 post-election audit result rows are loaded for West Virginia."
       },
       "cvr": {
-        "status": "needs_data",
-        "why": "West Virginia 2024 cast-vote-record availability and request paths have not been inventoried or normalized into this administration context registry yet.",
-        "caveat": "No CVR dataset or county CVR availability table is loaded."
+        "status": "candidate",
+        "reportingLevel": "county_request_path",
+        "sourceDocumentId": "wv-sos-foia-and-voter-data-request-paths",
+        "sourceUrl": "https://sos.wv.gov/about/Pages/FOIAReq.aspx",
+        "relatedSourceUrls": [
+          "https://sos.wv.gov/FormSearch/Elections/Informational/Voter%20Data%20Request.pdf",
+          "https://sos.wv.gov/west-virginia-county-clerk-directory"
+        ],
+        "localArtifact": "data/wv-2024-data-coverage-inventory.json",
+        "why": "West Virginia SOS FOIA, voter-data request, and county clerk paths are now documented for CVR/public-records availability follow-up, but no county CVR availability table or CVR dataset has been collected or normalized.",
+        "caveat": "Request-path inventory only; no CVR dataset, ballot-image record, or county CVR availability table is loaded. Voter-registration and voter-history products are not CVRs."
       },
       "incidents": {
         "status": "candidate",
-        "reportingLevel": "statewide_reporting_path",
+        "reportingLevel": "statewide_and_county_request_path",
         "sourceDocumentId": "wv-sos-election-security-complaint-reporting",
         "sourceUrl": "https://sos.wv.gov/elections/Pages/ElectionSecurity.aspx",
-        "why": "West Virginia Secretary of State election-security materials identify official complaint/reporting paths for election-law violations, but 2024 incident, correction, recount, and litigation records have not been normalized.",
-        "caveat": "Candidate source inventory only; not a loaded incident, correction, recount, or litigation dataset."
+        "relatedSourceUrls": [
+          "https://sos.wv.gov/FormSearch/Elections/Complaint_Challenge/ElectionsComplaintForm.pdf",
+          "https://sos.wv.gov/FormSearch/Elections/Informational/Canvassing%20Manual.pdf",
+          "https://sos.wv.gov/FormSearch/Elections/Informational/Recount%20Manual.pdf",
+          "https://sos.wv.gov/about/Pages/FOIAReq.aspx"
+        ],
+        "localArtifact": "data/wv-2024-data-coverage-inventory.json",
+        "why": "West Virginia SOS election-security, complaint, canvass, recount, and FOIA paths are documented, but 2024 incident, correction, complaint disposition, recount, and litigation records have not been normalized.",
+        "caveat": "Candidate source inventory only; not a loaded incident, correction, recount, complaint-disposition, or litigation dataset. Complaints and investigations may be confidential or restricted."
       }
     },
     {

--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -1386,23 +1386,32 @@
       "state": "WV",
       "name": "West Virginia",
       "priority": 12,
-      "currentStatus": "official_precinct_review_turnout_package_collected_admin_context_partial",
+      "currentStatus": "official_precinct_review_turnout_package_collected_admin_context_inventory_expanded",
       "officialSourcePages": [
         "https://results.enr.clarityelections.com/WV/122766/web.345435/",
         "https://results.enr.clarityelections.com/WV/122766/current_ver.txt",
         "https://sos.wv.gov/elections/Pages/ElectionSecurity.aspx",
-        "https://sos.wv.gov/elections/Pages/VoteRegTotals.aspx"
+        "https://sos.wv.gov/elections/Pages/VoteRegTotals.aspx",
+        "https://sos.wv.gov/elections/Pages/HistElecResults.aspx",
+        "https://sos.wv.gov/elections/Pages/Guidance.aspx",
+        "https://sos.wv.gov/FormSearch/Elections/Informational/Canvassing%20Manual.pdf",
+        "https://sos.wv.gov/FormSearch/Elections/Informational/Recount%20Manual.pdf",
+        "https://sos.wv.gov/FormSearch/Elections/Complaint_Challenge/ElectionsComplaintForm.pdf",
+        "https://sos.wv.gov/about/Pages/FOIAReq.aspx",
+        "https://sos.wv.gov/FormSearch/Elections/Informational/Voter%20Data%20Request.pdf",
+        "https://sos.wv.gov/west-virginia-county-clerk-directory"
       ],
       "requiredArtifacts": [
         "official county detailxml.zip reports for all 55 counties",
         "precinct boundary geometry if subcounty map overlays are required",
         "official 2024 post-election audit selection/outcome artifacts if published or obtainable",
         "CVR availability/request-path inventory",
-        "incident, correction, recount, and litigation source inventory"
+        "incident, correction, recount, and litigation source inventory",
+        "data/wv-2024-data-coverage-inventory.json documenting loaded artifacts, official request paths, historical-source leads, and display caveats"
       ],
       "preferredComparisonContest": "U.S. Senate; loaded from official county detail XML reports as precinct-level President-vs-U.S.-Senate review rows.",
-      "parserNeeded": "westVirginiaClarityCountyDetailXmlDirectory loaded for 55 county result rows, 1,648 precinct review rows, and 1,649 precinct turnout rows. Equipment context is loaded separately from Verified Voting county context; audit/CVR/incident records remain source-inventory tasks.",
-      "blocker": "West Virginia has official county detailxml.zip reports collected from the Secretary of State Clarity results app. The parser loads precinct-level President-versus-U.S.-Senate review rows and state-native precinct turnout denominators from VoterTurnout totalVoters/ballotsCast. Remaining gaps are official statewide precinct boundary geometry for subcounty overlays and normalized administration context for audit outcomes, CVR availability, incidents, corrections, recounts, and litigation.",
+      "parserNeeded": "westVirginiaClarityCountyDetailXmlDirectory loaded for 55 county result rows, 1,648 precinct review rows, and 1,649 precinct turnout rows. Equipment context is loaded separately from Verified Voting county context; data/wv-2024-data-coverage-inventory.json documents official SOS/county request paths for audit outcomes, CVR availability, recounts, corrections, incidents, litigation, precinct geometry, and historical baselines.",
+      "blocker": "West Virginia has official county detailxml.zip reports collected from the Secretary of State Clarity results app. The parser loads precinct-level President-versus-U.S.-Senate review rows and state-native precinct turnout denominators from VoterTurnout totalVoters/ballotsCast. Remaining gaps are official statewide precinct boundary geometry for subcounty overlays, normalized 2024 hand-count audit selection/outcome rows, CVR availability responses, recount/correction/incident/litigation records, and normalized 2012/2016/2020 historical baseline rows. The Wave 9 coverage inventory records the current official request/source paths without loading those rows.",
       "availableArtifacts": {
         "presidentialCountyResults": {
           "sourceTitle": "West Virginia SOS official county detail XML reports",
@@ -1432,6 +1441,12 @@
           "localFile": "data/wv-counties.geojson",
           "nameProperty": "NAME",
           "codeProperty": "COUNTY"
+        },
+        "coverageInventory": {
+          "sourceTitle": "West Virginia 2024 data coverage and administration source inventory",
+          "sourceUrl": "https://sos.wv.gov/elections/Pages/HistElecResults.aspx",
+          "localFile": "data/wv-2024-data-coverage-inventory.json",
+          "parserHint": "Documents loaded result/review/turnout/equipment artifacts, official SOS/county request paths for precinct geometry, audit/CVR/recount/incident/correction/litigation records, historical-source leads, and display caveats. Inventory only; no normalized administration rows are loaded."
         },
         "equipmentContext": {
           "sourceTitle": "Verified Voting Verifier West Virginia 2024 equipment context",

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -1846,7 +1846,12 @@
         "detail XML ZIP"
       ],
       "sourceUrls": [
-        "https://results.enr.clarityelections.com/WV/"
+        "https://results.enr.clarityelections.com/WV/",
+        "https://sos.wv.gov/elections/Pages/ElectionSecurity.aspx",
+        "https://sos.wv.gov/elections/Pages/HistElecResults.aspx",
+        "https://sos.wv.gov/elections/Pages/Guidance.aspx",
+        "https://sos.wv.gov/about/Pages/FOIAReq.aspx",
+        "https://sos.wv.gov/west-virginia-county-clerk-directory"
       ],
       "exampleUrls": [],
       "availableFields": [
@@ -1854,19 +1859,21 @@
         "precinct President rows",
         "precinct U.S. Senate rows",
         "precinct turnout rows",
-        "county equipment context"
+        "county equipment context",
+        "official SOS canvass/recount/complaint/FOIA/voter-data request paths documented in data/wv-2024-data-coverage-inventory.json",
+        "official historical results source leads for 2020 and 2008-2017"
       ],
       "missingFields": [
         "official statewide precinct boundary geometry",
         "normalized 2024 post-election audit selection/outcome artifacts",
-        "CVR availability/request-path inventory",
+        "normalized CVR availability rows",
         "incident, correction, recount, and litigation records"
       ],
-      "parserStatus": "westVirginiaClarityCountyDetailXmlDirectory loaded for results/review/turnout; Verified Voting county equipment context loaded",
+      "parserStatus": "westVirginiaClarityCountyDetailXmlDirectory loaded for results/review/turnout; Verified Voting county equipment context loaded; data/wv-2024-data-coverage-inventory.json documents official geometry, audit, CVR, recount, incident/correction, litigation, and historical-source request paths",
       "manualReviewBurden": "low",
       "confidence": "loaded",
-      "caveats": "Rows are advisory review inputs, not confirmed findings. Equipment context is jurisdiction-level metadata only. County map geometry is loaded; no official statewide precinct boundary geometry package was identified in this pass.",
-      "nextAction": "Collect or document an official statewide precinct boundary source if one exists, then inventory official WV SOS/county audit, CVR, incident, correction, recount, and litigation artifacts."
+      "caveats": "Rows are advisory review inputs, not confirmed findings. Equipment context is jurisdiction-level metadata only. County map geometry is loaded; no official statewide precinct boundary geometry package was identified in this pass. The Wave 9 inventory documents official request/source paths only; no audit outcome, CVR, incident, correction, recount, litigation, or historical baseline rows are loaded.",
+      "nextAction": "Request official statewide precinct boundary geometry or county precinct crosswalks, then request and normalize 2024 hand-count audit selections/outcomes, CVR availability responses, recount/correction/incident/litigation records, and official 2012/2016/2020 historical baseline artifacts."
     },
     {
       "state": "WY",

--- a/data/wv-2024-data-coverage-inventory.json
+++ b/data/wv-2024-data-coverage-inventory.json
@@ -1,0 +1,201 @@
+{
+  "schemaVersion": 1,
+  "state": "WV",
+  "stateName": "West Virginia",
+  "electionYear": 2024,
+  "checkedAt": "2026-07-01",
+  "purpose": "Wave 9 West Virginia source-coverage inventory for loaded official result, review, turnout, map, equipment, historical-source, and administration-context paths. This inventory records source availability and blockers; it does not promote production data and does not allege fraud or misconduct.",
+  "status": "official_precinct_review_turnout_county_map_loaded_admin_context_inventory_expanded",
+  "firstReads": {
+    "developerIndex": "docs/developer/index.md was not present in the worktree.",
+    "requiredFilesRead": [
+      "AGENTS.md",
+      "README.md",
+      "package.json",
+      "scripts/state-metadata.mjs",
+      "data/source-acquisition-tiers.json",
+      "data/native-import-source-packages.json",
+      "docs/turnout-collection-inventory.md",
+      "docs/native-import-source-packages.md",
+      "etl/state-configs/wv.json"
+    ]
+  },
+  "loadedArtifacts": [
+    {
+      "id": "wv-2024-county-detailxml-reports",
+      "sourceAuthority": "West Virginia Secretary of State",
+      "sourceUrl": "https://results.enr.clarityelections.com/WV/122766/web.345435/",
+      "localArtifactPath": "data/wv-2024-county-detailxml-reports",
+      "electionYear": 2024,
+      "reportingGrain": "precinct",
+      "parserOrNormalizationPath": "civic_etl.native nativeWestVirginiaClarityCountyDetailXmlDirectory via etl/state-configs/wv.json",
+      "expectedRowsOrTotals": {
+        "countyResultRows": 55,
+        "precinctReviewRows": 1648,
+        "precinctTurnoutRows": 1649,
+        "stateTotalVotes": 762390,
+        "trumpVotes": 533556,
+        "harrisVotes": 214309,
+        "otherVotes": 14525,
+        "turnoutBallotsCast": 770587,
+        "registeredVoters": 1187991
+      },
+      "confidenceNotes": "Official county detailxml.zip reports from the West Virginia Secretary of State Clarity results app. The parser loads certified county presidential totals, precinct President-versus-U.S. Senate review rows, and VoterTurnout precinct ballotsCast/totalVoters rows."
+    },
+    {
+      "id": "wv-2024-official-clarity-results",
+      "sourceAuthority": "West Virginia Secretary of State",
+      "sourceUrl": "https://results.enr.clarityelections.com/WV/122766/web.345435/",
+      "localArtifactPath": "data/wv-2024-official-results/details.json",
+      "electionYear": 2024,
+      "reportingGrain": "county",
+      "parserOrNormalizationPath": "legacy clarityCountyJson source context; active certified/review parser uses county detail XML directory",
+      "expectedRowsOrTotals": {
+        "countyResultRows": 55,
+        "stateTotalVotes": 762390
+      },
+      "confidenceNotes": "Official statewide Clarity package remains source provenance for the election package and county report discovery. The statewide JSON package itself is county-level."
+    },
+    {
+      "id": "wv-county-geometry",
+      "sourceAuthority": "U.S. Census Bureau",
+      "sourceUrl": "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE%3D%2754%27&outFields=NAME,BASENAME,GEOID,STATE,COUNTY&returnGeometry=true&outSR=4326&f=geojson",
+      "localArtifactPath": "data/wv-counties.geojson",
+      "electionYear": 2024,
+      "reportingGrain": "county",
+      "parserOrNormalizationPath": "censusTigerwebCountyGeojson via etl/state-configs/wv.json source wv-county-geometry",
+      "expectedRowsOrTotals": {
+        "geometryFeatures": 55
+      },
+      "confidenceNotes": "County geometry supports current county map joins. It is not precinct boundary geometry."
+    },
+    {
+      "id": "wv-2024-equipment-context",
+      "sourceAuthority": "Verified Voting Verifier",
+      "sourceUrl": "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/54",
+      "localArtifactPath": "data/wv-2024-equipment-context.csv",
+      "electionYear": 2024,
+      "reportingGrain": "county",
+      "parserOrNormalizationPath": "scripts/normalize-verifiedvoting-equipment.mjs; surfaced through data/admin-source-packages.json and API equipment context paths",
+      "expectedRowsOrTotals": {
+        "jurisdictions": 55
+      },
+      "confidenceNotes": "Jurisdiction-level election-administration context only. Do not infer every precinct or ballot mode used one identical setup; do not use this as vote, turnout, audit, incident, or cause evidence."
+    }
+  ],
+  "sourceFindings": [
+    {
+      "topic": "officialResultsComparisonAndTurnout",
+      "status": "loaded",
+      "sourceAuthority": "West Virginia Secretary of State",
+      "sourceUrl": "https://results.enr.clarityelections.com/WV/122766/web.345435/",
+      "localArtifactPath": "data/wv-2024-county-detailxml-reports",
+      "reportingGrain": "precinct",
+      "parserOrNormalizationPath": "westVirginiaClarityCountyDetailXmlDirectory",
+      "evidence": "The official 2024 General Election Clarity archive exposes county detailxml.zip reports. The parser confirms 55 county result rows, 1,648 precinct President-versus-U.S. Senate review rows, and 1,649 precinct turnout rows.",
+      "caveats": "Review rows are advisory screening inputs only, not findings. Precinct rows are table/chart inputs; current map geometry remains county-level."
+    },
+    {
+      "topic": "precinctBoundaryGeometry",
+      "status": "needs_data",
+      "sourceAuthority": "West Virginia Secretary of State and county clerks",
+      "sourceUrl": "https://sos.wv.gov/west-virginia-county-clerk-directory",
+      "relatedSourceUrls": [
+        "https://apps.sos.wv.gov/Elections/Voter/FindMyPollingPlace",
+        "https://sos.wv.gov/FormSearch/Elections/Informational/Voter%20Data%20Request.pdf"
+      ],
+      "localArtifactPath": "not collected",
+      "reportingGrain": "precinct boundary geometry or precinct-to-address/reporting-unit crosswalk",
+      "parserOrNormalizationPath": "not implemented",
+      "evidence": "The SOS polling-place lookup returns political districts and polling place for an individual voter record, and the SOS voter-data request form allows precinct number and precinct voter-registration-list requests. No official statewide precinct boundary GIS package was identified in this pass.",
+      "caveats": "Do not derive public precinct boundaries from voter records. Request an official GIS boundary file or a non-private precinct/reporting-unit crosswalk from the Secretary of State or county clerks before enabling subcounty map overlays."
+    },
+    {
+      "topic": "postElectionAudit",
+      "status": "policy_documented_outcomes_need_data",
+      "sourceAuthority": "West Virginia Secretary of State",
+      "sourceUrl": "https://sos.wv.gov/elections/Pages/ElectionSecurity.aspx",
+      "relatedSourceUrls": [
+        "https://sos.wv.gov/FormSearch/Elections/Informational/Canvassing%20Manual.pdf"
+      ],
+      "localArtifactPath": "not collected",
+      "reportingGrain": "county selected precinct hand-count audit",
+      "parserOrNormalizationPath": "not implemented",
+      "evidence": "The SOS election-security page documents a post-election hand-count audit after each election, and the canvassing manual documents random precinct selection, hand-count workflow, the 1% threshold, and transmission of the Canvass Audit Verification Form.",
+      "caveats": "The public source path documents policy and procedure only. No normalized 2024 county selection list, selected precincts, hand-count tallies, discrepancy rows, or outcome artifacts are loaded."
+    },
+    {
+      "topic": "recountsCorrectionsAndCanvassRecords",
+      "status": "procedure_documented_outcomes_need_data",
+      "sourceAuthority": "West Virginia Secretary of State",
+      "sourceUrl": "https://sos.wv.gov/FormSearch/Elections/Informational/Recount%20Manual.pdf",
+      "relatedSourceUrls": [
+        "https://sos.wv.gov/FormSearch/Elections/Informational/Canvassing%20Manual.pdf",
+        "https://sos.wv.gov/west-virginia-county-clerk-directory"
+      ],
+      "localArtifactPath": "not collected",
+      "reportingGrain": "contest/county recount request, recount result, canvass correction, or board record",
+      "parserOrNormalizationPath": "not implemented",
+      "evidence": "The SOS recount manual documents recount timelines and request procedures, while the canvassing manual documents board records, correction handling, certification timing, and county transmission paths.",
+      "caveats": "No official 2024 recount request/result packet, canvass correction row, or county board record set is normalized. Request county canvass records or SOS-held transmission records before loading this context."
+    },
+    {
+      "topic": "cvrAvailabilityAndRequestPaths",
+      "status": "request_path_documented_not_loaded",
+      "sourceAuthority": "West Virginia Secretary of State and county clerks",
+      "sourceUrl": "https://sos.wv.gov/about/Pages/FOIAReq.aspx",
+      "relatedSourceUrls": [
+        "https://sos.wv.gov/FormSearch/Elections/Informational/Voter%20Data%20Request.pdf",
+        "https://sos.wv.gov/west-virginia-county-clerk-directory"
+      ],
+      "localArtifactPath": "not collected",
+      "reportingGrain": "county CVR availability, public-records response, or export format/cost/timing inventory",
+      "parserOrNormalizationPath": "not implemented",
+      "evidence": "The SOS FOIA page provides state public-records request and completed-request database paths. The SOS voter-data request form documents statewide and partial voter-list/voter-history request products, including delimited text delivery, precinct number, and precinct voter-registration-list options.",
+      "caveats": "No CVR dataset or county CVR availability table is loaded. Voter-registration/voter-history products are not CVRs and may include privacy/use restrictions."
+    },
+    {
+      "topic": "incidentComplaintLitigation",
+      "status": "complaint_path_documented_records_need_data",
+      "sourceAuthority": "West Virginia Secretary of State",
+      "sourceUrl": "https://sos.wv.gov/FormSearch/Elections/Complaint_Challenge/ElectionsComplaintForm.pdf",
+      "relatedSourceUrls": [
+        "https://sos.wv.gov/elections/Pages/ElectionSecurity.aspx",
+        "https://sos.wv.gov/about/Pages/FOIAReq.aspx"
+      ],
+      "localArtifactPath": "not collected",
+      "reportingGrain": "incident, correction, complaint, investigation, or litigation record",
+      "parserOrNormalizationPath": "not implemented",
+      "evidence": "The SOS election-security page documents confidential complaint intake via See Something, Text Something, and the official election-law complaint form documents a sworn complaint path with SOS Investigations contact information.",
+      "caveats": "Complaints and investigations may be confidential or restricted. No 2024 incident, correction, complaint disposition, investigation, or litigation rows are normalized."
+    },
+    {
+      "topic": "historicalBaselines",
+      "status": "official_source_leads_confirmed_not_loaded",
+      "sourceAuthority": "West Virginia Secretary of State",
+      "sourceUrl": "https://sos.wv.gov/elections/Pages/HistElecResults.aspx",
+      "localArtifactPath": "not collected",
+      "reportingGrain": "county",
+      "parserOrNormalizationPath": "not implemented",
+      "evidence": "The SOS historical results page links the 2020 General Election Clarity archive and an official 2008-2017 historical results app, while 2024 uses the loaded Clarity path.",
+      "caveats": "No 2012, 2016, or 2020 West Virginia county historical baseline rows are loaded. A future normalizer should collect official SOS archives and reconcile county presidential totals before enabling historicalBaseline for WV."
+    }
+  ],
+  "websiteApiDisplayPathChecked": [
+    "/api/sources?state=WV&year=2024",
+    "/api/coverage?state=WV&year=2024",
+    "/api/review-rows?state=WV&year=2024&limit=500&includeMetrics=true",
+    "/api/turnout?state=WV&year=2024&limit=500",
+    "/api/admin-sources?state=WV&year=2024",
+    "/api/equipment?state=WV&year=2024",
+    "src/app/workspace-tabs.tsx Data & Sources, Turnout, Administration, and Review Export panels"
+  ],
+  "productionChecked": false,
+  "remainingRisks": [
+    "No official statewide precinct boundary geometry or precinct-to-result crosswalk is loaded, so current public map joins remain county-level even though WV has precinct review and turnout rows.",
+    "Post-election hand-count audit policy is documented, but 2024 county selection/outcome artifacts are not normalized.",
+    "CVR availability, recount outcomes, canvass corrections, complaint dispositions, incident records, and litigation records remain request-path items.",
+    "Historical baseline source leads are official, but no 2012, 2016, or 2020 WV historical baseline rows are loaded yet.",
+    "Current advisory indicators are data/reconciliation signals only and are not evidence of fraud or misconduct."
+  ]
+}

--- a/docs/native-import-source-packages.md
+++ b/docs/native-import-source-packages.md
@@ -138,8 +138,9 @@ Caveats: review rows are county-level President-versus-U.S. Senate two-year spec
 - Turnout denominator: totalVoters registered-voter field; expected 1,649 rows, 770,587 ballots cast, and 1,187,991 registered voters
 - County boundary: data/wv-counties.geojson
 - Equipment context: data/wv-2024-equipment-context.csv from Verified Voting, context only
+- Coverage/admin inventory: data/wv-2024-data-coverage-inventory.json documents official SOS/county request paths for precinct geometry, hand-count audit outcomes, CVR availability, recount/correction/incident/litigation records, and official historical baseline source leads
 
-Remaining gaps: official statewide precinct boundary geometry for subcounty overlays, 2024 audit selection/outcome artifacts, CVR availability/request paths, and incident/correction/recount/litigation inventories. The loaded review rows remain advisory screening inputs, not findings.
+Remaining gaps: official statewide precinct boundary geometry for subcounty overlays, normalized 2024 audit selection/outcome artifacts, CVR availability rows, incident/correction/recount/litigation records, and loaded 2012/2016/2020 historical baseline rows. The loaded review rows remain advisory screening inputs, not findings; the Wave 9 inventory records source/request paths only for the remaining administration context.
 
 ## Missouri Wave 5 Update
 

--- a/etl/state-configs/wv.json
+++ b/etl/state-configs/wv.json
@@ -48,6 +48,17 @@
       "timestampBasis": "Census TIGERweb county geography service artifact.",
       "confidence": "County geometry is used for West Virginia county map joins; precinct boundary geometry is not included in this package.",
       "status": "loaded"
+    },
+    {
+      "id": "wv-2024-data-coverage-inventory",
+      "category": "West Virginia 2024 data coverage and administration source inventory",
+      "url": "https://sos.wv.gov/elections/Pages/HistElecResults.aspx",
+      "localFile": "data/wv-2024-data-coverage-inventory.json",
+      "parser": "sourceCoverageInventoryJson",
+      "authority": "West Virginia Secretary of State; county clerks; U.S. Census Bureau; Verified Voting Verifier",
+      "timestampBasis": "Wave 9 source-coverage pass checked on July 1, 2026.",
+      "confidence": "Documents loaded West Virginia result/review/turnout/equipment artifacts and remaining official request paths for precinct geometry, audit outcomes, CVR availability, recount/correction/incident/litigation records, and historical baseline sources. Inventory only; no normalized administration rows are loaded.",
+      "status": "candidate"
     }
   ],
   "turnout": {
@@ -67,7 +78,7 @@
   "expected": {
     "jurisdictions": 55,
     "resultRows": 55,
-    "sources": 4,
+    "sources": 5,
     "geometryFeatures": 55,
     "stateTotal": 762390,
     "trump": 533556,

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "etl:import:ky": "npm run etl:prepare:ky && python -m civic_etl.cli import --config etl/state-configs/ky.json --out .etl/staging",
     "etl:import:ma": "python -m civic_etl.cli import --config etl/state-configs/ma.json --out .etl/staging",
     "etl:prepare:wv": "node scripts/collect-wv-clarity-county-reports.mjs",
+    "etl:validate:wv": "npm run etl:prepare:wv && python -m civic_etl.cli validate --config etl/state-configs/wv.json",
     "etl:import:wv": "npm run etl:prepare:wv && python -m civic_etl.cli import --config etl/state-configs/wv.json --out .etl/staging",
     "etl:prepare:ia": "node scripts/collect-ia-clarity-county-reports.mjs",
     "etl:import:ia": "npm run etl:prepare:ia && python -m civic_etl.cli import --config etl/state-configs/ia.json --out .etl/staging",

--- a/tests/python/test_west_virginia_coverage_inventory.py
+++ b/tests/python/test_west_virginia_coverage_inventory.py
@@ -1,0 +1,45 @@
+import json
+import unittest
+from pathlib import Path
+
+from civic_etl.pipeline import build_staging_artifact, load_config, validate_config
+
+
+class WestVirginiaCoverageInventoryTests(unittest.TestCase):
+    def setUp(self):
+        self.inventory = json.loads(Path("data/wv-2024-data-coverage-inventory.json").read_text(encoding="utf-8-sig"))
+
+    def test_inventory_preserves_loaded_result_review_and_turnout_counts(self):
+        config = load_config("etl/state-configs/wv.json")
+        report = validate_config(config)
+        artifact = build_staging_artifact(config, report)
+
+        self.assertTrue(report.passed)
+        self.assertEqual(config.expected.sources, len(config.sources))
+        self.assertEqual(artifact["native"]["metrics"]["nativeResultRows"], 55)
+        self.assertEqual(artifact["native"]["metrics"]["nativeReviewRows"], 1648)
+        self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutRows"], 1649)
+        self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutBallotsCast"], 770587)
+        self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutRegisteredVoters"], 1187991)
+
+        sources = {source["id"]: source for source in artifact["sources"]}
+        inventory_source = sources["wv-2024-data-coverage-inventory"]
+        self.assertEqual(inventory_source["status"], "candidate")
+        self.assertTrue(all(item["exists"] for item in inventory_source["metadata"]["artifacts"]))
+
+    def test_inventory_records_geometry_audit_cvr_and_historical_gaps(self):
+        self.assertEqual(self.inventory["state"], "WV")
+        self.assertEqual(self.inventory["checkedAt"], "2026-07-01")
+
+        findings = {item["topic"]: item for item in self.inventory["sourceFindings"]}
+        self.assertEqual(findings["precinctBoundaryGeometry"]["status"], "needs_data")
+        self.assertIn("Voter%20Data%20Request.pdf", findings["precinctBoundaryGeometry"]["relatedSourceUrls"][1])
+        self.assertEqual(findings["postElectionAudit"]["status"], "policy_documented_outcomes_need_data")
+        self.assertEqual(findings["cvrAvailabilityAndRequestPaths"]["status"], "request_path_documented_not_loaded")
+        self.assertEqual(findings["historicalBaselines"]["status"], "official_source_leads_confirmed_not_loaded")
+        self.assertFalse(self.inventory["productionChecked"])
+        self.assertTrue(any("not evidence of fraud or misconduct" in risk for risk in self.inventory["remainingRisks"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `data/wv-2024-data-coverage-inventory.json` documenting WV loaded official Clarity results/review/turnout, county geometry, equipment context, official admin request paths, historical-source leads, caveats, and remaining gaps.
- Add WV inventory/config/docs updates across source acquisition, native import, and admin source package registries.
- Add `etl:validate:wv` alias and focused Python coverage inventory tests.

## Sources added or confirmed
- WV SOS Clarity 2024 county detail XML result package: https://results.enr.clarityelections.com/WV/122766/web.345435/
- WV SOS Election Security / hand-count audit policy: https://sos.wv.gov/elections/Pages/ElectionSecurity.aspx
- WV SOS Canvassing Manual: https://sos.wv.gov/FormSearch/Elections/Informational/Canvassing%20Manual.pdf
- WV SOS Recount Manual: https://sos.wv.gov/FormSearch/Elections/Informational/Recount%20Manual.pdf
- WV SOS complaint form: https://sos.wv.gov/FormSearch/Elections/Complaint_Challenge/ElectionsComplaintForm.pdf
- WV SOS FOIA and county clerk request paths: https://sos.wv.gov/about/Pages/FOIAReq.aspx and https://sos.wv.gov/west-virginia-county-clerk-directory
- WV SOS voter data request and historical results leads: https://sos.wv.gov/FormSearch/Elections/Informational/Voter%20Data%20Request.pdf and https://sos.wv.gov/elections/Pages/HistElecResults.aspx

## Validation
- PASS: `npm run etl:validate:wv`
- PASS: `npm run etl:import:wv`
- PASS: `npm run native:report-indicators -- .etl/staging`
- PASS: `python -m unittest tests.python.test_west_virginia_coverage_inventory tests.python.test_pipeline.PipelineTests.test_west_virginia_clarity_detailxml_parser_builds_precinct_rows`
- PASS: `npm run validate:source-packages` with existing non-WV warnings
- PASS: `npm run validate:turnout-packages`
- PASS: `npm run validate:admin-packages`
- PASS: `npm run validate:source-acquisition-tiers`
- PASS: `npm run validate:maps` with existing multi-state equipment geometry warnings; WV county join remained 55/55
- PASS: `npm run validate:provenance`
- PASS: `git diff --check`
- NOT PASSED in this worktree: `npm run typecheck` and `npm run build` because dependencies/tools such as Next/React/lucide/drizzle were missing and typecheck also hit `tsconfig.tsbuildinfo` EPERM.

## Advisory indicators
- WV native review rows: 1,648
- Calculated advisory indicator rows: 102
- Flagged jurisdictions/counties/areas: 55 / 55 / 55
- Indicator types: `vote_share_pattern` 52; `average_down_ballot_difference` 50
- Production API/DB counts were not checked because production promotion/counts were not authorized.

## Risks and caveats
- No official statewide WV precinct boundary geometry or precinct-to-result crosswalk is loaded; current map joins remain county-level.
- Audit policy/request paths are documented, but 2024 selected precinct/outcome rows are not normalized.
- CVR availability, recount outcomes, canvass corrections, complaint dispositions, incident records, litigation records, and 2012/2016/2020 historical baseline rows remain source/request follow-up work.
- Advisory indicators are data/reconciliation signals only and are not evidence of fraud or misconduct.

## Review
- No review subagent was available in this environment; performed local diff review plus `git diff --check` and addressed generated collector timestamp/line-ending churn before staging.

## Conflict risk
Shared-file edits: `package.json`, `data/admin-source-packages.json`, `data/native-import-source-packages.json`, `data/source-acquisition-tiers.json`, and `docs/native-import-source-packages.md`. State-scoped edits: `etl/state-configs/wv.json`, `data/wv-2024-data-coverage-inventory.json`, `tests/python/test_west_virginia_coverage_inventory.py`.