### PR TITLE
[codex] Update Kansas source coverage inventory

### DIFF
--- a/data/ks-2024-data-coverage-inventory.json
+++ b/data/ks-2024-data-coverage-inventory.json
@@ -1,0 +1,187 @@
+{
+  "checkedAt": "2026-07-02",
+  "state": "KS",
+  "stateName": "Kansas",
+  "electionYear": 2024,
+  "status": "official_results_review_eac_turnout_county_geometry_equipment_context_loaded",
+  "summary": "Kansas has official Secretary of State 2024 presidential county result rows, official SOS precinct President-versus-U.S.-House review rows, official certified vote-total PDF provenance, EAC 2024 V2 county turnout fallback rows, Census county geometry, and county equipment context. State-native turnout, precinct geometry, historical baseline rows, and normalized audit/CVR/incident/recount/litigation records remain uncollected.",
+  "loadedArtifacts": [
+    {
+      "id": "ks-2024-presidential-results",
+      "sourceTitle": "Kansas Secretary of State 2024 Presidential Election Results workbook",
+      "sourceUrl": "https://sos.ks.gov/elections/24elec/2024-Presidential-Results.xlsx",
+      "localArtifact": "data/ks-2024-presidential-results.xlsx",
+      "reportingGrain": "county_result_from_precinct_workbook",
+      "parserNormalizationPath": "kansasPresidentialResultsXlsx via etl/state-configs/ks.json certifiedResults",
+      "expectedCounts": {
+        "countyRows": 105,
+        "stateTotal": 1327591,
+        "trump": 758802,
+        "harris": 544853,
+        "other": 23936
+      },
+      "confidence": "loaded_official",
+      "caveats": [
+        "County result rows aggregate the official SOS presidential workbook for map and certified-result display.",
+        "The workbook also supplies the presidential side of local review rows."
+      ]
+    },
+    {
+      "id": "ks-2024-general-us-house-precinct",
+      "sourceTitle": "Kansas Secretary of State 2024 General Election U.S. House precinct workbook",
+      "sourceUrl": "https://sos.ks.gov/elections/24elec/2024-General-Election-United-States-House-of-Representatives-Precinct-Results.xlsx",
+      "localArtifact": "data/ks-2024-general-us-house-precinct.xlsx",
+      "reportingGrain": "precinct",
+      "parserNormalizationPath": "kansasUsHousePrecinctXlsx via etl/state-configs/ks.json reviewCharts",
+      "expectedCounts": {
+        "reviewRows": 3739
+      },
+      "confidence": "loaded_official",
+      "caveats": [
+        "U.S. House is district-based, not a single statewide comparison contest.",
+        "Johnson, Sedgwick, Shawnee, and Wyandotte comparison rows are parsed from separate wide-format county tabs.",
+        "Three nonzero presidential local rows lack a matching U.S. House comparison and remain vote-share-only review rows."
+      ]
+    },
+    {
+      "id": "ks-2024-general-official-vote-totals",
+      "sourceTitle": "Kansas Secretary of State 2024 General Election Official Vote Totals PDF",
+      "sourceUrl": "https://sos.ks.gov/elections/24elec/2024-General-Election-Official-Vote-Totals.pdf",
+      "localArtifact": "data/ks-2024-general-official-vote-totals.pdf",
+      "reportingGrain": "state_certified_canvass_reference",
+      "parserNormalizationPath": "officialCanvassPdfReference provenance only",
+      "confidence": "loaded_official_reference",
+      "caveats": [
+        "Retained for certified-total provenance and manual reconciliation context; machine rows are parsed from the official XLSX workbooks."
+      ]
+    },
+    {
+      "id": "ks-2024-eac-turnout",
+      "sourceTitle": "U.S. EAC 2024 EAVS V2 Kansas county turnout fallback",
+      "sourceUrl": "https://www.eac.gov/research-and-data/studies-and-reports",
+      "localArtifact": "data/eac-2024-state-turnout/ks-2024-eac-turnout.csv",
+      "reportingGrain": "jurisdiction_county",
+      "parserNormalizationPath": "eacTurnoutCsv via etl/state-configs/ks.json turnout",
+      "expectedCounts": {
+        "turnoutRows": 105,
+        "ballotsCast": 1342102,
+        "registeredVoters": 2031119
+      },
+      "confidence": "loaded_official_fallback",
+      "caveats": [
+        "Prefer a Kansas-native turnout or voter-participation artifact if one is collected and reconciled; current rows are EAC fallback denominator context."
+      ]
+    },
+    {
+      "id": "ks-county-geometry",
+      "sourceTitle": "U.S. Census TIGERweb Kansas county geography",
+      "sourceUrl": "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE%3D%2720%27&outFields=NAME,BASENAME,GEOID,STATE,COUNTY&returnGeometry=true&outSR=4326&f=geojson",
+      "localArtifact": "data/ks-counties.geojson",
+      "reportingGrain": "county",
+      "parserNormalizationPath": "censusTigerwebCountyGeojson via etl/state-configs/ks.json",
+      "expectedCounts": {
+        "geometryFeatures": 105
+      },
+      "confidence": "loaded_official",
+      "caveats": [
+        "County geometry supports county map joins only; precinct boundary geometry is not loaded."
+      ]
+    },
+    {
+      "id": "ks-2024-equipment-context",
+      "sourceTitle": "Verified Voting Verifier Kansas 2024 equipment context",
+      "sourceUrl": "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/20",
+      "localArtifact": "data/verifiedvoting-ks-2024-equipment.json; data/ks-2024-equipment-context.csv; data/verifiedvoting-ks-2024-equipment-areas.geojson",
+      "reportingGrain": "county_context",
+      "parserNormalizationPath": "verifiedVotingEquipment via admin-source package registry",
+      "expectedCounts": {
+        "equipmentRows": 105
+      },
+      "confidence": "loaded_context_only",
+      "caveats": [
+        "Equipment context is not a vote, turnout, audit, CVR, incident, correction, recount, or litigation source and does not prove every precinct in a county used one identical configuration."
+      ]
+    }
+  ],
+  "sourceFindings": {
+    "stateNativeTurnout": {
+      "status": "not_loaded_eac_fallback_active",
+      "sourceUrl": "https://sos.ks.gov/elections/elections-statistics.html",
+      "currentArtifact": "data/eac-2024-state-turnout/ks-2024-eac-turnout.csv",
+      "requestNeed": "Official Kansas ballots-cast or voter-participation rows with registered-voter denominator, denominator timing, county or precinct grain, and statewide totals suitable for reconciliation before replacing EAC fallback."
+    },
+    "precinctBoundaryGeometry": {
+      "status": "not_loaded",
+      "loadedGeometry": {
+        "localArtifact": "data/ks-counties.geojson",
+        "reportingGrain": "county"
+      },
+      "requestNeed": "Official statewide precinct boundary geometry or a precinct-to-county/reporting-unit crosswalk if subcounty map overlays are required."
+    },
+    "historicalBaselines": {
+      "status": "official_source_path_documented_not_loaded",
+      "sourceUrl": "https://sos.ks.gov/elections/elections-statistics.html",
+      "targetYears": [
+        2012,
+        2016,
+        2020
+      ],
+      "caveat": "No 2012, 2016, or 2020 Kansas historical presidential baseline rows are loaded in this pass. Collect official SOS county workbooks/PDFs or request-produced tables before enabling historical baseline rows."
+    },
+    "postElectionAudit": {
+      "status": "not_inventoried_or_normalized",
+      "requestNeed": "Official 2024 Kansas post-election audit selection and outcome artifacts, if published or obtainable, with county/reporting-unit grain and discrepancy fields."
+    },
+    "cvrAvailability": {
+      "status": "not_loaded",
+      "requestNeed": "Official county or SOS CVR availability records, public-records request responses, or documented nonavailability notes before claiming CVR coverage."
+    },
+    "incidentsCorrectionsRecountsLitigation": {
+      "status": "not_loaded",
+      "requestNeed": "Official incident, correction, recount, election-contest, or litigation records for the 2024 general election, normalized only after authoritative source collection."
+    }
+  },
+  "displayApiCaveats": {
+    "publicSourceRoutesChecked": [
+      "/api/sources?state=KS&year=2024",
+      "/api/coverage?state=KS&year=2024",
+      "/api/native-source-packages?state=KS&year=2024",
+      "/api/turnout-sources?state=KS&year=2024",
+      "/api/admin-sources?state=KS&year=2024"
+    ],
+    "advisoryUse": "Kansas advisory indicators use official precinct President-versus-U.S.-House review rows where a same-row House comparison exists. U.S. House is district-based, and vote-share-only rows are retained when comparison rows are absent. Indicators are screening/context signals only, not claims of fraud or misconduct.",
+    "productionPromotion": "Not authorized from worker branch; no native:promote or native:counts run."
+  },
+  "gaps": [
+    {
+      "artifact": "state_native_turnout_denominator",
+      "status": "not_loaded_eac_fallback_active",
+      "remainingRisk": "EAC fallback turnout is official but not Kansas-native and may not match SOS reporting semantics."
+    },
+    {
+      "artifact": "precinct_boundary_geometry",
+      "status": "not_loaded",
+      "remainingRisk": "Public map joins remain county geometry only."
+    },
+    {
+      "artifact": "historical_presidential_baselines_2012_2016_2020",
+      "status": "official_source_path_documented_not_loaded",
+      "remainingRisk": "Historical context remains disabled until official artifacts are collected and normalized."
+    },
+    {
+      "artifact": "post_election_audit_rows",
+      "status": "not_loaded",
+      "remainingRisk": "No normalized audit selection/outcome rows are available."
+    },
+    {
+      "artifact": "cvr_availability_rows",
+      "status": "not_loaded",
+      "remainingRisk": "No CVR availability table or CVR dataset is available."
+    },
+    {
+      "artifact": "incident_correction_recount_litigation_rows",
+      "status": "not_loaded",
+      "remainingRisk": "Official records remain request/source-collection items."
+    }
+  ]
+}

