### PR TITLE
[codex] Add Nebraska source coverage guardrails

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "npm run test:api && npm run test:etl",
-    "test:api": "node tests/api/api-contract.test.mjs && node tests/api/seed-script.test.mjs && node tests/api/legacy-import.test.mjs && node tests/api/native-import.test.mjs && node tests/api/ne-canvass-voting-statistics.test.mjs && node tests/api/turnout-normalizer.test.mjs && node tests/api/vote-method-normalizer.test.mjs && node tests/api/wi-audit-normalizer.test.mjs && node tests/api/wi-review-completion.test.mjs && node tests/api/wi-remaining-data-status.test.mjs && node tests/api/wi-remaining-collection.test.mjs && node tests/api/swing-state-parity.test.mjs && node tests/api/mo-source-coverage.test.mjs && node tests/api/nv-source-coverage.test.mjs && node tests/api/electronic-integrity.test.mjs",
+    "test:api": "node tests/api/api-contract.test.mjs && node tests/api/seed-script.test.mjs && node tests/api/legacy-import.test.mjs && node tests/api/native-import.test.mjs && node tests/api/ne-canvass-voting-statistics.test.mjs && node tests/api/ne-source-coverage.test.mjs && node tests/api/turnout-normalizer.test.mjs && node tests/api/vote-method-normalizer.test.mjs && node tests/api/wi-audit-normalizer.test.mjs && node tests/api/wi-review-completion.test.mjs && node tests/api/wi-remaining-data-status.test.mjs && node tests/api/wi-remaining-collection.test.mjs && node tests/api/swing-state-parity.test.mjs && node tests/api/mo-source-coverage.test.mjs && node tests/api/nv-source-coverage.test.mjs && node tests/api/electronic-integrity.test.mjs",
     "test:etl": "python -m unittest discover -s tests/python",
     "db:generate": "drizzle-kit generate",
     "db:push": "node --env-file=.env.local ./node_modules/drizzle-kit/bin.cjs push",

--- a/src/app/workspace-tabs.tsx
+++ b/src/app/workspace-tabs.tsx
@@ -1424,6 +1424,26 @@ const stateDataNoteOverrides: Record<string, StateDataNoteOverride[]> = {
       why: "Historical baseline charts stay disabled until official SOS county presidential artifacts are collected from archive iframe targets, direct recap files, or the SOS request path and parsed with provenance.",
     },
   ],
