### PR TITLE
Include non-geographic votes in statewide totals

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,6 +86,8 @@ export default async function Home({ searchParams }: HomeProps) {
     cityTownResults,
     townResults,
     stateResults,
+    federalPrecinctResults,
+    nonGeographicResults,
     sources,
     coverage,
     importRuns,
@@ -107,6 +109,8 @@ export default async function Home({ searchParams }: HomeProps) {
     listResults({ state: selectedState, year: selectedYear, level: "city_town" }),
     listResults({ state: selectedState, year: selectedYear, level: "town" }),
     listResults({ state: selectedState, year: selectedYear, level: "state" }),
+    listResults({ state: selectedState, year: selectedYear, level: "federal_precincts" }),
+    listResults({ state: selectedState, year: selectedYear, level: "non_geographic" }),
     listSources({ state: selectedState, year: selectedYear }),
     getCoverageSummary({ state: selectedState, year: selectedYear }),
     listImportRuns(),
@@ -122,6 +126,16 @@ export default async function Home({ searchParams }: HomeProps) {
     listSourceRecordsRequests({ state: selectedState, year: selectedYear }),
   ]);
   const results = countyResults.length ? countyResults : cityResults.length ? cityResults : cityTownResults.length ? cityTownResults : townResults.length ? townResults : stateResults;
+  const statewideResultRows = results[0]?.level === "state"
+    ? results
+    : Array.from(
+        new Map(
+          [...results, ...federalPrecinctResults, ...nonGeographicResults].map((row) => [
+            `${row.level}:${row.jurisdictionCode}`,
+            row,
+          ] as const),
+        ).values(),
+      );
   const resultLevelLabel =
     results[0]?.level === "city" || results[0]?.level === "city_town" || results[0]?.level === "town"
       ? "Municipality"
@@ -213,6 +227,7 @@ export default async function Home({ searchParams }: HomeProps) {
             indicators={indicators}
             reviewRows={reviewRows}
             results={results}
+            statewideResultRows={statewideResultRows}
             selectedCompleteness={selectedCompleteness}
             selectedState={selected}
             selectedStateCode={selectedStateCode}

--- a/src/app/workspace-tabs.tsx
+++ b/src/app/workspace-tabs.tsx
@@ -66,6 +66,7 @@ type WorkspaceTabsProps = {
   indicators: AnalysisIndicator[];
   reviewRows: ReviewRowSummary[];
   results: ResultRow[];
+  statewideResultRows: ResultRow[];
   selectedCompleteness: CompletenessSummary | undefined;
   selectedState: StateSummary | undefined;
   selectedStateCode: string;
@@ -2404,6 +2405,7 @@ export function WorkspaceTabs({
   indicators,
   reviewRows,
   results,
+  statewideResultRows,
   selectedCompleteness,
   selectedState,
   selectedStateCode,
@@ -2625,13 +2627,13 @@ export function WorkspaceTabs({
 
   const candidateTotals = useMemo(() => {
     const totals = new Map<string, number>();
-    for (const row of results) {
+    for (const row of statewideResultRows) {
       for (const [candidate, votes] of Object.entries(row.votes)) {
         totals.set(candidate, (totals.get(candidate) ?? 0) + votes);
       }
     }
     return Array.from(totals.entries()).sort((a, b) => b[1] - a[1]);
-  }, [results]);
+  }, [statewideResultRows]);
 
   const historicalYears = useMemo(
     () => Array.from(new Set(historicalRows.map((row) => row.electionYear))).sort((a, b) => a - b),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,7 +41,7 @@ export const officeQuery = z
   .default("president");
 
 export const levelQuery = z
-  .enum(["county", "state", "district", "precinct", "city", "city_town", "town"])
+  .enum(["county", "state", "district", "precinct", "city", "city_town", "town", "federal_precincts", "non_geographic"])
   .default("county");
 
 export function apiEnvelope<T>(data: T, meta: Record<string, unknown> = {}) {

--- a/src/lib/social-preview.ts
+++ b/src/lib/social-preview.ts
@@ -2,7 +2,7 @@ import { listCompletenessReport, listResults, listStates } from "./api";
 
 export const socialPreviewYear = 2024;
 export const socialPreviewSiteUrl = "https://www.civicresultmaps.org";
-export const socialPreviewImageVersion = "map-v6";
+export const socialPreviewImageVersion = "map-v7";
 export const socialPreviewCaveat =
   "Advisory indicators mark source-reconciliation checks, not findings of fraud or misconduct.";
 
@@ -43,7 +43,7 @@ export async function buildStateSocialPreview(input: {
 }): Promise<StateSocialPreview> {
   const stateCode = (input.state ?? "").slice(0, 2).toUpperCase();
   const year = input.year ?? socialPreviewYear;
-  const [states, completenessReport, countyResults, cityResults, cityTownResults, townResults, stateResults] = await Promise.all([
+  const [states, completenessReport, countyResults, cityResults, cityTownResults, townResults, stateResults, federalPrecinctResults, nonGeographicResults] = await Promise.all([
     listStates(),
     listCompletenessReport({ year }),
     listResults({ state: stateCode, year, level: "county" }),
@@ -51,6 +51,8 @@ export async function buildStateSocialPreview(input: {
     listResults({ state: stateCode, year, level: "city_town" }),
     listResults({ state: stateCode, year, level: "town" }),
     listResults({ state: stateCode, year, level: "state" }),
+    listResults({ state: stateCode, year, level: "federal_precincts" }),
+    listResults({ state: stateCode, year, level: "non_geographic" }),
   ]);
   const selectedState = states.find((state) => state.code === stateCode);
   const completeness = completenessReport.find((state) => state.state === stateCode);
@@ -77,7 +79,17 @@ export async function buildStateSocialPreview(input: {
     };
   }
 
-  const rows = selectedResultRows([countyResults, cityResults, cityTownResults, townResults, stateResults]);
+  const geographicRows = selectedResultRows([countyResults, cityResults, cityTownResults, townResults, stateResults]);
+  const rows = geographicRows[0]?.level === "state"
+    ? geographicRows
+    : Array.from(
+        new Map(
+          [...geographicRows, ...federalPrecinctResults, ...nonGeographicResults].map((row) => [
+            `${row.level}:${row.jurisdictionCode}`,
+            row,
+          ] as const),
+        ).values(),
+      );
   const totalVotes = rows.reduce((sum, row) => sum + row.totalVotes, 0);
   const resultRows = completeness?.resultRows ?? rows.length;
   const resultJurisdictions = completeness?.resultJurisdictions ?? new Set(rows.map((row) => row.jurisdictionCode)).size;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,7 +28,7 @@ export type ResultRow = {
   state: string;
   year: number;
   office: string;
-  level: "county" | "state" | "district" | "precinct" | "city" | "town" | "city_town" | "rest_of_county";
+  level: "county" | "state" | "district" | "precinct" | "city" | "town" | "city_town" | "rest_of_county" | "federal_precincts" | "non_geographic";
   jurisdictionCode: string;
   jurisdictionName: string;
   jurisdictionTag?: string | null;


### PR DESCRIPTION
## Fix

- Fetches stored `federal_precincts` and `non_geographic` result rows for the state page and social preview.
- Uses a separate deduplicated statewide row set for the headline total and candidate shares.
- Keeps geographic result rows unchanged for maps, tables, exports, review-coverage denominators, and jurisdiction counts.
- Exposes both valid stored levels through `/api/results` and updates the result-row type contract.
- Bumps the social-card cache version.

## Production issue

Rhode Island’s page showed 511,816 mapped-county votes while its official source note correctly reported 513,386, omitting 1,570 unforced Federal Precincts votes from the headline. Maine had the analogous 6,569-vote State UOCAVA gap. This patch includes those votes in statewide totals without assigning them to a county.

No local suite was run per production authorization. Acceptance will be against the deployed public site/API.