### PR TITLE
Add Louisiana Wave 12 source coverage inventory

### DIFF
--- a/data/la-2024-data-coverage-inventory.json
+++ b/data/la-2024-data-coverage-inventory.json
@@ -1,0 +1,130 @@
+{
+  "checkedAt": "2026-07-02",
+  "state": "LA",
+  "stateName": "Louisiana",
+  "electionYear": 2024,
+  "status": "official_precinct_results_review_eac_turnout_parish_geometry_equipment_context_loaded",
+  "summary": "Louisiana has official Secretary of State 2024 parish presidential totals derived from precinct CSV rows, official precinct and vote-mode President-versus-U.S.-House review rows, EAC 2024 V2 jurisdiction turnout fallback rows, Census parish geometry, and county/parish equipment context. State-native turnout, precinct boundary geometry, 2012/2016/2020 historical baseline rows, and normalized audit/CVR/incident/correction/recount/litigation records remain uncollected.",
+  "officialSourcePages": [
+    "https://voterportal.sos.la.gov/static/",
+    "https://voterportal.sos.la.gov/static/20241105/resultsRace/Presidential",
+    "https://s3-us-west-2.amazonaws.com/mediaresults.sos.la.gov/HumanReadableElectionResults/20241105/Election+Results+(11-05-2024).xlsx",
+    "https://www.eac.gov/research-and-data/studies-and-reports",
+    "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE%3D%2722%27&outFields=NAME,BASENAME,GEOID,STATE,COUNTY&returnGeometry=true&outSR=4326&f=geojson"
+  ],
+  "loadedArtifacts": [
+    {
+      "id": "la-2024-sos-precinct-csv-results",
+      "sourceTitle": "Louisiana Secretary of State official 2024 general election precinct CSV results",
+      "sourceUrl": "https://voterportal.sos.la.gov/static/20241105/resultsRace/Presidential",
+      "localArtifact": "data/la-2024-general-election-results",
+      "reportingGrain": "precinct_vote_mode",
+      "parserNormalizationPath": "louisianaSosPrecinctCsvDirectory via etl/state-configs/la.json certifiedResults and reviewCharts",
+      "expectedCounts": { "parishRows": 64, "reviewRows": 3885, "stateTotal": 2006975, "trump": 1208505, "harris": 766870, "other": 31600 },
+      "confidence": "loaded_official",
+      "caveats": [
+        "President rows are aggregated to parish result rows for the map while local review rows retain parish, ward, precinct, and vote-mode keys where available.",
+        "U.S. House is district-based and candidate-specific, so Louisiana review charts are advisory source-review context rather than a statewide same-office comparison."
+      ]
+    },
+    {
+      "id": "la-2024-sos-human-readable-results",
+      "sourceTitle": "Louisiana Secretary of State 2024 general election human-readable workbook",
+      "sourceUrl": "https://s3-us-west-2.amazonaws.com/mediaresults.sos.la.gov/HumanReadableElectionResults/20241105/Election+Results+(11-05-2024).xlsx",
+      "localArtifact": "data/la-2024-general-election-results.xlsx",
+      "reportingGrain": "parish",
+      "parserNormalizationPath": "louisianaSosHumanReadableWorkbook retained in etl/state-configs/la.json sources for provenance/manual inspection",
+      "expectedCounts": { "parishRows": 64, "stateTotal": 2006975 },
+      "confidence": "loaded_official_reference",
+      "caveats": [
+        "The active native ETL reads the paired official precinct CSV artifacts directly; the workbook is retained for provenance and manual reconciliation."
+      ]
+    },
+    {
+      "id": "la-2024-eac-turnout",
+      "sourceTitle": "U.S. EAC 2024 EAVS V2 Louisiana jurisdiction turnout fallback",
+      "sourceUrl": "https://www.eac.gov/research-and-data/studies-and-reports",
+      "localArtifact": "data/eac-2024-state-turnout/la-2024-eac-turnout.csv",
+      "reportingGrain": "jurisdiction_parish",
+      "parserNormalizationPath": "eacTurnoutCsv via etl/state-configs/la.json turnout",
+      "expectedCounts": { "turnoutRows": 64, "ballotsCast": 2021588, "registeredVoters": 3046376 },
+      "confidence": "loaded_official_fallback",
+      "caveats": [
+        "Prefer a Louisiana-native turnout and registration denominator artifact if one is collected and reconciled.",
+        "EAC jurisdiction rows are official fallback denominator rows, not a substitute for precinct vote-history or ballot-cast records."
+      ]
+    },
+    {
+      "id": "la-county-geometry",
+      "sourceTitle": "U.S. Census TIGERweb Louisiana parish geography",
+      "sourceUrl": "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE%3D%2722%27&outFields=NAME,BASENAME,GEOID,STATE,COUNTY&returnGeometry=true&outSR=4326&f=geojson",
+      "localArtifact": "data/la-counties.geojson",
+      "reportingGrain": "parish",
+      "parserNormalizationPath": "censusTigerwebCountyGeojson via etl/state-configs/la.json",
+      "expectedCounts": { "geometryFeatures": 64 },
+      "confidence": "loaded_official",
+      "caveats": ["Parish geometry supports parish map joins only; precinct boundary geometry is not loaded."]
+    },
+    {
+      "id": "la-2024-equipment-context",
+      "sourceTitle": "Verified Voting Verifier Louisiana 2024 equipment context",
+      "sourceUrl": "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/22",
+      "localArtifact": "data/verifiedvoting-la-2024-equipment.json; data/la-2024-equipment-context.csv",
+      "reportingGrain": "parish_context",
+      "parserNormalizationPath": "verifiedVotingEquipment via admin-source package registry",
+      "expectedCounts": { "equipmentRows": 64 },
+      "confidence": "loaded_context_only",
+      "caveats": [
+        "Equipment context is not a vote, turnout, audit, CVR, incident, correction, recount, or litigation source and does not prove every precinct in a parish used one identical configuration."
+      ]
+    }
+  ],
+  "sourceFindings": {
+    "stateNativeTurnout": {
+      "status": "not_loaded_eac_fallback_active",
+      "currentArtifact": "data/eac-2024-state-turnout/la-2024-eac-turnout.csv",
+      "requestNeed": "Official Louisiana ballots-cast and registered-voter denominator rows with denominator timing and parish or precinct grain before replacing EAC fallback turnout."
+    },
+    "precinctBoundaryGeometry": {
+      "status": "not_loaded",
+      "loadedGeometry": { "localArtifact": "data/la-counties.geojson", "reportingGrain": "parish" },
+      "requestNeed": "Official statewide precinct boundary geometry or a precinct-to-parish crosswalk if subparish map overlays are required."
+    },
+    "historicalBaselines": {
+      "status": "not_loaded",
+      "targetYears": [2012, 2016, 2020],
+      "requestNeed": "Official Louisiana presidential result artifacts for 2012, 2016, and 2020 with parish totals, source URLs, parser path, and statewide reconciliation totals before enabling historical baseline rows."
+    },
+    "postElectionAudit": {
+      "status": "not_normalized",
+      "requestNeed": "Official 2024 Louisiana post-election audit selection and outcome artifacts, if published or obtainable, with parish/reporting-unit grain and discrepancy fields."
+    },
+    "cvrAvailability": {
+      "status": "not_loaded",
+      "requestNeed": "Official SOS or parish CVR availability records, public-records request responses, or documented nonavailability notes before claiming CVR coverage."
+    },
+    "incidentsCorrectionsRecountsLitigation": {
+      "status": "not_loaded",
+      "requestNeed": "Official incident, correction, recount, election-contest, or litigation records for the 2024 general election, normalized only after authoritative source collection."
+    }
+  },
+  "displayApiCaveats": {
+    "publicSourceRoutesChecked": [
+      "/api/sources?state=LA&year=2024",
+      "/api/coverage?state=LA&year=2024",
+      "/api/native-source-packages?state=LA&year=2024",
+      "/api/turnout-sources?state=LA&year=2024",
+      "/api/admin-sources?state=LA&year=2024"
+    ],
+    "advisoryUse": "Louisiana advisory indicators use official precinct and vote-mode President-versus-U.S.-House review rows. U.S. House is district-based, and the review rows are screening/context signals only, not claims of fraud or misconduct.",
+    "productionPromotion": "Not authorized from worker branch; no native:promote or native:counts run."
+  },
+  "gaps": [
+    { "artifact": "state_native_turnout_denominator", "status": "not_loaded_eac_fallback_active", "remainingRisk": "EAC fallback turnout is official but not Louisiana-native and may not match Secretary of State denominator semantics." },
+    { "artifact": "precinct_boundary_geometry", "status": "not_loaded", "remainingRisk": "Public map joins remain parish geometry only." },
+    { "artifact": "historical_presidential_baselines_2012_2016_2020", "status": "not_loaded", "remainingRisk": "Historical context remains disabled until official artifacts are collected and normalized." },
+    { "artifact": "post_election_audit_rows", "status": "not_loaded", "remainingRisk": "No normalized audit selection/outcome rows are available." },
+    { "artifact": "cvr_availability_rows", "status": "not_loaded", "remainingRisk": "No CVR availability table or CVR dataset is available." },
+    { "artifact": "incident_correction_recount_litigation_rows", "status": "not_loaded", "remainingRisk": "Official records remain request/source-collection items." }
+  ]
+}

