### PR TITLE
Expose city-town result rows

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,6 +40,7 @@ export default async function Home({ searchParams }: HomeProps) {
     completenessReport,
     countyResults,
     cityResults,
+    cityTownResults,
     sources,
     coverage,
     importRuns,
@@ -57,6 +58,7 @@ export default async function Home({ searchParams }: HomeProps) {
     listCompletenessReport({ year: selectedYear }),
     listResults({ state: selectedState, year: selectedYear, level: "county" }),
     listResults({ state: selectedState, year: selectedYear, level: "city" }),
+    listResults({ state: selectedState, year: selectedYear, level: "city_town" }),
     listSources({ state: selectedState, year: selectedYear }),
     getCoverageSummary({ state: selectedState, year: selectedYear }),
     listImportRuns(),
@@ -70,8 +72,8 @@ export default async function Home({ searchParams }: HomeProps) {
     listElectronicIntegrityArtifacts({ state: selectedState, year: selectedYear }),
     listElectronicIntegrityRequests({ state: selectedState, year: selectedYear }),
   ]);
-  const results = countyResults.length ? countyResults : cityResults;
-  const resultLevelLabel = results[0]?.level === "city" ? "Municipality" : undefined;
+  const results = countyResults.length ? countyResults : cityResults.length ? cityResults : cityTownResults;
+  const resultLevelLabel = results[0]?.level === "city" || results[0]?.level === "city_town" ? "Municipality" : undefined;
   const selected = states.find((state) => state.code === selectedState);
   const selectedStateCode = selected?.code ?? selectedState;
   const selectedCompleteness = completenessReport.find((summary) => summary.state === selectedStateCode);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,7 +41,7 @@ export const officeQuery = z
   .default("president");
 
 export const levelQuery = z
-  .enum(["county", "state", "district", "precinct"])
+  .enum(["county", "state", "district", "precinct", "city", "city_town"])
   .default("county");
 
 export function apiEnvelope<T>(data: T, meta: Record<string, unknown> = {}) {

--- a/src/lib/data-access.ts
+++ b/src/lib/data-access.ts
@@ -1235,11 +1235,14 @@ export async function getCoverageSummary(input: {
     return getCoverage(input.state, input.year);
   }
 
-  const [stateList, results, sources] = await Promise.all([
+  const [stateList, countyResults, cityResults, cityTownResults, sources] = await Promise.all([
     listStates(),
     listResults({ state: input.state, year: input.year, level: "county" }),
+    listResults({ state: input.state, year: input.year, level: "city" }),
+    listResults({ state: input.state, year: input.year, level: "city_town" }),
     listSources(input),
   ]);
+  const results = countyResults.length ? countyResults : cityResults.length ? cityResults : cityTownResults;
   const state = stateList.find((entry) => entry.code === input.state);
 
   if (!state) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,7 +28,7 @@ export type ResultRow = {
   state: string;
   year: number;
   office: string;
-  level: "county" | "state" | "district" | "precinct" | "city" | "rest_of_county";
+  level: "county" | "state" | "district" | "precinct" | "city" | "city_town" | "rest_of_county";
   jurisdictionCode: string;
   jurisdictionName: string;
   votes: Record<string, number>;
@@ -118,7 +118,7 @@ export type AnalysisIndicator = {
   electionYear: number;
   jurisdictionCode: string;
   jurisdictionName: string;
-  level: "county" | "state" | "district" | "precinct" | "city" | "rest_of_county";
+  level: "county" | "state" | "district" | "precinct" | "city" | "city_town" | "rest_of_county";
   type: string;
   severity: number;
   label: string;


### PR DESCRIPTION
## Summary
- allow the public results API to accept city_town result levels
- load city_town result rows as the page fallback after county and city rows
- include city_town rows in coverage summary fallback counts

## Verification
- npm run typecheck
- node tests/api/api-contract.test.mjs
- npm run build

## Context
Wave 17 promoted Rhode Island result rows at city_town grain. The database rows and indicators were present, but /api/results rejected level=city_town and the page only fell back to city rows.