### PR TITLE
[codex] Document Indiana source discovery blocker

### DIFF
--- a/data/in-2024-data-coverage-inventory.json
+++ b/data/in-2024-data-coverage-inventory.json
@@ -6,6 +6,11 @@
   "purpose": "State-scoped coverage inventory for Indiana 2024 result, review, turnout, map, historical, and election-administration context sources. This inventory records source availability and blockers; it does not promote production data and does not allege fraud or misconduct.",
   "status": "official_county_results_turnout_2012_2016_2020_historical_loaded_supplemental_precinct_review_vstop_audit_summary_loaded",
   "authorityPriority": "Official Indiana Election Division, Indiana Election Commission/Recount Commission, county election offices, official GIS/Census, and EAC sources first; secondary sources are context only and caveated.",
+  "completionDecision": {
+    "checkedAt": "2026-07-03",
+    "decision": "remain_in_source_discovery_queue",
+    "reason": "Indiana should remain out of completedNativeStates because official public ENR artifacts provide county President and U.S. Senate rows only, the collected JurR county JSON files do not contain President or U.S. Senate candidate rows, and current subcounty advisory flags depend on supplemental MIT/OpenElections precinct rows with upstream caveats. Official county results, county turnout, official historical baselines, and VSTOP audit-summary context are loaded, but official same-grain precinct/subcounty President and U.S. Senate rows remain the blocker for completed native local-review coverage."
+  },
   "requestMatrixArtifact": "data/in-2024-source-request-matrix.tsv",
   "loadedArtifacts": [
     {
@@ -414,6 +419,12 @@
     "publicContactPath": "Indiana Election Division contact path shown on the Election Division page: elections@iec.in.gov / 317-232-3939.",
     "requestMatrixArtifact": "data/in-2024-source-request-matrix.tsv"
   },
+  "displayCaveats": [
+    "Indiana county map/result totals are official Indiana Election Division ENR county rows.",
+    "Indiana local review/advisory rows are supplemental MIT/OpenElections precinct context and should keep the supplemental-source warning until official same-grain precinct/subcounty President and U.S. Senate rows are obtained.",
+    "Indiana turnout is official county-level Election Division turnout and registration context; it is not precinct-level turnout and Voters Voting is election-level turnout, not presidential contest votes.",
+    "VSTOP audit-summary rows are official administration context for seven voluntarily audited counties only; they are not certified-result replacements and are not proof of fraud or misconduct."
+  ],
   "gaps": [
     {
       "artifact": "official_precinct_or_local_reporting_unit_results",

--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -1,5 +1,5 @@
 {
-  "checkedAt": "2026-07-02",
+  "checkedAt": "2026-07-03",
   "purpose": "Native importer handoff package for the next states after Ohio and Wisconsin.",
   "notes": [
     "These packages point to official source artifacts already present in this repository.",
@@ -2335,6 +2335,11 @@
       "name": "Indiana",
       "priority": 1,
       "currentStatus": "official_county_results_turnout_2012_2016_2020_historical_loaded_supplemental_precinct_review_vstop_audit_summary_loaded_official_precinct_rows_missing",
+      "completionDecision": {
+        "checkedAt": "2026-07-03",
+        "decision": "remain_in_source_discovery_queue",
+        "reason": "Indiana should remain in sourceDiscoveryQueue rather than completedNativeStates because official public ENR artifacts provide county President and U.S. Senate rows only, collected JurR county JSON files do not contain President or U.S. Senate candidate rows, and subcounty advisory flags still depend on supplemental MIT/OpenElections precinct rows with upstream caveats. County results, county turnout, official historical baselines, and VSTOP audit-summary context are loaded, but official same-grain precinct/subcounty President and U.S. Senate rows remain the local-review blocker."
+      },
       "officialSourcePages": [
         "https://web.archive.org/web/20241229230948id_/https://enr.indianavoters.in.gov/site/data/OffCatC_1019_A.json",
         "https://web.archive.org/web/20241229230948id_/https://enr.indianavoters.in.gov/site/data/OffCatC_1006_A.json",
@@ -2368,7 +2373,7 @@
       ],
       "preferredComparisonContest": "U.S. Senate; official ENR supports certified county totals, and MIT/OpenElections supplemental rows support local President-vs-U.S.-Senate advisory review.",
       "parserNeeded": "indianaEnrCountyJson package loaded for official county results; normalizedTurnoutCsv loaded for official county turnout; historicalPresidentialCsv loaded for official 2012/2016/2020 county baselines; indianaEnrJurisdictionDirectoryInventory collected; localComparisonCsv loaded for MIT/OpenElections supplemental precinct President and U.S. Senate rows; scripts/normalize-in-audit-summary.mjs loads official VSTOP 2024 audit summary context. Future parsers are needed only if an official precinct/subcounty result export, detailed audit workpapers, CVR availability records, or incident/correction/recount rows are obtained.",
-      "blocker": "Official Indiana ENR county category JSON is collected and parsed for certified 2024 county totals, official county turnout is loaded, official 2012/2016/2020 county historical baselines are normalized, and the official VSTOP 2024 General Election audit summary is loaded for seven audited counties as context. Official JurR county jurisdiction JSON files are inventoried but do not contain President or U.S. Senate candidate result rows. Advisory flags still use MIT/OpenElections supplemental local rows, with caveats that MIT flags Indiana Senate/Governor overreporting in some counties and non-unique precinct labels. Official precinct-level candidate rows and normalized detailed audit/CVR/incident/correction records remain preferred/request-path items.",
+      "blocker": "Official Indiana ENR county category JSON is collected and parsed for certified 2024 county totals, official county turnout is loaded, official 2012/2016/2020 county historical baselines are normalized, and the official VSTOP 2024 General Election audit summary is loaded for seven audited counties as context. Official JurR county jurisdiction JSON files are inventoried but do not contain President or U.S. Senate candidate result rows. Advisory flags still use MIT/OpenElections supplemental local rows, with caveats that MIT flags Indiana Senate/Governor overreporting in some counties and non-unique precinct labels. Indiana remains out of completedNativeStates until official same-grain precinct/subcounty President and U.S. Senate rows are collected or the methodology explicitly accepts supplemental review rows as complete. Normalized detailed audit/CVR/incident/correction records remain preferred/request-path administration items.",
       "supplementalSourcePages": [
         "https://doi.org/10.7910/DVN/NYTPDU",
         "https://github.com/openelections/openelections-data-in/tree/master/2024/counties"

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -721,8 +721,8 @@
       ],
       "parserStatus": "indianaEnrCountyJson package loaded; official 2012/2016/2020 historicalPresidentialCsv loaded from ENRHistorical/AJAX and ENR archive sources; supplemental MIT/OpenElections precinct review rows loaded; scripts/normalize-in-audit-summary.mjs loads official VSTOP 2024 county audit-summary context rows; data/in-2024-source-request-matrix.tsv records official precinct/subcounty, geometry, turnout, audit-detail, CVR, and incident follow-up asks; official precinct/subcounty rows remain blocked.",
       "manualReviewBurden": "medium",
-      "confidence": "loaded",
-      "caveats": "Archived ENR category files contain 92 county RegionSummary rows for 2024, not precinct rows. Historical baselines are official county context for 2012, 2016, and 2020; 2012 is collected from the current Indiana Voters ENRHistorical table endpoint, while 2016 and 2020 use ENR archive JSON.",
+      "confidence": "loaded_with_caveat",
+      "caveats": "Archived ENR category files contain 92 county RegionSummary rows for 2024, not precinct rows. The current subcounty review rows are supplemental MIT/OpenElections context with upstream caveats, so Indiana should remain in source discovery until official same-grain precinct/subcounty President and U.S. Senate rows are obtained or the completion methodology changes. Historical baselines are official county context for 2012, 2016, and 2020; 2012 is collected from the current Indiana Voters ENRHistorical table endpoint, while 2016 and 2020 use ENR archive JSON.",
       "nextAction": "Use data/in-2024-source-request-matrix.tsv to request official same-grain precinct/subcounty 2024 President and U.S. Senate rows, precinct geometry/turnout if needed, detailed VSTOP audit workpapers, Recount Commission/CVR/incident records suitable for normalization."
     },
     {

--- a/docs/native-import-source-packages.md
+++ b/docs/native-import-source-packages.md
@@ -250,6 +250,8 @@ Expected validation: 17 county result rows, 17 county geometry features, 1,484,8
 
 Expected validation remains: 92 county result rows, 92 county geometry features, 2,936,677 presidential votes, 5,253 supplemental local review rows, 92 turnout rows, 276 official historical baseline rows for 2012/2016/2020, and 7 VSTOP audit-summary context rows. Advisory indicators are source/data reconciliation signals only; they are not claims of misconduct.
 
+Completion decision, checked 2026-07-03: keep Indiana in `sourceDiscoveryQueue` and out of `completedNativeStates`. The loaded county, turnout, historical, and VSTOP summary artifacts are useful and source-backed, but the local review/advisory rows still rely on supplemental MIT/OpenElections precinct context. Official same-grain precinct/subcounty President and U.S. Senate rows remain the blocker before the supplemental-source caveat can be removed.
+
 
 ## Idaho Wave 12 Update
 

--- a/tests/python/test_indiana_coverage_inventory.py
+++ b/tests/python/test_indiana_coverage_inventory.py
@@ -34,6 +34,21 @@ class IndianaCoverageInventoryTest(unittest.TestCase):
         self.assertIn(2012, historical["expectedCounts"]["years"])
         self.assertFalse(any(entry["artifact"] == "2012_historical_presidential_baseline" for entry in self.inventory["gaps"]))
 
+    def test_completion_decision_keeps_official_precinct_blocker_visible(self):
+        native_packages = json.loads(Path("data/native-import-source-packages.json").read_text(encoding="utf-8-sig"))
+        discovery = next(entry for entry in native_packages["sourceDiscoveryQueue"] if entry["state"] == "IN")
+        source_tiers = json.loads(Path("data/source-acquisition-tiers.json").read_text(encoding="utf-8-sig"))
+        source_tier = next(entry for entry in source_tiers["states"] if entry["state"] == "IN")
+
+        self.assertEqual(self.inventory["completionDecision"]["decision"], "remain_in_source_discovery_queue")
+        self.assertEqual(discovery["completionDecision"]["decision"], "remain_in_source_discovery_queue")
+        self.assertNotIn("IN", native_packages["completedNativeStates"])
+        self.assertIn("official same-grain precinct/subcounty", self.inventory["completionDecision"]["reason"])
+        self.assertIn("MIT/OpenElections", discovery["completionDecision"]["reason"])
+        self.assertEqual(source_tier["confidence"], "loaded_with_caveat")
+        self.assertIn("supplemental MIT/OpenElections", source_tier["caveats"])
+        self.assertTrue(any("supplemental MIT/OpenElections" in caveat for caveat in self.inventory["displayCaveats"]))
+
     def test_admin_source_paths_are_documented_but_not_normalized(self):
         self.assertEqual(self.admin["status"], "partial")
         self.assertEqual(self.admin["audit"]["status"], "partial")


### PR DESCRIPTION
## Scope

Indiana Wave 19 native data coverage decision and caveat cleanup.

## What changed

- Keeps Indiana out of `completedNativeStates` and records `remain_in_source_discovery_queue` because official same-grain precinct/subcounty President/Senate candidate rows are still not available in the collected public IN sources.
- Clarifies that current county-level official results, county turnout, historical baselines, and VSTOP audit summary context are loaded, while supplemental subcounty review rows rely on MIT/OpenElections with caveats.
- Adds display caveats to the Indiana coverage inventory and tightens source acquisition/package metadata.
- Adds a focused Python inventory test to keep the official precinct/subcounty blocker visible.

## Sources checked

Official Indiana 2024 ENR archive, Indiana Secretary of State election results archive, VSTOP post-election audit reports, voter registration/turnout statistics, recount commission pages, and statistics/maps pages. No public official same-grain precinct/subcounty candidate export for the 2024 President/Senate rows was found.

## Validation

- `python -m unittest tests.python.test_indiana_coverage_inventory`
- `npm run etl:validate:in`
- `npm run etl:import:in`
- `npm run native:report-indicators -- .etl/staging`
- `npm run validate:source-packages`
- `npm run validate:turnout-packages`
- `npm run validate:maps`
- `npm run validate:provenance`
- `npm run validate:source-acquisition-tiers`
- `npm run typecheck`
- `npm run test`
- `npm run build`

## Advisory indicator report

For IN staging: native review rows 5,253; calculated indicator rows 154; flagged jurisdictions 87; flagged areas 87; indicator types `vote_share_pattern`, `average_down_ballot_difference`, and `down_ballot_outliers`. Production indicator reflection was not checked because production promotion was not authorized.

## Website/API display path checked

Readiness and native-source display paths were inspected; no production promotion was run.

## Caveats and risks

Indiana should remain in source discovery until official same-grain precinct/subcounty President/Senate candidate rows are collected or the completion methodology explicitly accepts supplemental MIT/OpenElections review rows. Detailed audit workpapers, CVR availability, incident/correction/recount details, and equipment provenance remain request-path context where not already loaded.

## Review

Review subagent tooling was not exposed in this session after tool discovery; I completed a self-review of the diff and addressed no additional findings.