### PR TITLE
Activate West Virginia historical baselines

### DIFF
--- a/data/wv-2024-data-coverage-inventory.json
+++ b/data/wv-2024-data-coverage-inventory.json
@@ -210,14 +210,14 @@
     },
     {
       "topic": "historicalBaselines",
-      "status": "normalized_artifact_collected_importer_dispatch_blocked",
+      "status": "loaded_generic_historical_importer",
       "sourceAuthority": "West Virginia Secretary of State",
       "sourceUrl": "https://sos.wv.gov/elections/Pages/HistElecResults.aspx",
       "localArtifactPath": "data/wv-historical-presidential-baseline.csv",
       "reportingGrain": "county",
-      "parserOrNormalizationPath": "scripts/collect-wv-historical-baseline.mjs generated historicalPresidentialCsv-compatible rows; WV native dispatch update is required before rows appear in staging/API",
+      "parserOrNormalizationPath": "scripts/collect-wv-historical-baseline.mjs generated historicalPresidentialCsv-compatible rows loaded by the generic native historical importer",
       "evidence": "The SOS historical results page links the official 2020 General Election Clarity archive and the official 2008-2017 results app. This pass collected official SOS county presidential rows for 2012, 2016, and 2020 and normalized 165 county baseline rows.",
-      "caveats": "Historical rows are contextual baselines only. The 2012 and 2016 SOS legacy CSVs state that results do not include write-in candidate information, and 2012 does not match write-in-inclusive statewide totals. WV native staging does not emit these rows until the shared native importer dispatch is updated.",
+      "caveats": "Historical rows are contextual baselines only. The 2012 and 2016 SOS legacy CSVs state that results do not include write-in candidate information, and 2012 does not match write-in-inclusive statewide totals.",
       "expectedRows": 165,
       "targetYears": [
         2012,
@@ -242,7 +242,7 @@
     "No official statewide precinct boundary geometry or precinct-to-result crosswalk is loaded, so current public map joins remain county-level even though WV has precinct review and turnout rows.",
     "Post-election hand-count audit policy is documented, but 2024 county selection/outcome artifacts are not normalized.",
     "CVR availability, recount outcomes, canvass corrections, complaint dispositions, incident records, and litigation records remain request-path items.",
-    "Historical baseline source artifacts and normalized CSV are collected for 2012, 2016, and 2020, but WV native staging/API emission is blocked until the shared native importer dispatch is updated.",
+    "Historical baseline source artifacts and normalized CSV are collected for 2012, 2016, and 2020 and load through the generic native historical importer, with write-in caveats retained for 2012 and 2016.",
     "Current advisory indicators are data/reconciliation signals only and are not evidence of fraud or misconduct."
   ]
 }

--- a/etl/state-configs/wv.json
+++ b/etl/state-configs/wv.json
@@ -129,7 +129,8 @@
     "harris": 214309,
     "other": 14525,
     "reviewRows": 1648,
-    "turnoutRows": 1649
+    "turnoutRows": 1649,
+    "historicalBaselineRows": 165
   },
   "capabilities": {
     "sourcePlanner": true,
@@ -137,7 +138,7 @@
     "map": true,
     "reviewGraphs": true,
     "turnout": true,
-    "historicalBaseline": false
+    "historicalBaseline": true
   },
   "certifiedResults": {
     "format": "westVirginiaClarityCountyDetailXmlDirectory",
@@ -153,5 +154,18 @@
     "comparisonContest": "United States Senator",
     "coverageMode": "presidentVsSenate",
     "warning": "West Virginia review rows are precinct-level President-versus-U.S. Senate comparisons from official Secretary of State county detail XML report ZIPs. They are advisory review inputs, not confirmed findings."
+  },
+  "historicalBaselines": {
+    "format": "historicalPresidentialCsv",
+    "sourceId": "wv-historical-presidential-baseline",
+    "warning": "West Virginia historical baseline rows are county-level presidential context for 2012, 2016, and 2020 from official West Virginia Secretary of State sources. The 2012 and 2016 legacy results app states that write-in candidate information is not included, so use these as contextual baseline rows only, not as write-in-inclusive certified totals.",
+    "expected": {
+      "rowCount": 165,
+      "years": [
+        2012,
+        2016,
+        2020
+      ]
+    }
   }
 }

--- a/tests/python/test_west_virginia_coverage_inventory.py
+++ b/tests/python/test_west_virginia_coverage_inventory.py
@@ -21,8 +21,8 @@ class WestVirginiaCoverageInventoryTests(unittest.TestCase):
         self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutRows"], 1649)
         self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutBallotsCast"], 770587)
         self.assertEqual(artifact["native"]["metrics"]["nativeTurnoutRegisteredVoters"], 1187991)
-        self.assertEqual(artifact["native"]["metrics"].get("nativeHistoricalRows", 0), 0)
-        self.assertFalse(artifact["capabilities"]["historicalBaseline"])
+        self.assertEqual(artifact["native"]["metrics"]["nativeHistoricalRows"], 165)
+        self.assertTrue(artifact["capabilities"]["historicalBaseline"])
 
         sources = {source["id"]: source for source in artifact["sources"]}
         inventory_source = sources["wv-2024-data-coverage-inventory"]
@@ -38,10 +38,10 @@ class WestVirginiaCoverageInventoryTests(unittest.TestCase):
         self.assertIn("Voter%20Data%20Request.pdf", findings["precinctBoundaryGeometry"]["relatedSourceUrls"][1])
         self.assertEqual(findings["postElectionAudit"]["status"], "policy_documented_outcomes_need_data")
         self.assertEqual(findings["cvrAvailabilityAndRequestPaths"]["status"], "request_path_documented_not_loaded")
-        self.assertEqual(findings["historicalBaselines"]["status"], "normalized_artifact_collected_importer_dispatch_blocked")
+        self.assertEqual(findings["historicalBaselines"]["status"], "loaded_generic_historical_importer")
         self.assertEqual(findings["historicalBaselines"]["expectedRows"], 165)
         self.assertIn("write-in candidate information", findings["historicalBaselines"]["caveats"])
-        self.assertIn("shared native importer dispatch", findings["historicalBaselines"]["caveats"])
+        self.assertIn("contextual baselines only", findings["historicalBaselines"]["caveats"])
         self.assertFalse(self.inventory["productionChecked"])
         self.assertTrue(any("not evidence of fraud or misconduct" in risk for risk in self.inventory["remainingRisks"]))
 


### PR DESCRIPTION
## Summary
- enable WV historicalBaseline capability and generic historicalPresidentialCsv loader
- assert 165 WV historical rows for 2012/2016/2020
- update WV coverage inventory from importer-blocked to generic importer enabled

## Validation
- npm run etl:import:wv
- python -m unittest tests.python.test_west_virginia_coverage_inventory tests.python.test_pipeline.PipelineTests.test_west_virginia_clarity_detailxml_parser_builds_precinct_rows
- npm run test:etl

## Production note
This fixes the Wave 16 promotion gate so WV historical rows are visible after promotion. Rows remain contextual baselines with the 2012/2016 write-in caveat.