### PR TITLE
docs: add system and UI/UX topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ older `Camreyn/wisconsin-2024-election-mapper` project remains the legacy static
 GitHub Pages app and a source of migration knowledge for state configs, parser
 patterns, generated state registries, and validation expectations.
 
+## Documentation
+
+- [System topology](docs/system-topology.md) - Obsidian-ready Mermaid maps of
+  the product, API, runtime, data model, ETL, validation, and deployment paths.
+
 ## Stack
 
 - Next.js App Router and React for the frontend and public read API.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ patterns, generated state registries, and validation expectations.
 
 - [System topology](docs/system-topology.md) - Obsidian-ready Mermaid maps of
   the product, API, runtime, data model, ETL, validation, and deployment paths.
+- [UI/UX README](docs/ui-ux/README.md) - information architecture, journeys,
+  interaction states, responsive behavior, accessibility, and design ownership.
 
 ## Stack
 

--- a/docs/system-topology.md
+++ b/docs/system-topology.md
@@ -24,6 +24,10 @@ This is a subsystem-level topology. The many state-specific configs, collectors,
 normalizers, parsers, and tests are shown as repeated component families so the
 map remains readable.
 
+For product-facing information architecture, user journeys, interaction states,
+responsive behavior, accessibility, and design ownership, see the
+[UI/UX README](ui-ux/README.md).
+
 > [!tip] Obsidian
 > Open this note in Reading view; each Mermaid block is a separate level of detail.
 

