### PR TITLE
Fix live jurisdiction tag reporting

### DIFF
--- a/scripts/report-2024-county-list-coverage.mjs
+++ b/scripts/report-2024-county-list-coverage.mjs
@@ -8,6 +8,7 @@ const base = baseArg?.slice("--base=".length) ?? "https://www.civicresultmaps.or
 const year = Number(process.argv.find((arg) => arg.startsWith("--year="))?.slice("--year=".length) ?? 2024);
 const family = process.argv.find((arg) => arg.startsWith("--family="))?.slice("--family=".length) ?? (year === 2024 ? "results" : "historical");
 const failOnGaps = process.argv.includes("--fail-on-gaps");
+const reportRun = Date.now().toString(36);
 
 const overlayStates = new Set((overlayStatesArg ?? "").split(",").map((state) => state.trim().toUpperCase()).filter(Boolean));
 const invalidOverlayState = Array.from(overlayStates).find((state) => !/^[A-Z]{2}$/.test(state));
@@ -30,7 +31,9 @@ for (const state of overlayStates) {
 const useStagingForState = (state) => stagingSource && (!overlayStates.size || overlayStates.has(state));
 
 async function api(route) {
-  const response = await fetch(`${base}${route}`);
+  const url = new URL(route, base);
+  url.searchParams.set("reportRun", reportRun);
+  const response = await fetch(url, { cache: "no-store" });
   if (!response.ok) {
     throw new Error(`${route} returned ${response.status}`);
   }

--- a/scripts/report-national-county-flips.mjs
+++ b/scripts/report-national-county-flips.mjs
@@ -7,6 +7,7 @@ const overlayStatesArg = process.argv.find((arg) => arg.startsWith("--overlay-st
 const base = baseArg?.slice("--base=".length) ?? "https://www.civicresultmaps.org";
 const fromYear = Number(process.argv.find((arg) => arg.startsWith("--from="))?.slice("--from=".length) ?? 2020);
 const toYear = Number(process.argv.find((arg) => arg.startsWith("--to="))?.slice("--to=".length) ?? 2024);
+const reportRun = Date.now().toString(36);
 
 const overlayStates = new Set((overlayStatesArg ?? "").split(",").map((state) => state.trim().toUpperCase()).filter(Boolean));
 const invalidOverlayState = Array.from(overlayStates).find((state) => !/^[A-Z]{2}$/.test(state));
@@ -30,7 +31,9 @@ for (const state of overlayStates) {
 const useStagingForState = (state) => stagingSource && (!overlayStates.size || overlayStates.has(state));
 
 async function api(route) {
-  const response = await fetch(`${base}${route}`);
+  const url = new URL(route, base);
+  url.searchParams.set("reportRun", reportRun);
+  const response = await fetch(url, { cache: "no-store" });
   if (!response.ok) {
     throw new Error(`${route} returned ${response.status}`);
   }

--- a/src/lib/data-access.ts
+++ b/src/lib/data-access.ts
@@ -421,6 +421,7 @@ export async function listResults(input: {
         result_rows.state_code as "stateCode",
         elections.office,
         result_rows.level,
+        result_rows.jurisdiction_tag as "jurisdictionTag",
         result_rows.jurisdiction_code as "jurisdictionCode",
         result_rows.jurisdiction_name as "jurisdictionName",
         result_rows.candidate_name as "candidateName",


### PR DESCRIPTION
## Fix

- Selects the already-populated `result_rows.jurisdiction_tag` column in the public results query.
- Gives each national coverage/flip report run a unique live API query key and `no-store` request so post-promotion acceptance cannot reuse pre-promotion CDN responses.

## Production evidence

Fresh live responses contained the promoted rows and tags in the database, while `/api/results` emitted null tags because the SQL projection omitted the column. Canonical historical URLs also temporarily served pre-promotion cache entries, producing 3,103 instead of 3,113 matches.

Per production authorization, no additional local suite was run. Acceptance will be against the deployed public API and site.