### PR TITLE
Add generic native historical baseline loading

### DIFF
--- a/civic_etl/native.py
+++ b/civic_etl/native.py
@@ -5872,6 +5872,9 @@ def _assert_native_expected(config: EtlConfig, metrics: dict[str, Any]) -> None:
         "nativeReviewRows": config.expected.review_rows,
         "nativeTurnoutRows": config.expected.turnout_rows,
     }
+    expected_historical_rows = int_text(config.raw.get("expected", {}).get("historicalBaselineRows"))
+    if expected_historical_rows and "nativeHistoricalRows" in metrics:
+        checks["nativeHistoricalRows"] = expected_historical_rows
     mismatches = {
         key: {"actual": metrics.get(key), "expected": expected}
         for key, expected in checks.items()
@@ -5881,7 +5884,26 @@ def _assert_native_expected(config: EtlConfig, metrics: dict[str, Any]) -> None:
         raise ValueError(f"native {config.code} validation failed: {mismatches}")
 
 
-def build_native_payload(config: EtlConfig) -> dict[str, Any] | None:
+def _with_historical_baselines(
+    config: EtlConfig,
+    sources: dict[str, SourceConfig],
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    section = config.raw.get("historicalBaselines", {})
+    if section.get("format") != "historicalPresidentialCsv":
+        return payload
+    if "historicalRows" in payload:
+        return payload
+
+    historical_rows, historical_metrics = _historical_baseline_rows(config, sources)
+    return {
+        **payload,
+        "historicalRows": historical_rows,
+        "metrics": {**payload.get("metrics", {}), **historical_metrics},
+    }
+
+
+def _build_native_payload(config: EtlConfig) -> dict[str, Any] | None:
     turnout_format = config.raw.get("turnout", {}).get("format")
     if config.raw.get("turnoutOnly") and turnout_format in {"normalizedTurnoutCsv", "eacTurnoutCsv"}:
         sources = _source_map(config)
@@ -6421,3 +6443,14 @@ def build_native_payload(config: EtlConfig) -> dict[str, Any] | None:
         "turnoutRows": turnout_rows,
         "metrics": metrics,
     }
+
+
+def build_native_payload(config: EtlConfig) -> dict[str, Any] | None:
+    payload = _build_native_payload(config)
+    if payload is None:
+        return None
+
+    sources = _source_map(config)
+    payload = _with_historical_baselines(config, sources, payload)
+    _assert_native_expected(config, payload.get("metrics", {}))
+    return payload

--- a/tests/python/test_pipeline.py
+++ b/tests/python/test_pipeline.py
@@ -1304,6 +1304,111 @@ class PipelineTests(unittest.TestCase):
         self.assertEqual(ada_review["comparisonRepVotes"], 142602)
         self.assertEqual(ada_review["comparisonOtherVotes"], 12767)
 
+    def test_native_payload_appends_generic_historical_csv_rows(self):
+        tmp = self.fixture_dir("generic-historical-wrapper")
+        result_path = tmp / "id-results.csv"
+        historical_path = tmp / "id-historical.csv"
+        config_path = tmp / "id.json"
+        result_path.write_text(
+            "\n".join(
+                [
+                    "state,election_year,jurisdiction_name,trump,harris,other",
+                    "ID,2024,Ada,30,20,5",
+                    "ID,2024,Boise,30,15,0",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        historical_path.write_text(
+            "\n".join(
+                [
+                    "state,election_year,jurisdiction_name,source_id,source_level,row_method,dem_votes,rep_votes,other_votes,total_votes,source_url",
+                    "ID,2020,Ada,id-historical,county,fixture,100,120,5,225,https://example.test/id",
+                    "ID,2020,Boise,id-historical,county,fixture,80,90,3,173,https://example.test/id",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        config_path.write_text(
+            json.dumps(
+                {
+                    "code": "ID",
+                    "name": "Idaho",
+                    "authority": "Idaho Secretary of State",
+                    "electionYear": 2024,
+                    "office": "President",
+                    "sources": [
+                        {
+                            "id": "id-results",
+                            "category": "Fixture results",
+                            "url": "https://example.test/id-results",
+                            "localFile": result_path.as_posix(),
+                            "parser": "countyPresidentCsv",
+                            "authority": "Fixture",
+                            "timestampBasis": "Fixture",
+                            "confidence": "Fixture",
+                            "status": "loaded",
+                        },
+                        {
+                            "id": "id-historical",
+                            "category": "Fixture historical baseline",
+                            "url": "https://example.test/id-historical",
+                            "localFile": historical_path.as_posix(),
+                            "parser": "historicalPresidentialCsv",
+                            "authority": "Fixture",
+                            "timestampBasis": "Fixture",
+                            "confidence": "Fixture",
+                            "status": "loaded",
+                        },
+                    ],
+                    "expected": {
+                        "jurisdictions": 2,
+                        "resultRows": 2,
+                        "sources": 2,
+                        "stateTotal": 100,
+                        "trump": 60,
+                        "harris": 35,
+                        "other": 5,
+                        "reviewRows": 0,
+                        "turnoutRows": 0,
+                        "historicalBaselineRows": 2,
+                    },
+                    "capabilities": {
+                        "sourcePlanner": True,
+                        "certifiedResults": True,
+                        "map": False,
+                        "reviewGraphs": False,
+                        "turnout": False,
+                        "historicalBaseline": True,
+                    },
+                    "certifiedResults": {
+                        "format": "countyPresidentCsv",
+                        "sourceId": "id-results",
+                        "otherColumns": ["other"],
+                    },
+                    "historicalBaselines": {
+                        "format": "historicalPresidentialCsv",
+                        "sourceId": "id-historical",
+                        "expected": {"rowCount": 2, "years": [2020]},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        config = load_config(config_path)
+        report = validate_config(config)
+        artifact = build_staging_artifact(config, report)
+        native = artifact["native"]
+
+        self.assertTrue(report.passed)
+        self.assertEqual(native["parser"], "nativeIdahoCountyPresidentCsv")
+        self.assertEqual(native["metrics"]["nativeHistoricalRows"], 2)
+        self.assertEqual(native["metrics"]["nativeHistoricalYears"], [2020])
+        self.assertEqual(len(native["historicalRows"]), 2)
+        self.assertEqual(native["historicalRows"][0]["jurisdictionName"], "Ada County")
     def test_normalized_turnout_only_staging_parses_csv_contract(self):
         tmp = self.fixture_dir("normalized-turnout")
         csv_path = tmp / "az-turnout.csv"


### PR DESCRIPTION
## Summary
- wrap native payload creation so any state with the existing historicalPresidentialCsv config emits historicalRows without a state-specific native.py hook
- assert configured historicalBaselineRows once historical metrics are present
- add a fixture test covering a native parser path that does not manually load historical rows

## Validation
- python AST syntax parse for civic_etl/native.py and tests/python/test_pipeline.py
- python -m unittest tests.python.test_pipeline.PipelineTests.test_native_payload_appends_generic_historical_csv_rows
- python -m unittest tests.python.test_pipeline.PipelineTests.test_idaho_county_president_csv_builds_results_with_county_review_rows tests.python.test_pipeline.PipelineTests.test_kansas_presidential_house_xlsx_parser_builds_precinct_review_rows tests.python.test_pipeline.PipelineTests.test_native_payload_appends_generic_historical_csv_rows
- npm run test:etl

## Wave 16 coordination
This is the shared helper needed before AR/WV/NH/ID/KS historical-baseline PRs can safely enable production-visible historical rows without each state adding its own native importer hook.