### PR TITLE
[codex] Fix default API year filters

### DIFF
--- a/src/app/api/coverage/route.ts
+++ b/src/app/api/coverage/route.ts
@@ -4,7 +4,7 @@ import { apiEnvelope, getCoverageSummary, publicDataCacheHeaders, stateQuery, ye
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const state = stateQuery.parse(params.get("state") ?? "");
-  const year = yearQuery.parse(params.get("year") ?? "");
+  const year = yearQuery.parse(params.get("year") ?? "2024");
 
   return NextResponse.json(apiEnvelope(await getCoverageSummary({ state, year })), {
     headers: publicDataCacheHeaders,

--- a/src/app/api/indicators/route.ts
+++ b/src/app/api/indicators/route.ts
@@ -4,7 +4,7 @@ import { apiEnvelope, listIndicators, publicDataCacheHeaders, stateQuery, yearQu
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const state = stateQuery.parse(params.get("state") ?? "");
-  const year = yearQuery.parse(params.get("year") ?? "");
+  const year = yearQuery.parse(params.get("year") ?? "2024");
 
   return NextResponse.json(apiEnvelope(await listIndicators({ state, year })), {
     headers: publicDataCacheHeaders,

--- a/src/app/api/results/route.ts
+++ b/src/app/api/results/route.ts
@@ -4,7 +4,7 @@ import { apiEnvelope, levelQuery, listResults, publicDataCacheHeaders, stateQuer
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const state = stateQuery.parse(params.get("state") ?? "");
-  const year = yearQuery.parse(params.get("year") ?? "");
+  const year = yearQuery.parse(params.get("year") ?? "2024");
   const level = levelQuery.parse(params.get("level") ?? "county");
 
   return NextResponse.json(apiEnvelope(await listResults({ state, year, level })), {

--- a/src/app/api/review-rows/route.ts
+++ b/src/app/api/review-rows/route.ts
@@ -4,7 +4,7 @@ import { apiEnvelope, listReviewRows, publicDataCacheHeaders, stateQuery, yearQu
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const state = stateQuery.parse(params.get("state") ?? "");
-  const year = yearQuery.parse(params.get("year") ?? "");
+  const year = yearQuery.parse(params.get("year") ?? "2024");
   const limit = Number(params.get("limit") ?? 500);
   const includeMetrics = params.get("includeMetrics") === "true";
 

--- a/src/app/api/sources/route.ts
+++ b/src/app/api/sources/route.ts
@@ -4,7 +4,7 @@ import { apiEnvelope, listSources, publicDataCacheHeaders, stateQuery, yearQuery
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const state = stateQuery.parse(params.get("state") ?? "");
-  const year = yearQuery.parse(params.get("year") ?? "");
+  const year = yearQuery.parse(params.get("year") ?? "2024");
 
   return NextResponse.json(apiEnvelope(await listSources({ state, year })), {
     headers: publicDataCacheHeaders,

--- a/src/app/api/turnout/route.ts
+++ b/src/app/api/turnout/route.ts
@@ -4,7 +4,7 @@ import { apiEnvelope, listTurnoutRows, publicDataCacheHeaders, stateQuery, yearQ
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const state = stateQuery.parse(params.get("state") ?? "");
-  const year = yearQuery.parse(params.get("year") ?? "");
+  const year = yearQuery.parse(params.get("year") ?? "2024");
   const limit = Number(params.get("limit") ?? 500);
 
   return NextResponse.json(apiEnvelope(await listTurnoutRows({ limit, state, year })), {

--- a/src/app/api/vote-methods/route.ts
+++ b/src/app/api/vote-methods/route.ts
@@ -4,7 +4,7 @@ import { apiEnvelope, listVoteMethodRows, publicDataCacheHeaders, stateQuery, ye
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const state = stateQuery.parse(params.get("state") ?? "");
-  const year = yearQuery.parse(params.get("year") ?? "");
+  const year = yearQuery.parse(params.get("year") ?? "2024");
   const limit = Number(params.get("limit") ?? 500);
   const method = params.get("method") ?? undefined;
 

--- a/tests/api/api-contract.test.mjs
+++ b/tests/api/api-contract.test.mjs
@@ -46,6 +46,25 @@ test("public API route contracts exist", () => {
   assert.match(api, /Vercel-CDN-Cache-Control/);
 });
 
+
+test("public year-filtered APIs default missing year to 2024", () => {
+  const routes = [
+    "src/app/api/results/route.ts",
+    "src/app/api/sources/route.ts",
+    "src/app/api/coverage/route.ts",
+    "src/app/api/indicators/route.ts",
+    "src/app/api/review-rows/route.ts",
+    "src/app/api/turnout/route.ts",
+    "src/app/api/vote-methods/route.ts",
+  ];
+
+  for (const route of routes) {
+    const content = readFileSync(route, "utf8");
+    assert.match(content, /yearQuery\.parse\(params\.get\("year"\) \?\? "2024"\)/);
+    assert.doesNotMatch(content, /yearQuery\.parse\(params\.get\("year"\) \?\? ""\)/);
+  }
+});
+
 test("map joins support repository GeoJSON county name variants", () => {
   const explorer = readFileSync("src/app/results-explorer.tsx", "utf8");
   assert.match(explorer, /county_name/);


### PR DESCRIPTION
## Summary

Fixes public API routes that parsed a missing `year` query as an empty string. Zod coerced that to `0`, causing production 500s on endpoints such as `/api/results?state=AR` and `/api/indicators?state=AR` after Wave 11 verification.

Routes now default omitted year filters to 2024, matching the app's current public election cycle.

## Validation

- node tests/api/api-contract.test.mjs
- npm run typecheck
- npm run build