### PR TITLE
Add records response submission workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/records-response.yml
+++ b/.github/ISSUE_TEMPLATE/records-response.yml
@@ -1,0 +1,98 @@
+﻿name: Records request response
+description: Submit a public-records response or produced file for Civic Result Maps review.
+title: "[Records response] "
+labels:
+  - records-response
+  - electronic-integrity
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form when an election office, county, municipality, portal, or custodian responds to an information request. Please include official links or upload non-sensitive response files where GitHub allows it. Do not include private requester contact details unless they are already public and needed for review.
+  - type: input
+    id: state
+    attributes:
+      label: State
+      description: Two-letter code or full state name.
+      placeholder: WI
+    validations:
+      required: true
+  - type: input
+    id: request_id
+    attributes:
+      label: Request ID
+      description: Civic Result Maps tracking ID or IDs, if known.
+      placeholder: EI-2024-WI-CAST-VOTE-RECORDS
+    validations:
+      required: true
+  - type: dropdown
+    id: evidence_family
+    attributes:
+      label: Evidence family
+      options:
+        - Cast vote records
+        - Ballot images
+        - Tabulator logs
+        - Audit results
+        - Logic and accuracy records
+        - Chain of custody
+        - Reporting-unit results
+        - Multiple evidence families
+        - Other election records
+    validations:
+      required: true
+  - type: input
+    id: custodian
+    attributes:
+      label: Responding custodian
+      description: Office, county, municipality, records portal, or vendor that answered.
+      placeholder: County Clerk, State Election Office, records portal, etc.
+  - type: input
+    id: response_url
+    attributes:
+      label: Response or file URL
+      description: Official portal URL, public file link, GitHub attachment URL, or source page.
+      placeholder: https://...
+  - type: textarea
+    id: response_summary
+    attributes:
+      label: Response summary
+      description: Summarize what was provided, denied, redirected, fee-estimated, clarified, or still pending.
+      placeholder: The office provided a CSV export and said ballot images are not retained by...
+    validations:
+      required: true
+  - type: textarea
+    id: files_received
+    attributes:
+      label: Files received
+      description: List filenames, formats, dates, hashes if available, or attach files below after creating the issue.
+      placeholder: cvr_export_2024_general.csv; readme.pdf; portal message dated...
+  - type: dropdown
+    id: response_status
+    attributes:
+      label: Response status
+      options:
+        - Records produced
+        - Partial production
+        - Redirected to another custodian
+        - Fee estimate
+        - Clarification requested
+        - No responsive records
+        - Denied or exempted
+        - Still pending
+    validations:
+      required: true
+  - type: textarea
+    id: caveats
+    attributes:
+      label: Caveats and handling notes
+      description: Note redactions, field definitions, missing record layouts, fee limits, privacy concerns, or restrictions.
+  - type: checkboxes
+    id: responsible_submission
+    attributes:
+      label: Responsible submission checklist
+      options:
+        - label: I removed private requester contact details unless they are necessary and already public.
+          required: true
+        - label: I understand this submission documents source availability only and is not a claim of misconduct.
+          required: true

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1905,6 +1905,12 @@ input {
   text-decoration: none;
 }
 
