### PR TITLE
Preserve data during turnout-only native promotions

### DIFF
--- a/src/db/legacy-import.ts
+++ b/src/db/legacy-import.ts
@@ -1155,8 +1155,9 @@ export async function importLegacyState(input: LegacyImportInput) {
     storedReviewRows += 1;
   }
 
+  const turnoutRows = Array.isArray(appData.turnoutData) ? appData.turnoutData : [];
   let storedTurnoutRows = 0;
-  for (const [index, row] of (appData.turnoutData ?? []).entries()) {
+  for (const [index, row] of turnoutRows.entries()) {
     if (!row.county || !Number.isFinite(row.ballotsCast)) {
       continue;
     }

--- a/src/db/native-import.ts
+++ b/src/db/native-import.ts
@@ -812,7 +812,7 @@ export async function promoteNativeStagingArtifact(path: string) {
     returning id
   `;
 
-  const shouldReplaceResultRows = native.resultRows.length > 0 || !artifact.capabilities.certifiedResults;
+  const shouldReplaceResultRows = native.resultRows.length > 0;
   if (shouldReplaceResultRows) {
     await sql`
       delete from result_rows
@@ -822,8 +822,7 @@ export async function promoteNativeStagingArtifact(path: string) {
   }
   const shouldReplaceReviewRows =
     native.reviewRows.length > 0 ||
-    (native.resultRows.length > 0 && "nativeReviewRows" in native.metrics) ||
-    !artifact.capabilities.reviewGraphs;
+    (native.resultRows.length > 0 && "nativeReviewRows" in native.metrics);
   if (shouldReplaceReviewRows) {
     await sql`
       delete from review_rows
@@ -836,7 +835,8 @@ export async function promoteNativeStagingArtifact(path: string) {
         and election_year = ${electionYear}
     `;
   }
-  if (native.turnoutRows.length > 0) {
+  const shouldReplaceTurnoutRows = native.turnoutRows.length > 0;
+  if (shouldReplaceTurnoutRows) {
     await sql`
       delete from turnout_rows
       where state_code = ${stateCode}
@@ -844,7 +844,7 @@ export async function promoteNativeStagingArtifact(path: string) {
     `;
   }
   const historicalRows = native.historicalRows ?? [];
-  const shouldReplaceHistoricalRows = historicalRows.length > 0 || !artifact.capabilities.historicalBaseline;
+  const shouldReplaceHistoricalRows = historicalRows.length > 0;
   if (shouldReplaceHistoricalRows) {
     await sql`
       delete from historical_result_rows
@@ -1132,13 +1132,32 @@ export async function promoteNativeStagingArtifact(path: string) {
       'Native official-source ETL promotion.'
     )
     on conflict (state_code, election_year) do update set
-      certified_results = excluded.certified_results,
-      map = excluded.map,
-      review_graphs = excluded.review_graphs,
-      turnout = excluded.turnout,
-      historical_baseline = excluded.historical_baseline,
+      certified_results = case
+        when ${shouldReplaceResultRows} then excluded.certified_results
+        else capability_flags.certified_results
+      end,
+      map = case
+        when ${shouldReplaceResultRows} then excluded.map
+        else capability_flags.map
+      end,
+      review_graphs = case
+        when ${shouldReplaceReviewRows} then excluded.review_graphs
+        else capability_flags.review_graphs
+      end,
+      turnout = case
+        when ${shouldReplaceTurnoutRows} then excluded.turnout
+        else capability_flags.turnout
+      end,
+      historical_baseline = case
+        when ${shouldReplaceHistoricalRows} then excluded.historical_baseline
+        else capability_flags.historical_baseline
+      end,
       source_planner = excluded.source_planner,
-      notes = excluded.notes
+      notes = case
+        when ${shouldReplaceResultRows || shouldReplaceReviewRows || shouldReplaceHistoricalRows} then excluded.notes
+        when capability_flags.notes is null or capability_flags.notes = '' then excluded.notes
+        else capability_flags.notes
+      end
   `;
 
   await sql`

--- a/tests/api/native-import.test.mjs
+++ b/tests/api/native-import.test.mjs
@@ -17,10 +17,10 @@ test("native importer promotes validated staging artifacts only", () => {
   assert.match(importer, /review_rows/);
   assert.match(importer, /turnout_rows/);
   assert.match(importer, /shouldReplaceResultRows/);
-  assert.match(importer, /!artifact\.capabilities\.certifiedResults/);
+  assert.doesNotMatch(importer, /\|\| !artifact\.capabilities\.certifiedResults/);
   assert.match(importer, /shouldReplaceReviewRows/);
   assert.match(importer, /"nativeReviewRows" in native\.metrics/);
-  assert.match(importer, /!artifact\.capabilities\.reviewGraphs/);
+  assert.doesNotMatch(importer, /!artifact\.capabilities\.reviewGraphs/);
   assert.match(importer, /delete from analysis_indicators/);
   assert.match(importer, /analysisIndicatorsForNativeRows/);
   assert.match(importer, /reviewScopesForNativeRows/);
@@ -49,10 +49,21 @@ test("native importer promotes validated staging artifacts only", () => {
   assert.match(importer, /storedIndicatorRows/);
   assert.match(policy, /downBallotAverageThresholdPct: 2/);
   assert.match(policy, /voteShareCorrelationThreshold: 0\.35/);
-  assert.match(importer, /certified_results = excluded\.certified_results/);
-  assert.match(importer, /if \(native\.turnoutRows\.length > 0\)/);
+  assert.match(importer, /certified_results = case/);
+  assert.match(importer, /else capability_flags\.certified_results/);
+  assert.match(importer, /review_graphs = case/);
+  assert.match(importer, /else capability_flags\.review_graphs/);
+  assert.match(importer, /const shouldReplaceTurnoutRows = native\.turnoutRows\.length > 0/);
+  assert.match(importer, /if \(shouldReplaceTurnoutRows\)/);
   assert.doesNotMatch(importer, /parseLegacyBundle/);
   assert.match(script, /promoteNativeStagingArtifact/);
+});
+
+test("legacy importer tolerates non-array legacy turnout payloads", () => {
+  const importer = readFileSync("src/db/legacy-import.ts", "utf8");
+
+  assert.match(importer, /const turnoutRows = Array\.isArray\(appData\.turnoutData\) \? appData\.turnoutData : \[\]/);
+  assert.match(importer, /for \(const \[index, row\] of turnoutRows\.entries\(\)\)/);
 });
 
 test("native staging indicator report uses the shared review policy", () => {


### PR DESCRIPTION
## Summary
- Prevent turnout-only native staging promotions from deleting existing result rows, review rows, analysis indicators, or historical baselines when the artifact does not contain replacement rows.
- Preserve existing map/review/certified/historical capability flags on native promotion unless that surface is actually replaced.
- Make the legacy importer tolerate non-array legacy turnout payloads so production recovery can complete cleanly.

## Production recovery performed
Restored legacy result/review/indicator rows and then re-promoted native turnout for AL, CO, CT, DE, HI, ME, ND, NJ, NM, RI, VT, and WY using the patched importer path.

## Verification
- `node tests/api/native-import.test.mjs`
- `npm run typecheck`
- `npm run validate:maps`
- `npm run validate:provenance`
- `npm test`
- `npm run build`
- Live API check for affected states: `/api/results`, `/api/review-rows`, `/api/indicators`, and `/api/turnout` all returned nonzero rows for AL, CO, CT, DE, HI, ME, ND, NJ, NM, RI, VT, and WY after recovery.

## Caveats
- Advisory indicators remain sourced screening signals only, not claims of fraud or misconduct.
- Some map validator output still intentionally skips states configured as turnout-only, even when restored legacy result rows are visible through the live API.