### PR TITLE
Run Security smoke on successful production deployments

### DIFF
--- a/.github/workflows/security-production-smoke.yml
+++ b/.github/workflows/security-production-smoke.yml
@@ -10,7 +10,6 @@ jobs:
   smoke:
     if: >-
       github.event.deployment_status.state == 'success' &&
-      github.event.deployment.ref == 'main' &&
       github.event.deployment.environment == 'Production'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What changed

- removes the invalid `deployment.ref == 'main'` gate from the Security production smoke job
- continues to require a successful deployment whose environment is exactly `Production`

## Why

Vercel's GitHub deployment payload uses the deployed commit SHA in `deployment.ref`, even for `main`. The workflow received the successful Production event for merge `58bd45b` but skipped its only job because the ref was the SHA rather than the literal branch name.

## Validation

- inspected deployment `5446696067`: environment `Production`, ref/SHA `58bd45b...`
- confirmed the original workflow run was triggered but skipped
- ran `node scripts/verify-security-incidents-deployment.mjs --base-url=https://civicresultmaps.org`
- live production smoke passed for the national, Georgia, and Minnesota reports