### PR TITLE
Version the security incident data cache

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,7 +18,7 @@ import {
   listTurnoutRows as uncachedListTurnoutRows,
 } from "./data-access";
 import { listVoteMethodRows as uncachedListVoteMethodRows } from "./vote-methods";
-import { publicApiSchemaVersion } from "./api-version";
+import { publicApiSchemaVersion, securityIncidentApiSchemaVersion } from "./api-version";
 import { listSecurityIncidents as uncachedListSecurityIncidents } from "./security-incidents";
 
 export const publicDataRevalidateSeconds = 15 * 60;
@@ -158,7 +158,7 @@ export const listResults = cachePublicData(
 
 export const listSecurityIncidents = cachePublicData(
   uncachedListSecurityIncidents,
-  "security-incidents",
+  `security-incidents-${securityIncidentApiSchemaVersion}`,
 );
 
 export const listSources = cachePublicData(

--- a/tests/api/security-incidents.test.mjs
+++ b/tests/api/security-incidents.test.mjs
@@ -74,7 +74,7 @@ test("security incident API and server loader are wired", () => {
   assert.match(loader, /!requestedState \|\| row\.state === requestedState/);
   assert.match(loader, /listSecurityIncidentStateSummaries/);
   assert.match(loader, /getNationalSecurityIncidentReport/);
-  assert.match(api, /"security-incidents"/);
+  assert.match(api, /security-incidents-\$\{securityIncidentApiSchemaVersion\}/);
   assert.match(page, /securityIncidents={securityIncidents}/);
   assert.match(page, /href="\/security"/);
   assert.match(page, /securityIncidentStates={securityIncidentStateSummaries}/);


### PR DESCRIPTION
## Production finding

The post-merge smoke test for #172 found that the public `/api/security-incidents` response advertised schema `2.0.0` but Vercel's persistent Next.js data cache returned pre-v2 rows without `affectedLocationUnit`. That stale payload recombined Fulton and DeKalb into an invalid total of 11.

## Fix

- derive the security-incidents `unstable_cache` key from `securityIncidentApiSchemaVersion`
- isolate this invalidation to the security endpoint instead of flushing all public-data caches
- add a regression assertion that future schema changes remain part of the cache identity

## Validation

- `.\node_modules\.bin\tsc.cmd --noEmit --incremental false`
- `npm run test:security-incidents`
- `npm run validate:security-incidents`
- `npm run build`
- `git diff --check`
- independent bounded review: merge-ready; low security and Fluid CPU impact

## Required post-deploy smoke test

The public response must contain `affectedLocationUnit` on both rows, separate `affectedLocationUnits` totals of 5 polling locations and 6 voting precincts, and null legacy mixed-unit aggregates—not 11.