--- a/docs/system-topology.md
+++ b/docs/system-topology.md
@@ -1,0 +1,563 @@
+---
+aliases:
+  - Civic Result Maps Topology
+  - CivicResultMaps Architecture
+tags:
+  - civic-result-maps
+  - architecture
+  - topology
+  - mermaid
+updated: 2026-07-14
+---
+
+# Civic Result Maps system topology
+
+This is the shared map of Civic Result Maps for product, UX, engineering, data,
+and API work. Read the first diagram from top to bottom. The later diagrams zoom
+into the product surface, data lifecycle, runtime, and normalized data model.
+
+In one sentence: the project retains cited public records, turns them into
+reviewed normalized data, and serves that data through maps, review tools,
+exports, and a read-only API without hiding its provenance or limitations.
+
+This is a subsystem-level topology. The many state-specific configs, collectors,
+normalizers, parsers, and tests are shown as repeated component families so the
+map remains readable.
+
+> [!tip] Obsidian
+> Open this note in Reading view; each Mermaid block is a separate level of detail.
+
+> [!important] Interpretation boundary
+> Civic Result Maps publishes source-linked results, coverage limits, and
+> advisory review signals. An indicator or data gap is a prompt for source
+> reconciliation and human review, not a finding of fraud, tampering,
+> misconduct, or intent.
+
+## 1. The whole platform at a glance
+
+```mermaid
+flowchart TB
+  subgraph People["People and systems"]
+    Explorer["Public explorer or reviewer"]
+    UX["UX, research, and content teams"]
+    Consumer["API and data consumers"]
+    Maintainer["Data and software maintainers"]
+  end
+
+  subgraph Surfaces["Public product surfaces"]
+    Workspace["State Workspace<br/>maps, review, history, sources"]
+    National["National comparison<br/>county search and profiles"]
+    Trust["Readiness, evidence, and security<br/>coverage plus source-linked context"]
+    Developers["Developer portal<br/>OpenAPI and integration guidance"]
+    PublicAPI["Public read APIs<br/>versioned and compatibility routes"]
+    Releases["Immutable releases<br/>manifests and ZIP archives"]
+    Exports["Interactive exports<br/>CSV, JSON, review ZIP, SVG"]
+  end
+
+  subgraph Runtime["Next.js application on Vercel"]
+    Pages["App Router pages<br/>server-rendered data assembly"]
+    Client["React client components<br/>tabs, charts, maps, filters"]
+    Routes["API route handlers<br/>query validation and cache headers"]
+    Service["Shared data services<br/>src/lib/api.ts"]
+    Access["Queries and completeness logic<br/>src/lib/data-access.ts"]
+    Diagnostics["County comparison, review, security,<br/>social, release, and readiness logic"]
+  end
+
+  subgraph LiveData["Runtime data sources"]
+    Neon[("Neon Postgres<br/>normalized live rows")]
+    Registries[["Committed registries and context<br/>geography, incidents, requests, releases"]]
+    ReleaseFiles[["Immutable bulk archives<br/>public/data/releases/*.zip"]]
+    Seed[["Built-in seed fallback<br/>local development"]]
+    Geometry[["State GeoJSON plus bundled national GeoJSON<br/>browser-loaded map boundaries"]]
+  end
+
+  subgraph Pipeline["Reviewed data pipeline"]
+    Authorities["Official public sources<br/>state, local, EAC, Census, official GIS"]
+    Supplemental["Caveated supplemental context<br/>for explicitly documented uses"]
+    Artifacts[["Source artifacts in data/<br/>with provenance and caveats"]]
+    Configs[["State contracts<br/>etl/state-configs/*.json"]]
+    Collectors["Collection and normalization<br/>scripts/ and civic_etl/native.py"]
+    ETL["Python ETL engine<br/>validate and build"]
+    Staging[[".etl/staging/*-staging.json<br/>review artifact, not production"]]
+    Gates["Automated validation plus<br/>human source review"]
+    Promote["Authorized promotion CLI<br/>native or reviewed legacy path"]
+  end
+
+  subgraph Delivery["Quality and delivery"]
+    Tests["API, ETL, provenance, release,<br/>security, map, package, and build checks"]
+    Actions["GitHub Actions<br/>CI, PR preview, production smoke"]
+    Deploy["Vercel delivery<br/>preview and linked-main production"]
+    Analytics["Vercel Analytics"]
+  end
+
+  Explorer --> Workspace
+  Explorer --> National
+  Explorer --> Trust
+  UX --> Workspace
+  UX --> National
+  UX --> Trust
+  Consumer --> Developers
+  Consumer --> PublicAPI
+  Consumer --> Releases
+  Maintainer --> Pipeline
+  Maintainer --> Tests
+
+  Workspace --> Pages
+  National --> Pages
+  Trust --> Pages
+  Developers --> Pages
+  PublicAPI --> Routes
+  Releases --> Pages
+  Releases --> Routes
+  Pages --> Service
+  Routes --> Service
+  Service --> Access
+  Service --> Diagnostics
+  Pages --> Client
+  Client --> Exports
+  Client --> Analytics
+
+  Access --> Neon
+  Access -. local fallback .-> Seed
+  Service --> Registries
+  Client --> Geometry
+  Routes --> ReleaseFiles
+
+  Authorities --> Artifacts
+  Supplemental -. explicitly caveated .-> Artifacts
+  Artifacts --> Collectors
+  Configs --> Collectors
+  Collectors --> ETL
+  ETL --> Staging
+  Staging --> Gates
+  Gates --> Promote
+  Promote --> Neon
+  Registries --> Configs
+
+  Artifacts --> Tests
+  Configs --> Tests
+  Staging --> Tests
+  Tests --> Actions
+  Actions --> Deploy
+  Deploy --> Pages
+  Deploy --> Routes
+```
+
+The key distinction is between two paths:
+
+- The **read path** runs from the browser or API through Next.js into Neon or a
+  repository-backed registry.
+- The **write path** runs from cited source artifacts through reproducible ETL,
+  staging, validation, human review, and an explicit promotion command.
+
+## 2. Product and UX topology
+
+```mermaid
+flowchart TB
+  Shell["State Workspace<br/>/?state=XX&tab=..."]
+  Shell --> Header["Top bar, state switcher,<br/>national overview, metrics"]
+  Shell --> Tour["Guided tour and ELI5 help"]
+  Shell --> Notes["Persistent Data Notes<br/>readiness, caveats, next actions"]
+
+  Shell --> Explore
+  Shell --> Understand
+  Shell --> Share
+
+  subgraph Explore["Explore and review"]
+    Map["Map"]
+    Review["Review Center"]
+    History["History"]
+    Electronic["Electronic Integrity"]
+
+    Map --> MapModes["Winner | Margin | Votes<br/>Method | Equipment | Security"]
+    Map --> Drawer["Jurisdiction drawer<br/>results, indicators, source receipt"]
+    Review --> ReviewViews["Overview | Evidence Tools<br/>Screening | Indicators"]
+    Review --> ReviewCharts["Readiness, flag mix, scatter,<br/>drop-off, ticket-splitting proxy"]
+    History --> HistoryCharts["Share, margin, movement,<br/>Klimek-style and Shpilkin-style proxies"]
+    Electronic --> Requests["Evidence inventory and<br/>user-sent records-request drafts"]
+  end
+
+  subgraph Understand["Understand provenance and readiness"]
+    Planner["Source Planner"]
+    Data["Data and Sources"]
+    Guide["Review Guide"]
+    Imports["Import Runs"]
+    Planner --> Capability["Capability checklist and missing work"]
+    Data --> Bibliography["Authorities, URLs, artifacts,<br/>parsers, confidence, caveats"]
+    Guide --> Method["Responsible review rules,<br/>workflows, glossary, formulas"]
+    Imports --> Lineage["Parser, status, time, summary"]
+  end
+
+  subgraph Share["Share and participate"]
+    ExportTab["Exports & API"]
+    Support["Support"]
+    Contact["Contact"]
+    ExportTab --> Files["CSV, JSON, SVG,<br/>review-packet ZIP"]
+    ExportTab --> Links["Copyable public API URLs"]
+  end
+  Followup["External follow-up<br/>GitHub issues and user-sent email or portal requests"]
+  Drawer -. report a data issue .-> Followup
+  Requests --> Followup
+
+  OtherPages["Other first-class pages"]
+  OtherPages --> ComparePage["/compare<br/>national county swing and flip explorer"]
+  ComparePage --> CountyPage["/county/{fips}<br/>permanent county profile"]
+  OtherPages --> ReadinessPage["/readiness<br/>national status and state package details"]
+  OtherPages --> EvidencePage["/evidence<br/>records timeline; /timeline redirects here"]
+  OtherPages --> SecurityPage["/security<br/>source-linked incident explorer"]
+  OtherPages --> DeveloperPage["/developers<br/>v1 API documentation"]
+  DeveloperPage --> ReleasePage["/releases<br/>versioned manifests and bulk downloads"]
+  OtherPages --> SocialCard["/api/social-card<br/>state-aware share image"]
+```
+
+The workspace always carries the same safety context into the detailed views:
+source provenance, readiness badges, chart gates, warnings, and Data Notes are
+part of the experience rather than optional documentation.
+
+### Best starting point by audience
+
+| Audience | Start here | Then use |
+| --- | --- | --- |
+| General visitor | State Workspace -> Map | Data Notes, source drawer, Review Guide |
+| UX or product designer | Guided tour -> all workspace tabs | `/readiness`, `/compare`, and county profiles for cross-state and empty states |
+| Human reviewer | Data & Sources -> Review Center | History, Evidence, Security, Electronic Integrity, review-packet export |
+| API consumer | `/developers` -> `/api/v1/jurisdictions` | County profiles, comparisons, confidence definitions, OpenAPI, and releases |
+| Data engineer | State config -> ETL import -> staging | validators, indicator report, reviewed promotion |
+| Maintainer | CI workflow and tests | Vercel preview, production validators, API/UI verification |
+
+## 3. Data lifecycle and trust gates
+
+```mermaid
+flowchart TB
+  S1["Official election sources"]
+  S2["EAC and Census sources"]
+  S3["Official GIS, canvass,<br/>audit, recount, and admin records"]
+  S4["Caveated supplemental sources"]
+
+  Collect["Collectors and download scripts"]
+  Raw[["Raw retained artifacts<br/>CSV, XLSX, ZIP, JSON, PDF, HTML, GeoJSON"]]
+  Normalize["State-specific normalizers<br/>Node, Python, PDF text, or OCR"]
+  Normalized[["Normalized source files<br/>still reviewable and reproducible"]]
+
+  Config[["State ETL config<br/>sources, parsers, expected counts,<br/>capabilities, caveats"]]
+  Inventory[["Inventories and registries<br/>source tiers, packages, turnout,<br/>admin context, request tracking"]]
+  Canonical[["Canonical jurisdictions<br/>aliases, FIPS/GEOID, geometry keys"]]
+
+  Validate["Config and artifact validation<br/>required metadata, HTTPS, hashes,<br/>row counts, vote totals, joins"]
+  Parse["Native parser dispatch<br/>civic_etl/native.py"]
+  Stage[["Staging JSON<br/>promotion disabled by construction"]]
+  IndicatorReport["Pre-promotion advisory<br/>indicator count report"]
+  ReviewGate{"Human review accepts<br/>sources, totals, caveats, and risk"}
+  Promote["Promotion command"]
+  IndicatorCalc["Calculate and persist<br/>advisory indicators"]
+  Revision["Bump public data revision<br/>cache namespace"]
+  DB[("Neon normalized tables")]
+  Verify["Post-promotion counts,<br/>maps, provenance, packages, API/UI"]
+  ReleaseAssembly["Reviewed national release assembly"]
+  ReleaseVerify["Manifest, entries, coverage,<br/>and SHA-256 verification"]
+  ReleaseFiles[["Versioned catalog plus<br/>immutable public ZIP"]]
+
+  S1 --> Collect
+  S2 --> Collect
+  S3 --> Collect
+  S4 -. supplemental and labeled .-> Collect
+  Collect --> Raw
+  Raw --> Normalize
+  Normalize --> Normalized
+  Raw --> Config
+  Normalized --> Config
+  Inventory --> Config
+  Canonical --> Parse
+  Config --> Validate
+  Normalized --> Validate
+  Validate --> Parse
+  Parse --> Stage
+  Stage --> IndicatorReport
+  Stage --> ReviewGate
+  IndicatorReport --> ReviewGate
+  ReviewGate -->|accepted| Promote
+  ReviewGate -->|needs work| Collect
+  Promote --> IndicatorCalc
+  Promote --> DB
+  Promote --> Revision
+  IndicatorCalc --> DB
+  Revision --> DB
+  DB --> Verify
+  Verify -. when freezing a release .-> ReleaseAssembly
+  ReleaseAssembly --> ReleaseVerify
+  ReleaseVerify --> ReleaseFiles
+
+  CI["GitHub Actions"] -. repeats .-> Validate
+  CI -. blocks regressions with tests .-> Stage
+  CI -. verifies releases and security .-> ReleaseVerify
+```
+
+Important gates:
+
+1. A state config cannot request or authorize a production write.
+2. Staging artifacts explicitly say that human review is required and
+   production writing is not allowed.
+3. Promotion is a separate, intentional command with a configured database URL.
+4. Result, review, turnout, historical, equipment, source, capability,
+   validation, import-run, and indicator records retain lineage.
+5. Versioned national releases are separate committed snapshots whose manifest,
+   archive contents, coverage statement, and SHA-256 hashes are verified.
+6. `jurisdictionTag` is the canonical cross-year/cross-source join key. Ambiguous,
+   non-geographic, statewide-only, or otherwise unreviewed units are not forced
+   into county FIPS tags.
+
+## 4. Runtime and API request topology
+
+```mermaid
+flowchart TB
+  subgraph UIRequest["Interactive page request"]
+    Browser["Browser requests a product page"]
+    ServerPage["Next.js Server Component<br/>loads required datasets in parallel"]
+    Props["Rendered shell plus serialized props"]
+    InteractiveClient["Workspace or specialized explorer<br/>tabs, maps, tables, filters"]
+    Browser --> ServerPage --> Props --> InteractiveClient
+    InteractiveClient --> BrowserExports["Client-generated downloads"]
+    InteractiveClient --> GeoFetch["Fetch state GeoJSON or<br/>bundled national county geometry"]
+  end
+
+  subgraph APIRequest["Public API request"]
+    APIUser["API client"]
+    Handler["GET route handler"]
+    Query["Zod query parsing"]
+    Envelope["Response<br/>JSON envelope, CSV, image, or redirect"]
+    CDN["Vercel/CDN cache<br/>15 minute revalidation, 24 hour stale window"]
+    APIUser --> CDN
+    CDN -->|cache miss or revalidate| Handler
+    Handler --> Query
+    Query --> Envelope
+    Envelope --> CDN
+  end
+
+  subgraph SharedRead["Shared read services"]
+    APIService["Service modules<br/>src/lib/api.ts and src/lib/*"]
+    Cache["React and Next cache<br/>revision-keyed plus time-limited"]
+    DataAccess["Database queries and<br/>completeness aggregation"]
+    NationalServices["Canonical registry, county profiles,<br/>comparisons, releases, OpenAPI"]
+    RepoServices["Repository-backed registries,<br/>requests, vote methods, security"]
+    Diagnostics["Derived diagnostics and<br/>presentation summaries"]
+    APIService --> Cache
+    Cache --> DataAccess
+    APIService --> NationalServices
+    APIService --> RepoServices
+    APIService --> Diagnostics
+  end
+
+  subgraph Backing["Backing stores"]
+    Postgres[("Neon Postgres")]
+    Revision["public_data_revisions<br/>cache namespace"]
+    Repo[["Committed registries, geometry,<br/>incidents, requests, release catalog"]]
+    Archives[["Immutable public release ZIPs"]]
+    Seed[["Seed fallback"]]
+    DataAccess --> Postgres
+    DataAccess -. no configured database .-> Seed
+    NationalServices --> Postgres
+    NationalServices --> Repo
+    NationalServices --> Archives
+    RepoServices --> Repo
+    Postgres --- Revision
+    Revision -. keys .-> Cache
+  end
+
+  ServerPage --> APIService
+  Query --> APIService
+
+  subgraph PrivateWrite["Private and operational writes"]
+    Setup["POST /api/admin/setup-database<br/>SETUP_TOKEN"]
+    Legacy["POST /api/admin/import-legacy-state<br/>IMPORT_TOKEN"]
+    NativeCLI["native:promote CLI<br/>reviewed staging artifact"]
+    Setup --> Postgres
+    Legacy --> Postgres
+    NativeCLI --> Postgres
+    Setup -. bumps after seed .-> Revision
+    Legacy -. bumps after write .-> Revision
+    NativeCLI -. bumps after write .-> Revision
+  end
+```
+
+### Public endpoint families
+
+All public endpoints are read-only. JSON data endpoints return `{ data, meta }`;
+`meta` includes `generatedAt`, `source`, `schemaVersion`, and `releaseId`, with
+pagination metadata on collections. CSV routes return download headers, release
+downloads redirect to immutable archives, and the social-card route returns an
+image.
+
+| Family | Endpoints | Primary backing |
+| --- | --- | --- |
+| Stable county API (preferred) | `/api/v1/flips`, `/api/v1/counties/{fips}`, `/api/v1/jurisdictions`, `/api/v1/jurisdictions/search`, `/api/v1/confidence`, `/api/v1/releases`, `/api/v1/releases/{releaseId}`, `/api/v1/releases/{releaseId}/download`, `/api/v1/openapi` | Neon plus the canonical registry, release catalog, and immutable archive |
+| Compatibility aliases | `/api/flips`, `/api/counties/{fips}`, `/api/jurisdictions`, `/api/jurisdictions/search`, `/api/confidence`, `/api/releases`, `/api/releases/{releaseId}`, `/api/releases/{releaseId}/download`, `/api/openapi` | The same handlers as v1 |
+| State results and lineage | `/api/states`, `/api/elections`, `/api/results`, `/api/sources`, `/api/coverage`, `/api/completeness`, `/api/import-runs` | Neon and derived completeness logic, with local seed fallback |
+| Review | `/api/indicators`, `/api/review-rows` | Neon normalized review and indicator rows |
+| Context and administration | `/api/turnout`, `/api/historical-baselines`, `/api/equipment`, `/api/vote-methods`, `/api/security-incidents` | Neon rows plus normalized or versioned repository artifacts |
+| Planning registries | `/api/native-source-packages`, `/api/source-acquisition-tiers`, `/api/turnout-sources`, `/api/admin-sources` | Versioned JSON registries in `data/` |
+| Evidence workflows | `/api/electronic-integrity`, `/api/electronic-integrity-requests`, `/api/source-records-requests` | Versioned artifact, contact, tracker, and operation registries |
+| Cross-state status | `/api/swing-state-parity` | Versioned parity registry |
+| Sharing | `/api/social-card` | Result, completeness, comparison, or security services used by social metadata |
+
+New integrations should prefer `/api/v1`; the unversioned county platform routes
+are compatibility aliases, while state-focused routes remain unversioned. For
+large review or historical extracts, use `includeMetrics=true` only when the
+calculation metadata is required and respect row limits. For bulk county use,
+prefer pagination, compact JSON, CSV, or an immutable release ZIP.
+
+## 5. Normalized data model
+
+```mermaid
+flowchart TB
+  State["states<br/>state identity and authority"]
+  Election["elections<br/>year and office"]
+  Contest["contests<br/>state election contest"]
+  Candidate["candidates<br/>name, party, order"]
+  Jurisdiction["jurisdictions<br/>code, name, level, geometry key"]
+
+  Source["source_documents<br/>URL, authority, local artifact,<br/>parser, confidence, status"]
+  Run["import_runs<br/>parser, status, time, summary"]
+  Validation["validation_reports<br/>pass, errors, warnings, metrics"]
+  Revision["public_data_revisions<br/>cache namespace and update reason"]
+  Capability["capability_flags<br/>results, map, review, turnout,<br/>history, source planner"]
+
+  subgraph RowFamilies["Normalized row families"]
+    Results["result_rows<br/>candidate votes"]
+    ReviewRows["review_rows<br/>local vote share and comparison gaps"]
+    TurnoutRows["turnout_rows<br/>ballots, denominator, warning"]
+    HistoryRows["historical_result_rows<br/>prior-year party totals"]
+    EquipmentRows["equipment_rows<br/>administration context"]
+    Indicators["analysis_indicators<br/>advisory type, severity, explanation"]
+  end
+
+  Tags["jurisdictionTag<br/>logical canonical join key"]
+  Geometry["GeoJSON geometry<br/>client join by source names and geometry keys"]
+
+  State --> Jurisdiction
+  State --> Contest
+  State --> Source
+  State --> Run
+  State --> Capability
+  Election --> Contest
+  Contest --> Candidate
+  Contest --> Results
+  Jurisdiction -. map identity .-> Geometry
+
+  Run --> Validation
+  Run -. successful promotion bumps .-> Revision
+  Revision -. namespaces cached reads .-> Results
+  Run --> Results
+  Run --> ReviewRows
+  Run --> TurnoutRows
+  Run --> HistoryRows
+  Run --> EquipmentRows
+
+  Source -. provenance .-> Run
+  Source -. provenance .-> Results
+  Source -. provenance .-> ReviewRows
+  Source -. provenance .-> TurnoutRows
+  Source -. provenance .-> HistoryRows
+  Source -. provenance .-> EquipmentRows
+  Source -. provenance .-> Indicators
+
+  ReviewRows --> Indicators
+  Tags -. aligns .-> Results
+  Tags -. aligns .-> ReviewRows
+  Tags -. aligns .-> TurnoutRows
+  Tags -. aligns .-> HistoryRows
+  Tags -. aligns .-> EquipmentRows
+```
+
+`jurisdictionTag` is intentionally a logical canonical key across row families,
+not a substitute for each source's original display name or reporting unit.
+Source display names remain visible so reconciliation stays reviewable. The
+current map clients separately resolve committed GeoJSON properties to result
+display names and report missing or unmapped joins.
+
+National county comparisons and county profiles are derived read models, not
+separate database tables: they join normalized result, historical, turnout, and
+source rows to the canonical county registry. Vote-method, security-incident,
+request-tracker, release-catalog, and immutable archive data remain
+repository-backed.
+
+## 6. Repository component map
+
+| Component | Responsibility | Main path |
+| --- | --- | --- |
+| Product pages | State workspace, national comparison, county profiles, readiness, evidence, security, releases, developer docs, social metadata | `src/app/` |
+| Public and admin routes | Versioned and compatibility read APIs, cached envelopes, token-protected setup/legacy operations | `src/app/api/` |
+| Client experience | Tabs, guided tour, state and national maps, charts, search, exports, Data Notes | `src/app/workspace-tabs.tsx`, `src/app/results-explorer.tsx`, `src/app/compare/` |
+| Shared read layer | Revision-keyed caching, database/seed reads, completeness | `src/lib/api.ts`, `src/lib/data-access.ts`, `src/db/public-data-revision.ts` |
+| Domain logic | Canonical geography, county comparison/profile, review policy, security, releases, diagnostics, registry readers | `src/lib/` |
+| Database model and importers | Drizzle schema, native and legacy promotion, starter seed | `src/db/` |
+| Migrations | Postgres schema history | `drizzle/` |
+| ETL contracts | Per-state sources, parser choices, expected totals, capabilities | `etl/state-configs/` |
+| ETL engine | Config loading, validation, native parser dispatch, staging | `civic_etl/` |
+| Data operations | Collect, normalize, reconcile, report, validate, promote | `scripts/` |
+| Source and context artifacts | Official files, normalized files, geometry, inventories, registries, release catalog | `data/` |
+| Immutable public data products | National county geometry and versioned release ZIPs | `public/data/` |
+| Generated pre-production artifacts | Reviewable state staging output | `.etl/staging/` |
+| Tests | API/contracts and Python ETL/state coverage | `tests/api/`, `tests/python/` |
+| Request boundary | Production HTTP-to-HTTPS redirect | `src/proxy.ts` |
+| Runtime and task configuration | Next.js, Vercel, Drizzle, and npm command graph | `next.config.ts`, `vercel.json`, `drizzle.config.ts`, `package.json` |
+| Delivery | CI validation, Vercel preview deployment, and production security smoke | `.github/workflows/ci.yml`, `.github/workflows/security-production-smoke.yml`, `vercel.json` |
+| Static brand assets | Favicons, logos, UI icons, and public data assets | `public/` |
+| Operating documentation | Developer playbook, source packages, turnout, calculations | `docs/` |
+
+## 7. Source-of-truth guide
+
+| Question | Source of truth |
+| --- | --- |
+| What live result, review, turnout, history, and equipment rows are served? | Neon Postgres through `src/lib/data-access.ts` |
+| What happens locally without a database URL? | Built-in seed data supplies the basic read experience |
+| Where did a result or context row come from? | `source_documents`, the matching state config, and the retained `data/` artifact |
+| Is a state ready for a particular feature? | Live capability/completeness rows combined with versioned source-package registries |
+| Which geography joins across 2024, 2020, 2016, and other row families? | Reviewed `jurisdictionTag` values from `data/canonical-jurisdictions.json` |
+| What contract should a new API integration use? | `/api/v1`, documented by `src/lib/openapi.ts` and versioned in `src/lib/api-version.ts` |
+| Where does map geometry come from at runtime? | State maps fetch committed GeoJSON from raw GitHub `main/data`; national maps use `public/data/national-counties.geojson` |
+| Is a staging file live? | No. `.etl/staging` is a pre-production review boundary |
+| Is a release ZIP the same as the live API? | No. `data/national-data-releases.json` describes immutable, hashed snapshots in `public/data/releases/`; live API responses can evolve within their contract |
+| What invalidates cached live reads after promotion? | A transactional bump to the `public_data_revisions` cache namespace |
+| Who can write production data? | Explicit token-protected admin operations or an authorized promotion command; public APIs are read-only |
+| What does an advisory indicator prove? | Nothing by itself; it prioritizes source reconciliation and human review |
+
+## 8. Change-impact shortcuts
+
+```mermaid
+flowchart LR
+  UIChange["UX or chart change"] --> UIPaths["src/app and src/lib diagnostics"]
+  UIPaths --> UITests["typecheck, API tests, build,<br/>browser and accessibility verification"]
+
+  APIChange["API contract change"] --> APIPaths["route or alias, OpenAPI, API version,<br/>types, services, data access"]
+  APIPaths --> APITests["API contract tests, release verification, build"]
+
+  StateChange["State data change"] --> StatePaths["state config, source artifacts,<br/>normalizer or native parser"]
+  StatePaths --> StateChecks["state validate/import, staging,<br/>indicator report, provenance and map checks"]
+
+  SharedETL["Shared ETL or schema change"] --> SharedPaths["civic_etl, src/db, migrations,<br/>promotion and all-state validation"]
+  SharedPaths --> FullChecks["Python tests, API tests, all-state ETL,<br/>package validators, maps, provenance, build"]
+
+  NationalChange["Canonical geography or release change"] --> NationalPaths["canonical registry, county services,<br/>public geometry, release catalog and ZIP"]
+  NationalPaths --> NationalChecks["jurisdiction validation, national API tests,<br/>coverage reports and release:verify"]
+```
+
+## Primary implementation references
+
+- [README](../README.md)
+- [Developer playbook](developer/index.md)
+
+- [Native import source packages](native-import-source-packages.md)
+- [Turnout collection inventory](turnout-collection-inventory.md)
+- [Application data assembly](../src/app/page.tsx)
+- [Workspace experience](../src/app/workspace-tabs.tsx)
+- [Map and result explorer](../src/app/results-explorer.tsx)
+- [Shared API layer](../src/lib/api.ts)
+- [Public API contract](../src/lib/openapi.ts)
+- [Data access](../src/lib/data-access.ts)
+- [National county services](../src/lib/national-county-comparison-data.ts)
+- [Database schema](../src/db/schema.ts)
+- [Release catalog](../data/national-data-releases.json)
+- [Security incident registry](../data/election-security-incidents-2024.json)
+- [Native promotion](../src/db/native-import.ts)
+- [ETL pipeline](../civic_etl/pipeline.py)
+- [CI workflow](../.github/workflows/ci.yml)

