### PR TITLE
Bundle canonical FIPS registry at runtime

### DIFF
--- a/src/lib/jurisdiction-tags.ts
+++ b/src/lib/jurisdiction-tags.ts
@@ -1,5 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
-import path from "node:path";
+import canonicalRegistry from "../../data/canonical-jurisdictions.json" with { type: "json" };
 
 export type CanonicalJurisdiction = {
   jurisdictionTag: string;
@@ -48,22 +47,12 @@ export function normalizeJurisdictionAlias(value: string) {
     .toUpperCase();
 }
 
-function registryPath() {
-  return path.join(process.cwd(), "data", "canonical-jurisdictions.json");
-}
-
 export function getCanonicalJurisdictionRegistry() {
   if (cachedRegistry) {
     return cachedRegistry;
   }
 
-  const file = registryPath();
-  if (!existsSync(file)) {
-    cachedRegistry = { jurisdictions: [] };
-    return cachedRegistry;
-  }
-
-  cachedRegistry = JSON.parse(readFileSync(file, "utf8")) as Registry;
+  cachedRegistry = canonicalRegistry as Registry;
   return cachedRegistry;
 }
 


### PR DESCRIPTION
## Fix

Live verification found `/api/jurisdictions` deployed but returning a zero-row registry because a runtime filesystem read was not packaged into the serverless function.

This one-file hotfix switches the canonical registry to a static JSON import, guaranteeing all 3,144 rows are embedded in the runtime bundle.

No database promotion or FIPS backfill has run yet. Live verification will be repeated after deployment.