### PR TITLE
Build in-context workspace layout editor

### DIFF
--- a/src/app/admin/layout/layout-editor.module.css
+++ b/src/app/admin/layout/layout-editor.module.css
@@ -207,6 +207,648 @@
   padding: 4px 7px;
 }
 
+.workspacePreview {
+  background: #0d1514;
+  border: 1px solid #2b3d3a;
+  border-radius: 10px;
+  margin: 0 18px 18px;
+  overflow: hidden;
+}
+
+.previewChrome {
+  align-items: center;
+  background:
+    linear-gradient(120deg, rgba(59, 197, 170, 0.1), transparent 45%),
+    #121c1b;
+  border-bottom: 1px solid #2b3d3a;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  padding: 16px;
+}
+
+.previewBrand {
+  display: grid;
+  gap: 3px;
+}
+
+.previewBrand span,
+.previewContext span,
+.previewSection header span,
+.previewNotesHeading span {
+  color: #54d6bd;
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.previewBrand strong {
+  font-size: 15px;
+}
+
+.previewFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  justify-content: flex-end;
+}
+
+.previewFilters span {
+  background: #192523;
+  border: 1px solid #324743;
+  border-radius: 6px;
+  color: #b8c7c4;
+  font-size: 11px;
+  padding: 7px 9px;
+}
+
+.previewTabBar,
+.previewSectionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.previewTabBar {
+  align-items: stretch;
+  background: #141d1c;
+  border-bottom: 1px solid #2b3d3a;
+  display: flex;
+  gap: 7px;
+  overflow-x: auto;
+  padding: 9px;
+  scrollbar-color: #39504c transparent;
+}
+
+.previewSortable {
+  position: relative;
+}
+
+.tabItem {
+  flex: 0 0 auto;
+}
+
+.previewTabButton {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  color: #91a4a0;
+  cursor: pointer;
+  display: flex;
+  gap: 7px;
+  min-height: 42px;
+  padding: 7px 72px 7px 11px;
+  text-align: left;
+}
+
+.previewTabButton:hover {
+  background: #1b2826;
+  color: #f4f1ea;
+}
+
+.activeTabButton {
+  background: rgba(59, 197, 170, 0.11);
+  border-color: rgba(84, 214, 189, 0.34);
+  color: #7ee0cd;
+}
+
+.elementTools {
+  display: flex;
+  gap: 3px;
+  position: absolute;
+  right: 7px;
+  top: 7px;
+  z-index: 2;
+}
+
+.elementTools button,
+.settingsHeader button,
+.positionSetting button,
+.settingsFooter button {
+  align-items: center;
+  background: #21302e;
+  border: 1px solid #3a514d;
+  border-radius: 6px;
+  color: #e9efed;
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  min-height: 28px;
+  padding: 5px 6px;
+}
+
+.elementTools button:hover,
+.elementTools button:focus-visible,
+.settingsHeader button:hover,
+.positionSetting button:hover:not(:disabled) {
+  background: #2b3d3a;
+  border-color: #57bdaa;
+  color: #8ce2d1;
+}
+
+.dragHandle {
+  cursor: grab !important;
+  touch-action: none;
+}
+
+.dragHandle:active {
+  cursor: grabbing !important;
+}
+
+.hiddenElement {
+  opacity: 0.6;
+}
+
+.hiddenElement::after {
+  border: 1px dashed rgba(240, 195, 106, 0.48);
+  border-radius: inherit;
+  content: "";
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.hiddenElement .elementTools {
+  opacity: 1;
+}
+
+.hiddenBadge,
+.requiredBadge {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 10px;
+  font-weight: 800;
+  gap: 4px;
+  padding: 3px 6px;
+  white-space: nowrap;
+}
+
+.hiddenBadge {
+  background: rgba(240, 195, 106, 0.12);
+  color: #e6ce8f;
+}
+
+.hiddenWarning {
+  align-items: center;
+  background: rgba(240, 195, 106, 0.08);
+  border-bottom: 1px solid rgba(240, 195, 106, 0.2);
+  color: #dfca92;
+  display: flex;
+  font-size: 12px;
+  gap: 8px;
+  margin: 0;
+  padding: 9px 13px;
+}
+
+.previewWorkspaceBody {
+  align-items: start;
+  display: grid;
+  gap: 13px;
+  grid-template-columns: minmax(0, 1fr) minmax(185px, 215px);
+  padding: 13px;
+}
+
+.previewMain {
+  display: grid;
+  gap: 11px;
+  min-width: 0;
+}
+
+.previewContext {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.previewContext div {
+  display: grid;
+  gap: 2px;
+}
+
+.previewContext h3,
+.previewSection h3,
+.previewNotes h3 {
+  margin: 0;
+}
+
+.previewContext h3 {
+  font-size: 18px;
+}
+
+.previewContext small {
+  background: #182321;
+  border: 1px solid #2f4541;
+  border-radius: 999px;
+  color: #9fb0ad;
+  font-size: 10px;
+  padding: 5px 7px;
+}
+
+.previewSectionList {
+  display: grid;
+  gap: 10px;
+}
+
+.sectionItem {
+  border-radius: 8px;
+}
+
+.previewSection {
+  background: #141e1d;
+  border: 1px solid #2b3d3a;
+  border-radius: 8px;
+  min-height: 132px;
+  overflow: hidden;
+}
+
+.previewSection > header {
+  align-items: flex-start;
+  border-bottom: 1px solid #293b39;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  min-height: 58px;
+  padding: 12px 78px 10px 12px;
+}
+
+.previewSection > header > div:first-child {
+  display: grid;
+  gap: 3px;
+}
+
+.previewSection h3 {
+  font-size: 14px;
+}
+
+.previewBadges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  justify-content: flex-end;
+}
+
+.sectionItem .elementTools {
+  right: 11px;
+  top: 11px;
+}
+
+.previewNotes {
+  background: #141e1d;
+  border: 1px solid #2b3d3a;
+  border-radius: 8px;
+  display: grid;
+  gap: 9px;
+  padding: 12px;
+  position: sticky;
+  top: 12px;
+}
+
+.previewNotesHeading {
+  align-items: center;
+  color: #7fcdbd;
+  display: flex;
+  justify-content: space-between;
+}
+
+.previewNotes h3 {
+  font-size: 15px;
+}
+
+.previewNotes > p {
+  color: #94a7a3;
+  font-size: 11px;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.previewNoteCard {
+  background: #101817;
+  border: 1px solid #2c403c;
+  border-radius: 6px;
+  display: grid;
+  gap: 3px;
+  padding: 9px;
+}
+
+.previewNoteCard strong {
+  font-size: 11px;
+}
+
+.previewNoteCard span {
+  color: #8fa19e;
+  font-size: 10px;
+}
+
+.mapPreview,
+.chartPreview,
+.rowsPreview,
+.actionsPreview,
+.textPreview {
+  min-height: 92px;
+  padding: 13px;
+}
+
+.mapPreview {
+  background:
+    linear-gradient(rgba(84, 214, 189, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(84, 214, 189, 0.04) 1px, transparent 1px),
+    #101918;
+  background-size: 18px 18px;
+  display: grid;
+  gap: 13px;
+  grid-template-columns: minmax(0, 1fr) 26px;
+}
+
+.mapShape {
+  background:
+    radial-gradient(circle at 28% 42%, rgba(84, 214, 189, 0.55) 0 6%, transparent 7%),
+    radial-gradient(circle at 62% 48%, rgba(240, 195, 106, 0.5) 0 7%, transparent 8%),
+    linear-gradient(135deg, rgba(45, 126, 111, 0.75), rgba(42, 84, 78, 0.5));
+  border: 1px solid rgba(84, 214, 189, 0.24);
+  clip-path: polygon(6% 21%, 29% 8%, 47% 17%, 67% 12%, 94% 31%, 88% 67%, 65% 88%, 43% 78%, 23% 90%, 8% 64%);
+  min-height: 78px;
+}
+
+.mapLegend {
+  display: grid;
+  gap: 5px;
+}
+
+.mapLegend i,
+.chartPreview i,
+.rowsPreview i,
+.actionsPreview i,
+.textPreview i {
+  background: #304640;
+  border-radius: 3px;
+  display: block;
+}
+
+.mapLegend i:nth-child(1) { background: #2f806f; }
+.mapLegend i:nth-child(2) { background: #4da691; }
+.mapLegend i:nth-child(3) { background: #b18d4d; }
+.mapLegend i:nth-child(4) { background: #775147; }
+
+.chartPreview {
+  align-items: end;
+  border-bottom: 1px solid #344844;
+  display: flex;
+  gap: 8px;
+}
+
+.chartPreview i {
+  background: linear-gradient(#54d6bd, #275b51);
+  flex: 1;
+}
+
+.chartPreview i:nth-child(1) { height: 45%; }
+.chartPreview i:nth-child(2) { height: 74%; }
+.chartPreview i:nth-child(3) { height: 58%; }
+.chartPreview i:nth-child(4) { height: 86%; }
+.chartPreview i:nth-child(5) { height: 66%; }
+
+.rowsPreview,
+.textPreview {
+  display: grid;
+  gap: 8px;
+}
+
+.rowsPreview i {
+  border: 1px solid #38504b;
+  height: 21px;
+}
+
+.textPreview i {
+  height: 9px;
+}
+
+.textPreview i:nth-child(1) { width: 94%; }
+.textPreview i:nth-child(2) { width: 78%; }
+.textPreview i:nth-child(3) { width: 58%; }
+
+.actionsPreview {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.actionsPreview i {
+  border: 1px solid #42605a;
+  height: 31px;
+  width: 28%;
+}
+
+.settingsDialog {
+  background: transparent;
+  border: 0;
+  color: #f4f1ea;
+  margin: auto;
+  max-height: calc(100vh - 32px);
+  max-width: 540px;
+  overflow: visible;
+  padding: 0;
+  width: calc(100% - 28px);
+}
+
+.settingsDialog::backdrop {
+  background: rgba(2, 8, 7, 0.76);
+  backdrop-filter: blur(3px);
+}
+
+.settingsCard {
+  background: #141d1c;
+  border: 1px solid #3a504c;
+  border-radius: 12px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.58);
+  overflow: hidden;
+}
+
+.settingsHeader {
+  align-items: flex-start;
+  border-bottom: 1px solid #2b3d3a;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  padding: 18px;
+}
+
+.settingsHeader > div {
+  display: grid;
+  gap: 4px;
+}
+
+.settingsHeader span {
+  color: #54d6bd;
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.settingsHeader h2 {
+  font-size: 20px;
+  margin: 0;
+}
+
+.settingsHeader button {
+  height: 32px;
+  width: 32px;
+}
+
+.settingsBody {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+}
+
+.visibilitySetting {
+  align-items: center;
+  background: #101817;
+  border: 1px solid #2d413d;
+  border-radius: 8px;
+  cursor: pointer;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 13px;
+  position: relative;
+}
+
+.visibilitySetting > div,
+.positionSetting > div:first-child {
+  display: grid;
+  gap: 4px;
+}
+
+.visibilitySetting strong,
+.positionSetting strong {
+  font-size: 13px;
+}
+
+.visibilitySetting div span,
+.positionSetting div span,
+.codeOwnedNotice span,
+.lockedSetting span {
+  color: #9badaa;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.visibilitySetting input {
+  height: 1px;
+  opacity: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.toggleControl {
+  background: #334541;
+  border: 1px solid #4a5d59;
+  border-radius: 999px;
+  display: block;
+  height: 26px;
+  padding: 2px;
+  transition: background 160ms ease;
+  width: 46px;
+}
+
+.toggleControl i {
+  background: #dae4e1;
+  border-radius: 50%;
+  display: block;
+  height: 20px;
+  transition: transform 160ms ease;
+  width: 20px;
+}
+
+.visibilitySetting input:checked + .toggleControl {
+  background: #3bc5aa;
+  border-color: #64dbc4;
+}
+
+.visibilitySetting input:checked + .toggleControl i {
+  background: #06231e;
+  transform: translateX(18px);
+}
+
+.visibilitySetting input:focus-visible + .toggleControl {
+  outline: 2px solid #f0c36a;
+  outline-offset: 3px;
+}
+
+.visibilitySetting input:disabled + .toggleControl {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.lockedSetting,
+.codeOwnedNotice {
+  align-items: flex-start;
+  border-radius: 7px;
+  display: flex;
+  gap: 9px;
+  padding: 10px;
+}
+
+.lockedSetting {
+  background: rgba(240, 195, 106, 0.08);
+  border: 1px solid rgba(240, 195, 106, 0.25);
+  color: #e3cd94;
+}
+
+.codeOwnedNotice {
+  background: rgba(84, 214, 189, 0.06);
+  border: 1px solid rgba(84, 214, 189, 0.2);
+  color: #7ed8c7;
+}
+
+.positionSetting {
+  background: #101817;
+  border: 1px solid #2d413d;
+  border-radius: 8px;
+  display: grid;
+  gap: 12px;
+  padding: 13px;
+}
+
+.positionSetting > div:last-child {
+  display: flex;
+  gap: 8px;
+}
+
+.positionSetting button {
+  gap: 6px;
+  min-height: 34px;
+  padding: 7px 10px;
+}
+
+.positionSetting button:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+.settingsFooter {
+  background: #111918;
+  border-top: 1px solid #2b3d3a;
+  display: flex;
+  justify-content: flex-end;
+  padding: 13px 18px;
+}
+
+.settingsFooter button {
+  background: #3bc5aa;
+  border-color: #3bc5aa;
+  color: #06231e;
+  font-weight: 850;
+  min-width: 86px;
+  padding: 8px 13px;
+}
+
 .saveForm,
 .publishForm {
   display: grid;
@@ -341,7 +983,38 @@
     grid-template-columns: 1fr;
   }
 
-  .sortableItem {
+  .workspacePreview {
+    margin-inline: 10px;
+  }
+
+  .previewChrome {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .previewFilters {
+    justify-content: flex-start;
+  }
+
+  .previewWorkspaceBody {
+    grid-template-columns: 1fr;
+  }
+
+  .previewNotes {
+    position: static;
+  }
+
+  .previewSection > header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .previewBadges {
+    justify-content: flex-start;
+  }
+
+  .positionSetting > div:last-child {
     display: grid;
+    grid-template-columns: 1fr 1fr;
   }
 }

--- a/src/app/admin/layout/layout-editor.tsx
+++ b/src/app/admin/layout/layout-editor.tsx
@@ -6,13 +6,16 @@ import {
   ArrowDown,
   ArrowUp,
   Eye,
+  EyeOff,
   GripVertical,
   LockKeyhole,
   RotateCcw,
   Save,
   Send,
+  Settings2,
+  X,
 } from "lucide-react";
-import { useActionState, useMemo, useState } from "react";
+import { useActionState, useEffect, useMemo, useRef, useState } from "react";
 import {
   initialLayoutActionState,
   requestLayoutPublicationAction,
@@ -66,6 +69,10 @@ const registryByTab = new Map<WorkspaceTabId, WorkspaceTabRegistryEntry>(
   workspaceLayoutRegistry.map((tab) => [tab.id, tab]),
 );
 
+type SettingsTarget =
+  | { kind: "tab"; tabId: WorkspaceTabId }
+  | { kind: "section"; sectionId: WorkspaceSectionId; tabId: WorkspaceTabId };
+
 function moveItem<T>(items: T[], from: number, to: number) {
   if (from === to || from < 0 || to < 0 || from >= items.length || to >= items.length) return items;
   const result = [...items];
@@ -74,22 +81,24 @@ function moveItem<T>(items: T[], from: number, to: number) {
   return result;
 }
 
-function SortableItem({
+function SortablePreviewItem({
   children,
   dragId,
   group,
+  hidden,
   index,
   label,
-  last,
-  onMove,
+  onSettings,
+  variant,
 }: {
   children: React.ReactNode;
   dragId: string;
   group: string;
+  hidden: boolean;
   index: number;
   label: string;
-  last: boolean;
-  onMove: (delta: -1 | 1) => void;
+  onSettings: () => void;
+  variant: "section" | "tab";
 }) {
   const { handleRef, isDragSource, ref } = useSortable({
     id: dragId,
@@ -98,21 +107,229 @@ function SortableItem({
     type: group,
     accept: group,
   });
+
   return (
-    <li className={`${styles.sortableItem} ${isDragSource ? styles.dragging : ""}`} ref={ref}>
-      <div className={styles.rowControls}>
-        <button aria-label={`Drag ${label}`} className={styles.dragHandle} ref={handleRef} type="button">
+    <li
+      className={[
+        styles.previewSortable,
+        variant === "tab" ? styles.tabItem : styles.sectionItem,
+        hidden ? styles.hiddenElement : "",
+        isDragSource ? styles.dragging : "",
+      ].join(" ")}
+      ref={ref}
+    >
+      {children}
+      <div className={styles.elementTools}>
+        <button
+          aria-label={"Configure " + label}
+          onClick={onSettings}
+          title={"Configure " + label}
+          type="button"
+        >
+          <Settings2 aria-hidden size={16} />
+        </button>
+        <button
+          aria-label={"Drag " + label + " to a new position"}
+          className={styles.dragHandle}
+          ref={handleRef}
+          title={"Drag " + label}
+          type="button"
+        >
           <GripVertical aria-hidden size={18} />
         </button>
-        <button aria-label={`Move ${label} up`} disabled={index === 0} onClick={() => onMove(-1)} type="button">
-          <ArrowUp aria-hidden size={15} />
-        </button>
-        <button aria-label={`Move ${label} down`} disabled={last} onClick={() => onMove(1)} type="button">
-          <ArrowDown aria-hidden size={15} />
-        </button>
       </div>
-      {children}
     </li>
+  );
+}
+
+function SectionPreviewContent({ sectionId }: { sectionId: WorkspaceSectionId }) {
+  if (sectionId === "results-map") {
+    return (
+      <div className={styles.mapPreview} aria-hidden>
+        <div className={styles.mapShape} />
+        <div className={styles.mapLegend}><i /><i /><i /><i /></div>
+      </div>
+    );
+  }
+
+  if (["historical-summary", "historical-charts", "indicators", "screening"].includes(sectionId)) {
+    return (
+      <div className={styles.chartPreview} aria-hidden>
+        <i /><i /><i /><i /><i />
+      </div>
+    );
+  }
+
+  if (["source-provenance", "source-plan", "source-records-request", "cvr-requests", "downloads", "api-links", "import-history"].includes(sectionId)) {
+    return (
+      <div className={styles.rowsPreview} aria-hidden>
+        <i /><i /><i />
+      </div>
+    );
+  }
+
+  if (["review-packet", "support-actions", "contact-options", "guided-workflows", "evidence-tools"].includes(sectionId)) {
+    return (
+      <div className={styles.actionsPreview} aria-hidden>
+        <i /><i /><i />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.textPreview} aria-hidden>
+      <i /><i /><i />
+    </div>
+  );
+}
+
+function PreviewTabBar({
+  activeTabId,
+  manifest,
+  onSelect,
+  onSettings,
+}: {
+  activeTabId: WorkspaceTabId;
+  manifest: WorkspaceLayoutManifestV1;
+  onSelect: (tabId: WorkspaceTabId) => void;
+  onSettings: (target: SettingsTarget) => void;
+}) {
+  return (
+    <ol aria-label="Workspace tabs" className={styles.previewTabBar}>
+      {manifest.tabs.map((tab, tabIndex) => {
+        const registry = registryByTab.get(tab.id)!;
+        return (
+          <SortablePreviewItem
+            dragId={"tab:" + tab.id}
+            group="layout-tabs"
+            hidden={!tab.visible}
+            index={tabIndex}
+            key={tab.id}
+            label={registry.label}
+            onSettings={() => onSettings({ kind: "tab", tabId: tab.id })}
+            variant="tab"
+          >
+            <button
+              aria-pressed={activeTabId === tab.id}
+              className={[
+                styles.previewTabButton,
+                activeTabId === tab.id ? styles.activeTabButton : "",
+              ].join(" ")}
+              onClick={() => onSelect(tab.id)}
+              type="button"
+            >
+              <span>{registry.label}</span>
+              {!tab.visible && (
+                <small className={styles.hiddenBadge}><EyeOff aria-hidden size={11} /> Hidden</small>
+              )}
+            </button>
+          </SortablePreviewItem>
+        );
+      })}
+    </ol>
+  );
+}
+
+function PreviewSectionList({
+  onSettings,
+  registry,
+  tab,
+}: {
+  onSettings: (target: SettingsTarget) => void;
+  registry: WorkspaceTabRegistryEntry;
+  tab: WorkspaceLayoutManifestV1["tabs"][number];
+}) {
+  return (
+    <ol aria-label={registry.label + " sections"} className={styles.previewSectionList}>
+      {tab.sections.map((section, sectionIndex) => {
+        const sectionRegistry = registry.sections.find((item) => item.id === section.id)!;
+        return (
+          <SortablePreviewItem
+            dragId={"section:" + tab.id + ":" + section.id}
+            group={"layout-sections-" + tab.id}
+            hidden={!section.visible}
+            index={sectionIndex}
+            key={section.id}
+            label={sectionRegistry.label}
+            onSettings={() => onSettings({
+              kind: "section",
+              sectionId: section.id,
+              tabId: tab.id,
+            })}
+            variant="section"
+          >
+            <article aria-label={sectionRegistry.label + " preview"} className={styles.previewSection}>
+              <header>
+                <div>
+                  <span>Section {sectionIndex + 1}</span>
+                  <h3>{sectionRegistry.label}</h3>
+                </div>
+                <div className={styles.previewBadges}>
+                  {!section.visible && (
+                    <small className={styles.hiddenBadge}><EyeOff aria-hidden size={11} /> Hidden</small>
+                  )}
+                  {sectionRegistry.required && (
+                    <small className={styles.requiredBadge}><LockKeyhole aria-hidden size={11} /> Required</small>
+                  )}
+                </div>
+              </header>
+              <SectionPreviewContent sectionId={section.id} />
+            </article>
+          </SortablePreviewItem>
+        );
+      })}
+    </ol>
+  );
+}
+
+function PreviewWorkspaceBody({
+  onSettings,
+  registry,
+  tab,
+}: {
+  onSettings: (target: SettingsTarget) => void;
+  registry: WorkspaceTabRegistryEntry;
+  tab: WorkspaceLayoutManifestV1["tabs"][number];
+}) {
+  return (
+    <>
+      {!tab.visible && (
+        <p className={styles.hiddenWarning} role="status">
+          <EyeOff aria-hidden size={15} />
+          This tab is hidden from the public site. It remains here so you can inspect, move, or restore it.
+        </p>
+      )}
+
+      <div className={styles.previewWorkspaceBody}>
+        <main className={styles.previewMain}>
+          <div className={styles.previewContext}>
+            <div>
+              <span>Selected tab</span>
+              <h3>{registry.label}</h3>
+            </div>
+            <small>{tab.sections.filter((section) => section.visible).length} visible sections</small>
+          </div>
+          <PreviewSectionList onSettings={onSettings} registry={registry} tab={tab} />
+        </main>
+
+        <aside className={styles.previewNotes} aria-label="Fixed Data Notes preview">
+          <div className={styles.previewNotesHeading}>
+            <span>Fixed panel</span>
+            <LockKeyhole aria-label="Locked in place" size={14} />
+          </div>
+          <h3>Data Notes</h3>
+          <p>Source caveats and coverage notes stay visible beside every workspace tab.</p>
+          <div className={styles.previewNoteCard}>
+            <strong>Source coverage</strong>
+            <span>Official-source context</span>
+          </div>
+          <div className={styles.previewNoteCard}>
+            <strong>Reporting grain</strong>
+            <span>Jurisdiction details</span>
+          </div>
+        </aside>
+      </div>
+    </>
   );
 }
 
@@ -126,6 +343,10 @@ export function LayoutEditor({
   revisions,
 }: LayoutEditorProps) {
   const [manifest, setManifest] = useState(() => cloneWorkspaceLayoutManifest(baseManifest));
+  const [activeTabId, setActiveTabId] = useState<WorkspaceTabId>(
+    () => baseManifest.tabs.find((tab) => tab.visible)?.id ?? baseManifest.tabs[0]?.id ?? "map",
+  );
+  const [settingsTarget, setSettingsTarget] = useState<SettingsTarget | null>(null);
   const [changeSummary, setChangeSummary] = useState("");
   const [selectedRevisionId, setSelectedRevisionId] = useState(parentRevisionId ?? revisions[0]?.id ?? "");
   const [environment, setEnvironment] = useState<"preview" | "production">("preview");
@@ -134,7 +355,52 @@ export function LayoutEditor({
     requestLayoutPublicationAction,
     initialLayoutActionState,
   );
+  const settingsDialogRef = useRef<HTMLDialogElement>(null);
   const dirty = useMemo(() => JSON.stringify(manifest) !== JSON.stringify(baseManifest), [baseManifest, manifest]);
+  const activeTab = manifest.tabs.find((tab) => tab.id === activeTabId) ?? manifest.tabs[0]!;
+  const activeRegistry = registryByTab.get(activeTab.id)!;
+  const settingsDetails = useMemo(() => {
+    if (!settingsTarget) return null;
+    const tabIndex = manifest.tabs.findIndex((tab) => tab.id === settingsTarget.tabId);
+    const tab = manifest.tabs[tabIndex];
+    const tabRegistry = registryByTab.get(settingsTarget.tabId);
+    if (!tab || !tabRegistry) return null;
+
+    if (settingsTarget.kind === "tab") {
+      return {
+        cannotHideLast: false,
+        index: tabIndex,
+        itemCount: manifest.tabs.length,
+        label: tabRegistry.label,
+        required: Boolean(tabRegistry.required),
+        target: settingsTarget,
+        visible: tab.visible,
+      };
+    }
+
+    const sectionIndex = tab.sections.findIndex((section) => section.id === settingsTarget.sectionId);
+    const section = tab.sections[sectionIndex];
+    const sectionRegistry = tabRegistry.sections.find((item) => item.id === settingsTarget.sectionId);
+    if (!section || !sectionRegistry) return null;
+    const visibleCount = tab.sections.filter((item) => item.visible).length;
+
+    return {
+      cannotHideLast: tab.visible && section.visible && visibleCount === 1,
+      index: sectionIndex,
+      itemCount: tab.sections.length,
+      label: sectionRegistry.label,
+      required: Boolean(sectionRegistry.required),
+      target: settingsTarget,
+      visible: section.visible,
+    };
+  }, [manifest, settingsTarget]);
+
+  useEffect(() => {
+    const dialog = settingsDialogRef.current;
+    if (!dialog) return;
+    if (settingsTarget && !dialog.open) dialog.showModal();
+    if (!settingsTarget && dialog.open) dialog.close();
+  }, [settingsTarget]);
 
   function moveTab(index: number, delta: -1 | 1) {
     setManifest((current) => ({ ...current, tabs: moveItem(current.tabs, index, index + delta) }));
@@ -196,19 +462,42 @@ export function LayoutEditor({
     }
   }
 
+  function moveSettingsTarget(delta: -1 | 1) {
+    if (!settingsDetails) return;
+    if (settingsDetails.target.kind === "tab") {
+      moveTab(settingsDetails.index, delta);
+      return;
+    }
+    moveSection(settingsDetails.target.tabId, settingsDetails.index, delta);
+  }
+
+  function toggleSettingsTarget() {
+    if (!settingsDetails) return;
+    if (settingsDetails.target.kind === "tab") {
+      toggleTab(settingsDetails.target.tabId);
+      return;
+    }
+    toggleSection(settingsDetails.target.tabId, settingsDetails.target.sectionId);
+  }
+
   return (
     <div className={styles.editorShell}>
       <section className={styles.editorPanel}>
         <div className={styles.panelHeading}>
           <div>
-            <p>Workspace manifest</p>
-            <h2>Order and visibility</h2>
-            <span>Drag rows or use the arrow buttons. Text, icons, and content remain locked in code.</span>
+            <p>Visual workspace editor</p>
+            <h2>Arrange the live workspace</h2>
+            <span>Select a tab to inspect its sections. Use each six-dot handle to move it or the gear to change its settings.</span>
           </div>
           <button
             className={styles.secondaryButton}
             disabled={!dirty}
-            onClick={() => setManifest(cloneWorkspaceLayoutManifest(embeddedWorkspaceLayoutManifest))}
+            onClick={() => {
+              const resetManifest = cloneWorkspaceLayoutManifest(embeddedWorkspaceLayoutManifest);
+              setManifest(resetManifest);
+              setActiveTabId(resetManifest.tabs.find((tab) => tab.visible)?.id ?? "map");
+              setSettingsTarget(null);
+            }}
             type="button"
           >
             <RotateCcw aria-hidden size={15} /> Reset default
@@ -217,73 +506,114 @@ export function LayoutEditor({
 
         <div className={styles.fixedNotice}>
           <LockKeyhole aria-hidden size={17} />
-          <span><strong>Data Notes is fixed.</strong> It stays outside the editable manifest so caveats cannot be hidden or reordered away.</span>
+          <span><strong>Safety rails stay active.</strong> Required tabs and sections remain visible, and Data Notes stays fixed beside the workspace.</span>
         </div>
 
         <DragDropProvider onDragEnd={handleDragEnd}>
-          <ol className={styles.tabList}>
-            {manifest.tabs.map((tab, tabIndex) => {
-              const registry = registryByTab.get(tab.id)!;
-              return (
-                <SortableItem
-                  dragId={`tab:${tab.id}`}
-                  group="layout-tabs"
-                  index={tabIndex}
-                  key={tab.id}
-                  label={registry.label}
-                  last={tabIndex === manifest.tabs.length - 1}
-                  onMove={(delta) => moveTab(tabIndex, delta)}
-                >
-                  <div className={styles.itemBody}>
-                    <div className={styles.itemHeading}>
-                      <label>
-                        <input
-                          checked={tab.visible}
-                          disabled={Boolean(registry.required)}
-                          onChange={() => toggleTab(tab.id)}
-                          type="checkbox"
-                        />
-                        <strong>{registry.label}</strong>
-                      </label>
-                      {registry.required && <span className={styles.requiredBadge}><LockKeyhole size={12} /> Required</span>}
-                    </div>
-                    <ol className={styles.sectionList}>
-                      {tab.sections.map((section, sectionIndex) => {
-                        const sectionRegistry = registry.sections.find((item) => item.id === section.id)!;
-                        const visibleCount = tab.sections.filter((item) => item.visible).length;
-                        const cannotHideLast = tab.visible && section.visible && visibleCount === 1;
-                        return (
-                          <SortableItem
-                            dragId={`section:${tab.id}:${section.id}`}
-                            group={`layout-sections-${tab.id}`}
-                            index={sectionIndex}
-                            key={section.id}
-                            label={sectionRegistry.label}
-                            last={sectionIndex === tab.sections.length - 1}
-                            onMove={(delta) => moveSection(tab.id, sectionIndex, delta)}
-                          >
-                            <div className={styles.sectionBody}>
-                              <label>
-                                <input
-                                  checked={section.visible}
-                                  disabled={Boolean(sectionRegistry.required) || cannotHideLast}
-                                  onChange={() => toggleSection(tab.id, section.id)}
-                                  type="checkbox"
-                                />
-                                <span>{sectionRegistry.label}</span>
-                              </label>
-                              {sectionRegistry.required && <LockKeyhole aria-label="Required section" size={13} />}
-                            </div>
-                          </SortableItem>
-                        );
-                      })}
-                    </ol>
-                  </div>
-                </SortableItem>
-              );
-            })}
-          </ol>
+          <div aria-label="Workspace layout preview" className={styles.workspacePreview}>
+            <header className={styles.previewChrome}>
+              <div className={styles.previewBrand}>
+                <span>CivicResultMaps</span>
+                <strong>Public workspace preview</strong>
+              </div>
+              <div className={styles.previewFilters} aria-label="Example production context">
+                <span>2024 General</span>
+                <span>United States</span>
+              </div>
+            </header>
+            <PreviewTabBar
+              activeTabId={activeTab.id}
+              manifest={manifest}
+              onSelect={setActiveTabId}
+              onSettings={setSettingsTarget}
+            />
+            <PreviewWorkspaceBody
+              onSettings={setSettingsTarget}
+              registry={activeRegistry}
+              tab={activeTab}
+            />
+          </div>
         </DragDropProvider>
+
+        <dialog
+          aria-labelledby={settingsDetails ? "layout-settings-title" : undefined}
+          className={styles.settingsDialog}
+          onCancel={(event) => {
+            event.preventDefault();
+            setSettingsTarget(null);
+          }}
+          onClose={() => setSettingsTarget(null)}
+          ref={settingsDialogRef}
+        >
+          {settingsDetails && (
+            <div className={styles.settingsCard}>
+              <header className={styles.settingsHeader}>
+                <div>
+                  <span>{settingsDetails.target.kind === "tab" ? "Tab settings" : "Section settings"}</span>
+                  <h2 id="layout-settings-title">{settingsDetails.label}</h2>
+                </div>
+                <button aria-label="Close settings" onClick={() => setSettingsTarget(null)} type="button">
+                  <X aria-hidden size={18} />
+                </button>
+              </header>
+
+              <div className={styles.settingsBody}>
+                <label className={styles.visibilitySetting}>
+                  <div>
+                    <strong>Show on the public site</strong>
+                    <span>Hidden items remain visible in this editor so they can be restored.</span>
+                  </div>
+                  <input
+                    checked={settingsDetails.visible}
+                    disabled={settingsDetails.required || settingsDetails.cannotHideLast}
+                    onChange={toggleSettingsTarget}
+                    type="checkbox"
+                  />
+                  <span aria-hidden className={styles.toggleControl}><i /></span>
+                </label>
+
+                {(settingsDetails.required || settingsDetails.cannotHideLast) && (
+                  <div className={styles.lockedSetting}>
+                    <LockKeyhole aria-hidden size={16} />
+                    <span>
+                      {settingsDetails.required
+                        ? "This element is required and cannot be hidden."
+                        : "A visible tab must keep at least one visible section."}
+                    </span>
+                  </div>
+                )}
+
+                <div className={styles.positionSetting}>
+                  <div>
+                    <strong>Position</strong>
+                    <span>Move it one place at a time, or close this window and use the six-dot handle.</span>
+                  </div>
+                  <div>
+                    <button disabled={settingsDetails.index === 0} onClick={() => moveSettingsTarget(-1)} type="button">
+                      <ArrowUp aria-hidden size={15} /> Earlier
+                    </button>
+                    <button
+                      disabled={settingsDetails.index === settingsDetails.itemCount - 1}
+                      onClick={() => moveSettingsTarget(1)}
+                      type="button"
+                    >
+                      <ArrowDown aria-hidden size={15} /> Later
+                    </button>
+                  </div>
+                </div>
+
+                <div className={styles.codeOwnedNotice}>
+                  <LockKeyhole aria-hidden size={15} />
+                  <span>Its label, icon, text, and data remain code-owned. This editor changes only order and visibility.</span>
+                </div>
+              </div>
+
+              <footer className={styles.settingsFooter}>
+                <button onClick={() => setSettingsTarget(null)} type="button">Done</button>
+              </footer>
+            </div>
+          )}
+        </dialog>
 
         <form action={saveAction} className={styles.saveForm}>
           <input name="manifest" type="hidden" value={JSON.stringify(manifest)} />

--- a/tests/api/workspace-layout-admin-policy.test.mjs
+++ b/tests/api/workspace-layout-admin-policy.test.mjs
@@ -46,3 +46,20 @@ test("server authorization filters Clerk emails by verified status", () => {
   assert.equal(actions.match(/await requireLayoutAdmin\(\)/g)?.length, 4);
   assert.match(exitRoute, /await requireLayoutAdmin\(\)/);
 });
+
+test("layout editor exposes an in-context preview with direct manipulation controls", () => {
+  const editor = readFileSync("src/app/admin/layout/layout-editor.tsx", "utf8");
+  const css = readFileSync("src/app/admin/layout/layout-editor.module.css", "utf8");
+
+  assert.match(editor, /function PreviewTabBar/);
+  assert.match(editor, /function PreviewWorkspaceBody/);
+  assert.match(editor, /GripVertical/);
+  assert.match(editor, /Settings2/);
+  assert.match(editor, /<dialog/);
+  assert.match(editor, /showModal\(\)/);
+  assert.match(editor, /Data Notes/);
+  assert.match(editor, /changes only order and visibility/);
+  assert.match(css, /\.workspacePreview/);
+  assert.match(css, /\.settingsDialog::backdrop/);
+  assert.match(css, /\.hiddenElement::after/);
+});


### PR DESCRIPTION
## What changed

- Replaces the abstract nested tab/section list with a production-like workspace preview.
- Adds a gear to every configurable tab and section.
- Adds a six-dot drag handle to every movable tab and section.
- Opens a focused settings dialog for visibility and keyboard-friendly earlier/later positioning.
- Keeps hidden items visible in the admin preview so they can always be restored.
- Shows the fixed Data Notes rail and preserves all required-tab, required-section, and last-visible-section safety rules.
- Adds responsive preview/dialog styling and a focused editor contract test.

## Why

The previous editor showed configuration rows but did not make it easy to understand how a revision would affect the public workspace. This puts layout controls directly on a recognizable preview while keeping the existing safe order-and-visibility-only boundary.

## Validation

- `npm run typecheck`
- `npm run test:layout`
- `npm run build`
- Local protected route check: Clerk redirect loaded, page had content, no framework error overlay, and no browser console errors.

## Review note

The editor itself is Clerk-protected, so the authenticated visual pass should be completed on the Vercel preview while signed in as an allowlisted admin.