--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -17,6 +17,7 @@
     "IL",
     "KS",
     "KY",
+    "LA",
     "MD",
     "MI",
     "MN",
@@ -1221,6 +1222,83 @@
         "Historical baselines are county-level context only; the 2020 PD43+ county rows sum one non-D/R vote above the statewide summary line and the collector preserves official displayed county rows.",
         "County geometry is loaded, but no official precinct/ward/municipal geometry or reporting-unit crosswalk is loaded.",
         "The coverage inventory records audit/CVR/log/L&A/custody/incident/recount/litigation request paths only; normalized administration rows are not loaded."
+      ]
+    },
+    {
+      "state": "LA",
+      "name": "Louisiana",
+      "priority": 15,
+      "nativeReadiness": "complete_parish_map_precinct_review_eac_turnout_admin_context_inventory",
+      "authority": "Louisiana Secretary of State; U.S. Election Assistance Commission; U.S. Census Bureau; Verified Voting",
+      "configFile": "etl/state-configs/la.json",
+      "legacyReferenceBundle": "data/la-app-data.js",
+      "artifacts": {
+        "presidentialCountyResults": {
+          "sourceTitle": "Louisiana Secretary of State official 2024 general election precinct CSV results",
+          "sourceUrl": "https://voterportal.sos.la.gov/static/20241105/resultsRace/Presidential",
+          "localFile": "data/la-2024-general-election-results",
+          "parserHint": "louisianaSosPrecinctCsvDirectory aggregates official precinct/vote-mode President CSV rows to 64 parish result rows and reconciles to 2,006,975 presidential votes."
+        },
+        "localReviewRows": {
+          "sourceTitle": "Louisiana Secretary of State official 2024 general election precinct CSV results, U.S. House contests",
+          "sourceUrl": "https://voterportal.sos.la.gov/static/20241105/resultsRace/Presidential",
+          "localFile": "data/la-2024-general-election-results",
+          "level": "precinct_vote_mode",
+          "comparisonContest": "U.S. House",
+          "parserHint": "louisianaSosPrecinctCsvDirectory pairs President rows with U.S. House rows where parish, ward, precinct, and vote-mode keys align; district/candidate effects are caveated in reviewCharts."
+        },
+        "turnout": {
+          "sourceTitle": "EAC 2024 jurisdiction turnout fallback",
+          "sourceUrl": "https://www.eac.gov/research-and-data/studies-and-reports",
+          "localFile": "data/eac-2024-state-turnout/la-2024-eac-turnout.csv",
+          "level": "jurisdiction",
+          "denominator": "EAC A1a Total Reg registered voters",
+          "ballotsCast": "EAC normalized ballots cast"
+        },
+        "countyBoundary": {
+          "sourceTitle": "U.S. Census TIGERweb parish geography",
+          "sourceUrl": "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE%3D%2722%27&outFields=NAME,BASENAME,GEOID,STATE,COUNTY&returnGeometry=true&outSR=4326&f=geojson",
+          "localFile": "data/la-counties.geojson",
+          "nameProperty": "NAME",
+          "codeProperty": "COUNTY"
+        },
+        "coverageInventory": {
+          "sourceTitle": "Louisiana 2024 data coverage and administration source inventory",
+          "sourceUrl": "https://voterportal.sos.la.gov/static/",
+          "localFile": "data/la-2024-data-coverage-inventory.json",
+          "parserHint": "Documents loaded SOS/EAC/Census/equipment artifacts and remaining official-source request paths; no normalized administration rows are loaded beyond equipment context."
+        },
+        "equipmentContext": {
+          "sourceTitle": "Verified Voting Verifier Louisiana 2024 equipment context",
+          "sourceUrl": "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/22",
+          "localFile": "data/la-2024-equipment-context.csv",
+          "parserHint": "Context only; do not use for votes, turnout, audit conclusions, incidents, or proof of precinct-uniform equipment."
+        }
+      },
+      "expected": {
+        "countyRows": 64,
+        "geometryFeatures": 64,
+        "stateTotal": 2006975,
+        "trump": 1208505,
+        "harris": 766870,
+        "other": 31600,
+        "localReviewRows": 3885,
+        "turnoutRows": 64
+      },
+      "validationStatus": {
+        "localArtifactsPresent": true,
+        "generatedBundleTotalsReconcile": true,
+        "reviewMode": "president_vs_us_house_precinct_vote_mode",
+        "turnoutMode": "eac_2024_v2_jurisdiction_fallback",
+        "adminInventoryStatus": "equipment_context_loaded_audit_cvr_incident_paths_documented_not_normalized"
+      },
+      "caveats": [
+        "Louisiana uses parishes rather than counties; package fields named countyRows/countyBoundary represent parish rows and parish geometry for validator compatibility.",
+        "U.S. House is district-based and candidate-specific, so review rows are advisory source-review context rather than same-office statewide comparison rows.",
+        "Turnout rows use EAC 2024 V2 jurisdiction fallback data until a state-native Louisiana turnout and registration denominator artifact is collected.",
+        "Parish geometry is loaded; precinct boundary geometry or precinct-to-parish crosswalks are not loaded.",
+        "Equipment context is loaded from Verified Voting as supplemental administration metadata; normalized official audit/recount/CVR/incident/correction/litigation rows are not loaded.",
+        "Official 2012, 2016, and 2020 historical baseline rows are not loaded; data/la-2024-data-coverage-inventory.json records the remaining official-source need."
       ]
     }
   ],

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -715,30 +715,45 @@
       "stateName": "Louisiana",
       "jurisdictionName": "Statewide",
       "scope": "statewide",
