### PR TITLE
Scope Clerk middleware to admin routes

### DIFF
--- a/src/lib/ui-layout-admin-policy.ts
+++ b/src/lib/ui-layout-admin-policy.ts
@@ -7,6 +7,10 @@ export function parseLayoutAdminAllowlist(value: string | undefined) {
   );
 }
 
+export function isPrivateAdminPath(pathname: string) {
+  return pathname === "/admin" || pathname.startsWith("/admin/");
+}
+
 export function selectAuthorizedLayoutAdminEmail(
   verifiedEmails: string[],
   allowlistValue: string | undefined,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,7 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
 import type { NextFetchEvent, NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { isPrivateAdminPath } from "@/lib/ui-layout-admin-policy";
 import {
   isLayoutVisitorId,
   LAYOUT_VISITOR_COOKIE,
@@ -52,7 +53,7 @@ export async function proxy(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.redirect(secureUrl, 308);
   }
 
-  if (authenticatedProxy) {
+  if (authenticatedProxy && isPrivateAdminPath(request.nextUrl.pathname)) {
     const response = await authenticatedProxy(request, event);
     if (response) return response;
   }

--- a/tests/api/workspace-layout-admin-policy.test.mjs
+++ b/tests/api/workspace-layout-admin-policy.test.mjs
@@ -2,9 +2,19 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
+  isPrivateAdminPath,
   parseLayoutAdminAllowlist,
   selectAuthorizedLayoutAdminEmail,
 } from "../../src/lib/ui-layout-admin-policy.ts";
+
+test("Clerk middleware is scoped to private admin routes", () => {
+  assert.equal(isPrivateAdminPath("/"), false);
+  assert.equal(isPrivateAdminPath("/api/states"), false);
+  assert.equal(isPrivateAdminPath("/administrator"), false);
+  assert.equal(isPrivateAdminPath("/admin"), true);
+  assert.equal(isPrivateAdminPath("/admin/layout"), true);
+  assert.equal(isPrivateAdminPath("/admin/sign-in"), true);
+});
 
 test("layout admin allowlist is normalized and fails closed", () => {
   assert.deepEqual([...parseLayoutAdminAllowlist(undefined)], []);


### PR DESCRIPTION
## Summary

- scope Clerk middleware to `/admin` and `/admin/*`
- preserve the public visitor-cookie proxy behavior
- add route-policy coverage for public, lookalike, and admin paths

## Why

The Clerk Marketplace resource currently supplies development-mode keys. Running Clerk middleware on every matched request caused public production HTML routes to enter Clerk's development handshake. Restricting Clerk to the private admin tree keeps the public election explorer independent of admin authentication.

## Validation

- `npm run test:layout`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- live rollback smoke checks: `/`, `/api/states`, and `/admin/layout` all return 200
- repaired production deployment has no error-level runtime logs

## Follow-up after merge

Production Clerk keys should only be re-enabled after this fix is deployed. The Edge Config store still needs to be connected to the Vercel project through the Storage dashboard before `EDGE_CONFIG` is restored.