--- a/docs/ui-ux/README.md
+++ b/docs/ui-ux/README.md
@@ -1,0 +1,518 @@
+---
+aliases:
+  - Civic Result Maps UI UX README
+  - Civic Result Maps UX topology
+  - UI UX architecture
+tags:
+  - civic-result-maps
+  - ui
+  - ux
+  - information-architecture
+  - accessibility
+  - topology
+  - mermaid
+updated: 2026-07-14
+---
+
+# Civic Result Maps UI/UX README
+
+This is the product-facing companion to the [system topology](../system-topology.md).
+It describes the implemented information architecture, interaction model, trust
+states, responsive behavior, accessibility contract, and component ownership for
+Civic Result Maps.
+
+Use it when designing a feature, reviewing a flow, changing a React component,
+writing interface copy, or integrating the public API with a user-facing product.
+The diagrams are layered so a product designer can start with journeys, a UX
+developer can follow state and component ownership, and an engineer can find the
+runtime boundary behind each surface.
+
+> [!tip] Obsidian
+> Open this note in Reading view. Each Mermaid block is an independent zoom level.
+
+> [!important] Interpretation boundary
+> Results, readiness states, source gaps, and advisory indicators must remain
+> visibly distinct. An advisory indicator or missing record is a prompt for
+> source reconciliation and human review, not evidence of fraud, tampering,
+> misconduct, intent, or an incorrect outcome.
+
+## 1. Experience contract
+
+| Principle | Required interface behavior |
+| --- | --- |
+| Context before interpretation | Put year, geography, coverage, source status, and caveats before or beside maps and charts. |
+| Missingness stays visible | Never turn missing, blocked, non-comparable, or statewide-only data into a zero or a fabricated county value. |
+| Provenance is one action away | Keep source authority, URL, parser, confidence, and retained-artifact context reachable from the result or claim. |
+| Progressive disclosure | Start with a legible overview, then reveal the jurisdiction, methodology, evidence, and lineage details needed for deeper review. |
+| Shareable state | Important selections belong in stable routes or query parameters so a view can be copied, revisited, and tested. |
+| One selection across views | Map, table, drawer, URL, and export state should identify the same jurisdiction and filters. |
+| Neutral, actionable language | Explain what is loaded, what is limited, why it matters, and what evidence or action comes next. |
+| Accessible by more than color | Pair every color or shape with text, status labels, accessible names, and keyboard-operable controls. |
+
+## 2. Product information architecture
+
+```mermaid
+flowchart TB
+  Product["Civic Result Maps"]
+
+  Product --> Workspace["State Workspace<br/>/?state=XX"]
+  Product --> Compare["/compare<br/>national county comparison"]
+  Product --> Readiness["/readiness<br/>coverage and work queue"]
+  Product --> Evidence["/evidence<br/>records and evidence timeline"]
+  Product --> Security["/security<br/>source-linked incident explorer"]
+  Product --> Releases["/releases<br/>immutable public datasets"]
+  Product --> Developers["/developers<br/>public API guidance"]
+  Timeline["/timeline"] -. permanent redirect .-> Evidence
+
+  Workspace --> GlobalNav["Global app navigation"]
+  Workspace --> StateNav["State search, filters,<br/>status and data-family badges"]
+  Workspace --> Overview["National overview and readiness"]
+  Workspace --> CountyJump["Global county search"]
+  Workspace --> StateContext["State, year, metrics,<br/>coverage and warnings"]
+  Workspace --> Workbench["11-tab workbench<br/>plus persistent Data Notes"]
+
+  Compare --> CompareMap["National map and table"]
+  Compare --> County["/county/{fips}<br/>permanent county profile"]
+  County --> Traceability["History, turnout, equipment,<br/>review context and sources"]
+
+  Readiness -. open a state's next work .-> Workbench
+  Evidence -. source and records context .-> Workbench
+  Security -. state and county context .-> Workspace
+  Developers --> API["/api/v1<br/>JSON and CSV contracts"]
+  Releases --> Archives["Manifest and immutable ZIP"]
+  API --> Compare
+  API --> County
+```
+
+The State Workspace is the main exploratory workbench. The other pages are
+first-class task surfaces, not modal variants of the workspace:
+
+- Compare is optimized for cross-year, cross-state county comparisons.
+- County profiles are permanent, FIPS-addressed detail pages.
+- Readiness turns source and parser gaps into a reviewable work queue.
+- Evidence and Security organize source-linked context without merging it into
+  election-result claims.
+- Releases and Developers support reproducible downloads and integrations.
+
+## 3. State Workspace anatomy
+
+```mermaid
+flowchart TB
+  Request["Route request<br/>state, year, tab, mode, fips"]
+  Server["src/app/page.tsx<br/>server data composition"]
+  Request --> Server
+
+  Server --> Topbar["Sticky top bar<br/>brand and global apps"]
+  Server --> Shell["Workspace grid"]
+
+  Shell --> Sidebar["State sidebar<br/>filter, search, status, badges"]
+  Shell --> Main["Main panel"]
+
+  Main --> National["NationalOverview"]
+  Main --> Search["GlobalCountySearch"]
+  Main --> Header["Selected state and year<br/>coverage status"]
+  Main --> Metrics["Jurisdictions, votes,<br/>sources, validation"]
+  Main --> Tabs["WorkspaceTabs"]
+
+  Tabs --> TabBar["Guided tour plus 11 sections"]
+  Tabs --> Body["Active tab content"]
+  Tabs --> Notes["Collapsible Data Notes<br/>ready, partial, proxy, missing, blocked"]
+
+  Body --> MapTab["Map"]
+  Body --> ReviewTab["Review Center"]
+  Body --> HistoryTab["History"]
+  Body --> EvidenceTabs["Electronic Integrity<br/>Source Planner<br/>Data and Sources"]
+  Body --> ExplainTabs["Review Guide<br/>Exports and API<br/>Import Runs"]
+  Body --> CommunityTabs["Support and Contact"]
+
+  MapTab --> Explorer["ResultsExplorer"]
+  Explorer --> Controls["Layer, method, zoom and pan"]
+  Explorer --> Map["Keyboard-operable map"]
+  Explorer --> Drawer["Selected-jurisdiction drawer"]
+  Explorer --> Table["Searchable, sortable results table"]
+  MapTab --> ContextStack["Provenance, capability,<br/>and statewide snapshot panels"]
+
+  Map -. same selection .-> Drawer
+  Drawer -. same selection .-> Table
+  Table -. same selection .-> Map
+```
+
+### Workspace tabs
+
+| Tab | User intent | Primary content | When data is limited |
+| --- | --- | --- | --- |
+| Map | Explore where results and context occur | Winner, margin, volume, vote-method, equipment, and security layers; table; jurisdiction drawer | Show an explicit geometry, join, statewide-only, or result-row message instead of a blank or invented map. |
+| Review Center | Triage source-backed advisory prompts | Overview, Evidence Tools, Screening, Indicators, Methodology | Keep the evidence-readiness toolkit available and explain why charts are absent, gated, or partial. |
+| History | Compare supported election years | Share, margin, movement, Klimek-style, and Shpilkin-style views | Label unavailable denominators and proxy methods; preserve non-comparable geography. |
+| Electronic Integrity | Find retained administration evidence | Artifact inventory, request queue, and user-sent request drafts | Identify the missing record and responsible authority without implying misconduct. |
+| Source Planner | Decide what to collect or fix next | Capability checklist, blockers, and source-package status | Make the next evidence or parser task explicit. |
+| Data & Sources | Inspect the evidence behind the UI | Sources, results, review rows, turnout, vote methods, equipment, history | Show status and caveats for each family independently. |
+| Review Guide | Understand safe interpretation | Responsible-review rules, glossary, workflows, and formulas | This remains useful even when no state data is loaded. |
+| Exports & API | Reuse the current view | CSV, JSON, SVG, review-package ZIP, and API links | Export only what is actually loaded and include the same caveats and source manifest. |
+| Import Runs | Audit how data arrived | Parser, status, timestamps, summaries, validation lineage | Distinguish no run from a failed or partial run. |
+| Support | Find public evidence resources | EAC, NIST, certification, survey, and standards links | Keep links contextual and clearly external. |
+| Contact | Report or continue work | Project contact and data-issue paths | Preserve the exact state, jurisdiction, source, chart, and date in the handoff. |
+
+## 4. Core user journeys
+
+```mermaid
+flowchart TB
+  Start{"What is the user trying to do?"}
+
+  Start --> Explore["Explore one state"]
+  Start --> CompareTask["Compare counties or years"]
+  Start --> ReviewTask["Review a gap or advisory prompt"]
+  Start --> Integrate["Build with or download the data"]
+
+  subgraph StateJourney["State exploration"]
+    Explore --> ChooseState["Choose state and year"]
+    ChooseState --> ReadNotes["Read coverage status and Data Notes"]
+    ReadNotes --> ChooseLayer["Choose map layer"]
+    ChooseLayer --> SelectArea["Select map shape or table row"]
+    SelectArea --> InspectSource["Inspect drawer, source and caveat"]
+    InspectSource --> ProfileOrExport["Open county profile or export"]
+  end
+
+  subgraph ComparisonJourney["National comparison"]
+    CompareTask --> SetPair["Choose from and to years"]
+    SetPair --> Filter["Filter state, direction or county"]
+    Filter --> SyncViews["Map, table and URL update together"]
+    SyncViews --> CountyProfile["Open permanent county profile"]
+    CountyProfile --> FrozenData["Use release manifest or ZIP when reproducibility matters"]
+  end
+
+  subgraph ReviewJourney["Evidence-led review"]
+    ReviewTask --> ReadinessFirst["Check readiness and blockers"]
+    ReadinessFirst --> Planner["Open Source Planner or Data and Sources"]
+    Planner --> ReviewCenter["Use Evidence Tools before screening"]
+    ReviewCenter --> Gate{"Chart quality state"}
+    Gate -->|ready| InspectPrompt["Inspect advisory row and source"]
+    Gate -->|acknowledgement required| AcceptLimits["Read and acknowledge specific limits"]
+    Gate -->|blocked| CollectEvidence["Collect or reconcile missing evidence"]
+    AcceptLimits --> InspectPrompt
+    InspectPrompt --> EvidenceTimeline["Cross-check evidence timeline or administration context"]
+    EvidenceTimeline --> ReviewExport["Export review packet or continue source follow-up"]
+  end
+
+  subgraph IntegrationJourney["API and releases"]
+    Integrate --> DeveloperPage["Read /developers and OpenAPI"]
+    DeveloperPage --> LiveAPI["Use /api/v1 for live, paginated reads"]
+    DeveloperPage --> ReleasePage["Use /releases for a frozen snapshot"]
+  end
+
+  Trust["Trust rail<br/>year + geography + readiness + source + caveat"]
+  Trust -. accompanies .-> ReadNotes
+  Trust -. accompanies .-> SyncViews
+  Trust -. accompanies .-> ReviewCenter
+  Trust -. accompanies .-> LiveAPI
+```
+
+## 5. Interaction and deep-link topology
+
+```mermaid
+flowchart LR
+  URL["Shareable URL"]
+  Server["Server-selected datasets"]
+  Props["Serialized page props"]
+  Client["Client interaction state"]
+  URL --> Server --> Props --> Client
+
+  subgraph WorkspaceState["State Workspace"]
+    StateYearTab["state + year + tab"]
+    ModeFips["mode + fips"]
+    Selection["Selected jurisdiction"]
+    StateYearTab -->|navigation| Server
+    ModeFips -->|history.replaceState| URL
+    Selection --> Map["Map highlight"]
+    Selection --> Drawer["Detail drawer"]
+    Selection --> Table["Table callout and row"]
+    Selection --> ModeFips
+  end
+
+  subgraph CompareState["National comparison"]
+    CompareParams["from + to + direction + state + q<br/>sort + order + page + pageSize + fips"]
+    CompareParams -->|debounced request| CompareAPI["/api/flips"]
+    CompareAPI --> CompareClient["National map and table"]
+    CompareClient -->|history.replaceState| URL
+  end
+
+  subgraph SearchState["Global county search"]
+    SearchInput["County name, alias or FIPS"]
+    SearchInput --> SearchAPI["/api/jurisdictions/search"]
+    SearchAPI --> ProfileRoute["/county/{fips}"]
+  end
+
+  Client --> StateYearTab
+  Client --> ModeFips
+  URL --> CompareParams
+```
+
+### URL ownership
+
+| Surface | State | Behavior |
+| --- | --- | --- |
+| State Workspace | `state` | Two-letter state selection. Choosing a state returns to that state's default workspace view. |
+| State Workspace | `year` | `2016`, `2020`, or `2024`. Historical years apply to the Map tab; non-map tabs return to 2024 context. |
+| State Workspace | `tab` | One of the 11 workspace tab keys. Tab selection is linkable and triggers navigation so the server loads only the required families. |
+| State Workspace | `mode` | `winner`, `margin`, `volume`, `method`, `equipment`, or `security`. Updated in place by ResultsExplorer. |
+| State Workspace | `fips` | Five-digit canonical county selection when the result row has a `county:<GEOID>` tag. Synchronizes map, drawer, table, and URL. |
+| Compare | `from`, `to`, `direction`, `state`, `q` | Defines the comparison dataset and fetch request. Search is debounced. |
+| Compare | `sort`, `order`, `page`, `pageSize`, `fips` | Defines presentation and selection state without changing the comparison contract. |
+| County profile | `/county/{fips}` | Permanent route for one canonical county or county equivalent. |
+
+When adding a new shareable control, decide explicitly whether it changes the
+server dataset, the client presentation, or both. Preserve unknown-safe defaults,
+back/forward behavior, and a useful first render without interaction.
+
+## 6. Trust and data-state topology
+
+```mermaid
+flowchart TB
+  Evidence["Loaded rows, source records,<br/>joins, denominators and validation"]
+  Classify{"Quality classification"}
+  Evidence --> Classify
+
+  Classify --> Ready["Ready"]
+  Classify --> Partial["Partial"]
+  Classify --> Proxy["Proxy"]
+  Classify --> Missing["Missing"]
+  Classify --> Blocked["Blocked"]
+
+  Ready --> NormalUI["Render the supported view<br/>with source access"]
+  Partial --> CaveatedUI["Render available content<br/>plus exact limitation"]
+  Proxy --> ProxyUI["Label the substitute<br/>and name preferred evidence"]
+  Missing --> EmptyUI["Explicit empty state<br/>never zero-fill"]
+  Blocked --> BlockerUI["Do not render an unsafe claim<br/>show blocker and next action"]
+
+  NormalUI --> DataNotes["Data Notes"]
+  CaveatedUI --> DataNotes
+  ProxyUI --> DataNotes
+  EmptyUI --> DataNotes
+  BlockerUI --> DataNotes
+
+  DataNotes --> Planner["Source Planner and Readiness"]
+  DataNotes --> Provenance["Data and Sources"]
+
+  ReviewInput["Review or history chart"] --> Diagnostic{"Chart diagnostic"}
+  Diagnostic --> ChartReady["ready"]
+  Diagnostic --> Acknowledge["acknowledgement_required"]
+  Diagnostic --> ChartBlocked["blocked"]
+  Acknowledge -->|user reads chart-specific limits| ChartReady
+  ChartBlocked --> Planner
+```
+
+### State semantics
+
+| State | Meaning | Required UX |
+| --- | --- | --- |
+| Ready | Preferred evidence and required joins are available for this view. | Render normally, retain provenance, and avoid claiming more than the source supports. |
+| Partial | Some rows, URLs, joins, fields, or jurisdictions are incomplete. | Keep usable content visible; state the exact missing scope and how it affects interpretation. |
+| Proxy | A weaker but documented variable or source substitutes for the preferred evidence. | Use the word "Proxy," identify the substitute, and say what preferred evidence is absent. |
+| Missing | No usable data is loaded for the requested family or scope. | Use an intentional empty state, not `0`, an empty chart, or an unqualified blank map. |
+| Blocked | The view cannot responsibly make the requested comparison. | Suppress the claim or chart and present the blocker, responsible source, and next action. |
+| Acknowledgement required | A chart has rows, but specific coverage or reconciliation limits need to be read first. | Keep the chart gated until the user acknowledges those chart-specific limitations. |
+
+Quality describes evidence fitness and display readiness. It is not a credibility
+rating for voters, candidates, jurisdictions, or election outcomes.
+
+## 7. Responsive topology
+
+```mermaid
+flowchart LR
+  Desktop["> 1180px<br/>state sidebar + main panel<br/>content + Data Notes rail"]
+  NotesStack["<= 1180px<br/>Data Notes moves above content"]
+  Tablet["<= 980px<br/>workspace, top bar, controls,<br/>charts and detail grids stack"]
+  Compact["<= 640px<br/>comparison, security and search<br/>controls use compact layouts"]
+  Small["<= 520px<br/>county jump and dense callouts<br/>collapse to one column"]
+
+  Desktop --> NotesStack --> Tablet --> Compact --> Small
+
+  Tablet --> TabContract["Tab bar remains horizontally scrollable"]
+  Tablet --> StateContract["Sidebar becomes static;<br/>state list receives a bounded height"]
+  Tablet --> GateContract["Chart acknowledgement gate<br/>moves inline above the chart"]
+  Compact --> TouchContract["Labels stay visible;<br/>controls retain touch targets"]
+```
+
+The global stylesheet and page-local CSS modules use several content-driven
+breakpoints rather than one universal device taxonomy:
+
+| Scope | Breakpoints | Primary behavior |
+| --- | --- | --- |
+| Workspace and shared UI | 1180, 980, 520px; top-bar wrapping at 1120px | Collapse the sidebar/main and content/detail grids, move Data Notes, stack controls and warnings. |
+| Compare and Security | 1240, 900, 640px | Reduce multi-column explorers, move controls and details into a linear reading order. |
+| County profile | 1050, 700px | Collapse profile grids and dense context sections. |
+| Developers and Releases | 820, 540px | Stack hero, endpoint, and release content. |
+| Global county search | 620px | Stack search input, state scope, and result affordances. |
+
+Design at the behavioral boundaries, not only at named device presets. Check long
+state names, source titles, caveats, table columns, chart labels, and URL-driven
+empty states at every boundary.
+
+## 8. Visual system topology
+
+```mermaid
+flowchart TB
+  Tokens["globals.css tokens<br/>color, type, line, panel, shadow"]
+  Shared["Shared patterns<br/>top bar, panel, pill, badge,<br/>table, tab, warning, empty state"]
+  Components["Shared React components<br/>brand, state switcher, search,<br/>tour, ELI5, workspace, map"]
+  Modules["Page-local CSS modules<br/>compare, county, platform, security, search"]
+  Pages["Product pages"]
+
+  Tokens --> Shared
+  Shared --> Components
+  Tokens --> Modules
+  Components --> Pages
+  Modules --> Pages
+
+  Copy["Content semantics<br/>ready, partial, proxy, missing, blocked"]
+  Copy --> Shared
+  Copy --> Components
+```
+
+### Foundation tokens
+
+| Token or family | Current role |
+| --- | --- |
+| `--background`, `--panel`, `--panel-strong`, `--panel-hover` | Dark application canvas and progressive surface hierarchy. |
+| `--foreground`, `--muted`, `--quiet` | Primary, secondary, and low-emphasis text. Essential caveats must not use the quietest treatment. |
+| `--line` | Neutral structure for panels, tables, controls, and separators. |
+| `--accent`, `--accent-soft`, `--accent-line` | Active controls, selected states, links, and ready status. |
+| `--gold` | Partial, proxy, caution, and acknowledgement-required states. |
+| `--red` | Missing or blocked state and explicitly labeled Republican/candidate encoding where applicable. Never rely on hue alone. |
+| `--blue` | Explicitly labeled Democratic/candidate encoding and selected informational emphasis where applicable. Never rely on hue alone. |
+| `--font-interface` | Geist/Inter/Segoe UI interface stack. |
+| `--font-code` | Geist Mono/Cascadia/Consolas for IDs, counts, paths, and machine-facing values. |
+| `--shadow` | High-level floating or elevated panels; do not use it to make every grouping card-like. |
+
+Current shared styling is class-based in `globals.css`, while specialized pages
+use CSS modules. There is no separate packaged design-system library. Reuse an
+existing semantic pattern before adding a new one, and promote a repeated local
+pattern into shared CSS only when its meaning is genuinely cross-product.
+
+### Visual invariants
+
+- The application is dark-first and declares `color-scheme: dark`.
+- Accent green means selected, linked, live, or ready; it does not mean a
+  political party.
+- Gold means caution, partial, proxy, or acknowledgement required.
+- Red and blue need explicit text labels when they encode political results.
+- Panels use restrained borders and an 8px radius; pills are reserved for
+  compact status or controls.
+- Lucide icons support visible labels and hierarchy; they do not replace labels.
+- Inline SVG charts and maps require direct labels, accessible names, and an
+  adjacent textual caveat when a method is limited.
+
+## 9. Accessibility and interaction contract
+
+| Concern | Current implementation anchor | Requirement for new work |
+| --- | --- | --- |
+| Document structure | `html lang="en"`, semantic `header`, `nav`, `main`, `section`, `aside`, headings | Preserve a logical heading and landmark order when moving panels. |
+| County search | Combobox/listbox pattern, active descendant, keyboard navigation, Escape, live result count | Keep input, popup, active option, status, and navigation behavior synchronized. |
+| Map geography | SVG title, per-shape accessible name, keyboard focus, Enter/Space selection, labeled pan/zoom controls | Every pointer action needs a keyboard equivalent and visible selected state. |
+| Map/table synchronization | Shared selected jurisdiction and FIPS URL state | Focus and selection must not disagree across map, drawer, table, and copied link. |
+| Dynamic feedback | `role="status"`, `role="note"`, `aria-live="polite"` in warnings, search, and tour | Announce meaningful changes without moving focus unexpectedly. |
+| Guided help | Guided tour with closable controls and polite announcements; ELI5 buttons expose expanded state | Help cannot cover the only way to complete a task and must work at narrow widths. |
+| Motion | `prefers-reduced-motion: reduce` rules in shared and comparison styles | Any new animation needs a reduced-motion path and must not carry essential meaning. |
+| Status color | Visible words such as Ready, Partial, Proxy, Missing, and Blocked | Never ship a color-only status, map legend, or chart series distinction. |
+| Tables and charts | Semantic tables, labeled controls, SVG titles, textual caveats and empty states | Verify keyboard access, names, units, long labels, and non-visual equivalents. |
+| External evidence | Visible source labels and links with clear context | Do not hide authority, reporting grain, caveat, or destination behind an unlabeled icon. |
+
+This document records the intended contract; it is not a substitute for browser,
+keyboard, screen-reader, zoom, contrast, and reduced-motion verification.
+
+## 10. Component ownership map
+
+| Surface or concern | Primary implementation | Owns |
+| --- | --- | --- |
+| Global metadata and analytics | `src/app/layout.tsx` | Language, metadata defaults, icons, social defaults, Vercel Analytics. |
+| State Workspace composition | `src/app/page.tsx` | URL parsing, conditional server data loads, top bar, selected state/year, summary metrics, props passed into the workbench. |
+| State discovery | `src/app/state-switcher.tsx` | State filters, search, readiness badges, selected-state navigation, list scroll memory. |
+| National progress summary | `src/app/national-overview.tsx` | Cross-state loading and readiness overview. |
+| Global county lookup | `src/app/global-county-search.tsx` | Accessible county/FIPS search and navigation to permanent profiles. |
+| Workspace and trust UX | `src/app/workspace-tabs.tsx` | Tabs, guided content, Data Notes, review gates, charts, source planner, exports, support and contact. |
+| State map and result table | `src/app/results-explorer.tsx` | Map layers, geometry fetch, map/table/drawer selection, FIPS and mode URL state, join warnings. |
+| Guided help | `src/app/guided-tour.tsx`, `src/app/eli5.tsx` | Step navigation, spotlight positioning, announcements, contextual plain-language help. |
+| National comparison | `src/app/compare/` | Comparison filters, API fetch, map/table selection, pagination, share URL, CSV path. |
+| County profile | `src/app/county/[fips]/` | Permanent county history, turnout, provenance, equipment, and review context. |
+| Readiness | `src/app/readiness/page.tsx` | National work queue, coverage semantics, source packages, parser and blocker details. |
+| Evidence timeline | `src/app/evidence/`, `src/app/timeline/` | Evidence and records timeline; legacy route redirect. |
+| Security explorer | `src/app/security/` | Incident filters, national map, source report, and clearly separated election overlay. |
+| API and release pages | `src/app/developers/`, `src/app/releases/` | Integration guidance, contract examples, immutable release catalog and downloads. |
+| Social previews | `src/app/api/social-card/route.tsx`, `src/lib/social-preview.ts` | State, comparison, and security share imagery and metadata. |
+| Shared visual foundation | `src/app/globals.css` | Tokens and shared workspace/readiness/timeline patterns. |
+| Specialized page styling | Page-local `*.module.css` files | Compare, county, platform, search, and security layout details. |
+
+## 11. UI/API boundary
+
+The UI uses two read patterns:
+
+1. Server Components call shared service functions for the initial workspace,
+   county profile, readiness, and page metadata.
+2. Interactive clients call public endpoints where filters change in place,
+   notably county search and national comparison.
+
+For a UI change that touches API data:
+
+- Prefer the stable `/api/v1` contract for new external integrations.
+- Keep legacy unversioned UI routes only where the existing product owns them.
+- Preserve `{ data, meta }`, schema/release identifiers, pagination, confidence,
+  caveats, and source fields in any client normalization.
+- Distinguish a live API view from an immutable release.
+- Treat a missing field as unknown, not as zero, false, or "no incident."
+
+## 12. Design-to-code change topology
+
+```mermaid
+flowchart LR
+  Goal["User goal or observed problem"]
+  Surface["Choose owning page and component"]
+  States["Model ready, partial, proxy,<br/>missing, blocked and error states"]
+  Interaction["Define URL, selection,<br/>loading and feedback behavior"]
+  Trust["Add source, caveat,<br/>readiness and next action"]
+  Access["Keyboard, names, focus,<br/>motion, contrast and zoom"]
+  Responsive["Desktop, 1180, 980,<br/>640 and 320px checks"]
+  Verify["Typecheck, tests, build,<br/>browser and content review"]
+  Docs["Update topology or user guidance"]
+
+  Goal --> Surface --> States --> Interaction --> Trust --> Access --> Responsive --> Verify --> Docs
+```
+
+### Handoff checklist
+
+- [ ] The user goal and primary task are stated before choosing a component.
+- [ ] The owning route, server boundary, client component, service, and CSS scope
+      are identified.
+- [ ] Ready, loading, partial, proxy, missing, blocked, error, and no-match states
+      are considered where applicable.
+- [ ] State, year, geography, reporting grain, source, and caveat remain visible.
+- [ ] Map, table, drawer, URL, export, and profile selection agree.
+- [ ] Deep links survive refresh and have safe defaults.
+- [ ] New charts or indicators have methodology, evidence fitness, units, labels,
+      and a non-visual explanation.
+- [ ] Pointer, keyboard, focus, announcements, zoom, contrast, and reduced motion
+      are verified.
+- [ ] Layout is checked near 1180, 980, 640, and 320px, plus any page-local
+      breakpoint touched by the change.
+- [ ] Long source titles, caveats, state names, county names, FIPS values, table
+      columns, and empty states do not clip or overlap.
+- [ ] Public-facing language does not turn a gap or advisory signal into an
+      allegation or conclusion.
+- [ ] Relevant API tests, typecheck, build, and browser flows are run.
+
+## Primary implementation references
+
+- [System topology](../system-topology.md)
+- [Repository README](../../README.md)
+- [Application shell and server composition](../../src/app/page.tsx)
+- [Workspace experience](../../src/app/workspace-tabs.tsx)
+- [State map and result explorer](../../src/app/results-explorer.tsx)
+- [State discovery](../../src/app/state-switcher.tsx)
+- [Global county search](../../src/app/global-county-search.tsx)
+- [Guided tour](../../src/app/guided-tour.tsx)
+- [Shared visual foundation](../../src/app/globals.css)
+- [National comparison](../../src/app/compare/compare-explorer.tsx)
+- [County profile](../../src/app/county/[fips]/page.tsx)
+- [Readiness dashboard](../../src/app/readiness/page.tsx)
+- [Security explorer](../../src/app/security/security-explorer.tsx)
+- [Public API documentation page](../../src/app/developers/page.tsx)
+- [Public API contract](../../src/lib/openapi.ts)


### PR DESCRIPTION
## Summary

- add an Obsidian-ready, layered system topology for product, UX, engineering, data, and API audiences
- add a dedicated UI/UX README covering information architecture, workspace anatomy, core journeys, deep-link state, trust states, responsive behavior, accessibility, visual foundations, component ownership, and the UI/API boundary
- map the runtime, API families, ETL trust gates, normalized data model, repository components, and change-impact paths
- link the two topology documents from the repository README and from each other

## Validation

- parsed all 14 Mermaid diagrams with Mermaid 11.12.0
- verified all 37 local Markdown links across the README and topology documents resolve
- verified system coverage of all 43 API routes, 9 product page routes, and 16 schema tables
- verified UI/UX coverage of all 11 workspace tabs, 6 map modes, 5 evidence-quality states, and 3 chart-diagnostic states
- ran `git diff --check`

## Notes

Advisory indicators and data gaps are documented as review prompts, not evidence of fraud, tampering, misconduct, or intent.