### PR TITLE
Clarify county profile search

### DIFF
--- a/src/app/county/[fips]/page.tsx
+++ b/src/app/county/[fips]/page.tsx
@@ -128,7 +128,7 @@ export default async function CountyPage({ params }: CountyPageProps) {
               <h2>Find another county</h2>
               <p>Search the current canonical registry by name, alias, state, or FIPS.</p>
             </div>
-            <GlobalCountySearch defaultState={profile.state} label="County search" />
+            <GlobalCountySearch defaultState={profile.state} key={"county-profile-search-" + profile.state} label="County search" />
           </aside>
         </section>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5948,9 +5948,95 @@ td {
     grid-template-columns: 1fr;
   }
 }
-.workspace-search-row {
-  margin: 18px 0 8px;
-  max-width: 760px;
+.workspace-county-jump {
+  align-items: end;
+  background: linear-gradient(135deg, rgba(53, 199, 163, 0.1), rgba(23, 25, 24, 0.82) 55%);
+  border: 1px solid var(--accent-line);
+  border-left: 3px solid var(--accent);
+  border-radius: 12px;
+  display: grid;
+  gap: 22px;
+  grid-template-columns: minmax(280px, 0.8fr) minmax(390px, 1.2fr);
+  margin: 18px 0 14px;
+  max-width: 1020px;
+  padding: 16px 18px;
+}
+
+.workspace-county-jump-copy {
+  align-items: start;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.workspace-county-jump-icon {
+  align-items: center;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  border-radius: 9px;
+  color: var(--accent);
+  display: inline-flex;
+  height: 36px;
+  justify-content: center;
+  width: 36px;
+}
+
+.workspace-county-jump-heading {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.workspace-county-jump-heading .section-label {
+  margin: 0;
+}
+
+.workspace-county-jump-heading > span {
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.61rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  padding: 2px 7px;
+  text-transform: uppercase;
+}
+
+.workspace-county-jump h2 {
+  font-size: 1rem;
+  margin: 5px 0 4px;
+}
+
+.workspace-county-jump-copy > div > p:last-child {
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.45;
+  margin: 0;
+  max-width: 48ch;
+}
+
+.workspace-county-search {
+  min-width: 0;
+}
+
+@media (max-width: 1200px) {
+  .workspace-county-jump {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+    max-width: 760px;
+  }
+}
+
+@media (max-width: 520px) {
+  .workspace-county-jump {
+    padding: 14px;
+  }
+
+  .workspace-county-jump-copy {
+    grid-template-columns: 1fr;
+  }
 }
 
 .year-switcher {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import {
   CircleDashed,
   Database,
   GitCompareArrows,
+  MapPin,
   Radar,
 } from "lucide-react";
 import { BrandMark } from "./brand-mark";
@@ -343,9 +344,26 @@ export default async function Home({ searchParams }: HomeProps) {
         <section className="main-panel">
           <NationalOverview report={completenessReport} year={2024} />
 
-          <div className="workspace-search-row">
-            <GlobalCountySearch defaultState={selectedStateCode} label="Jump to any county profile" />
-          </div>
+          <section aria-labelledby="county-profile-jump-title" className="workspace-county-jump">
+            <div className="workspace-county-jump-copy">
+              <span aria-hidden className="workspace-county-jump-icon"><MapPin size={18} /></span>
+              <div>
+                <div className="workspace-county-jump-heading">
+                  <p className="section-label">County profiles</p>
+                  <span>Separate page</span>
+                </div>
+                <h2 id="county-profile-jump-title">Open a county profile</h2>
+                <p>Search nationwide by county name or five-digit FIPS. This opens a separate county history page and does not filter the state map.</p>
+              </div>
+            </div>
+            <GlobalCountySearch
+              className="workspace-county-search"
+              defaultState={selectedStateCode}
+              key={"county-profile-search-" + selectedStateCode}
+              label="County or FIPS"
+              placeholder="Enter county name, alias, or five-digit FIPS"
+            />
+          </section>
 
           <div className="dashboard-head">
             <div>

--- a/tests/api/national-platform-features.test.mjs
+++ b/tests/api/national-platform-features.test.mjs
@@ -91,6 +91,9 @@ test("comparison, county profile, global search, and confidence surfaces are wir
   const guidedTour = readFileSync("src/app/guided-tour.tsx", "utf8");
 
   assert.match(home, /GlobalCountySearch/);
+  assert.match(home, /Open a county profile/);
+  assert.match(home, /does not filter the state map/);
+  assert.match(home, /key=\{"county-profile-search-" \+ selectedStateCode\}/);
   assert.match(home, /supportedPresidentialYears/);
   assert.match(home, /initialMapMode/);
   assert.match(home, /needsReview/);
@@ -100,6 +103,7 @@ test("comparison, county profile, global search, and confidence surfaces are wir
   assert.match(county, /2016/);
   assert.match(county, /2020/);
   assert.match(county, /2024/);
+  assert.match(county, /key=\{"county-profile-search-" \+ profile\.state\}/);
   assert.match(county, /not evidence or findings of fraud/);
   assert.match(search, /role="combobox"/);
   for (const level of ["exact", "derived", "partial", "proxy", "non_geographic", "unavailable"]) {


### PR DESCRIPTION
## Summary

- restyle the county-profile lookup as a distinct destination card instead of a second sidebar-style filter
- explain that it opens a separate county history page and does not filter the current state map
- synchronize its state scope with the active workspace state on both the national workspace and county-profile page
- stack the card cleanly at the persistent-sidebar breakpoint and preserve accessible labels/region semantics
- add regression coverage for the explanatory copy and state-derived remount key

## Validation

- `npm.cmd run typecheck` — passed
- `npm.cmd run build -- --webpack` — passed (46 static pages)
- `node tests\api\national-platform-features.test.mjs` — passed
- `node --experimental-strip-types tests\api\county-profile.test.mjs` — passed
- `git diff --check` — passed
- browser verification at desktop, 1100px, and mobile widths — passed; no overflow, console errors, or Next.js error overlay
- verified state synchronization (Washington → Minnesota), county result lookup, and navigation to `/county/27053`

## Full-suite note

The full Windows `npm.cmd test` run reached the existing Georgia deterministic-CSV assertion and failed only because generated CSV used CRLF while the committed fixture uses LF. This branch does not touch the Georgia pipeline or fixtures; all preceding Georgia assertions passed.