--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -14,6 +14,7 @@
     "GA",
     "IA",
     "IL",
+    "KS",
     "KY",
     "MD",
     "MI",
@@ -924,6 +925,69 @@
         "Historical rows are context only; the 2020 media export reports the original November general-election export total and should not be mixed with recount tables without reconciliation."
       ],
       "legacyReferenceBundle": "data/ga-app-data.js"
+    },
+    {
+      "state": "KS",
+      "name": "Kansas",
+      "priority": 26,
+      "nativeReadiness": "complete_county_map_precinct_review_eac_turnout_equipment_admin_inventory",
+      "authority": "Kansas Secretary of State; U.S. Election Assistance Commission; U.S. Census Bureau",
+      "configFile": "etl/state-configs/ks.json",
+      "legacyReferenceBundle": "data/ks-2024-presidential-results.xlsx",
+      "artifacts": {
+        "presidentialCountyResults": {
+          "sourceTitle": "Kansas SOS official 2024 Presidential Election Results workbook",
+          "sourceUrl": "https://sos.ks.gov/elections/24elec/2024-Presidential-Results.xlsx",
+          "localFile": "data/ks-2024-presidential-results.xlsx",
+          "parserHint": "kansasPresidentialResultsXlsx parses sheet 2024 Presidential Results; aggregate County rows by Party and Votes for certified county map totals."
+        },
+        "localReviewRows": {
+          "sourceTitle": "Kansas SOS official 2024 General Election U.S. House precinct workbook",
+          "sourceUrl": "https://sos.ks.gov/elections/24elec/2024-General-Election-United-States-House-of-Representatives-Precinct-Results.xlsx",
+          "localFile": "data/ks-2024-general-us-house-precinct.xlsx",
+          "level": "precinct",
+          "comparisonContest": "U.S. House",
+          "parserHint": "Pair official presidential precinct rows with U.S. House precinct rows by county and precinct; Johnson, Sedgwick, Shawnee, and Wyandotte are read from separate wide-format county tabs."
+        },
+        "turnout": {
+          "sourceTitle": "EAC 2024 Kansas jurisdiction turnout fallback",
+          "sourceUrl": "https://www.eac.gov/research-and-data/studies-and-reports",
+          "localFile": "data/eac-2024-state-turnout/ks-2024-eac-turnout.csv",
+          "level": "jurisdiction",
+          "denominator": "EAC A1a Total Reg registered voters",
+          "ballotsCast": "EAC normalized ballots cast"
+        },
+        "countyBoundary": {
+          "sourceTitle": "U.S. Census TIGERweb county geography",
+          "sourceUrl": "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE%3D%2720%27&outFields=NAME,BASENAME,GEOID,STATE,COUNTY&returnGeometry=true&outSR=4326&f=geojson",
+          "localFile": "data/ks-counties.geojson",
+          "nameProperty": "NAME",
+          "codeProperty": "COUNTY"
+        }
+      },
+      "expected": {
+        "countyRows": 105,
+        "geometryFeatures": 105,
+        "stateTotal": 1327591,
+        "trump": 758802,
+        "harris": 544853,
+        "other": 23936,
+        "localReviewRows": 3739,
+        "turnoutRows": 105
+      },
+      "validationStatus": {
+        "localArtifactsPresent": true,
+        "generatedBundleTotalsReconcile": true,
+        "reviewMode": "president_vs_us_house_precinct_workbooks_with_vote_share_only_rows",
+        "turnoutMode": "eac_2024_v2_jurisdiction_fallback"
+      },
+      "caveats": [
+        "U.S. House is district-based rather than a single statewide comparison contest, so review rows are advisory screening inputs only.",
+        "Three nonzero presidential local rows do not have a matching House comparison row and are retained as vote-share-only rows.",
+        "Turnout rows use EAC 2024 V2 jurisdiction fallback data until a Kansas-native turnout/registration artifact is collected and reconciled.",
+        "County boundary geometry is loaded for map joins; official precinct boundary geometry is not included.",
+        "data/ks-2024-data-coverage-inventory.json documents equipment context plus remaining historical, audit, CVR, incident/correction, recount, litigation, turnout, and precinct-geometry gaps."
+      ]
     }
   ],
   "sourceDiscoveryQueue": [

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -579,30 +579,50 @@
       "stateName": "Kansas",
       "jurisdictionName": "Statewide",
       "scope": "statewide",
-      "dataFamily": "results_turnout",
-      "tier": "unknown",
-      "reportingGrain": "county",
+      "dataFamily": "results_review_turnout_equipment_admin_inventory",
+      "tier": "tier_1_official_export_database",
+      "reportingGrain": "precinct",
       "exportFormats": [
-        "eac fallback turnout"
+        "XLSX",
+        "PDF",
+        "GeoJSON",
+        "EAC fallback CSV",
+        "equipment context CSV"
       ],
       "sourceUrls": [
-        "https://sos.ks.gov/elections/elections-statistics.html"
+        "https://sos.ks.gov/elections/elections-statistics.html",
+        "https://sos.ks.gov/elections/24elec/2024-Presidential-Results.xlsx",
+        "https://sos.ks.gov/elections/24elec/2024-General-Election-United-States-House-of-Representatives-Precinct-Results.xlsx",
+        "https://sos.ks.gov/elections/24elec/2024-General-Election-Official-Vote-Totals.pdf",
+        "https://www.eac.gov/research-and-data/studies-and-reports",
+        "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/20"
       ],
-      "exampleUrls": [],
+      "exampleUrls": [
+        "https://sos.ks.gov/elections/24elec/2024-Presidential-Results.xlsx",
+        "https://sos.ks.gov/elections/24elec/2024-General-Election-United-States-House-of-Representatives-Precinct-Results.xlsx"
+      ],
       "availableFields": [
-        "county presidential totals",
-        "EAC fallback turnout"
+        "official county presidential totals from SOS presidential workbook",
+        "official precinct presidential rows from SOS presidential workbook",
+        "official precinct U.S. House comparison rows from SOS workbook",
+        "official certified vote-total PDF provenance",
+        "EAC fallback county turnout and registered-voter denominator rows",
+        "Census county geometry",
+        "county equipment context from Verified Voting Verifier"
       ],
       "missingFields": [
-        "local review rows",
-        "same-grain comparison contest",
-        "state-native turnout denominator"
+        "state-native turnout denominator and ballots-cast rows",
+        "precinct boundary geometry or precinct crosswalk",
+        "official 2012, 2016, and 2020 historical presidential baseline rows",
+        "normalized post-election audit selection/outcome rows",
+        "official CVR availability or request-produced CVR records",
+        "official incident, correction, recount, and litigation records"
       ],
-      "parserStatus": "EAC turnout config exists; local review source not classified",
-      "manualReviewBurden": "unknown",
-      "confidence": "candidate",
-      "caveats": "Statewide acquisition path still needs classification.",
-      "nextAction": "Classify official Kansas result exports and local reporting-unit availability."
+      "parserStatus": "nativeKansasPresidentialHouseXlsx package loaded from official Kansas SOS presidential and U.S. House workbooks; EAC fallback turnout and Census county geometry loaded; data/ks-2024-data-coverage-inventory.json documents remaining official-source gaps",
+      "manualReviewBurden": "low",
+      "confidence": "loaded",
+      "caveats": "U.S. House is district-based, so precinct review rows are advisory screening context. Three nonzero presidential local rows lack matching House comparison rows and are kept as vote-share-only rows. Turnout remains EAC fallback until Kansas-native turnout/registration rows are collected and reconciled. County geometry is loaded; precinct geometry, historical baselines, and normalized audit/CVR/incident/recount/litigation rows are not loaded.",
+      "nextAction": "Use data/ks-2024-data-coverage-inventory.json as the current KS source-search record; next steps are Kansas-native turnout denominators, precinct geometry/crosswalks, official historical baselines, and official audit/CVR/incident/correction/recount/litigation records."
     },
     {
       "state": "KY",

--- a/data/turnout-source-packages.json
+++ b/data/turnout-source-packages.json
@@ -1551,6 +1551,36 @@
       ]
     },
     {
+      "state": "KS",
+      "name": "Kansas",
+      "authority": "U.S. Election Assistance Commission; Kansas Secretary of State result/review rows provide election context",
+      "sourceLevel": "jurisdiction",
+      "turnoutSource": {
+        "sourceTitle": "U.S. EAC 2024 EAVS V2 Kansas jurisdiction turnout fallback",
+        "sourceUrl": "https://www.eac.gov/research-and-data/studies-and-reports",
+        "localFile": "data/eac-2024-state-turnout/ks-2024-eac-turnout.csv",
+        "parser": "eacTurnoutCsv"
+      },
+      "denominatorSource": {
+        "sourceTitle": "U.S. EAC 2024 EAVS V2 Kansas registered-voter denominator",
+        "sourceUrl": "https://www.eac.gov/research-and-data/studies-and-reports",
+        "localFile": "data/eac-2024-state-turnout/ks-2024-eac-registered-voter-denominator.json",
+        "parser": "eacA1aRegisteredVoterDenominator",
+        "denominatorType": "registeredVoters",
+        "denominatorTiming": "eacReported"
+      },
+      "expected": {
+        "turnoutRows": 105,
+        "registeredVoters": 2031119,
+        "ballotsCast": 1342102
+      },
+      "caveats": [
+        "EAC fallback turnout is official denominator context, not a Kansas-native turnout replacement.",
+        "Collect and reconcile a Kansas SOS or county ballots-cast plus registered-voter artifact before replacing the active turnout source.",
+        "The active Kansas review rows use official SOS President-versus-U.S.-House precinct workbooks; turnout remains county/jurisdiction fallback."
+      ]
+    },
+    {
       "state": "WI",
       "name": "Wisconsin",
       "authority": "U.S. Election Assistance Commission; Wisconsin Elections Commission ward results provide result/review rows",

--- a/docs/native-import-source-packages.md
+++ b/docs/native-import-source-packages.md
@@ -218,6 +218,22 @@ Expected validation: 17 county result rows, 17 county geometry features, 1,484,8
 
 Expected validation remains: 92 county result rows, 92 county geometry features, 2,936,677 presidential votes, 5,253 supplemental local review rows, 92 turnout rows, and 184 historical baseline rows for 2016/2020. Advisory indicators are source/data reconciliation signals only; they are not claims of misconduct.
 
+## Kansas Wave 11 Update
+
+- Config: `etl/state-configs/ks.json`
+- Authority: Kansas Secretary of State; U.S. Election Assistance Commission; U.S. Census Bureau
+- County results source: `data/ks-2024-presidential-results.xlsx`, from the official Kansas SOS 2024 Presidential Election Results workbook
+- Local review source: `data/ks-2024-general-us-house-precinct.xlsx`, from the official Kansas SOS U.S. House precinct workbook
+- Comparison contest: U.S. House by congressional district, paired to official presidential precinct rows, with district-based and vote-share-only caveats
+- Turnout source: EAC 2024 county/jurisdiction fallback rows at `data/eac-2024-state-turnout/ks-2024-eac-turnout.csv`
+- County boundary: `data/ks-counties.geojson`
+- Equipment context: `data/ks-2024-equipment-context.csv` from Verified Voting, context only
+- Coverage inventory: `data/ks-2024-data-coverage-inventory.json`
+
+Expected validation: 105 county result rows, 105 county geometry features, 1,327,591 presidential votes, 758,802 Trump votes, 544,853 Harris votes, 23,936 other votes, 3,739 precinct review rows, and 105 EAC fallback turnout rows.
+
+Remaining gaps: Kansas-native turnout/registration denominators, official precinct boundary geometry or a precinct crosswalk, official 2012/2016/2020 county historical presidential baselines, normalized post-election audit rows, CVR availability records, and official incident/correction/recount/litigation records. Current advisory rows are public-interest screening inputs only, not findings.
+
 ## Native ETL Acceptance Criteria
 
 For each state, the native importer should fail before promotion if:

--- a/docs/turnout-collection-inventory.md
+++ b/docs/turnout-collection-inventory.md
@@ -7,9 +7,9 @@ This is an internal collection inventory. It is not rendered in the Civic Result
 ## Summary
 
 - States checked: 50
-- Turnout loaded in database or validated native staging: 12
-- Loaded through official EAC fallback while state-native ward denominator remains missing: 1
-- Need native turnout package: 37
+- Turnout loaded in database or validated native staging: 14
+- Loaded through official EAC fallback while state-native denominator remains missing: 2
+- Need native turnout package: 36
 
 ## Loaded Turnout
 
@@ -18,6 +18,7 @@ This is an internal collection inventory. It is not rendered in the Civic Result
 | AZ Arizona | 15 | county | totalEligibleRegistration | `data/az-2024-general-canvass-president.csv` |
 | IN Indiana | 92 | county | registeredVoters | `data/in-2024-general-turnout.csv` |
 | IA Iowa | 1,651 | precinct | registeredVoters | `data/ia-2024-county-detailxml-reports` |
+| KS Kansas | 105 | jurisdiction | registeredVoters | `data/eac-2024-state-turnout/ks-2024-eac-turnout.csv` |
 | MI Michigan | 83 | county | novemberActiveRegisteredVoters | `data/mi-2024-voter-turnout.txt` |
 | MN Minnesota | 4,103 | precinct | registeredVotersPlusElectionDayRegistrations | `data/mn-2024-general-federal-state-results-by-precinct-official.xlsx` |
 | MO Missouri | 116 | jurisdiction | registeredVoters | `data/mo-2024-general-turnout.csv` |
@@ -33,13 +34,14 @@ This is an internal collection inventory. It is not rendered in the Civic Result
 
 | State | Current status | Needed |
 | --- | --- | --- |
+| KS Kansas | Native presidential and precinct review ETL is loaded from official Kansas Secretary of State workbooks, and official EAC 2024 EAVS V2 county/jurisdiction turnout rows are configured as fallback context. | Official Kansas ballots-cast or voter-participation rows with registered-voter denominator timing. Prefer precinct or county rows that can be reconciled to the SOS result workbooks; keep EAC fallback caveats visible until then. |
 | WI Wisconsin | Native presidential and review ETL is loaded, and official EAC 2024 EAVS V2 local-jurisdiction turnout rows are configured and loaded as fallback context. | Official Wisconsin registered-voter denominator data. Prefer ward-level data that can join to the WEC ward workbook; county- or municipality-level is usable only with caveats. |
 
 ## States Needing Native Turnout Packages Or State-Native Replacements
 
 These states still need a state-native turnout package or review of whether fallback turnout coverage is sufficient for the current caveats.
 
-`AK`, `AL`, `AR`, `CA`, `CO`, `CT`, `DE`, `FL`, `GA`, `HI`, `ID`, `IL`, `KS`, `KY`, `LA`, `MA`, `MD`, `ME`, `MS`, `MT`, `NC`, `ND`, `NE`, `NJ`, `NM`, `NV`, `NY`, `OK`, `OR`, `RI`, `SD`, `TN`, `TX`, `UT`, `VT`, `WA`, `WY`
+`AK`, `AL`, `AR`, `CA`, `CO`, `CT`, `DE`, `FL`, `GA`, `HI`, `ID`, `IL`, `KY`, `LA`, `MA`, `MD`, `ME`, `MS`, `MT`, `NC`, `ND`, `NE`, `NJ`, `NM`, `NV`, `NY`, `OK`, `OR`, `RI`, `SD`, `TN`, `TX`, `UT`, `VT`, `WA`, `WY`
 
 ## Standard Request For Each Missing State
 
@@ -118,6 +120,10 @@ Nevada still uses EAC 2024 V2 county/jurisdiction fallback turnout rows in `data
 ## Georgia Update
 
 Georgia still uses official EAC 2024 V2 county/jurisdiction fallback turnout rows at `data/eac-2024-state-turnout/ga-2024-eac-turnout.csv`, totaling 159 rows, 5,297,500 ballots cast, and 8,234,335 registered voters. The 2024 Georgia SOS media export is loaded for county results and precinct President-versus-U.S.-House review rows, and official 2012/2016/2020 SOS media exports are now normalized for county historical baselines, but no Georgia-native ballots-cast plus registered-voter denominator package was loaded in this pass. Keep Georgia in the native-turnout-needed list until a state or county denominator artifact is collected and reconciled.
+
+## Kansas Update
+
+Kansas currently uses official EAC 2024 V2 county/jurisdiction fallback turnout rows at `data/eac-2024-state-turnout/ks-2024-eac-turnout.csv`, totaling 105 jurisdiction rows, 1,342,102 ballots cast, and 2,031,119 registered voters. Native Kansas result and review rows are loaded from official Kansas Secretary of State presidential and U.S. House precinct workbooks, but no Kansas-native turnout or voter-participation denominator artifact is loaded. Keep EAC fallback active until a Kansas SOS or county ballots-cast plus registered-voter source is collected and reconciled. See `data/ks-2024-data-coverage-inventory.json` for the current source and caveat record.
 
 ## Kentucky Update
 

--- a/etl/state-configs/ks.json
+++ b/etl/state-configs/ks.json
@@ -59,6 +59,28 @@
       "timestampBasis": "Census TIGERweb county geography service artifact.",
       "confidence": "County geometry is used for Kansas county map joins; precinct boundary geometry is not included in this package.",
       "status": "loaded"
+    },
+    {
+      "id": "ks-2024-equipment-context",
+      "category": "County equipment context",
+      "url": "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/20",
+      "localFile": "data/ks-2024-equipment-context.csv",
+      "parser": "verifiedVotingEquipmentContext",
+      "authority": "Verified Voting Verifier",
+      "timestampBasis": "Verifier county equipment context artifact retained for 2024 Kansas administration metadata.",
+      "confidence": "Context only. County-level equipment rows are not vote, turnout, audit, CVR, or incident records and do not prove precinct-level uniformity.",
+      "status": "candidate"
+    },
+    {
+      "id": "ks-2024-data-coverage-inventory",
+      "category": "Kansas source coverage and remaining-gap inventory",
+      "url": "https://sos.ks.gov/elections/elections-statistics.html",
+      "localFile": "data/ks-2024-data-coverage-inventory.json",
+      "parser": "sourceCoverageInventoryJson",
+      "authority": "Kansas Secretary of State; U.S. Election Assistance Commission; U.S. Census Bureau; Verified Voting Verifier",
+      "timestampBasis": "Wave 11 Kansas coverage inventory created July 2, 2026 from committed official artifacts and source-package registries.",
+      "confidence": "Inventory only. Documents loaded official artifacts, EAC fallback turnout, county geometry, equipment context, and remaining historical, audit, CVR, incident, correction, recount, litigation, and precinct-geometry gaps.",
+      "status": "candidate"
     }
   ],
   "turnout": {
@@ -78,7 +100,7 @@
   "expected": {
     "jurisdictions": 105,
     "resultRows": 105,
-    "sources": 5,
+    "sources": 7,
     "geometryFeatures": 105,
     "stateTotal": 1327591,
     "trump": 758802,

--- a/tests/python/test_kansas_coverage_inventory.py
+++ b/tests/python/test_kansas_coverage_inventory.py
@@ -1,0 +1,72 @@
+import json
+import unittest
+from pathlib import Path
+
+
+class KansasCoverageInventoryTests(unittest.TestCase):
+    def load_json(self, path):
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+
+    def test_kansas_config_registers_official_sources_and_inventory(self):
+        config = self.load_json("etl/state-configs/ks.json")
+        sources = {source["id"]: source for source in config["sources"]}
+
+        self.assertEqual(config["expected"]["sources"], len(config["sources"]))
+        self.assertEqual(config["expected"]["resultRows"], 105)
+        self.assertEqual(config["expected"]["reviewRows"], 3739)
+        self.assertEqual(config["expected"]["turnoutRows"], 105)
+        self.assertEqual(sources["ks-2024-presidential-results"]["authority"], "Kansas Secretary of State")
+        self.assertEqual(sources["ks-2024-general-us-house-precinct"]["parser"], "kansasUsHousePrecinctXlsx")
+        self.assertEqual(sources["ks-2024-data-coverage-inventory"]["localFile"], "data/ks-2024-data-coverage-inventory.json")
+        self.assertEqual(sources["ks-2024-equipment-context"]["status"], "candidate")
+        self.assertIn("district-based", config["reviewCharts"]["warning"])
+
+    def test_kansas_inventory_keeps_loaded_and_missing_artifacts_distinct(self):
+        inventory = self.load_json("data/ks-2024-data-coverage-inventory.json")
+        artifacts = {artifact["id"]: artifact for artifact in inventory["loadedArtifacts"]}
+        findings = inventory["sourceFindings"]
+
+        self.assertEqual(artifacts["ks-2024-presidential-results"]["confidence"], "loaded_official")
+        self.assertEqual(artifacts["ks-2024-presidential-results"]["expectedCounts"]["stateTotal"], 1327591)
+        self.assertEqual(artifacts["ks-2024-general-us-house-precinct"]["expectedCounts"]["reviewRows"], 3739)
+        self.assertEqual(artifacts["ks-2024-eac-turnout"]["confidence"], "loaded_official_fallback")
+        self.assertEqual(artifacts["ks-2024-eac-turnout"]["expectedCounts"]["registeredVoters"], 2031119)
+        self.assertEqual(artifacts["ks-county-geometry"]["expectedCounts"]["geometryFeatures"], 105)
+        self.assertEqual(artifacts["ks-2024-equipment-context"]["confidence"], "loaded_context_only")
+
+        self.assertEqual(findings["stateNativeTurnout"]["status"], "not_loaded_eac_fallback_active")
+        self.assertEqual(findings["historicalBaselines"]["targetYears"], [2012, 2016, 2020])
+        self.assertEqual(findings["postElectionAudit"]["status"], "not_inventoried_or_normalized")
+        self.assertEqual(findings["cvrAvailability"]["status"], "not_loaded")
+        self.assertIn("not claims of fraud or misconduct", inventory["displayApiCaveats"]["advisoryUse"])
+
+    def test_kansas_registries_are_aligned(self):
+        tiers = self.load_json("data/source-acquisition-tiers.json")
+        native_packages = self.load_json("data/native-import-source-packages.json")
+        turnout_packages = self.load_json("data/turnout-source-packages.json")
+        admin_packages = self.load_json("data/admin-source-packages.json")
+
+        tier = next(entry for entry in tiers["states"] if entry["state"] == "KS" and entry["scope"] == "statewide")
+        self.assertEqual(tier["tier"], "tier_1_official_export_database")
+        self.assertIn("official precinct U.S. House comparison rows from SOS workbook", tier["availableFields"])
+        self.assertIn("data/ks-2024-data-coverage-inventory.json", tier["parserStatus"])
+
+        self.assertIn("KS", native_packages["completedNativeStates"])
+        native_ks = next(entry for entry in native_packages["states"] if entry["state"] == "KS")
+        self.assertEqual(native_ks["expected"]["localReviewRows"], 3739)
+        self.assertEqual(native_ks["artifacts"]["localReviewRows"]["comparisonContest"], "U.S. House")
+        self.assertIn("data/ks-2024-data-coverage-inventory.json", " ".join(native_ks["caveats"]))
+
+        turnout_ks = next(entry for entry in turnout_packages["loadedPackages"] if entry["state"] == "KS")
+        self.assertEqual(turnout_ks["expected"]["turnoutRows"], 105)
+        self.assertIn("EAC fallback", " ".join(turnout_ks["caveats"]))
+
+        admin_ks = next(entry for entry in admin_packages["stateYearStatuses"] if entry["state"] == "KS")
+        self.assertEqual(admin_ks["equipment"]["expectedJurisdictions"], 105)
+        self.assertEqual(admin_ks["audit"]["status"], "needs_data")
+        self.assertEqual(admin_ks["cvr"]["status"], "needs_data")
+        self.assertEqual(admin_ks["incidents"]["status"], "needs_data")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## State and task scope

Kansas / KS Wave 11 source coverage cleanup. This updates Kansas-specific provenance, source-package classification, turnout inventory notes, and focused tests. No production promotion was run.

## Sources added or confirmed

- Confirmed official Kansas SOS 2024 Presidential Results workbook as the loaded county result and presidential review source.
- Confirmed official Kansas SOS 2024 General U.S. House precinct workbook as the same-grain comparison review source.
- Confirmed official Kansas SOS certified vote totals PDF as provenance/reference context.
- Confirmed EAC 2024 V2 Kansas county/jurisdiction turnout fallback rows.
- Confirmed Census TIGERweb county geometry and existing Verified Voting county equipment context.
- Added `data/ks-2024-data-coverage-inventory.json` documenting loaded artifacts and remaining gaps.

## Scripts/configs changed

- `etl/state-configs/ks.json`: registers Kansas equipment context and coverage inventory as candidate provenance sources; expected source count updated to 7.
- `data/source-acquisition-tiers.json`: upgrades KS from unknown/county-only to loaded official XLSX precinct review coverage with EAC fallback caveats.
- `data/native-import-source-packages.json`: adds KS package and completed-native status.
- `data/turnout-source-packages.json` and `docs/turnout-collection-inventory.md`: document KS EAC fallback turnout as loaded fallback while Kansas-native turnout remains needed.
- `docs/native-import-source-packages.md`: adds Kansas Wave 11 summary.
- `tests/python/test_kansas_coverage_inventory.py`: adds focused registry/inventory assertions.

## Validation commands run

- `python -m unittest tests.python.test_kansas_coverage_inventory` - pass
- `npm run etl:validate:ks` - pass, with expected candidate-source warnings for the equipment context and coverage inventory provenance sources
- `npm run etl:import:ks` - pass after sandbox escalation to create `.etl/staging`
- `npm run native:report-indicators -- .etl/staging` - pass
- `npm run validate:source-packages` - pass with existing non-KS legacy bundle/app-ready warnings
- `npm run validate:turnout-packages` - pass
- `npm run validate:maps` - pass with existing non-KS equipment-geometry warnings
- `npm run validate:provenance` - pass
- `npm run validate:admin-packages` - pass
- `npm run typecheck` - pass after `npm install`
- `npm run build` - pass after `npm install`
- `npm test` - pass on rerun with longer timeout
- `git diff --cached --check` - pass

## Website/API display path checked

- Source and coverage display paths are documented in the KS inventory for `/api/sources`, `/api/coverage`, `/api/native-source-packages`, `/api/turnout-sources`, and `/api/admin-sources`.
- `validate:maps` confirmed KS production county map joins: 105 result rows, 105 boundaries, 0 unmatched/unmapped rows.
- `validate:provenance` confirmed KS production provenance currently has 105 result rows, 4 source records, 0 missing source IDs, and 0 missing source URLs. The newly added source records are staging/config provenance until production promotion is separately authorized.

## Advisory indicator report

From `npm run native:report-indicators -- .etl/staging`:

- Native review row count: 3,739
- Calculated advisory indicator row count: 155
- Flagged county/jurisdiction count: 95
- Flagged area count: 95
- Indicator types: `vote_share_pattern` (76), `average_down_ballot_difference` (78), `down_ballot_outliers` (1)
- Production API/DB reflection: production stored indicator counts were not checked; no promotion or `native:counts` command was run.

These are advisory screening/context signals only, not claims of fraud or misconduct.

## Caveats and remaining risks

- Kansas turnout remains EAC fallback until a Kansas-native ballots-cast plus registered-voter denominator artifact is collected and reconciled.
- U.S. House is district-based, so KS review rows are advisory context rather than a single statewide comparison contest.
- Three nonzero presidential local rows lack matching U.S. House comparison rows and remain vote-share-only rows.
- County geometry is loaded; precinct boundary geometry/crosswalks are not loaded.
- 2012/2016/2020 official historical baseline rows are not loaded.
- Audit, CVR availability, incident/correction, recount, and litigation records remain unnormalized source/request gaps.

## Review result

No review subagent tool was available in this session. Local diff review plus `git diff --cached --check` found no issues.