### PR TITLE
Document NY Wave 13 coverage status

### DIFF
--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -2070,6 +2070,11 @@
       "name": "New York",
       "priority": 10,
       "currentStatus": "official_county_results_historical_loaded_partial_local_review_eac_turnout_admin_paths_documented",
+      "completionDecision": {
+        "checkedAt": "2026-07-02",
+        "decision": "remain_in_source_discovery_queue",
+        "reason": "NY should remain in sourceDiscoveryQueue rather than completedNativeStates because local review rows are partial supplemental OpenElections/legacy NYC coverage, 13 county equivalents remain outside normalized review coverage, active turnout is still EAC fallback, and precinct/election-district geometry plus normalized audit/CVR/incident/recount/litigation rows are not loaded."
+      },
       "officialSourcePages": [
         "https://elections.ny.gov/election-results",
         "https://results.elections.ny.gov/",

--- a/data/ny-2024-data-coverage-inventory.json
+++ b/data/ny-2024-data-coverage-inventory.json
@@ -2,9 +2,35 @@
   "state": "NY",
   "stateName": "New York",
   "electionYear": 2024,
-  "checkedAt": "2026-07-01",
+  "checkedAt": "2026-07-02",
   "purpose": "State-scoped coverage inventory for New York 2024 result, review, turnout, map, historical, and election-administration context sources. This inventory records source availability and blockers; it does not promote production data and does not allege fraud or misconduct.",
   "status": "official_county_results_historical_loaded_partial_local_review_eac_turnout_admin_paths_documented",
+  "completionDecision": {
+    "checkedAt": "2026-07-02",
+    "decision": "remain_in_source_discovery_queue",
+    "reason": "New York has official county-certified President and U.S. Senate rows, county geometry, EAC fallback turnout, official county historical baselines, and partial supplemental local review rows, but it is not completed native coverage because the local review package is still partial, turnout is not state-native, and precinct/election-district geometry plus normalized audit/CVR/incident/recount/litigation records are not loaded.",
+    "reviewCoverage": {
+      "reviewRows": 9753,
+      "coveredCountyEquivalents": 49,
+      "missingCountyEquivalents": 13,
+      "excludedOrNotYetReviewedCounties": [
+        "Herkimer County",
+        "Jefferson County",
+        "Monroe County",
+        "Nassau County",
+        "Ontario County",
+        "Orange County",
+        "Orleans County",
+        "Oswego County",
+        "Rockland County",
+        "Schuyler County",
+        "Steuben County",
+        "Wyoming County",
+        "Yates County"
+      ]
+    },
+    "promotionCaveat": "Do not move NY to completedNativeStates until either statewide official same-grain local review coverage is collected or the coordinator intentionally accepts partial supplemental review coverage with visible caveats."
+  },
   "authorityPriority": "Official New York State Board of Elections, county boards of elections, official GIS/Census, EAC, and official court/board records first; OpenElections and Verified Voting remain supplemental context only.",
   "loadedArtifacts": [
     {
@@ -174,8 +200,8 @@
         "maps or district configuration documentation",
         "poll-site and reporting-unit downloads"
       ],
-      "result": "The Flateau/VEDA site is the official future statewide publication path for election results, poll sites, district maps, downloads, and compliance reports.",
-      "blocker": "As checked on 2026-07-01, the dashboard showed no election data available. The statute-backed collection path applies to elections on or after April 1, 2026, so it is a future source path rather than a 2024 replacement package."
+      "result": "The Flateau/VEDA site is the official future statewide publication path for election results, poll sites, district maps, downloads, and compliance reports. As checked again on 2026-07-02, the dashboard showed 0 total elections for 2026 and no election data available.",
+      "blocker": "The statute-backed collection path applies to elections on or after April 1, 2026, so it is a future source path rather than a 2024 replacement package."
     },
     {
       "sourceAuthority": "New York State Board of Elections",

--- a/docs/native-import-source-packages.md
+++ b/docs/native-import-source-packages.md
@@ -410,6 +410,10 @@ Expected validation: 120 county result rows, 120 county geometry features, 3,067
 
 Expected validation: 62 county result rows, 62 county geometry features, 9,753 supplemental local review rows, 62 EAC fallback turnout rows, and 186 official county historical baseline rows. Remaining risks: Herkimer, Jefferson, Monroe, Nassau, Ontario, Orange, Orleans, Oswego, Rockland, Schuyler, Steuben, Wyoming, and Yates remain outside normalized local review coverage; Monroe appears in the local-review manifest with zero parsed rows. County-certified NYSBOE rows remain the map authority. Remaining source needs are official full-state election-district President and U.S. Senate rows, state-native ballots-cast/voter-history rows paired with enrollment denominators, precinct/election-district geometry or crosswalks, and normalized audit/CVR/incident/correction/recount/litigation records. Current advisory rows are public-interest screening inputs only, not findings.
 
+## New York Wave 13 Check
+
+Wave 13 keeps NY in `sourceDiscoveryQueue` rather than `completedNativeStates`. The native staging artifact validates and produces 9,753 supplemental local review rows, but the coverage remains partial: 49 county equivalents are covered and 13 remain excluded or not yet reviewed, active turnout is still EAC fallback, and VEDA/Flateau is still a future official publication path rather than a 2024 replacement package. The completion decision is recorded in `data/ny-2024-data-coverage-inventory.json` and `data/native-import-source-packages.json`.
+
 ## California Wave 11 Update
 
 - Config: etl/state-configs/ca.json

--- a/docs/turnout-collection-inventory.md
+++ b/docs/turnout-collection-inventory.md
@@ -148,6 +148,10 @@ Kentucky currently uses official EAC 2024 V2 county/jurisdiction fallback turnou
 
 New York still uses official EAC 2024 V2 county/jurisdiction fallback turnout rows at `data/eac-2024-state-turnout/ny-2024-eac-turnout.csv`, totaling 62 rows, 8,389,626 ballots cast, and 13,579,416 registered voters. A July 1, 2026 official-source pass documented NYSBOE state-native denominator leads: the Enrollment by County page includes `Voters Registered by County as of 11/01/2024`, and the Enrollment by Election District page publishes county-by-county election-district enrollment reports. These are denominator leads only, not ballots-cast or voter-history turnout replacements. Keep NY in the native-turnout-needed path until a state-native ballots-cast/voter-history artifact is collected and reconciled with county or election-district enrollment denominators. See `data/ny-2024-data-coverage-inventory.json` for source URLs, request fields, and caveats.
 
+## New York Wave 13 Check
+
+The July 2, 2026 NY check did not identify a state-native ballots-cast or voter-history artifact that can replace EAC fallback turnout. The NYSBOE county enrollment report and election-district enrollment pages remain denominator leads only, and VEDA/Flateau still has no 2024 replacement data. Keep NY in the native-turnout-needed path.
+
 ## California Update
 
 California now uses official Secretary of State 2024 General Election voter participation rows at data/ca-2024-voter-participation-stats-by-county.csv, normalized from data/ca-2024-voter-participation-stats-by-county.pdf by scripts/normalize-ca-turnout.mjs. The rows include 58 counties, 16,140,044 total voters, and 22,595,659 registered voters. The registered-voter denominator is the SOS 15-day Report of Registration total, so it does not include voters who registered or updated registration through Same Day Voter Registration after the 15-day close. Current CA turnout is county-level and should stay caveated if future precinct/local review rows are added.

--- a/tests/api/native-import.test.mjs
+++ b/tests/api/native-import.test.mjs
@@ -80,11 +80,16 @@ test("review indicator reads require enabled review graph capability", () => {
 test("new york coverage inventory preserves supplemental review caveats", () => {
   const config = JSON.parse(readFileSync("etl/state-configs/ny.json", "utf8"));
   const inventory = JSON.parse(readFileSync("data/ny-2024-data-coverage-inventory.json", "utf8"));
+  const nativePackages = JSON.parse(readFileSync("data/native-import-source-packages.json", "utf8"));
   const localReviewManifest = JSON.parse(readFileSync("data/ny-2024-local-review-sources.json", "utf8"));
   const localReview = inventory.loadedArtifacts.find((artifact) => artifact.id === "ny-2024-local-review-openelections");
+  const discoveryNy = nativePackages.sourceDiscoveryQueue.find((entry) => entry.state === "NY");
   const monroeSource = localReviewManifest.files.find((file) => file.file === "Monroe.xlsx");
   const rocklandSource = localReviewManifest.excludedFiles.find((file) => file.file === "Rockland (president only).xlsx");
 
+  assert.equal(inventory.completionDecision.decision, "remain_in_source_discovery_queue");
+  assert.equal(discoveryNy.completionDecision.decision, "remain_in_source_discovery_queue");
+  assert.equal(nativePackages.completedNativeStates.includes("NY"), false);
   assert.match(config.reviewCharts.warning, /county-certified result totals remain the map authority/);
   assert.equal(localReview.expectedCounts.reviewRows, 9753);
   assert.equal(localReview.expectedCounts.missingCountyEquivalents, 13);
@@ -97,4 +102,6 @@ test("new york coverage inventory preserves supplemental review caveats", () => 
   assert.ok(localReview.excludedOrNotYetReviewedCounties.includes("Rockland County"));
   assert.ok(localReview.excludedOrNotYetReviewedCounties.includes("Monroe County"));
   assert.match(inventory.displayCaveats.join(" "), /EAC turnout rows are fallback context/);
+  assert.match(inventory.completionDecision.reason, /turnout is not state-native/);
+  assert.match(discoveryNy.completionDecision.reason, /13 county equivalents/);
 });


### PR DESCRIPTION
## State and task scope

NY Wave 13 worker pass. This PR keeps New York in `sourceDiscoveryQueue` rather than moving it to `completedNativeStates`, with a documented completion decision and partial-review caveats.

## Sources added or confirmed

- Confirmed NYSBOE official county President/U.S. Senate source package remains loaded from document 476.
- Confirmed `data/ny-2024-local-review.csv` regenerates 9,753 supplemental local review rows from OpenElections/legacy NYC sources.
- Confirmed NYSBOE Enrollment by County and Enrollment by Election District remain denominator leads only.
- Rechecked VEDA/Flateau on July 2, 2026: still no 2024 replacement package; dashboard remains a future source path.

## Scripts/configs changed

- Updated `data/ny-2024-data-coverage-inventory.json` with a Wave 13 completion decision.
- Updated `data/native-import-source-packages.json` to record why NY remains in the discovery queue.
- Updated `docs/native-import-source-packages.md` and `docs/turnout-collection-inventory.md` with Wave 13 notes.
- Extended `tests/api/native-import.test.mjs` to guard the NY queue/completion decision.

## Validation commands run

- `npm install`
- `npm run etl:prepare:ny` (required elevation in this worktree to create `.etl` and rewrite generated artifacts)
- `npm run etl:import:ny` (required elevation in this worktree)
- `python -m civic_etl.cli validate --config etl/state-configs/ny.json`
- `npm run native:report-indicators -- .etl/staging`
- `node tests/api/native-import.test.mjs`
- `npm run validate:source-packages` (passes with pre-existing warnings for unrelated missing legacy bundles/app-ready county files)
- `npm run validate:turnout-packages`
- `npm run validate:admin-packages`
- `git diff --check`

## Website/API display path checked

Inspected the readiness/native source package path through `src/lib/native-source-packages.ts`, `/api/native-source-packages`, `/api/coverage`, `/api/results`, and the readiness page usage of `sourceDiscoveryQueue`. This change is metadata/docs/test only and does not promote production data.

## Advisory indicator counts

From `npm run native:report-indicators -- .etl/staging` for NY:

- Native review rows: 9,753
- Calculated advisory indicator rows: 84
- Flagged county/jurisdiction count: 49
- Flagged area count: 49
- Indicator types: `vote_share_pattern`, `average_down_ballot_difference`
- Production API/DB stored indicator counts: not checked; production promotion was not authorized.

## Caveats and remaining risks

NY remains partial. Local review rows cover 49 county equivalents and exclude or do not yet review 13 county equivalents: Herkimer, Jefferson, Monroe, Nassau, Ontario, Orange, Orleans, Oswego, Rockland, Schuyler, Steuben, Wyoming, and Yates. EAC turnout remains fallback until a state-native ballots-cast/voter-history artifact is paired with NYSBOE enrollment denominators. Precinct/election-district geometry, official statewide local result rows, and normalized audit/CVR/incident/recount/litigation records remain source-collection gaps.

No fraud or misconduct claims are made; advisory indicators remain source-review signals only.

## Review result

Requested read-only review subagent was not available as a callable tool in this session; tool discovery only exposed GitHub PR tools. I performed a read-only diff review locally, found one Markdown spacing issue, fixed it, and reran the focused checks. No remaining review findings.