+  NE: [
+    {
+      key: "review",
+      evidence: "Nebraska review rows use official county-level President-versus-U.S. Senate two-year special election canvass rows.",
+      status: "partial",
+      why: "The current Nebraska review screen is county context only. The source inventory did not identify a public statewide precinct/subcounty President plus U.S. Senate export or matching reporting-unit geometry/crosswalk.",
+    },
+    {
+      key: "turnout",
+      evidence: "EAC 2024 V2 county fallback rows are loaded; the Nebraska canvass voting-statistics reconciliation reports 965,236 Total Voting versus 965,145 EAC ballots cast.",
+      status: "partial",
+      why: "The generated Nebraska reconciliation shows a 91-vote canvass-minus-EAC difference across 34 county rows with no registered-voter denominator delta, so EAC fallback remains active until replacement semantics are reviewed.",
+    },
+    {
+      key: "equipment",
+      evidence: "Nebraska equipment context is loaded from supplemental Verified Voting rows while official equipment records remain a request-path item.",
+      status: "partial",
+      why: "Use the equipment rows as jurisdiction-level administration context only; request official Nebraska SOS or county equipment records before treating them as source-native equipment provenance.",
+    },
+  ],
   NC: [
     {
       key: "map",

--- a/tests/api/ne-source-coverage.test.mjs
+++ b/tests/api/ne-source-coverage.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+const adminInventory = readJson("data/ne-2024-admin-source-inventory.json");
+const reconciliationSummary = readJson("data/ne-2024-canvass-voting-statistics-reconciliation-summary.json");
+const neConfig = readJson("etl/state-configs/ne.json");
+const nativePackages = readJson("data/native-import-source-packages.json");
+const acquisitionTiers = readJson("data/source-acquisition-tiers.json");
+const turnoutPackages = readJson("data/turnout-source-packages.json");
+const adminPackages = readJson("data/admin-source-packages.json");
+
+const nativeNe = nativePackages.states.find((entry) => entry.state === "NE");
+const discoveryNe = nativePackages.sourceDiscoveryQueue.find((entry) => entry.state === "NE");
+const tierNe = acquisitionTiers.states.find((entry) => entry.state === "NE");
+const turnoutNe = turnoutPackages.stateYearStatuses.find((entry) => entry.state === "NE" && entry.year === 2024);
+const adminNe = adminPackages.stateYearStatuses.find((entry) => entry.state === "NE" && entry.electionYear === 2024);
+
+test("Nebraska inventory keeps precinct, geometry, and admin request blockers explicit", () => {
+  assert.equal(adminInventory.sameGrainComparison.status, "county_loaded_precinct_blocked");
+  assert.equal(adminInventory.sameGrainComparison.loadedReportingGrain, "county");
+  assert.match(adminInventory.sameGrainComparison.requestPath, /President and U\.S\. Senate/);
+  assert.match(adminInventory.sameGrainComparison.caveat, /did not identify an official statewide precinct\/subcounty/);
+
+  assert.equal(adminInventory.geometry.status, "county_loaded_precinct_or_subcounty_blocked");
+  assert.equal(adminInventory.geometry.loadedArtifact, "data/ne-counties.geojson");
+  assert.match(adminInventory.geometry.needed, /publishable reporting-unit crosswalk/);
+  assert.match(adminInventory.geometry.caveat, /District shapefiles are not a substitute/);
+
+  assert.equal(adminInventory.auditRecountCvrLitigation.status, "needs_source_inventory");
+  assert.ok(adminInventory.auditRecountCvrLitigation.needed.some((item) => /post-election audit/.test(item)));
+  assert.ok(adminInventory.auditRecountCvrLitigation.needed.some((item) => /CVR availability/.test(item)));
+  assert.ok(adminInventory.auditRecountCvrLitigation.needed.some((item) => /recount records/.test(item)));
+  assert.match(adminInventory.auditRecountCvrLitigation.requestPath, /Nebraska Secretary of State Elections Division/);
+
+  assert.equal(adminInventory.reportedProblemsCorrectionsIncidents.status, "partial_canvass_inventory");
+  assert.deepEqual(
+    adminInventory.reportedProblemsCorrectionsIncidents.identifiedItems.map((item) => item.jurisdiction),
+    ["Dawson County", "Gage County", "Johnson County"],
+  );
+  assert.match(adminInventory.reportedProblemsCorrectionsIncidents.caveat, /not evidence of fraud or misconduct/);
+});
+
+test("Nebraska turnout reconciliation remains caveated before replacing EAC fallback", () => {
+  assert.equal(adminInventory.turnoutDenominators.loadedTurnoutSource.rows, 93);
+  assert.equal(adminInventory.turnoutDenominators.loadedTurnoutSource.ballotsCast, 965145);
+  assert.equal(adminInventory.turnoutDenominators.loadedTurnoutSource.registeredVoters, 1263487);
+  assert.equal(adminInventory.turnoutDenominators.stateNativeSources[0].statewideTotalVoting, 965236);
+  assert.equal(adminInventory.turnoutDenominators.stateNativeSources[0].ballotsCastDeltaCanvassMinusEac, 91);
+  assert.equal(adminInventory.turnoutDenominators.stateNativeSources[0].registeredVotersDeltaCanvassMinusEac, 0);
+
+  assert.equal(reconciliationSummary.rowCount, 93);
+  assert.equal(reconciliationSummary.deltas.rowsWithBallotDelta, 34);
+  assert.equal(reconciliationSummary.deltas.ballotsCastCanvassMinusEac, 91);
+  assert.match(reconciliationSummary.activeTurnoutDecision, /Keep EAC fallback turnout active/);
+
+  assert.equal(neConfig.turnout.sourceId, "ne-2024-eac-turnout");
+  assert.equal(neConfig.turnout.stateNativeCanvassVotingStatistics.totalVoting, 965236);
+  assert.equal(neConfig.turnout.stateNativeCanvassVotingStatistics.eacBallotsCast, 965145);
+  assert.equal(neConfig.turnout.stateNativeCanvassVotingStatistics.rowsWithBallotDelta, 34);
+  assert.equal(neConfig.expected.sources, neConfig.sources.length);
+});
+
+test("Nebraska registries expose source coverage caveats and request paths", () => {
+  assert.ok(nativeNe, "NE native package entry is present");
+  assert.match(nativeNe.nativeReadiness, /precinct_path_blocked/);
+  assert.match(nativeNe.caveats.join("\n"), /not precinct\/subcounty scatter plots/);
+  assert.match(nativeNe.artifacts.turnout.parserHint, /91-vote canvass-minus-EAC/);
+
+  assert.ok(discoveryNe, "NE source discovery queue entry is present");
+  assert.equal(discoveryNe.priority, 7);
+  assert.ok(discoveryNe.requiredArtifacts.some((item) => /precinct-level or local reporting-unit result rows for President/.test(item)));
+  assert.ok(discoveryNe.requiredArtifacts.some((item) => /CVR availability statement/.test(item)));
+  assert.match(discoveryNe.blocker, /do not expose a statewide public precinct\/subcounty President plus U\.S\. Senate/);
+
+  assert.ok(tierNe, "NE source acquisition tier entry is present");
+  assert.equal(tierNe.tier, "tier_6_official_pdf_hostile");
+  assert.match(tierNe.missingFields.join("\n"), /official public precinct\/subcounty U\.S\. Senate result rows/);
+  assert.match(tierNe.nextAction, /request official audit, recount, CVR/);
+
+  assert.ok(turnoutNe, "NE turnout status entry is present");
+  assert.equal(turnoutNe.status, "loaded");
+  assert.equal(turnoutNe.coverage.stateNativeCanvassBallotsCastDelta, 91);
+  assert.equal(turnoutNe.coverage.stateNativeCanvassRowsWithBallotDelta, 34);
+
+  assert.ok(adminNe, "NE admin source package entry is present");
+  assert.equal(adminNe.audit.status, "needs_data");
+  assert.equal(adminNe.cvr.status, "needs_data");
+  assert.equal(adminNe.incidents.status, "partial");
+  assert.match(adminNe.inventory.caveat, /not a normalized incident or audit outcome package/);
+});
+
+test("Nebraska display notes explain county review and turnout reconciliation limits", () => {
+  const tabs = readFileSync("src/app/workspace-tabs.tsx", "utf8");
+
+  assert.match(tabs, /Nebraska review rows use official county-level President-versus-U\.S\. Senate two-year special election/);
+  assert.match(tabs, /county context only/);
+  assert.match(tabs, /91-vote canvass-minus-EAC difference across 34 county rows/);
+  assert.match(tabs, /EAC fallback remains active until replacement semantics are reviewed/);
+  assert.match(tabs, /request official Nebraska SOS or county equipment records/);
+});


### PR DESCRIPTION
## Summary

- Adds Nebraska-specific explorer notes for county-level review limits, EAC/canvass turnout reconciliation, and supplemental equipment context.
- Adds an API/source-coverage regression test covering the Nebraska admin inventory, turnout reconciliation, native/source-acquisition/turnout/admin registries, and the new display caveats.
- Wires the new Nebraska source coverage test into `npm run test:api`.

## Validation

- `node tests/api/ne-canvass-voting-statistics.test.mjs`
- `node tests/api/ne-source-coverage.test.mjs`
- `python -m unittest tests.python.test_nebraska_historical`
- `npm run etl:reconcile:ne:turnout`
- `python -m civic_etl.cli validate --config etl/state-configs/ne.json`
- `python -m civic_etl.cli import --config etl/state-configs/ne.json --out .etl/staging`
- `npm run native:report-indicators -- .etl/staging`
- `npm run validate:source-packages`
- `npm run validate:turnout-packages`
- `npm run validate:maps`
- `npm run validate:provenance`
- `npm run test` (API passed; ETL initially hit sandbox write denial for `.etl-test`, then `npm run test:etl` passed with worktree write access)
- `npm run typecheck` (rerun with worktree write access for `tsconfig.tsbuildinfo`)
- `npm run build`

## Indicator Report

For Nebraska staging: 93 native review rows, 6 calculated advisory indicator rows, 6 flagged county/jurisdiction rows, 6 flagged areas, indicator type `county_down_ballot_distribution`. Production reflection was not checked and no production promotion/counts command was run.

## Notes

`docs/developer/index.md` is absent on `origin/main` and this worktree, so that required first read remains blocked. `gh` is not installed, so this draft PR was opened through the GitHub connector after pushing with local Git.