### PR TITLE
Fix production visibility checks for non-county states

### DIFF
--- a/scripts/validate-production-map-joins.mjs
+++ b/scripts/validate-production-map-joins.mjs
@@ -118,10 +118,10 @@ for (const state of states) {
       fetchJson(`${appBaseUrl}/api/coverage?state=${state}&year=2024`).catch(() => null),
     ]);
     const skipReason = resultlessMapSkipReason(state, config, productionCoverage);
-    if ((results.data?.length ?? 0) === 0 && skipReason) {
+    if (skipReason) {
       report.push({
         state,
-        resultRows: 0,
+        resultRows: results.data?.length ?? 0,
         boundaries: geojson.features?.length ?? 0,
         blankNames: 0,
         unmatched: [],

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,7 +41,7 @@ export const officeQuery = z
   .default("president");
 
 export const levelQuery = z
-  .enum(["county", "state", "district", "precinct", "city", "city_town"])
+  .enum(["county", "state", "district", "precinct", "city", "city_town", "town"])
   .default("county");
 
 export function apiEnvelope<T>(data: T, meta: Record<string, unknown> = {}) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,7 +28,7 @@ export type ResultRow = {
   state: string;
   year: number;
   office: string;
-  level: "county" | "state" | "district" | "precinct" | "city" | "city_town" | "rest_of_county";
+  level: "county" | "state" | "district" | "precinct" | "city" | "city_town" | "town" | "rest_of_county";
   jurisdictionCode: string;
   jurisdictionName: string;
   votes: Record<string, number>;
@@ -118,7 +118,7 @@ export type AnalysisIndicator = {
   electionYear: number;
   jurisdictionCode: string;
   jurisdictionName: string;
-  level: "county" | "state" | "district" | "precinct" | "city" | "city_town" | "rest_of_county";
+  level: "county" | "state" | "district" | "precinct" | "city" | "city_town" | "town" | "rest_of_county";
   type: string;
   severity: number;
   label: string;


### PR DESCRIPTION
## Summary

- Skip production map-join checks for states whose local config intentionally has `capabilities.map: false`, even when certified result rows are loaded.
- Add `town` to the public result-level API parser and result/indicator TypeScript contracts so promoted Connecticut town-level result rows are queryable.

## Why

Post-promotion validation for PR #150 exposed two visibility issues:

- Illinois has certified result rows but map capability is intentionally disabled because the rows include non-county election jurisdictions without matching county geometry. The validator was treating those rows as a map failure instead of a disabled-map skip.
- Connecticut result rows are promoted at `level: "town"`, but the public results route only accepted county/state/district/precinct/city/city_town levels.

## Validation

- `npm run validate:maps`
- `npm run validate:source-acquisition-tiers`
- `npm run typecheck`
- `npm run test:api`

Note: The data promotion itself was already completed from merged `origin/main`; this PR is only the public route/validator follow-up needed for clean checks and Connecticut town-result API visibility.