### PR TITLE
Show town-level results in workspace

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,6 +43,7 @@ export default async function Home({ searchParams }: HomeProps) {
     countyResults,
     cityResults,
     cityTownResults,
+    townResults,
     stateResults,
     sources,
     coverage,
@@ -63,6 +64,7 @@ export default async function Home({ searchParams }: HomeProps) {
     listResults({ state: selectedState, year: selectedYear, level: "county" }),
     listResults({ state: selectedState, year: selectedYear, level: "city" }),
     listResults({ state: selectedState, year: selectedYear, level: "city_town" }),
+    listResults({ state: selectedState, year: selectedYear, level: "town" }),
     listResults({ state: selectedState, year: selectedYear, level: "state" }),
     listSources({ state: selectedState, year: selectedYear }),
     getCoverageSummary({ state: selectedState, year: selectedYear }),
@@ -78,9 +80,9 @@ export default async function Home({ searchParams }: HomeProps) {
     listElectronicIntegrityRequests({ state: selectedState, year: selectedYear }),
     listSourceRecordsRequests({ state: selectedState, year: selectedYear }),
   ]);
-  const results = countyResults.length ? countyResults : cityResults.length ? cityResults : cityTownResults.length ? cityTownResults : stateResults;
+  const results = countyResults.length ? countyResults : cityResults.length ? cityResults : cityTownResults.length ? cityTownResults : townResults.length ? townResults : stateResults;
   const resultLevelLabel =
-    results[0]?.level === "city" || results[0]?.level === "city_town"
+    results[0]?.level === "city" || results[0]?.level === "city_town" || results[0]?.level === "town"
       ? "Municipality"
       : results[0]?.level === "state"
         ? "Statewide"


### PR DESCRIPTION
## Summary

- Include `town` result rows in the main workspace result fetch fallback.
- Treat town rows with the same municipality label used for city/city_town rows.

## Why

Production verification after PR #151 showed Connecticut data is live in the API at `/api/results?state=CT&year=2024&level=town`, and its Review Center/Data & Sources/Turnout/Indicators are visible. The main workspace still showed `Rows 0` for Connecticut because `src/app/page.tsx` fetched county/city/city_town/state result levels but not `town`.

## Validation

- `npm run typecheck`
- Production API check confirmed CT town results: 169 rows.

This PR is only for UI visibility; the production data promotion is already complete.