-      "dataFamily": "results_turnout",
-      "tier": "unknown",
-      "reportingGrain": "parish",
+      "dataFamily": "results_review_turnout_equipment_admin_context",
+      "tier": "tier_2_official_dashboard_endpoint",
+      "reportingGrain": "precinct_vote_mode_and_parish",
       "exportFormats": [
-        "eac fallback turnout"
+        "Louisiana SOS static precinct CSV endpoints",
+        "Louisiana SOS human-readable XLSX workbook",
+        "EAC fallback turnout CSV",
+        "Census TIGERweb GeoJSON"
       ],
       "sourceUrls": [
-        "https://voterportal.sos.la.gov/static/"
+        "https://voterportal.sos.la.gov/static/",
+        "https://voterportal.sos.la.gov/static/20241105/resultsRace/Presidential",
+        "https://s3-us-west-2.amazonaws.com/mediaresults.sos.la.gov/HumanReadableElectionResults/20241105/Election+Results+(11-05-2024).xlsx",
+        "https://www.eac.gov/research-and-data/studies-and-reports",
+        "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/State_County/MapServer/1/query?where=STATE%3D%2722%27&outFields=NAME,BASENAME,GEOID,STATE,COUNTY&returnGeometry=true&outSR=4326&f=geojson"
       ],
