### PR TITLE
Use statewide rows for headline totals

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -145,7 +145,7 @@ export default async function Home({ searchParams }: HomeProps) {
   const selected = states.find((state) => state.code === selectedState);
   const selectedStateCode = selected?.code ?? selectedState;
   const selectedCompleteness = completenessReport.find((summary) => summary.state === selectedStateCode);
-  const totalVotes = results.reduce((sum, row) => sum + row.totalVotes, 0);
+  const totalVotes = statewideResultRows.reduce((sum, row) => sum + row.totalVotes, 0);
 
   return (
     <main className="app-shell">


### PR DESCRIPTION
The live browser acceptance for PR #159 showed the new supplemental API rows and candidate-total path working, but the headline still reduced the geographic `results` array. This one-line correction reduces the already-deduplicated `statewideResultRows` array instead, so RI displays 513,386 and ME displays 831,375 without changing map/review rows.

No local suite was run per production authorization; acceptance will be repeated on the deployed pages.