### PR TITLE
Correct Minnesota historical baseline capability

### DIFF
--- a/docs/native-import-source-packages.md
+++ b/docs/native-import-source-packages.md
@@ -55,6 +55,7 @@ Remaining gaps are a Colorado Clarity parser and committed official result artif
 - Turnout source: `data/mn-2024-general-federal-state-results-by-precinct-official.xlsx`
 - Turnout denominator: `REG7AM + EDR`
 - County boundary: `data/mn-counties.geojson`
+- Historical baseline status: not loaded in native ETL; production may still expose pre-native historical rows until official 2012/2016/2020 Minnesota source artifacts are normalized.
 
 Expected validation:
 
@@ -68,8 +69,9 @@ Expected validation:
 | State total | 3,253,920 |
 | Local review rows | 4,075 |
 | Turnout rows | 4,103 |
+| Native historical baseline rows | 0 |
 
-Caveat: precinct boundary GeoJSON is not included. County map joins are ready.
+Caveat: precinct boundary GeoJSON is not included. County map joins are ready. Native Minnesota historical baseline rows are not enabled until official historical source artifacts are collected, parsed, and reconciled.
 
 ## Michigan
 

--- a/etl/state-configs/mn.json
+++ b/etl/state-configs/mn.json
@@ -81,6 +81,6 @@
     "map": true,
     "reviewGraphs": true,
     "turnout": true,
-    "historicalBaseline": true
+    "historicalBaseline": false
   }
 }

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -204,6 +204,8 @@ class PipelineTests(unittest.TestCase):
         self.assertEqual(artifact["native"]["metrics"]["nativeReviewRows"], 4075)
         self.assertEqual(artifact["native"]["metrics"]["nativeComparisonRows"], 4075)
         self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutRows"], 4103)
+        self.assertFalse(artifact["capabilities"]["historicalBaseline"])
+        self.assertEqual(len(artifact["native"].get("historicalRows", [])), 0)
         self.assertTrue(any(row["coverageMode"] == "presidentVsSenate" for row in artifact["native"]["reviewRows"]))
 
     def test_pennsylvania_native_staging_parses_bulk_files(self):


### PR DESCRIPTION
## Summary
- Correct Minnesota native ETL metadata so it no longer advertises `historicalBaseline` without native historical source rows.
- Add a regression assertion that MN staging emits zero historical rows until official historical artifacts are collected.
- Document the distinction between MN pre-native production historical rows and active native ETL historical coverage.

## Production promotion performed
- Promoted validated SD staging to add 198 historical baseline rows for 2012/2016/2020 while preserving existing result/review/indicator surfaces.
- Promoted validated VA staging to load the full native artifact, including 400 historical rows for 2012/2016/2020 and recalculated advisory indicators.

## Verification
- `npm run etl:validate:mn`
- `python -m civic_etl.cli validate --config etl/state-configs/sd.json`
- `npm run etl:validate:va`
- `npm run native:report-indicators -- .etl/staging`
- `npm run validate:maps`
- `npm run validate:provenance`
- `python -m unittest tests.python.test_pipeline.PipelineTests.test_minnesota_native_staging_parses_precinct_workbook`
- `npm run validate:source-packages`
- `npm run typecheck`
- `npm test`
- `npm run build`

## Live API verification
- SD `/api/historical-baselines?state=SD` returns 198 rows across 2012, 2016, and 2020.
- VA `/api/historical-baselines?state=VA` returns 400 rows across 2012, 2016, and 2020.
- SD and VA results, review rows, indicators, turnout, maps, and provenance validators all pass.

## Caveats
- Minnesota still has production historical rows from pre-native data, but active native ETL does not yet regenerate them. Future MN work should collect and normalize official 2012/2016/2020 Minnesota historical artifacts before re-enabling native historical baselines.
- Advisory indicators remain source-driven screening signals only, not claims of fraud or misconduct.