-      "exampleUrls": [],
+      "exampleUrls": [
+        "https://voterportal.sos.la.gov/static/20241105/resultsRace/Presidential"
+      ],
       "availableFields": [
-        "parish presidential totals",
-        "EAC fallback turnout"
+        "official parish presidential totals",
+        "official precinct and vote-mode President rows",
+        "official precinct and vote-mode U.S. House comparison rows where same-grain keys align",
+        "EAC fallback turnout rows",
+        "parish geometry",
+        "parish equipment context from Verified Voting Verifier",
+        "data/la-2024-data-coverage-inventory.json coverage inventory"
       ],
       "missingFields": [
-        "local review rows",
-        "same-grain comparison contest",
-        "state-native turnout denominator"
+        "state-native turnout denominator rows",
+        "precinct boundary geometry or precinct-to-parish crosswalks",
+        "official 2012/2016/2020 historical baseline artifacts normalized into ETL",
+        "normalized official audit, recount, CVR availability, incident, correction, and litigation rows"
       ],
-      "parserStatus": "EAC turnout config exists; local review source not classified",
-      "manualReviewBurden": "unknown",
-      "confidence": "candidate",
-      "caveats": "Louisiana uses parishes rather than counties.",
-      "nextAction": "Classify official Louisiana result exports and precinct/parish comparison availability."
+      "parserStatus": "louisianaSosPrecinctCsvDirectory loaded for official parish President result rows and precinct/vote-mode President-versus-U.S.-House review rows; EAC fallback turnout, Census parish geometry, admin equipment context, and data/la-2024-data-coverage-inventory.json are documented",
+      "manualReviewBurden": "medium",
+      "confidence": "loaded_with_caveat",
+      "caveats": "Louisiana uses parishes rather than counties. U.S. House is district-based and candidate-specific, so review rows are advisory source-review context, not same-office statewide comparison rows. EAC turnout remains a fallback until state-native denominator artifacts are collected.",
+      "nextAction": "Collect state-native turnout/registration denominator rows, precinct boundary geometry/crosswalks, official 2012/2016/2020 historical baseline artifacts, and normalized audit/CVR/incident/correction/recount/litigation records."
     },
     {
       "state": "MA",

--- a/docs/native-import-source-packages.md
+++ b/docs/native-import-source-packages.md
@@ -397,3 +397,19 @@ Expected validation: 62 county result rows, 62 county geometry features, 9,753 s
 Expected validation: 58 county result rows, 58 county geometry features, 58 county review rows, 58 county turnout rows, 174 historical baseline rows, 15,865,475 presidential votes, 9,276,179 Harris votes, 6,081,697 Trump votes, and 507,599 other presidential votes.
 
 Caveats: review rows are county-level President-versus-U.S.-Senate full-term comparisons, not precinct or city/local scatter plots. The SOS turnout denominator is the 15-day Report of Registration and excludes later Same Day Voter Registration updates. County geometry is loaded; precinct geometry and normalized audit/CVR/incident/correction/recount/litigation rows are not loaded. Current advisory rows are public-interest screening inputs only, not findings.
+
+## Louisiana Wave 12 Update
+
+- Config: `etl/state-configs/la.json`
+- Authority: Louisiana Secretary of State; U.S. Election Assistance Commission; U.S. Census Bureau; Verified Voting equipment context
+- Parish results source: `data/la-2024-general-election-results`, parsed from official Louisiana SOS static precinct CSV rows
+- Local review source: `data/la-2024-general-election-results`
+- Comparison contest: U.S. House by district, matched at parish/ward/precinct/vote-mode keys where available
+- Turnout source: EAC 2024 parish/jurisdiction fallback rows at `data/eac-2024-state-turnout/la-2024-eac-turnout.csv`
+- Parish boundary: `data/la-counties.geojson`
+- Coverage/admin inventory: `data/la-2024-data-coverage-inventory.json`
+- Equipment context: `data/la-2024-equipment-context.csv` from Verified Voting, context only
+
+Expected validation: 64 parish result rows, 64 parish geometry features, 3,885 precinct/vote-mode review rows, 64 EAC fallback turnout rows, 2,006,975 presidential votes, 1,208,505 Trump votes, 766,870 Harris votes, and 31,600 other presidential votes.
+
+Caveats: Louisiana uses parishes rather than counties, and current map joins are parish-level. U.S. House is district-based and candidate-specific, so review rows are advisory source-review context rather than same-office statewide comparison rows. State-native turnout, precinct boundary geometry/crosswalks, official 2012/2016/2020 historical baselines, and normalized official audit/CVR/incident/correction/recount/litigation rows remain source-collection gaps. Current advisory rows are public-interest screening inputs only, not findings.

--- a/docs/turnout-collection-inventory.md
+++ b/docs/turnout-collection-inventory.md
@@ -148,3 +148,7 @@ California now uses official Secretary of State 2024 General Election voter part
 ## Massachusetts Update
 
 Massachusetts currently uses official EAC 2024 V2 jurisdiction fallback turnout rows at `data/eac-2024-state-turnout/ma-2024-eac-turnout.csv`, totaling 351 jurisdiction rows, 3,512,930 ballots cast, and 5,142,343 registered voters. Wave 11 confirmed the official Massachusetts Secretary turnout statistics page reports the same 2024 statewide registered-voter and total-votes-cast figures, so the statewide denominator is cross-checked. The state page is not a local turnout replacement because it does not provide the city/town, ward, or precinct rows needed to replace the active EAC fallback package. See `data/ma-2024-data-coverage-inventory.json` for source URLs, caveats, and request fields.
+
+## Louisiana Update
+
+Louisiana currently uses official EAC 2024 V2 parish/jurisdiction fallback turnout rows at `data/eac-2024-state-turnout/la-2024-eac-turnout.csv`, totaling 64 rows, 2,021,588 ballots cast, and 3,046,376 registered voters. Native Louisiana result and review rows are loaded from official Louisiana Secretary of State precinct CSV artifacts, but no Louisiana-native ballots-cast plus registered-voter denominator package was loaded in this pass. Keep EAC fallback active until a Secretary of State or parish denominator artifact is collected, normalized, and reconciled. See `data/la-2024-data-coverage-inventory.json` for the current source and caveat record.

--- a/etl/state-configs/la.json
+++ b/etl/state-configs/la.json
@@ -48,6 +48,28 @@
       "timestampBasis": "Census TIGERweb parish geography service artifact.",
       "confidence": "Parish geometry is used for Louisiana parish map joins; precinct boundary geometry is not included in this package.",
       "status": "loaded"
+    },
+    {
+      "id": "la-2024-equipment-context",
+      "category": "Parish equipment context",
+      "url": "https://verifiedvoting.org/verifier/#mode/navigate/map/voteEquip/mapType/ppEquip/year/2024/state/22",
+      "localFile": "data/la-2024-equipment-context.csv",
+      "parser": "verifiedVotingEquipmentContext",
+      "authority": "Verified Voting Verifier",
+      "timestampBasis": "Verifier parish equipment context artifact retained for 2024 Louisiana administration metadata.",
+      "confidence": "Context only. Parish-level equipment rows are not vote, turnout, audit, CVR, or incident records and do not prove precinct-level uniformity.",
+      "status": "candidate"
+    },
+    {
+      "id": "la-2024-data-coverage-inventory",
+      "category": "Louisiana source coverage and remaining-gap inventory",
+      "url": "https://voterportal.sos.la.gov/static/",
+      "localFile": "data/la-2024-data-coverage-inventory.json",
+      "parser": "sourceCoverageInventoryJson",
+      "authority": "Louisiana Secretary of State; U.S. Election Assistance Commission; U.S. Census Bureau; Verified Voting Verifier",
+      "timestampBasis": "Wave 12 Louisiana coverage inventory created July 2, 2026 from committed official artifacts, official source pages, and source-package registries.",
+      "confidence": "Inventory only. Documents loaded official precinct result/review artifacts, EAC fallback turnout, parish geometry, equipment context, and remaining historical, audit, CVR, incident, correction, recount, litigation, turnout, and precinct-geometry gaps.",
+      "status": "candidate"
     }
   ],
   "turnout": {
@@ -87,7 +109,7 @@
   "expected": {
     "jurisdictions": 64,
     "resultRows": 64,
-    "sources": 4,
+    "sources": 6,
     "stateTotal": 2006975,
     "trump": 1208505,
     "harris": 766870,

--- a/tests/python/test_louisiana_coverage_inventory.py
+++ b/tests/python/test_louisiana_coverage_inventory.py
@@ -1,0 +1,72 @@
+import json
+import unittest
+from pathlib import Path
+
+
+class LouisianaCoverageInventoryTests(unittest.TestCase):
+    def load_json(self, path):
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+
+    def test_louisiana_config_registers_official_sources_and_inventory(self):
+        config = self.load_json("etl/state-configs/la.json")
+        sources = {source["id"]: source for source in config["sources"]}
+
+        self.assertEqual(config["expected"]["sources"], len(config["sources"]))
+        self.assertEqual(config["expected"]["resultRows"], 64)
+        self.assertEqual(config["expected"]["reviewRows"], 3885)
+        self.assertEqual(config["expected"]["turnoutRows"], 64)
+        self.assertEqual(sources["la-2024-sos-precinct-csv-results"]["authority"], "Louisiana Secretary of State")
+        self.assertEqual(sources["la-2024-sos-precinct-csv-results"]["parser"], "louisianaSosPrecinctCsvDirectory")
+        self.assertEqual(sources["la-2024-data-coverage-inventory"]["localFile"], "data/la-2024-data-coverage-inventory.json")
+        self.assertEqual(sources["la-2024-equipment-context"]["status"], "candidate")
+        self.assertIn("district", config["reviewCharts"]["warning"])
+
+    def test_louisiana_inventory_keeps_loaded_and_missing_artifacts_distinct(self):
+        inventory = self.load_json("data/la-2024-data-coverage-inventory.json")
+        artifacts = {artifact["id"]: artifact for artifact in inventory["loadedArtifacts"]}
+        findings = inventory["sourceFindings"]
+
+        self.assertEqual(artifacts["la-2024-sos-precinct-csv-results"]["confidence"], "loaded_official")
+        self.assertEqual(artifacts["la-2024-sos-precinct-csv-results"]["expectedCounts"]["stateTotal"], 2006975)
+        self.assertEqual(artifacts["la-2024-sos-precinct-csv-results"]["expectedCounts"]["reviewRows"], 3885)
+        self.assertEqual(artifacts["la-2024-eac-turnout"]["confidence"], "loaded_official_fallback")
+        self.assertEqual(artifacts["la-2024-eac-turnout"]["expectedCounts"]["registeredVoters"], 3046376)
+        self.assertEqual(artifacts["la-county-geometry"]["expectedCounts"]["geometryFeatures"], 64)
+        self.assertEqual(artifacts["la-2024-equipment-context"]["confidence"], "loaded_context_only")
+
+        self.assertEqual(findings["stateNativeTurnout"]["status"], "not_loaded_eac_fallback_active")
+        self.assertEqual(findings["historicalBaselines"]["targetYears"], [2012, 2016, 2020])
+        self.assertEqual(findings["postElectionAudit"]["status"], "not_normalized")
+        self.assertEqual(findings["cvrAvailability"]["status"], "not_loaded")
+        self.assertIn("not claims of fraud or misconduct", inventory["displayApiCaveats"]["advisoryUse"])
+
+    def test_louisiana_registries_are_aligned(self):
+        tiers = self.load_json("data/source-acquisition-tiers.json")
+        native_packages = self.load_json("data/native-import-source-packages.json")
+        turnout_packages = self.load_json("data/turnout-source-packages.json")
+        admin_packages = self.load_json("data/admin-source-packages.json")
+
+        tier = next(entry for entry in tiers["states"] if entry["state"] == "LA" and entry["scope"] == "statewide")
+        self.assertEqual(tier["tier"], "tier_2_official_dashboard_endpoint")
+        self.assertIn("official precinct and vote-mode President rows", tier["availableFields"])
+        self.assertIn("data/la-2024-data-coverage-inventory.json", tier["parserStatus"])
+
+        self.assertIn("LA", native_packages["completedNativeStates"])
+        native_la = next(entry for entry in native_packages["states"] if entry["state"] == "LA")
+        self.assertEqual(native_la["expected"]["localReviewRows"], 3885)
+        self.assertEqual(native_la["artifacts"]["localReviewRows"]["comparisonContest"], "U.S. House")
+        self.assertIn("data/la-2024-data-coverage-inventory.json", " ".join(native_la["caveats"]))
+
+        turnout_la = next(entry for entry in turnout_packages["stateYearStatuses"] if entry["state"] == "LA")
+        self.assertEqual(turnout_la["expectedTurnoutRows"], 64)
+        self.assertIn("EAC", turnout_la["sourceTitle"])
+
+        admin_la = next(entry for entry in admin_packages["stateYearStatuses"] if entry["state"] == "LA")
+        self.assertEqual(admin_la["equipment"]["expectedJurisdictions"], 64)
+        self.assertEqual(admin_la["audit"]["status"], "needs_data")
+        self.assertEqual(admin_la["cvr"]["status"], "needs_data")
+        self.assertEqual(admin_la["incidents"]["status"], "needs_data")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds Louisiana Wave 12 source coverage inventory documenting loaded SOS precinct CSV results/review rows, EAC fallback turnout, Census parish geometry, equipment context, and remaining source gaps.
- Updates the LA ETL config, source acquisition tier, native package registry, and docs to reflect the already-loaded official Louisiana SOS precinct/vote-mode review path.
- Adds a focused Python coverage inventory test for LA registry/config alignment.

## Validation
- PASS `python -m civic_etl.cli validate --config etl/state-configs/la.json` (candidate-source warnings for inventory/equipment context only)
- PASS `python -m civic_etl.cli import --config etl/state-configs/la.json --out .etl/staging`
- PASS `npm run native:report-indicators -- .etl/staging`
- PASS `python -m unittest tests.python.test_louisiana_coverage_inventory`
- PASS `npm run validate:source-packages` (pre-existing legacy bundle warnings, plus LA app-data warning)
- PASS `npm run validate:source-acquisition-tiers`
- PASS `npm run validate:turnout-packages`
- PASS `npm run validate:admin-packages`
- PASS `npm run validate:maps` (pre-existing equipment geometry warnings, including LA 70 geometry features vs 64 equipment rows)
- PASS `npm run validate:provenance`
- PASS `npm run test`
- PASS `npm run typecheck`
- PASS `npm run build`
- PASS `git diff --check` (CRLF warnings only)

## Advisory Indicator Report
- Native review rows: 3,885
- Calculated advisory indicator rows: 75
- Flagged jurisdiction count: 48
- Flagged area count: 48
- Indicator types: `average_down_ballot_difference`, `vote_share_pattern`, `down_ballot_outliers`
- Production API/DB checked: no. No `native:promote` or `native:counts` run.

## Caveats / Remaining Risks
- Louisiana uses parishes rather than counties; public map joins remain parish-level.
- U.S. House is district-based and candidate-specific, so review rows are advisory source-review context, not same-office statewide comparison rows.
- State-native turnout, precinct boundary geometry/crosswalks, official 2012/2016/2020 historical baselines, and normalized official audit/CVR/incident/correction/recount/litigation rows remain source-collection gaps.
- `docs/developer/index.md` was absent during first reads.

Review result: coordinator self-review completed after validation; no unresolved LA-scoped issues found.