### PR TITLE
Include FIPS registry in Vercel source

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -26,6 +26,7 @@ tsconfig.tsbuildinfo
 # needed in Vercel deployment bundles.
 data/**
 !data/admin-source-packages.json
+!data/canonical-jurisdictions.json
 !data/electronic-integrity-artifacts.json
 !data/electronic-integrity-received-files.json
 !data/electronic-integrity-request-contacts.json


### PR DESCRIPTION
The runtime hotfix correctly uses a static import, but the preview build exposed that `.vercelignore` excludes `data/**`. This one-line deployment fix whitelists `data/canonical-jurisdictions.json`, consistent with the other small runtime registries already whitelisted.

The failed hotfix build never replaced the working production deployment.