+.request-response-link {
+  background: rgba(53, 199, 163, 0.12);
+  border-color: var(--accent-line);
+  color: var(--accent);
+}
+
 .request-attention-banner {
   align-items: center;
   background: linear-gradient(90deg, rgba(240, 195, 106, 0.16), rgba(53, 199, 163, 0.08));

--- a/src/app/workspace-tabs.tsx
+++ b/src/app/workspace-tabs.tsx
@@ -38,6 +38,7 @@ import type {
   CoverageSummary,
   ElectronicIntegrityStateSummary,
   ElectronicIntegrityRequestOperationSummary,
+  ElectronicIntegrityRequestSummary,
   EquipmentClusterDiagnostic,
   EquipmentRowSummary,
   HistoricalResultRowSummary,
@@ -119,6 +120,7 @@ type WorkspaceTourContext = {
   hasEquipmentRows: boolean;
   hasHistoricalRows: boolean;
   hasImportRuns: boolean;
+  hasElectronicRequests: boolean;
   hasResults: boolean;
   hasReviewRows: boolean;
   hasSources: boolean;
@@ -268,6 +270,7 @@ const glossaryEntries: GlossaryEntry[] = [
 
 const githubIssueUrl = "https://github.com/Camreyn/civicresultmaps/issues/new";
 const githubDataReviewTemplate = "data-review.yml";
+const githubRecordsResponseTemplate = "records-response.yml";
 
 const tourFeatureRegistry: TourFeature[] = [
   {
@@ -493,6 +496,47 @@ const tourFeatureRegistry: TourFeature[] = [
               title: "Historical coverage depends on rows",
             },
           ],
+  },
+  {
+    key: "electronic",
+    build: (context) => [
+      {
+        body: "Electronic Integrity tracks whether records like CVRs, ballot images, logs, audits, and custody files are available. Missing records are a request queue, not a finding.",
+        fallbackTarget: "[data-tour='workspace']",
+        id: "electronic-integrity",
+        tab: "electronic",
+        target: "[data-tour='electronic-integrity']",
+        title: "Open electronic records",
+      },
+      {
+        body: "Start here before sending anything. The guide explains what the request asks for, what a normal response can look like, and why this is an evidence-availability request.",
+        fallbackTarget: "[data-tour='electronic-integrity']",
+        id: "request-guide-button",
+        tab: "electronic",
+        target: "[data-tour='request-guide-button']",
+        title: "Read the request guide",
+      },
+      {
+        body: context.hasElectronicRequests
+          ? "Use Copy email draft to review or paste the request manually. Use Open mail app when the recipient is known, and Find custodian when the request needs a county, municipal, or portal route."
+          : `${context.stateName} does not currently have an open electronic-records request draft, so this step points back to the evidence panel.`,
+        fallbackTarget: "[data-tour='electronic-integrity']",
+        id: "request-email-draft",
+        skipIfMissing: true,
+        tab: "electronic",
+        target: "[data-tour='request-email-draft']",
+        title: "Send the request",
+      },
+      {
+        body: "After an office responds, click Submit response. GitHub opens a records-response form with the state and request IDs prefilled; add the response summary, file links or attachments, status, and caveats.",
+        fallbackTarget: "[data-tour='electronic-integrity']",
+        id: "submit-request-response",
+        skipIfMissing: true,
+        tab: "electronic",
+        target: "[data-tour='submit-request-response']",
+        title: "Submit received records",
+      },
+    ],
   },
   {
     key: "planner",
@@ -1209,6 +1253,48 @@ function buildReportIssueUrl(input: {
   }
 
   return `${githubIssueUrl}?${params.toString()}`;
+}
+
+function buildRecordsResponseIssueUrl(input: {
+  evidenceFamily: string;
+  requestIds: string[];
+  responseUrl?: string;
+  stateCode: string;
+  stateName: string;
+  custodian?: string;
+}) {
+  const requestId = input.requestIds.length ? input.requestIds.join(", ") : `${input.stateCode} request IDs unknown`;
+  const params = new URLSearchParams({
+    caveats:
+      "Note redactions, fee limits, missing field definitions, record-layout gaps, privacy concerns, or follow-up needed before these records can be parsed.",
+    custodian: input.custodian ?? "",
+    evidence_family: input.evidenceFamily,
+    labels: "records-response,electronic-integrity",
+    request_id: requestId,
+    response_status: "Records produced",
+    response_summary:
+      "Please summarize what the custodian provided, denied, redirected, fee-estimated, clarified, or left pending. Attach files after GitHub opens the issue if they are not public URLs.",
+    state: `${input.stateName} (${input.stateCode})`,
+    template: githubRecordsResponseTemplate,
+    title: `[Records response] ${input.stateCode} ${requestId}`,
+  });
+
+  if (input.responseUrl) {
+    params.set("response_url", input.responseUrl);
+  }
+
+  return `${githubIssueUrl}?${params.toString()}`;
+}
+
+function buildRequestResponseIssueUrl(request: ElectronicIntegrityRequestSummary) {
+  return buildRecordsResponseIssueUrl({
+    custodian: request.primaryCustodian,
+    evidenceFamily: request.artifactLabel,
+    requestIds: [request.requestId],
+    responseUrl: request.sourceUrl || request.recipientPortalUrl || request.recipientLookupUrl || undefined,
+    stateCode: request.state,
+    stateName: request.stateName,
+  });
 }
 
 function dataNoteStatus(hasRows: boolean, capability?: boolean, partial?: boolean): QualityBadgeStatus {
@@ -2695,6 +2781,14 @@ export function WorkspaceTabs({
     stateCode: selectedStateCode,
     stateName,
   });
+  const recordsResponseUrl = buildRecordsResponseIssueUrl({
+    custodian: electronicRequestRows[0]?.primaryCustodian,
+    evidenceFamily: electronicRequestRows.length > 1 ? "Multiple evidence families" : electronicRequestRows[0]?.artifactLabel ?? "Other election records",
+    requestIds: electronicStateDraft?.requestIds ?? electronicRequestRows.map((request) => request.requestId),
+    responseUrl: electronicRequestRows[0]?.sourceUrl || electronicRequestRows[0]?.recipientPortalUrl || electronicRequestRows[0]?.recipientLookupUrl || undefined,
+    stateCode: selectedStateCode,
+    stateName,
+  });
   const validationChecks = [
     {
       detail: `${coverage?.loadedJurisdictions ?? results.length} loaded jurisdictions`,
@@ -2727,6 +2821,7 @@ export function WorkspaceTabs({
     () =>
       buildWorkspaceTourSteps({
         hasCoverage: Boolean(coverage),
+        hasElectronicRequests: electronicRequestRows.length > 0,
         hasHistoricalRows: historicalRows.length > 0,
         hasImportRuns: selectedImportRuns.length > 0,
         hasResults: results.length > 0,
@@ -2738,6 +2833,7 @@ export function WorkspaceTabs({
       }),
     [
       coverage,
+      electronicRequestRows.length,
       historicalRows.length,
       results.length,
       reviewRows.length,
@@ -4296,8 +4392,9 @@ export function WorkspaceTabs({
                       <strong>How it works here</strong>
                       <p>
                         The app prepares a draft from the missing evidence list for {stateName}. Review the draft,
-                        verify the custodian, then use copy, email, or the lookup link to send it outside the app. The
-                        site does not automatically submit requests.
+                        verify the custodian, then use copy, email, or the lookup link to send it outside the app. When
+                        an office replies, use Submit response to open the GitHub form with this state and request IDs
+                        prefilled for review. The site does not automatically submit requests.
                       </p>
                     </article>
                   </div>
@@ -4330,7 +4427,7 @@ export function WorkspaceTabs({
                   detail={electronicIntegrityStatus?.riskPosture ?? "No electronic-integrity package is registered."}
                   status={electronicQualityStatus(electronicIntegrityStatus?.overallStatus)}
                 />
-                <button className="secondary-button" onClick={() => setRequestGuideOpen(true)} type="button">
+                <button className="secondary-button" data-tour="request-guide-button" onClick={() => setRequestGuideOpen(true)} type="button">
                   <BookOpen aria-hidden size={15} />
                   Request guide
                 </button>
@@ -4477,22 +4574,26 @@ export function WorkspaceTabs({
                       </span>
                     </div>
                     {electronicStateDraft && (
-                      <div className="request-draft-panel">
+                      <div className="request-draft-panel" data-tour="request-email-draft">
                         <div>
                           <strong>Email draft</strong>
                           <span>{electronicStateDraft.routingHint} {electronicStateDraft.recipientHint}</span>
                         </div>
                         <div className="request-draft-actions">
-                          <button className="secondary-button" onClick={copyElectronicDraft} type="button">
+                          <button className="secondary-button" data-tour="copy-request-draft" onClick={copyElectronicDraft} type="button">
                             <Copy aria-hidden size={15} />
                             {copiedElectronicDraft ? "Copied" : "Copy email draft"}
                           </button>
-                          <a className="secondary-button" href={electronicStateDraft.mailtoHref}>
+                          <a className="secondary-button" data-tour="open-request-draft" href={electronicStateDraft.mailtoHref}>
                             <Mail aria-hidden size={15} />
                             Open mail app
                           </a>
-                          <a className="secondary-button" href={electronicRequestRows[0]?.recipientLookupUrl} rel="noreferrer" target="_blank">
+                          <a className="secondary-button" data-tour="find-request-custodian" href={electronicRequestRows[0]?.recipientLookupUrl} rel="noreferrer" target="_blank">
                             Find custodian
+                          </a>
+                          <a className="secondary-button request-response-link" data-tour="submit-request-response" href={recordsResponseUrl} rel="noreferrer" target="_blank">
+                            <Send aria-hidden size={15} />
+                            Submit response
                           </a>
                         </div>
                       </div>
@@ -4506,6 +4607,7 @@ export function WorkspaceTabs({
                             <th>Status</th>
                             <th>Route</th>
                             <th>Response</th>
+                            <th>Submit</th>
                           </tr>
                         </thead>
                         <tbody>
@@ -4524,6 +4626,11 @@ export function WorkspaceTabs({
                                 )}
                               </td>
                               <td>{request.responseSummary || request.feeStatus}</td>
+                              <td>
+                                <a className="table-source-link" href={buildRequestResponseIssueUrl(request)} rel="noreferrer" target="_blank">
+                                  Submit response
+                                </a>
+                              </td>
                             </tr>
                           ))}
                         </tbody>

--- a/tests/api/api-contract.test.mjs
+++ b/tests/api/api-contract.test.mjs
@@ -187,6 +187,7 @@ test("review indicators explain advisory meaning", () => {
   const explorer = readFileSync("src/app/results-explorer.tsx", "utf8");
   const overview = readFileSync("src/app/national-overview.tsx", "utf8");
   const dataReviewTemplate = readFileSync(".github/ISSUE_TEMPLATE/data-review.yml", "utf8");
+  const recordsResponseTemplate = readFileSync(".github/ISSUE_TEMPLATE/records-response.yml", "utf8");
   const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 
   assert.match(eli5, /ELI5/);
@@ -201,6 +202,12 @@ test("review indicators explain advisory meaning", () => {
   assert.match(tabs, /githubIssueUrl/);
   assert.match(tabs, /githubDataReviewTemplate/);
   assert.match(tabs, /template: githubDataReviewTemplate/);
+  assert.match(tabs, /githubRecordsResponseTemplate/);
+  assert.match(tabs, /buildRecordsResponseIssueUrl/);
+  assert.match(tabs, /records-response,electronic-integrity/);
+  assert.match(tabs, /Submit response/);
+  assert.match(tabs, /submit-request-response/);
+  assert.match(tabs, /request-email-draft/);
   assert.match(tabs, /issue_type/);
   assert.match(tabs, /what_looks_wrong/);
   assert.doesNotMatch(tabs, /## What looks wrong\?/);
@@ -328,6 +335,10 @@ test("raw review turnout and historical APIs are exposed", () => {
   assert.match(readFileSync("src/app/results-explorer.tsx", "utf8"), /activeFeatures/);
   assert.match(readFileSync("src/app/guided-tour.tsx", "utf8"), /Jump to tour step/);
   assert.match(readFileSync("src/app/guided-tour.tsx", "utf8"), /skipIfMissing/);
+  assert.match(tabs, /Open electronic records/);
+  assert.match(tabs, /Read the request guide/);
+  assert.match(tabs, /Send the request/);
+  assert.match(tabs, /Submit received records/);
 });
 
 test("equipment administration context is source-first and exportable", () => {

--- a/tests/api/electronic-integrity.test.mjs
+++ b/tests/api/electronic-integrity.test.mjs
@@ -198,9 +198,18 @@ test("timeline source collection events are backed by explicit source records", 
 
 test("electronic request API exposes browser-ready email body and routing hints", () => {
   const source = readFileSync("src/lib/electronic-integrity-requests.ts", "utf8");
+  const workspace = readFileSync("src/app/workspace-tabs.tsx", "utf8");
+  const recordsTemplate = readFileSync(".github/ISSUE_TEMPLATE/records-response.yml", "utf8");
   assert.match(source, /requestEmailBody/);
   assert.match(source, /mailtoHref/);
   assert.match(source, /recipientHint/);
   assert.match(source, /routingHint/);
   assert.match(source, /Verify recipient email/);
+  assert.match(workspace, /buildRecordsResponseIssueUrl/);
+  assert.match(workspace, /githubRecordsResponseTemplate/);
+  assert.match(workspace, /Submit response/);
+  assert.match(workspace, /request-guide-button/);
+  assert.match(recordsTemplate, /Records request response/);
+  assert.match(recordsTemplate, /Response status/);
+  assert.match(recordsTemplate, /private requester contact details/);
 });


### PR DESCRIPTION
## Summary
- add a dedicated GitHub issue form for records-request responses and produced files
- add Electronic Integrity buttons for submitting batch or per-request responses with prefilled state/request metadata
- extend the guided tour to explain request sending and response submission controls

## Verification
- node tests/api/api-contract.test.mjs
- node tests/api/electronic-integrity.test.mjs
- npm run test:api
- npm run typecheck
- npm run build
- local browser check on /?state=WI Electronic Integrity tab

## Notes
- Replaces closed draft PR #137 after renaming the branch from `codex/request-response-submission` to `feature/request-response-submission`.