### PR TITLE
Expand workspace layout builder customization

### DIFF
--- a/docs/developer/ui-layout-operations.md
+++ b/docs/developer/ui-layout-operations.md
@@ -6,26 +6,28 @@ The workspace layout system is a constrained production page builder for allowli
 
 | Scope | Editable controls |
 | --- | --- |
-| Workspace | Theme, tab style, content width, default tab, and the initial Data Notes state |
-| Tab | Order, visibility where allowed, section spacing, and Data Notes position |
-| Production component | Order, visibility where allowed, surface, emphasis, and Results Map height |
-| Approved custom block | Add, reorder, hide, delete, edit content, set density, surface, emphasis, and responsive width |
-| Review workflow | Desktop/tablet/mobile preview, before/after/split comparison, undo, redo, validation, immutable save, draft preview, and protected publication |
+| Workspace | Theme, accent, spacing, type scale, corners, shadows, tab style, content width, default tab, and initial Data Notes state |
+| Tab | Visibility where allowed, density, Data Notes position, and a responsive row/column hierarchy |
+| Production component | Move between columns, responsive width, visibility where allowed, surface, emphasis, density, and allowlisted variants |
+| Approved content block | Add, drag, hide, delete, format rich text, manage media, configure links/items, and attach visibility rules |
+| Review workflow | Desktop/tablet/mobile preview, undo, redo, validation, immutable save, reusable templates, draft preview, and protected publication |
 
-The approved custom component library contains Narrative, Callout, Metric strip, Link list, and Divider.
+The approved content library contains Heading, Rich text, Narrative, Callout, Metric strip, Link list, Button group, Image, Video, Accordion, and Divider. Images use the linked Vercel Blob store; video blocks accept only YouTube or Vimeo IDs.
 
 The canvas is a production-shaped preview with representative fixtures. It mirrors navigation, content hierarchy, responsive widths, hidden states, and the fixed Data Notes surface; it does not duplicate live election queries inside the admin page. Use **Draft preview** after saving to inspect the exact public runtime with real data before publication.
 
-Production component width and internal spacing remain tied to their tested application layouts. Responsive 12-column width controls apply to approved custom blocks: desktop supports 4, 6, 8, or 12 columns; tablet supports 6 or 12; mobile is always 12.
+Rows use a responsive 12-column grid. Desktop spans are 3, 4, 6, 8, 9, or 12; tablet spans are 6 or 12; mobile is always 12. Production behavior remains code-owned even when its position, presentation, or allowlisted variant changes.
 
 ## Safety boundaries
 
-- The registry in `src/lib/workspace-layout.ts` is the code-owned list of allowed tabs and production sections.
+- The registries in `src/lib/workspace-layout.ts` and `src/lib/workspace-layout-v2.ts` are the code-owned lists of allowed tabs and production components.
 - Map, Review Center, Data & Sources, and Review Guide are required tabs.
 - Results Map and Source Provenance are required production sections.
 - Every visible tab must retain at least one visible production section.
-- Data Notes remains a fixed trust surface. Operators may change its initial open state and side/below placement, but not its source-driven content or remove it.
-- Custom blocks are supplemental, always follow production components, and are limited to 12 per tab.
+- Data Notes remains a fixed trust surface. Operators may change its initial open state and side, below, or drawer placement, but not its source-driven content or remove it.
+- Custom blocks are supplemental, can share rows with production components, and are limited to 12 per tab and 20 rows per tab.
+- Required production components cannot use data-dependent visibility rules.
+- Visibility rules use only allowlisted public state, year, capability, data-availability, and validation facts; viewport rules are CSS-safe and mobile remains stacked.
 - Custom text is escaped. Links accept only safe internal paths, HTTPS URLs, and email links; protocol-relative links such as `//example.com` are rejected.
 - Verified labels, data queries, interactions, source caveats, and authorization remain code-owned.
 - Every manifest is validated against the exact registry and protected by a SHA-256 digest.
@@ -38,7 +40,8 @@ Production component width and internal spacing remain tied to their tested appl
 | Surface | Responsibility |
 | --- | --- |
 | `/admin/layout` | Clerk-protected page builder, validation, immutable revisions, preview, and publication requests |
-| Neon tables | Immutable revisions, idempotent publication requests, and audit events |
+| Neon tables | Immutable revisions, idempotent publication requests, audit events, shared templates, managed assets, and immutable asset references |
+| Vercel Blob | Public `layout-media/` images with authenticated uploads, MIME/size limits, and stored dimensions/alt text |
 | Vercel Edge Config | `workspaceLayoutStable` and `workspaceLayoutCandidate` envelopes |
 | Vercel Flags | Browser-stable evaluation of `workspace-layout-candidate` |
 | GitHub Actions | Protected, serialized Edge Config publisher with environment approvals |
@@ -54,7 +57,7 @@ Configure `DATABASE_URL` or `POSTGRES_URL`, then apply all checked-in Drizzle mi
 npm run db:push
 ```
 
-The layout schema is introduced by `drizzle/0004_uneven_hellcat.sql` and completed by `drizzle/0005_lazy_human_torch.sql`. Apply migrations separately to preview and production databases before enabling the editor there.
+The immutable revision schema is introduced by migrations 0004 and 0005. Migration `drizzle/0006_broad_quicksilver.sql` enables schema v2 and adds managed assets, shared templates, and immutable asset-reference tables. Apply migrations separately to preview and production databases before enabling Builder v3 there.
 
 ### 2. Configure private administration
 
@@ -65,6 +68,7 @@ Set these application environment variables:
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk browser configuration |
 | `CLERK_SECRET_KEY` | Clerk server authentication |
 | `UI_LAYOUT_ADMIN_EMAILS` | Comma-separated verified email allowlist; matching is case-insensitive |
+| `BLOB_READ_WRITE_TOKEN` | Vercel Blob upload token, normally injected by the linked Blob store |
 
 Authorization is checked on the page and again in every Server Action. A signed-in user needs at least one verified Clerk email that matches the allowlist.
 
@@ -98,14 +102,14 @@ Keep `UI_LAYOUT_PUBLISH_WORKFLOW_ENABLED=false` until the workflow and protected
 
 ## Builder workflow
 
-1. Open `/admin/layout` and choose a tab in the left Structure pane.
-2. Drag tabs or components with the six-dot handle. Keyboard-accessible Earlier/Later controls are available in the inspector.
-3. Select a component or its gear to configure it in the right Inspector pane.
-4. Add approved blocks from the Component Library. Custom blocks stay after production components.
-5. Switch among Desktop, Tablet, and Mobile, then use Before, After, or Compare.
-6. Use Undo or Redo while editing. **Reset saved** restores the currently loaded saved manifest.
-7. Resolve all blocking pre-publish checks and review warnings about hidden surfaces or custom editorial copy.
-8. Enter a change summary and select **Save immutable revision**.
+1. Open `/admin/layout` and choose a fixed production tab in the left Build pane.
+2. Add rows and columns, then drag components by the six-dot handle or move whole rows with the arrow controls.
+3. Select a row, column, component, or its gear to configure it in the right inspector.
+4. Add approved content blocks, choose production variants, or start from a built-in/shared template.
+5. Switch among Desktop, Tablet, and Mobile and set each column span at the active breakpoint.
+6. Use Undo or Redo while editing. **Reset** restores the currently loaded saved manifest.
+7. Resolve blocking validation, verify rich text/media alt text and visibility rules, then save an optional reusable template.
+8. Enter a change summary and select **Save revision**. Saving never publishes the active layout.
 
 Saving creates a child revision; it does not overwrite or publish the active layout.
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "drizzle-kit";
 import { getDatabaseUrl } from "./src/db/url";
 
 export default defineConfig({
-  schema: "./src/db/schema.ts",
+  schema: ["./src/db/schema.ts", "./src/db/ui-layout-v3-schema.ts"],
   out: "./drizzle",
   dialect: "postgresql",
   dbCredentials: {

--- a/drizzle/0006_broad_quicksilver.sql
+++ b/drizzle/0006_broad_quicksilver.sql
@@ -1,0 +1,60 @@
+CREATE TABLE "ui_layout_assets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"url" text NOT NULL,
+	"pathname" text NOT NULL,
+	"content_type" text NOT NULL,
+	"size_bytes" integer NOT NULL,
+	"width" integer NOT NULL,
+	"height" integer NOT NULL,
+	"alt" text DEFAULT '' NOT NULL,
+	"actor_id" text NOT NULL,
+	"actor_email" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	CONSTRAINT "ui_layout_assets_dimensions_check" CHECK ("ui_layout_assets"."width" > 0 and "ui_layout_assets"."height" > 0),
+	CONSTRAINT "ui_layout_assets_size_check" CHECK ("ui_layout_assets"."size_bytes" > 0 and "ui_layout_assets"."size_bytes" <= 5242880)
+);
+--> statement-breakpoint
+CREATE TABLE "ui_layout_revision_assets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"revision_id" uuid NOT NULL,
+	"asset_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "ui_layout_template_assets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"template_id" uuid NOT NULL,
+	"asset_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "ui_layout_templates" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"description" text DEFAULT '' NOT NULL,
+	"manifest" jsonb NOT NULL,
+	"is_shared" boolean DEFAULT true NOT NULL,
+	"actor_id" text NOT NULL,
+	"actor_email" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ui_layout_revisions" DROP CONSTRAINT "ui_layout_revisions_schema_version_check";--> statement-breakpoint
+ALTER TABLE "ui_layout_revisions" DROP CONSTRAINT "ui_layout_revisions_registry_version_check";--> statement-breakpoint
+ALTER TABLE "ui_layout_revision_assets" ADD CONSTRAINT "ui_layout_revision_assets_revision_id_ui_layout_revisions_id_fk" FOREIGN KEY ("revision_id") REFERENCES "public"."ui_layout_revisions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ui_layout_revision_assets" ADD CONSTRAINT "ui_layout_revision_assets_asset_id_ui_layout_assets_id_fk" FOREIGN KEY ("asset_id") REFERENCES "public"."ui_layout_assets"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ui_layout_template_assets" ADD CONSTRAINT "ui_layout_template_assets_template_id_ui_layout_templates_id_fk" FOREIGN KEY ("template_id") REFERENCES "public"."ui_layout_templates"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "ui_layout_template_assets" ADD CONSTRAINT "ui_layout_template_assets_asset_id_ui_layout_assets_id_fk" FOREIGN KEY ("asset_id") REFERENCES "public"."ui_layout_assets"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "ui_layout_assets_created_at_idx" ON "ui_layout_assets" USING btree ("created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "ui_layout_assets_pathname_idx" ON "ui_layout_assets" USING btree ("pathname");--> statement-breakpoint
+CREATE UNIQUE INDEX "ui_layout_assets_url_idx" ON "ui_layout_assets" USING btree ("url");--> statement-breakpoint
+CREATE UNIQUE INDEX "ui_layout_revision_assets_unique_idx" ON "ui_layout_revision_assets" USING btree ("revision_id","asset_id");--> statement-breakpoint
+CREATE INDEX "ui_layout_revision_assets_revision_idx" ON "ui_layout_revision_assets" USING btree ("revision_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "ui_layout_template_assets_unique_idx" ON "ui_layout_template_assets" USING btree ("template_id","asset_id");--> statement-breakpoint
+CREATE INDEX "ui_layout_template_assets_template_idx" ON "ui_layout_template_assets" USING btree ("template_id");--> statement-breakpoint
+CREATE INDEX "ui_layout_templates_created_at_idx" ON "ui_layout_templates" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "ui_layout_templates_name_idx" ON "ui_layout_templates" USING btree ("name");--> statement-breakpoint
+ALTER TABLE "ui_layout_revisions" ADD CONSTRAINT "ui_layout_revisions_schema_version_check" CHECK ("ui_layout_revisions"."schema_version" in (1, 2));--> statement-breakpoint
+ALTER TABLE "ui_layout_revisions" ADD CONSTRAINT "ui_layout_revisions_registry_version_check" CHECK ("ui_layout_revisions"."registry_version" in (1, 2));

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,3049 @@
+{
+  "id": "9c837ddc-5e01-4f53-b80c-64cca830e989",
+  "prevId": "5f95c457-9b14-4533-96d8-47ddcaa9db90",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analysis_indicators": {
+      "name": "analysis_indicators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_year": {
+          "name": "election_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_code": {
+          "name": "jurisdiction_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_name": {
+          "name": "jurisdiction_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_tag": {
+          "name": "jurisdiction_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indicator_type": {
+          "name": "indicator_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_indicators_unique_idx": {
+          "name": "analysis_indicators_unique_idx",
+          "columns": [
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "election_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "jurisdiction_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "indicator_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_indicators_state_code_states_code_fk": {
+          "name": "analysis_indicators_state_code_states_code_fk",
+          "tableFrom": "analysis_indicators",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_indicators_source_document_id_source_documents_id_fk": {
+          "name": "analysis_indicators_source_document_id_source_documents_id_fk",
+          "tableFrom": "analysis_indicators",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidates": {
+      "name": "candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "party": {
+          "name": "party",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ballot_order": {
+          "name": "ballot_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "candidates_contest_name_party_idx": {
+          "name": "candidates_contest_name_party_idx",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "party",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "candidates_contest_id_contests_id_fk": {
+          "name": "candidates_contest_id_contests_id_fk",
+          "tableFrom": "candidates",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capability_flags": {
+      "name": "capability_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_year": {
+          "name": "election_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certified_results": {
+          "name": "certified_results",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "map": {
+          "name": "map",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "review_graphs": {
+          "name": "review_graphs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "turnout": {
+          "name": "turnout",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "historical_baseline": {
+          "name": "historical_baseline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_planner": {
+          "name": "source_planner",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "capability_flags_state_year_idx": {
+          "name": "capability_flags_state_year_idx",
+          "columns": [
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "election_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capability_flags_state_code_states_code_fk": {
+          "name": "capability_flags_state_code_states_code_fk",
+          "tableFrom": "capability_flags",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contests": {
+      "name": "contests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "election_id": {
+          "name": "election_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "office": {
+          "name": "office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "contests_election_state_office_idx": {
+          "name": "contests_election_state_office_idx",
+          "columns": [
+            {
+              "expression": "election_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "office",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contests_election_id_elections_id_fk": {
+          "name": "contests_election_id_elections_id_fk",
+          "tableFrom": "contests",
+          "tableTo": "elections",
+          "columnsFrom": [
+            "election_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contests_state_code_states_code_fk": {
+          "name": "contests_state_code_states_code_fk",
+          "tableFrom": "contests",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.elections": {
+      "name": "elections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "office": {
+          "name": "office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_date": {
+          "name": "election_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "elections_year_office_idx": {
+          "name": "elections_year_office_idx",
+          "columns": [
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "office",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.equipment_rows": {
+      "name": "equipment_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_run_id": {
+          "name": "import_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_year": {
+          "name": "election_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_code": {
+          "name": "jurisdiction_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_name": {
+          "name": "jurisdiction_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_tag": {
+          "name": "jurisdiction_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'county'"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "system_name": {
+          "name": "system_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "equipment_type": {
+          "name": "equipment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "usage": {
+          "name": "usage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'context'"
+        },
+        "paper_record": {
+          "name": "paper_record",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_recorded'"
+        },
+        "standard_system": {
+          "name": "standard_system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "accessible_system": {
+          "name": "accessible_system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "absentee_system": {
+          "name": "absentee_system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "poll_book_system": {
+          "name": "poll_book_system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tabulation": {
+          "name": "tabulation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "registered_voters": {
+          "name": "registered_voters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "precincts": {
+          "name": "precincts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_places": {
+          "name": "polling_places",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "equipment_rows_state_year_jurisdiction_usage_idx": {
+          "name": "equipment_rows_state_year_jurisdiction_usage_idx",
+          "columns": [
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "election_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "jurisdiction_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "equipment_rows_import_run_id_import_runs_id_fk": {
+          "name": "equipment_rows_import_run_id_import_runs_id_fk",
+          "tableFrom": "equipment_rows",
+          "tableTo": "import_runs",
+          "columnsFrom": [
+            "import_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "equipment_rows_state_code_states_code_fk": {
+          "name": "equipment_rows_state_code_states_code_fk",
+          "tableFrom": "equipment_rows",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "equipment_rows_source_document_id_source_documents_id_fk": {
+          "name": "equipment_rows_source_document_id_source_documents_id_fk",
+          "tableFrom": "equipment_rows",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.historical_result_rows": {
+      "name": "historical_result_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_run_id": {
+          "name": "import_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_year": {
+          "name": "election_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_level": {
+          "name": "source_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_method": {
+          "name": "row_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "jurisdiction_code": {
+          "name": "jurisdiction_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_name": {
+          "name": "jurisdiction_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_tag": {
+          "name": "jurisdiction_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_unit": {
+          "name": "local_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "dem_votes": {
+          "name": "dem_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rep_votes": {
+          "name": "rep_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_votes": {
+          "name": "other_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_votes": {
+          "name": "total_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "historical_rows_state_year_source_local_idx": {
+          "name": "historical_rows_state_year_source_local_idx",
+          "columns": [
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "election_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "jurisdiction_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "historical_result_rows_import_run_id_import_runs_id_fk": {
+          "name": "historical_result_rows_import_run_id_import_runs_id_fk",
+          "tableFrom": "historical_result_rows",
+          "tableTo": "import_runs",
+          "columnsFrom": [
+            "import_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "historical_result_rows_state_code_states_code_fk": {
+          "name": "historical_result_rows_state_code_states_code_fk",
+          "tableFrom": "historical_result_rows",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "historical_result_rows_source_document_id_source_documents_id_fk": {
+          "name": "historical_result_rows_source_document_id_source_documents_id_fk",
+          "tableFrom": "historical_result_rows",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_runs": {
+      "name": "import_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_year": {
+          "name": "election_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parser": {
+          "name": "parser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "import_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staged'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_runs_state_code_states_code_fk": {
+          "name": "import_runs_state_code_states_code_fk",
+          "tableFrom": "import_runs",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "import_runs_source_document_id_source_documents_id_fk": {
+          "name": "import_runs_source_document_id_source_documents_id_fk",
+          "tableFrom": "import_runs",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jurisdictions": {
+      "name": "jurisdictions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geometry_key": {
+          "name": "geometry_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "jurisdictions_state_code_level_code_idx": {
+          "name": "jurisdictions_state_code_level_code_idx",
+          "columns": [
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jurisdictions_state_code_states_code_fk": {
+          "name": "jurisdictions_state_code_states_code_fk",
+          "tableFrom": "jurisdictions",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_data_revisions": {
+      "name": "public_data_revisions",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "1"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'migration'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "public_data_revisions_scope_check": {
+          "name": "public_data_revisions_scope_check",
+          "value": "\"public_data_revisions\".\"scope\" = 'public'"
+        },
+        "public_data_revisions_revision_check": {
+          "name": "public_data_revisions_revision_check",
+          "value": "\"public_data_revisions\".\"revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.result_rows": {
+      "name": "result_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_run_id": {
+          "name": "import_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_code": {
+          "name": "jurisdiction_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_name": {
+          "name": "jurisdiction_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_tag": {
+          "name": "jurisdiction_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_name": {
+          "name": "candidate_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "party": {
+          "name": "party",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes": {
+          "name": "votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "result_rows_contest_jurisdiction_candidate_idx": {
+          "name": "result_rows_contest_jurisdiction_candidate_idx",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "jurisdiction_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "candidate_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "party",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "result_rows_import_run_id_import_runs_id_fk": {
+          "name": "result_rows_import_run_id_import_runs_id_fk",
+          "tableFrom": "result_rows",
+          "tableTo": "import_runs",
+          "columnsFrom": [
+            "import_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_rows_contest_id_contests_id_fk": {
+          "name": "result_rows_contest_id_contests_id_fk",
+          "tableFrom": "result_rows",
+          "tableTo": "contests",
+          "columnsFrom": [
+            "contest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_rows_state_code_states_code_fk": {
+          "name": "result_rows_state_code_states_code_fk",
+          "tableFrom": "result_rows",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "result_rows_source_document_id_source_documents_id_fk": {
+          "name": "result_rows_source_document_id_source_documents_id_fk",
+          "tableFrom": "result_rows",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_rows": {
+      "name": "review_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_run_id": {
+          "name": "import_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_year": {
+          "name": "election_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_code": {
+          "name": "jurisdiction_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_name": {
+          "name": "jurisdiction_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_tag": {
+          "name": "jurisdiction_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_unit": {
+          "name": "local_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "dem_candidate": {
+          "name": "dem_candidate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rep_candidate": {
+          "name": "rep_candidate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dem_votes": {
+          "name": "dem_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rep_votes": {
+          "name": "rep_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dem_share": {
+          "name": "dem_share",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rep_share": {
+          "name": "rep_share",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harris_votes": {
+          "name": "harris_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trump_votes": {
+          "name": "trump_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_votes": {
+          "name": "total_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harris_share": {
+          "name": "harris_share",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trump_share": {
+          "name": "trump_share",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dem_dropoff": {
+          "name": "dem_dropoff",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rep_dropoff": {
+          "name": "rep_dropoff",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "review_rows_state_year_jurisdiction_local_idx": {
+          "name": "review_rows_state_year_jurisdiction_local_idx",
+          "columns": [
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "election_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "jurisdiction_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_unit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_rows_import_run_id_import_runs_id_fk": {
+          "name": "review_rows_import_run_id_import_runs_id_fk",
+          "tableFrom": "review_rows",
+          "tableTo": "import_runs",
+          "columnsFrom": [
+            "import_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_rows_state_code_states_code_fk": {
+          "name": "review_rows_state_code_states_code_fk",
+          "tableFrom": "review_rows",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_rows_source_document_id_source_documents_id_fk": {
+          "name": "review_rows_source_document_id_source_documents_id_fk",
+          "tableFrom": "review_rows",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_documents": {
+      "name": "source_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_year": {
+          "name": "election_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authority": {
+          "name": "authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_artifact": {
+          "name": "local_artifact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parser": {
+          "name": "parser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp_basis": {
+          "name": "timestamp_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'candidate'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_documents_state_code_states_code_fk": {
+          "name": "source_documents_state_code_states_code_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_documents_slug_unique": {
+          "name": "source_documents_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.states": {
+      "name": "states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authority": {
+          "name": "authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "county_label": {
+          "name": "county_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'County'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "states_code_unique": {
+          "name": "states_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnout_rows": {
+      "name": "turnout_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_run_id": {
+          "name": "import_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_year": {
+          "name": "election_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_code": {
+          "name": "jurisdiction_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_name": {
+          "name": "jurisdiction_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jurisdiction_tag": {
+          "name": "jurisdiction_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ballots_cast": {
+          "name": "ballots_cast",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_voters": {
+          "name": "registered_voters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnout_pct": {
+          "name": "turnout_pct",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denominator_note": {
+          "name": "denominator_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warning_required": {
+          "name": "warning_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "turnout_rows_state_year_level_jurisdiction_idx": {
+          "name": "turnout_rows_state_year_level_jurisdiction_idx",
+          "columns": [
+            {
+              "expression": "state_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "election_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "jurisdiction_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnout_rows_import_run_id_import_runs_id_fk": {
+          "name": "turnout_rows_import_run_id_import_runs_id_fk",
+          "tableFrom": "turnout_rows",
+          "tableTo": "import_runs",
+          "columnsFrom": [
+            "import_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "turnout_rows_state_code_states_code_fk": {
+          "name": "turnout_rows_state_code_states_code_fk",
+          "tableFrom": "turnout_rows",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "turnout_rows_source_document_id_source_documents_id_fk": {
+          "name": "turnout_rows_source_document_id_source_documents_id_fk",
+          "tableFrom": "turnout_rows",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ui_layout_audit_events": {
+      "name": "ui_layout_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_id": {
+          "name": "publication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ui_layout_audit_events_created_at_idx": {
+          "name": "ui_layout_audit_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ui_layout_audit_events_revision_id_ui_layout_revisions_id_fk": {
+          "name": "ui_layout_audit_events_revision_id_ui_layout_revisions_id_fk",
+          "tableFrom": "ui_layout_audit_events",
+          "tableTo": "ui_layout_revisions",
+          "columnsFrom": [
+            "revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ui_layout_audit_events_publication_id_ui_layout_publications_id_fk": {
+          "name": "ui_layout_audit_events_publication_id_ui_layout_publications_id_fk",
+          "tableFrom": "ui_layout_audit_events",
+          "tableTo": "ui_layout_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ui_layout_publications": {
+      "name": "ui_layout_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "ui_layout_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "ui_layout_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "ui_layout_publication_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ui_layout_publication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edge_digest": {
+          "name": "edge_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ui_layout_publications_requested_at_idx": {
+          "name": "ui_layout_publications_requested_at_idx",
+          "columns": [
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ui_layout_publications_revision_id_idx": {
+          "name": "ui_layout_publications_revision_id_idx",
+          "columns": [
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ui_layout_publications_revision_id_ui_layout_revisions_id_fk": {
+          "name": "ui_layout_publications_revision_id_ui_layout_revisions_id_fk",
+          "tableFrom": "ui_layout_publications",
+          "tableTo": "ui_layout_revisions",
+          "columnsFrom": [
+            "revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ui_layout_publications_idempotency_key_unique": {
+          "name": "ui_layout_publications_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ui_layout_revisions": {
+      "name": "ui_layout_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registry_version": {
+          "name": "registry_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_digest": {
+          "name": "manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_revision_id": {
+          "name": "parent_revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ui_layout_revisions_created_at_idx": {
+          "name": "ui_layout_revisions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ui_layout_revisions_manifest_digest_idx": {
+          "name": "ui_layout_revisions_manifest_digest_idx",
+          "columns": [
+            {
+              "expression": "manifest_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ui_layout_revisions_parent_revision_id_ui_layout_revisions_id_fk": {
+          "name": "ui_layout_revisions_parent_revision_id_ui_layout_revisions_id_fk",
+          "tableFrom": "ui_layout_revisions",
+          "tableTo": "ui_layout_revisions",
+          "columnsFrom": [
+            "parent_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ui_layout_revisions_parent_revision_unique": {
+          "name": "ui_layout_revisions_parent_revision_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "parent_revision_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ui_layout_revisions_schema_version_check": {
+          "name": "ui_layout_revisions_schema_version_check",
+          "value": "\"ui_layout_revisions\".\"schema_version\" in (1, 2)"
+        },
+        "ui_layout_revisions_registry_version_check": {
+          "name": "ui_layout_revisions_registry_version_check",
+          "value": "\"ui_layout_revisions\".\"registry_version\" in (1, 2)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validation_reports": {
+      "name": "validation_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "import_run_id": {
+          "name": "import_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_code": {
+          "name": "state_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_year": {
+          "name": "election_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "validation_reports_import_run_id_import_runs_id_fk": {
+          "name": "validation_reports_import_run_id_import_runs_id_fk",
+          "tableFrom": "validation_reports",
+          "tableTo": "import_runs",
+          "columnsFrom": [
+            "import_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "validation_reports_state_code_states_code_fk": {
+          "name": "validation_reports_state_code_states_code_fk",
+          "tableFrom": "validation_reports",
+          "tableTo": "states",
+          "columnsFrom": [
+            "state_code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ui_layout_assets": {
+      "name": "ui_layout_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ui_layout_assets_created_at_idx": {
+          "name": "ui_layout_assets_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ui_layout_assets_pathname_idx": {
+          "name": "ui_layout_assets_pathname_idx",
+          "columns": [
+            {
+              "expression": "pathname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ui_layout_assets_url_idx": {
+          "name": "ui_layout_assets_url_idx",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ui_layout_assets_dimensions_check": {
+          "name": "ui_layout_assets_dimensions_check",
+          "value": "\"ui_layout_assets\".\"width\" > 0 and \"ui_layout_assets\".\"height\" > 0"
+        },
+        "ui_layout_assets_size_check": {
+          "name": "ui_layout_assets_size_check",
+          "value": "\"ui_layout_assets\".\"size_bytes\" > 0 and \"ui_layout_assets\".\"size_bytes\" <= 5242880"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ui_layout_revision_assets": {
+      "name": "ui_layout_revision_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ui_layout_revision_assets_unique_idx": {
+          "name": "ui_layout_revision_assets_unique_idx",
+          "columns": [
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ui_layout_revision_assets_revision_idx": {
+          "name": "ui_layout_revision_assets_revision_idx",
+          "columns": [
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ui_layout_revision_assets_revision_id_ui_layout_revisions_id_fk": {
+          "name": "ui_layout_revision_assets_revision_id_ui_layout_revisions_id_fk",
+          "tableFrom": "ui_layout_revision_assets",
+          "tableTo": "ui_layout_revisions",
+          "columnsFrom": [
+            "revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ui_layout_revision_assets_asset_id_ui_layout_assets_id_fk": {
+          "name": "ui_layout_revision_assets_asset_id_ui_layout_assets_id_fk",
+          "tableFrom": "ui_layout_revision_assets",
+          "tableTo": "ui_layout_assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ui_layout_template_assets": {
+      "name": "ui_layout_template_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ui_layout_template_assets_unique_idx": {
+          "name": "ui_layout_template_assets_unique_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ui_layout_template_assets_template_idx": {
+          "name": "ui_layout_template_assets_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ui_layout_template_assets_template_id_ui_layout_templates_id_fk": {
+          "name": "ui_layout_template_assets_template_id_ui_layout_templates_id_fk",
+          "tableFrom": "ui_layout_template_assets",
+          "tableTo": "ui_layout_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ui_layout_template_assets_asset_id_ui_layout_assets_id_fk": {
+          "name": "ui_layout_template_assets_asset_id_ui_layout_assets_id_fk",
+          "tableFrom": "ui_layout_template_assets",
+          "tableTo": "ui_layout_assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ui_layout_templates": {
+      "name": "ui_layout_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ui_layout_templates_created_at_idx": {
+          "name": "ui_layout_templates_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ui_layout_templates_name_idx": {
+          "name": "ui_layout_templates_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.import_status": {
+      "name": "import_status",
+      "schema": "public",
+      "values": [
+        "staged",
+        "validated",
+        "promoted",
+        "failed"
+      ]
+    },
+    "public.source_status": {
+      "name": "source_status",
+      "schema": "public",
+      "values": [
+        "loaded",
+        "candidate",
+        "needs_data",
+        "superseded",
+        "documented_exclusion"
+      ]
+    },
+    "public.ui_layout_channel": {
+      "name": "ui_layout_channel",
+      "schema": "public",
+      "values": [
+        "candidate",
+        "stable"
+      ]
+    },
+    "public.ui_layout_environment": {
+      "name": "ui_layout_environment",
+      "schema": "public",
+      "values": [
+        "preview",
+        "production"
+      ]
+    },
+    "public.ui_layout_publication_action": {
+      "name": "ui_layout_publication_action",
+      "schema": "public",
+      "values": [
+        "stage",
+        "promote",
+        "rollback"
+      ]
+    },
+    "public.ui_layout_publication_status": {
+      "name": "ui_layout_publication_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "dispatched",
+        "publishing",
+        "published",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1784151488416,
       "tag": "0005_lazy_human_torch",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1784237938939,
+      "tag": "0006_broad_quicksilver",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        hostname: "**.public.blob.vercel-storage.com",
+        protocol: "https",
+      },
+    ],
+  },
   typedRoutes: true,
   outputFileTracingIncludes: {
     "/api/**/*": ["./data/canonical-jurisdictions.json"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,18 @@
         "@dnd-kit/helpers": "^0.5.0",
         "@dnd-kit/react": "^0.5.0",
         "@flags-sdk/vercel": "^1.4.5",
+        "@lexical/link": "^0.48.0",
+        "@lexical/list": "^0.48.0",
+        "@lexical/react": "^0.48.0",
+        "@lexical/rich-text": "^0.48.0",
         "@neondatabase/serverless": "^1.0.2",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/blob": "^2.6.1",
         "@vercel/edge-config": "^1.4.3",
         "drizzle-orm": "0.44.2",
         "flags": "^4.2.0",
         "jszip": "^3.10.1",
+        "lexical": "^0.48.0",
         "lucide-react": "^0.468.0",
         "next": "^16.1.5",
         "pdf-parse": "^2.4.5",
@@ -26,6 +32,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.61.1",
         "@types/node": "^22.10.2",
         "@types/react": "^19.0.2",
@@ -37,6 +44,19 @@
         "tesseract.js": "^7.0.0",
         "typescript": "^5.7.2",
         "xlsx": "^0.18.5"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1472,6 +1492,59 @@
         "flags": "*"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.20",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.20.tgz",
+      "integrity": "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -2078,6 +2151,491 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lexical/a11y": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/a11y/-/a11y-0.48.0.tgz",
+      "integrity": "sha512-18W4ehyipkUim4YVoDZitoH63Om3j6iCN4c84zdqE9RgkWf/PE4rvI/8BHTm6Ni7NkVE14nimXgkpaP5ok15zA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/clipboard": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.48.0.tgz",
+      "integrity": "sha512-xO2trk6+yBl8XXa/VNe20kXczmPxFoWtUHjidbBLEtlGBj+mo63pJj6H5o/WlZsoMKmIOJxwxsn2ejrS8G0/7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.48.0",
+        "@lexical/html": "0.48.0",
+        "@lexical/internal": "0.48.0",
+        "@lexical/list": "0.48.0",
+        "@lexical/selection": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "@types/trusted-types": "^2.0.7",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/code-core": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code-core/-/code-core-0.48.0.tgz",
+      "integrity": "sha512-+O1Ge06AuSo6+r8R2Xk6SkWG07H5/e4K/Scw9aqCM/BRjITxgvFTHTNvgQbaobCsP0uBJiwW1+ZGeWAWcBCY4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.48.0",
+        "@lexical/html": "0.48.0",
+        "@lexical/internal": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/devtools-core": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.48.0.tgz",
+      "integrity": "sha512-4kvKWW6ebgQnJNLXPLmw7dqgSChvzYIBNYtfuR6c48Sw+V/QXQTWqfIUbCIe5X4uG8EEXd5O/udXaJx7GBuP+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/html": "0.48.0",
+        "@lexical/link": "0.48.0",
+        "@lexical/mark": "0.48.0",
+        "@lexical/table": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.x",
+        "react-dom": ">=18.x",
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/dragon": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.48.0.tgz",
+      "integrity": "sha512-uPuu7fVca9vmL/Oz30CRZ7FIPIodwMrTgNsRmV8jE6Qd6a7RNiTW7r3+EhbhIdkLb/sjcWsYyOMyUR1TJAB0wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/extension": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.48.0.tgz",
+      "integrity": "sha512-4uBObgz84mVbQWiumndmIhkuJL0ojHiMwFSvSUM/FCo1YMVIZvpI56blI0y+2Vix/oLui9EgVQSJjjWV4NAszw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/hashtag": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.48.0.tgz",
+      "integrity": "sha512-hPQtdnbVoNAFsmfnCGfgY7mDbvk6mIznlCRmIR7tLeQKXqz/0Tb6eH3W24EESk9hAF8wFUYNKWE1/Kb3Hl2vEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/text": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/history": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.48.0.tgz",
+      "integrity": "sha512-NllvUfO+u3mfi5uC8k2CodwdzeeopFFVtMZ/NMifzFbZFysdWi9m9mqfO46NrEA1rSFOydyefv6oMzC8ULXInA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/html": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.48.0.tgz",
+      "integrity": "sha512-uBxlgKl4YgSNEgHJSshdBqtGDzruWdx1ewop+u6faT67qHUdP3P0cUXIrG6NToDWvsL6fzCstAbN76PMER1Pnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.48.0",
+        "@lexical/internal": "0.48.0",
+        "@lexical/selection": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/internal": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/internal/-/internal-0.48.0.tgz",
+      "integrity": "sha512-sRwg53K7N0ZQ7KNAvcCY38LSwGizbXP1zlR1lIojZp0GoqHWNvR+vL49t1wYXu1nXx3Osf4ilHHm+aGcwq5hTw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/link": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.48.0.tgz",
+      "integrity": "sha512-E0UDmNLUXs/yMCnnE7hbFO0CvhWghmqa+qqPksFfzLkpMHdPpdS1yg59YEbYoNHLi/DXIu4cFRvpHIEuooxwNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.48.0",
+        "@lexical/html": "0.48.0",
+        "@lexical/internal": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/list": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.48.0.tgz",
+      "integrity": "sha512-9Qe/Vur44v9F9enj55SUzf79FVsijcGOQug7SpiIU8ekLr7JNzcilKYBYcZ6etGEo7bqQHsYMHXeJcSBbCI2zA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.48.0",
+        "@lexical/html": "0.48.0",
+        "@lexical/internal": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/mark": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.48.0.tgz",
+      "integrity": "sha512-DTtypWvnYSXyNUxEmsUnh4y0xXkmdk8Y72EZl8WDHcCwjqaLJlUakH7p/TuSJczs3uVSaoJzu0yh7oGkP1Vsvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/markdown": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.48.0.tgz",
+      "integrity": "sha512-1WasBenW4bEsa5xtnycVo8G2hcxIqyYLn3/r98yD2Y+54ZyeFuIQfOeJYhIgCh4YkKpfqyrFwkMQwAOsQDqZjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/code-core": "0.48.0",
+        "@lexical/internal": "0.48.0",
+        "@lexical/link": "0.48.0",
+        "@lexical/list": "0.48.0",
+        "@lexical/rich-text": "0.48.0",
+        "@lexical/selection": "0.48.0",
+        "@lexical/text": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/overflow": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.48.0.tgz",
+      "integrity": "sha512-1YEvMz2tW3EbwrON9mjrkjMVl/vdTcPYSn9P1j6mf5gj0LOoLDNI4TbvSD4SViy+TDghxNdG8YdCISyU2b4YKA==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/plain-text": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.48.0.tgz",
+      "integrity": "sha512-q4f/4VZKVgCrIW2FhDFR2RII1BU0ljedPgEmJ8XQn1zc+JOFPom8Lp0lV5nyEvZaAJYwM/TfoJ9g2V7ESFKznA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.48.0",
+        "@lexical/dragon": "0.48.0",
+        "@lexical/extension": "0.48.0",
+        "@lexical/selection": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/react": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.48.0.tgz",
+      "integrity": "sha512-uVh9/QSrbtjLjVbxfJ+sfiMyhUq/rv7H6uBEVDDIw1rkZJSDY1fvf/CX+dyKgwcDFjKQZ8/9i5f9UCVPeQ01hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.19",
+        "@lexical/a11y": "0.48.0",
+        "@lexical/devtools-core": "0.48.0",
+        "@lexical/dragon": "0.48.0",
+        "@lexical/extension": "0.48.0",
+        "@lexical/hashtag": "0.48.0",
+        "@lexical/history": "0.48.0",
+        "@lexical/internal": "0.48.0",
+        "@lexical/link": "0.48.0",
+        "@lexical/list": "0.48.0",
+        "@lexical/mark": "0.48.0",
+        "@lexical/markdown": "0.48.0",
+        "@lexical/overflow": "0.48.0",
+        "@lexical/plain-text": "0.48.0",
+        "@lexical/rich-text": "0.48.0",
+        "@lexical/table": "0.48.0",
+        "@lexical/text": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "@lexical/yjs": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.x",
+        "react-dom": ">=18.x",
+        "typescript": ">=5.2",
+        "yjs": ">=13.5.22"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "yjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/rich-text": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.48.0.tgz",
+      "integrity": "sha512-QMXFnwCKAQ4yzxvx5FwmANcx3K+NaBkGTxAVD8s8pOKDD/U5rzDS1iIvhH6TLWaFp7VzvLmLB+Sl1Ie/RnkaDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.48.0",
+        "@lexical/dragon": "0.48.0",
+        "@lexical/extension": "0.48.0",
+        "@lexical/html": "0.48.0",
+        "@lexical/selection": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/selection": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.48.0.tgz",
+      "integrity": "sha512-Uc0wTrEtHcYK6z/aHHjkgH3vX/R4Bf8mO+qH3VbxfSAKYzNYktM0j+ZGdq5kIEL4frnw/9SulNCXlH7xpjuDgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/table": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.48.0.tgz",
+      "integrity": "sha512-t9Mz7q6ODLUz0lG5Xn9EY/5YiVpTHCqlPQP4EtFXlnBQT3DuKeDS3cC0Cn8sGSZc11YY5OLDfWpB64Frs9BL3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.48.0",
+        "@lexical/extension": "0.48.0",
+        "@lexical/html": "0.48.0",
+        "@lexical/internal": "0.48.0",
+        "@lexical/utils": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/text": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.48.0.tgz",
+      "integrity": "sha512-ktTMRbsX4wKxdG2OpZCkrqtt8k9Vg/ZpWdukOQ0r1xPRtCuL1T+q91l7cy2ywIuCfMGYS0aoZGB4LdpUMe/H1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/utils": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.48.0.tgz",
+      "integrity": "sha512-W4k4P+y6jmRfna8+ad4X+iMd5h8es5PC3bUw5tbi7MRApxaaFG/0w+uJiZVSwbT2Q6JnA2xhBaqzPgt/Gn6djg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.48.0",
+        "@lexical/selection": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lexical/yjs": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.48.0.tgz",
+      "integrity": "sha512-fFsE8EnPM/2KK9rMJ0z6T+Da5UW5V4P+XiAA03LoHTY5YQ/Oy8Q0i7Wcmocv/B/SpsY2o8g07euZEfudl9MVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.48.0",
+        "@lexical/selection": "0.48.0",
+        "lexical": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2",
+        "yjs": ">=13.5.22"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.80",
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
@@ -2608,6 +3166,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.60.1",
@@ -3270,6 +3834,46 @@
         }
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.6.1.tgz",
+      "integrity": "sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "^3.6.1",
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/@vercel/oidc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.0.tgz",
+      "integrity": "sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.0",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@vercel/cli-config": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
@@ -3671,6 +4275,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3688,9 +4301,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
-      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -5760,6 +6373,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -5931,6 +6567,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6136,6 +6778,17 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6328,6 +6981,45 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lexical": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.48.0.tgz",
+      "integrity": "sha512-KK4Tyr/cPsleoZ7XvhGRiRmcrZidSmoFUdIXK9nPubIifoC+80Dc5THyc4xtGKtsW24S1TsHzk5gmfBU+TxmEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/internal": "0.48.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lie": {
@@ -7223,6 +7915,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7848,6 +8549,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
     "node_modules/tesseract.js": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
@@ -7873,6 +8580,18 @@
       "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -8082,7 +8801,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8133,6 +8852,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -8439,6 +9167,24 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yjs": {
+      "version": "13.6.31",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
+      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "etl:prepare:dc": "node scripts/normalize-dc-certified-results.mjs",
     "etl:validate:dc": "npm run etl:prepare:dc && python -m civic_etl.cli validate --config etl/state-configs/dc.json",
     "etl:import:dc": "npm run etl:prepare:dc && python -m civic_etl.cli import --config etl/state-configs/dc.json --out .etl/staging",
-    "test:layout": "node --experimental-strip-types tests/api/workspace-layout.test.mjs && node --experimental-strip-types tests/api/workspace-layout-resolution.test.mjs && node --experimental-strip-types tests/api/workspace-layout-publisher-policy.test.mjs && node --experimental-strip-types tests/api/workspace-layout-visitor.test.mjs && node --experimental-strip-types tests/api/workspace-layout-admin-policy.test.mjs",
+    "test:layout": "node --experimental-strip-types tests/api/workspace-layout.test.mjs && node --experimental-strip-types tests/api/workspace-layout-v2.test.mjs && node --experimental-strip-types tests/api/workspace-layout-resolution.test.mjs && node --experimental-strip-types tests/api/workspace-layout-publisher-policy.test.mjs && node --experimental-strip-types tests/api/workspace-layout-visitor.test.mjs && node --experimental-strip-types tests/api/workspace-layout-admin-policy.test.mjs",
     "test:e2e": "playwright test"
   },
   "dependencies": {
@@ -205,12 +205,18 @@
     "@dnd-kit/helpers": "^0.5.0",
     "@dnd-kit/react": "^0.5.0",
     "@flags-sdk/vercel": "^1.4.5",
+    "@lexical/link": "^0.48.0",
+    "@lexical/list": "^0.48.0",
+    "@lexical/react": "^0.48.0",
+    "@lexical/rich-text": "^0.48.0",
     "@neondatabase/serverless": "^1.0.2",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/blob": "^2.6.1",
     "@vercel/edge-config": "^1.4.3",
     "drizzle-orm": "0.44.2",
     "flags": "^4.2.0",
     "jszip": "^3.10.1",
+    "lexical": "^0.48.0",
     "lucide-react": "^0.468.0",
     "next": "^16.1.5",
     "pdf-parse": "^2.4.5",
@@ -219,6 +225,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.61.1",
     "@types/node": "^22.10.2",
     "@types/react": "^19.0.2",

--- a/src/app/admin/layout/actions.ts
+++ b/src/app/admin/layout/actions.ts
@@ -14,7 +14,7 @@ import {
   updateLayoutPublication,
   type LayoutPublicationEnvironment,
 } from "@/lib/ui-layout-repository";
-import { validateWorkspaceLayoutManifest } from "@/lib/workspace-layout";
+import { validateWorkspaceLayoutManifestAny } from "@/lib/workspace-layout-digest";
 import {
   isWorkspaceLayoutPublicationAction,
   isWorkspaceLayoutPublicationEnvironment,
@@ -33,7 +33,7 @@ export async function saveLayoutRevisionAction(
     const actor = await requireLayoutAdmin();
     const rawManifest = String(formData.get("manifest") ?? "");
     const manifest = JSON.parse(rawManifest) as unknown;
-    const validation = validateWorkspaceLayoutManifest(manifest);
+    const validation = validateWorkspaceLayoutManifestAny(manifest);
     if (!validation.ok) return { kind: "error", message: validation.errors.join(" ") };
     const parentValue = String(formData.get("parentRevisionId") ?? "").trim();
     const revision = await createLayoutRevision({

--- a/src/app/admin/layout/layout-editor-v3.module.css
+++ b/src/app/admin/layout/layout-editor-v3.module.css
@@ -1,0 +1,850 @@
+.editor {
+  --builder-accent: #16a579;
+  color: #e8f3ef;
+  display: grid;
+  gap: 1rem;
+}
+
+.toolbar,
+.builderShell,
+.operations,
+.library,
+.stage,
+.inspector,
+.operationCard {
+  border: 1px solid rgba(157, 195, 182, 0.2);
+  border-radius: 18px;
+  background: rgba(8, 20, 18, 0.96);
+  box-shadow: 0 18px 56px rgba(0, 0, 0, 0.24);
+}
+
+.toolbar {
+  align-items: center;
+  display: flex;
+  gap: 0.8rem;
+  justify-content: space-between;
+  padding: 0.7rem 0.8rem;
+  position: sticky;
+  top: 0.6rem;
+  z-index: 30;
+}
+
+.toolbar button,
+.stageHeader button,
+.rowControls button,
+.operations button,
+.inspector button,
+.asideTitle {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid rgba(185, 214, 204, 0.2);
+  border-radius: 9px;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  gap: 0.4rem;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0.42rem 0.65rem;
+}
+
+.toolbar button:hover,
+.stageHeader button:hover,
+.rowControls button:hover,
+.operations button:hover,
+.inspector button:hover {
+  background: rgba(56, 200, 155, 0.12);
+  border-color: rgba(68, 223, 173, 0.48);
+}
+
+.toolbar button:disabled,
+.operations button:disabled,
+.rowControls button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.toolbarGroup,
+.toolbarStatus,
+.segmented {
+  align-items: center;
+  display: flex;
+  gap: 0.35rem;
+}
+
+.segmented {
+  background: rgba(0, 0, 0, 0.24);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 0.2rem;
+}
+
+.segmented button {
+  border-color: transparent;
+}
+
+.segmented button[aria-pressed="true"] {
+  background: #dffbf1;
+  color: #08251e;
+}
+
+.toolbarStatus {
+  color: #a9bdb6;
+  font-size: 0.78rem;
+}
+
+.validBadge,
+.errorBadge {
+  border-radius: 999px;
+  font-weight: 750;
+  padding: 0.32rem 0.55rem;
+}
+
+.validBadge {
+  background: rgba(37, 193, 139, 0.14);
+  color: #7be7bf;
+}
+
+.errorBadge {
+  background: rgba(242, 112, 112, 0.14);
+  color: #ffb1b1;
+}
+
+.builderShell {
+  background: #07110f;
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr) minmax(260px, 320px);
+  min-height: 760px;
+  overflow: clip;
+}
+
+.library,
+.stage,
+.inspector {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  min-width: 0;
+}
+
+.library {
+  border-right: 1px solid rgba(157, 195, 182, 0.16);
+  overflow: auto;
+  padding: 0.7rem;
+}
+
+.library section {
+  border-top: 1px solid rgba(157, 195, 182, 0.12);
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+}
+
+.library h2 {
+  color: #91aaa1;
+  font-size: 0.7rem;
+  letter-spacing: 0.11em;
+  margin: 0 0 0.55rem;
+  text-transform: uppercase;
+}
+
+.asideTitle {
+  background: transparent;
+  border: 0;
+  font-weight: 800;
+  justify-content: flex-start;
+  padding-inline: 0.25rem;
+  width: 100%;
+}
+
+.asideTitle span {
+  margin-left: auto;
+}
+
+.tabList,
+.blockPalette,
+.templateList {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.tabList button,
+.blockPalette button,
+.templateList button {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(157, 195, 182, 0.13);
+  border-radius: 10px;
+  color: #dce9e4;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  gap: 0.55rem;
+  padding: 0.55rem 0.6rem;
+  text-align: left;
+  width: 100%;
+}
+
+.tabList button span {
+  flex: 1;
+}
+
+.tabList button[aria-pressed="true"] {
+  background: rgba(37, 193, 139, 0.14);
+  border-color: rgba(76, 224, 176, 0.45);
+  color: #effff9;
+}
+
+.blockPalette button > span,
+.templateList button {
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+.blockPalette strong,
+.templateList strong {
+  font-size: 0.78rem;
+}
+
+.blockPalette small,
+.templateList small {
+  color: #8fa69e;
+  display: block;
+  font-size: 0.67rem;
+  line-height: 1.35;
+  margin-top: 0.12rem;
+}
+
+.stage {
+  background:
+    radial-gradient(circle at 50% 0%, rgba(42, 153, 120, 0.08), transparent 32rem),
+    #0a1513;
+  overflow: auto;
+  padding: 1rem;
+}
+
+.stageHeader {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin: 0 auto 0.8rem;
+  max-width: 1180px;
+}
+
+.stageHeader span,
+.inspectorHeader span {
+  color: #85a198;
+  display: block;
+  font-size: 0.66rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.stageHeader h2 {
+  font-size: 1rem;
+  margin: 0.14rem 0 0;
+}
+
+.viewport {
+  --preview-scale: 1;
+  background: #f3f7f5;
+  border: 1px solid rgba(210, 235, 227, 0.23);
+  border-radius: 14px;
+  box-shadow: 0 20px 70px rgba(0, 0, 0, 0.34);
+  color: #10211d;
+  margin: 0 auto;
+  min-height: 650px;
+  overflow: hidden;
+  transition: max-width 180ms ease;
+}
+
+.desktop { max-width: 1180px; }
+.tablet { max-width: 760px; }
+.mobile { max-width: 390px; }
+
+.sitePreviewHeader {
+  align-items: center;
+  background: #091815;
+  color: #eaf9f4;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 0.8rem 1rem;
+}
+
+.previewBrand,
+.previewMetrics,
+.previewTabs {
+  align-items: center;
+  display: flex;
+  gap: 0.7rem;
+}
+
+.previewBrand > span {
+  align-items: center;
+  background: #1bb082;
+  border-radius: 8px;
+  color: #061510;
+  display: inline-flex;
+  font-size: 0.68rem;
+  font-weight: 900;
+  height: 28px;
+  justify-content: center;
+  width: 28px;
+}
+
+.previewMetrics {
+  color: #91aaa1;
+  font-size: 0.62rem;
+}
+
+.previewMetrics strong {
+  color: #fff;
+  display: block;
+}
+
+.previewTabs {
+  background: #fff;
+  border-bottom: 1px solid #dbe5e1;
+  overflow: hidden;
+  padding: 0 0.85rem;
+  white-space: nowrap;
+}
+
+.previewTabs span {
+  border-bottom: 2px solid transparent;
+  color: #65736f;
+  font-size: 0.58rem;
+  padding: 0.62rem 0.2rem;
+}
+
+.previewTabs .activePreviewTab {
+  border-color: #138d68;
+  color: #0a3d30;
+  font-weight: 800;
+}
+
+.rows {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+}
+
+.row {
+  border: 1px dashed rgba(28, 111, 86, 0.36);
+  border-radius: 10px;
+  padding: 1.7rem 0.55rem 0.55rem;
+  position: relative;
+}
+
+.row[data-selected="true"] {
+  border-color: #15956e;
+  box-shadow: 0 0 0 2px rgba(21, 149, 110, 0.1);
+}
+
+.rowControls {
+  align-items: center;
+  display: flex;
+  gap: 0.2rem;
+  left: 0.45rem;
+  position: absolute;
+  top: 0.28rem;
+}
+
+.rowControls span {
+  color: #55736a;
+  font-size: 0.57rem;
+  font-weight: 800;
+  margin-right: 0.2rem;
+  text-transform: uppercase;
+}
+
+.rowControls button {
+  background: #edf4f1;
+  border-color: #d0ded9;
+  color: #315049;
+  font-size: 0.55rem;
+  min-height: 20px;
+  padding: 0.15rem 0.3rem;
+}
+
+.columns {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+
+.columns[data-gap="small"] { gap: 0.35rem; }
+.columns[data-gap="large"] { gap: 1rem; }
+
+.column {
+  align-content: start;
+  border: 1px dashed transparent;
+  border-radius: 9px;
+  display: grid;
+  gap: 0.5rem;
+  grid-column: span var(--builder-span, 12);
+  min-height: 55px;
+  min-width: 0;
+  padding: 0.25rem;
+}
+
+.column[data-empty="true"],
+.column[data-selected="true"] {
+  background: rgba(23, 135, 101, 0.035);
+  border-color: rgba(23, 135, 101, 0.25);
+}
+
+.builderNode {
+  background: #fff;
+  border: 1px solid #d4e1dc;
+  border-radius: 9px;
+  box-shadow: 0 5px 16px rgba(25, 55, 46, 0.07);
+  cursor: default;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.builderNode[data-selected="true"] {
+  border-color: #0e9368;
+  box-shadow: 0 0 0 2px rgba(14, 147, 104, 0.17);
+}
+
+.builderNode[data-visible="false"] {
+  opacity: 0.54;
+}
+
+.nodeToolbar {
+  align-items: center;
+  background: #edf5f2;
+  border-bottom: 1px solid #d9e7e2;
+  color: #527068;
+  display: flex;
+  font-size: 0.56rem;
+  gap: 0.35rem;
+  min-height: 28px;
+  padding: 0.2rem 0.35rem;
+  text-transform: uppercase;
+}
+
+.nodeToolbar span { flex: 1; }
+
+.nodeToolbar button {
+  background: transparent;
+  border: 0;
+  color: #3b5f55;
+  cursor: pointer;
+  display: inline-flex;
+  padding: 0.1rem;
+}
+
+.dragHandle { cursor: grab !important; }
+.dragHandle:active { cursor: grabbing !important; }
+
+.nodePreview {
+  padding: 0.65rem;
+}
+
+.nodePreview > strong {
+  color: #16352d;
+  display: block;
+  font-size: 0.7rem;
+  margin-bottom: 0.4rem;
+}
+
+.nodePreview p {
+  color: #597069;
+  font-size: 0.62rem;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.nodePreview img {
+  border-radius: 7px;
+  display: block;
+  height: auto;
+  max-height: 190px;
+  object-fit: cover;
+  width: 100%;
+}
+
+.mapSketch {
+  background: linear-gradient(145deg, #d8eee5, #c6ded7);
+  border-radius: 7px;
+  height: 140px;
+  overflow: hidden;
+  position: relative;
+}
+
+.mapSketch span {
+  background: rgba(18, 142, 104, 0.7);
+  clip-path: polygon(9% 8%, 82% 0, 100% 43%, 73% 100%, 18% 83%, 0 41%);
+  inset: 18% 22%;
+  position: absolute;
+}
+
+.mapSketch i {
+  background: #fff;
+  border-radius: 999px;
+  height: 8px;
+  position: absolute;
+  width: 8px;
+}
+
+.mapSketch i:nth-child(2) { left: 36%; top: 28%; }
+.mapSketch i:nth-child(3) { left: 58%; top: 50%; }
+.mapSketch i:nth-child(4) { left: 44%; top: 67%; }
+
+.textSketch,
+.metricSketch {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.textSketch span,
+.metricSketch b {
+  background: #dce8e4;
+  border-radius: 999px;
+  display: block;
+  height: 5px;
+}
+
+.textSketch span:nth-child(2) { width: 76%; }
+.textSketch span:nth-child(3) { width: 52%; }
+
+.metricSketch span {
+  color: #648078;
+  font-size: 0.55rem;
+}
+
+.metricSketch b:first-of-type { background: #3972cf; width: 57%; }
+.metricSketch b:last-of-type { background: #d75459; width: 43%; }
+
+.pillSketch {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.28rem;
+}
+
+.pillSketch span {
+  background: #e3efeb;
+  border-radius: 999px;
+  color: #3a5c52;
+  font-size: 0.5rem;
+  padding: 0.24rem 0.38rem;
+}
+
+.imagePlaceholder,
+.emptyColumn,
+.emptyCanvas {
+  align-items: center;
+  color: #6a817a;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.6rem;
+  gap: 0.3rem;
+  justify-content: center;
+  min-height: 72px;
+}
+
+.emptyColumn,
+.emptyCanvas {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  width: 100%;
+}
+
+.inspector {
+  border-left: 1px solid rgba(157, 195, 182, 0.16);
+  overflow: auto;
+}
+
+.inspectorHeader {
+  align-items: center;
+  background: #0b1b18;
+  border-bottom: 1px solid rgba(157, 195, 182, 0.14);
+  display: flex;
+  gap: 0.55rem;
+  padding: 0.8rem;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.inspectorHeader div { flex: 1; }
+.inspectorHeader strong { display: block; font-size: 0.8rem; margin-top: 0.12rem; }
+.inspectorHeader button { min-height: 28px; padding: 0.25rem; }
+
+.inspectorBody {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.inspector fieldset,
+.inspectorBody fieldset {
+  border: 1px solid rgba(157, 195, 182, 0.16);
+  border-radius: 12px;
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+  padding: 0.75rem;
+}
+
+.inspector legend,
+.inspectorBody legend {
+  color: #9ab3aa;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 0 0.25rem;
+  text-transform: uppercase;
+}
+
+.inspector label,
+.operations label {
+  color: #a9bbb5;
+  display: grid;
+  font-size: 0.68rem;
+  gap: 0.3rem;
+}
+
+.inspector input,
+.inspector select,
+.inspector textarea,
+.operations input,
+.operations select {
+  background: #07120f;
+  border: 1px solid rgba(178, 211, 200, 0.22);
+  border-radius: 8px;
+  color: #e9f5f0;
+  font: inherit;
+  min-height: 36px;
+  padding: 0.45rem 0.55rem;
+  width: 100%;
+}
+
+.inspector input[type="color"] {
+  padding: 0.2rem;
+  width: 58px;
+}
+
+.switchLabel,
+.confirm {
+  align-items: center;
+  display: flex !important;
+  gap: 0.45rem !important;
+}
+
+.switchLabel input,
+.confirm input,
+.viewportChecks input {
+  min-height: auto;
+  width: auto;
+}
+
+.switchLabel small { margin-left: auto; }
+
+.breakpointSummary,
+.viewportChecks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.breakpointSummary span,
+.viewportChecks label {
+  background: rgba(255, 255, 255, 0.045);
+  border-radius: 999px;
+  color: #a8beb6;
+  font-size: 0.6rem;
+  padding: 0.32rem 0.48rem;
+}
+
+.uploadButton {
+  align-items: center;
+  background: rgba(34, 170, 127, 0.11);
+  border: 1px solid rgba(67, 211, 166, 0.3);
+  border-radius: 9px;
+  color: #caffec !important;
+  cursor: pointer;
+  display: flex !important;
+  justify-content: center;
+  min-height: 38px;
+}
+
+.uploadButton input { display: none; }
+
+.assetGrid {
+  display: grid;
+  gap: 0.35rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  max-height: 280px;
+  overflow: auto;
+}
+
+.assetGrid button {
+  display: block;
+  min-width: 0;
+  padding: 0.25rem;
+}
+
+.assetGrid img {
+  aspect-ratio: 16 / 10;
+  border-radius: 6px;
+  display: block;
+  object-fit: cover;
+  width: 100%;
+}
+
+.assetGrid span {
+  display: block;
+  font-size: 0.55rem;
+  overflow: hidden;
+  padding-top: 0.25rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.itemsEditor {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.itemsEditor > div {
+  align-items: start;
+  display: grid;
+  gap: 0.3rem;
+  grid-template-columns: 1fr auto;
+}
+
+.itemsEditor > div input,
+.itemsEditor > div textarea { grid-column: 1; }
+.itemsEditor > div button { grid-column: 2; grid-row: 1; min-height: 34px; padding: 0.3rem; }
+
+.dangerButton {
+  border-color: rgba(240, 100, 100, 0.36) !important;
+  color: #ffb7b7 !important;
+}
+
+.operations {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.operationCard {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.operationCard > div:first-child {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.55rem;
+}
+
+.operationCard > div:first-child span { display: grid; gap: 0.15rem; }
+.operationCard > div:first-child strong { font-size: 0.86rem; }
+.operationCard > div:first-child small { color: #8ca39b; font-size: 0.68rem; }
+.operationCard form { display: grid; gap: 0.55rem; }
+.operationCard form button { justify-self: start; }
+
+.errorList,
+.historyList {
+  color: #f0b5b5;
+  display: grid;
+  font-size: 0.66rem;
+  gap: 0.35rem;
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.historyList { color: #c6d8d2; }
+.historyList li { display: grid; gap: 0.12rem; }
+.historyList span { color: #839991; font-size: 0.61rem; }
+
+.publication,
+.notice,
+.successMessage,
+.errorMessage {
+  align-items: center;
+  display: flex;
+  font-size: 0.67rem;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.publication { justify-content: space-between; }
+.publication span { color: #91a69f; }
+.notice { color: #9fb4ad; }
+.successMessage { color: #75e4bb; }
+.errorMessage { color: #ffb0b0; }
+
+.spin { animation: spin 800ms linear infinite; }
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+:global(.layout-rich-editor) {
+  background: #07120f;
+  border: 1px solid rgba(178, 211, 200, 0.22);
+  border-radius: 9px;
+  min-height: 150px;
+  overflow: hidden;
+  position: relative;
+}
+
+:global(.layout-rich-toolbar) {
+  border-bottom: 1px solid rgba(178, 211, 200, 0.14);
+  display: flex;
+  gap: 0.2rem;
+  padding: 0.3rem;
+}
+
+:global(.layout-rich-toolbar button) {
+  min-height: 28px;
+  padding: 0.25rem;
+}
+
+:global(.layout-rich-content) {
+  color: #e9f5f0;
+  font-size: 0.74rem;
+  line-height: 1.55;
+  min-height: 110px;
+  outline: none;
+  padding: 0.65rem;
+}
+
+:global(.layout-rich-placeholder) {
+  color: #637d74;
+  font-size: 0.72rem;
+  left: 0.65rem;
+  pointer-events: none;
+  position: absolute;
+  top: 3rem;
+}
+
+:global(.layout-rich-bold) { font-weight: 800; }
+:global(.layout-rich-italic) { font-style: italic; }
+:global(.layout-rich-code) { background: #162823; border-radius: 3px; font-family: monospace; padding: 0.08rem 0.2rem; }
+:global(.layout-rich-link) { color: #6be3bb; text-decoration: underline; }
+
+@media (max-width: 1180px) {
+  .builderShell { grid-template-columns: 220px minmax(0, 1fr); }
+  .inspector { border-left: 0; border-top: 1px solid rgba(157, 195, 182, 0.16); grid-column: 1 / -1; max-height: 520px; }
+}
+
+@media (max-width: 780px) {
+  .toolbar { align-items: stretch; flex-direction: column; position: static; }
+  .toolbarGroup, .toolbarStatus, .segmented { justify-content: center; }
+  .builderShell { display: block; }
+  .library, .inspector { border: 0; border-bottom: 1px solid rgba(157, 195, 182, 0.16); max-height: none; }
+  .stage { padding: 0.55rem; }
+  .previewMetrics { display: none; }
+  .operations { grid-template-columns: 1fr; }
+}

--- a/src/app/admin/layout/layout-editor-v3.tsx
+++ b/src/app/admin/layout/layout-editor-v3.tsx
@@ -1,0 +1,840 @@
+"use client";
+
+import { upload } from "@vercel/blob/client";
+import {
+  ArrowDown,
+  ArrowUp,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Columns3,
+  Copy,
+  Eye,
+  EyeOff,
+  FileImage,
+  GripVertical,
+  History,
+  Laptop,
+  LayoutGrid,
+  LoaderCircle,
+  LockKeyhole,
+  MonitorSmartphone,
+  Plus,
+  Redo2,
+  RotateCcw,
+  Save,
+  Send,
+  Settings2,
+  Smartphone,
+  Tablet,
+  Trash2,
+  TriangleAlert,
+  Undo2,
+  X,
+} from "lucide-react";
+import { useActionState, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+import {
+  requestLayoutPublicationAction,
+  saveLayoutRevisionAction,
+  startLayoutDraftPreviewAction,
+} from "./actions";
+import { initialLayoutActionState, type LayoutActionState } from "./layout-action-state";
+import { LayoutRichTextEditor } from "./layout-rich-text-editor";
+import { saveLayoutTemplateAction } from "./template-actions";
+import {
+  cloneWorkspaceLayoutManifestV2,
+  createWorkspaceCustomNodeV2,
+  createWorkspaceLayoutId,
+  flattenWorkspaceNodes,
+  isWorkspaceCustomNodeV2,
+  isWorkspaceProductionNodeV2,
+  richTextDocumentFromPlainText,
+  validateWorkspaceLayoutManifestV2,
+  workspaceVisibilityCapabilityKeys,
+  workspaceVisibilityDataKeys,
+  workspaceLayoutRegistryV2,
+  workspaceStarterTemplates,
+  type WorkspaceCustomBlockKindV2,
+  type WorkspaceCustomNodeV2,
+  type WorkspaceLayoutColumnV2,
+  type WorkspaceLayoutManifestV2,
+  type WorkspaceLayoutNodeV2,
+  type WorkspaceLayoutRowV2,
+  type WorkspaceLayoutTabV2,
+  type WorkspaceProductionNodeV2,
+  type WorkspaceVisibilityConditionV1,
+} from "@/lib/workspace-layout-v2";
+import type { WorkspaceTabId } from "@/lib/workspace-layout";
+import styles from "./layout-editor-v3.module.css";
+
+export type LayoutRevisionSummary = {
+  actorEmail: string;
+  changeSummary: string;
+  createdAt: string;
+  id: string;
+  manifest: WorkspaceLayoutManifestV2;
+  manifestDigest: string;
+  parentRevisionId: string | null;
+};
+
+export type LayoutPublicationSummary = {
+  action: string;
+  channel: string;
+  completedAt: string | null;
+  environment: string;
+  failureMessage: string | null;
+  id: string;
+  requestedAt: string;
+  revisionId: string;
+  status: string;
+};
+
+export type LayoutAssetSummary = {
+  alt: string;
+  contentType: string;
+  height: number;
+  id: string;
+  pathname: string;
+  sizeBytes: number;
+  url: string;
+  width: number;
+};
+
+export type LayoutTemplateSummary = {
+  actorEmail: string;
+  description: string;
+  id: string;
+  manifest: WorkspaceLayoutManifestV2;
+  name: string;
+  updatedAt: string;
+};
+
+type LayoutEditorProps = {
+  activeDraftRevisionId?: string;
+  assets: LayoutAssetSummary[];
+  baseManifest: WorkspaceLayoutManifestV2;
+  parentRevisionId: string | null;
+  publications: LayoutPublicationSummary[];
+  publisherEnabled: boolean;
+  requestKey: string;
+  revisions: LayoutRevisionSummary[];
+  templates: LayoutTemplateSummary[];
+};
+
+type Viewport = "desktop" | "tablet" | "mobile";
+type Selection =
+  | { kind: "workspace" }
+  | { kind: "tab"; tabId: WorkspaceTabId }
+  | { columnId: string; kind: "column"; rowId: string; tabId: WorkspaceTabId }
+  | { kind: "row"; rowId: string; tabId: WorkspaceTabId }
+  | { columnId: string; kind: "node"; nodeId: string; rowId: string; tabId: WorkspaceTabId };
+
+const customBlocks: Array<{ description: string; id: WorkspaceCustomBlockKindV2; label: string }> = [
+  { description: "A titled section marker", id: "heading", label: "Heading" },
+  { description: "Formatted explanatory copy", id: "rich-text", label: "Rich text" },
+  { description: "Highlighted context or caution", id: "callout", label: "Callout" },
+  { description: "Plain explanatory paragraph", id: "narrative", label: "Narrative" },
+  { description: "A row of key values", id: "metric-strip", label: "Metrics" },
+  { description: "Links shown as a compact list", id: "link-list", label: "Link list" },
+  { description: "Prominent linked actions", id: "button-group", label: "Buttons" },
+  { description: "Managed image from Vercel Blob", id: "image", label: "Image" },
+  { description: "YouTube or Vimeo embed", id: "video", label: "Video" },
+  { description: "Expandable question or detail rows", id: "accordion", label: "Accordion" },
+  { description: "Visual section break", id: "divider", label: "Divider" },
+];
+
+export function LayoutEditor({
+  activeDraftRevisionId,
+  assets,
+  baseManifest,
+  parentRevisionId,
+  publications,
+  publisherEnabled,
+  requestKey,
+  revisions,
+  templates,
+}: LayoutEditorProps) {
+  const [history, setHistory] = useState(() => ({ entries: [cloneWorkspaceLayoutManifestV2(baseManifest)], index: 0 }));
+  const manifest = history.entries[history.index];
+  const [activeTabId, setActiveTabId] = useState<WorkspaceTabId>(() => manifest.settings.defaultTab);
+  const [selection, setSelection] = useState<Selection>({ kind: "workspace" });
+  const [viewport, setViewport] = useState<Viewport>("desktop");
+  const [changeSummary, setChangeSummary] = useState("");
+  const [environment, setEnvironment] = useState<"preview" | "production">("preview");
+  const [selectedRevisionId, setSelectedRevisionId] = useState(parentRevisionId ?? revisions[0]?.id ?? "");
+  const [draggedNodeId, setDraggedNodeId] = useState<string | null>(null);
+  const [sessionAssets, setSessionAssets] = useState<LayoutAssetSummary[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [libraryOpen, setLibraryOpen] = useState(true);
+  const [saveState, saveAction, saving] = useActionState(saveLayoutRevisionAction, initialLayoutActionState);
+  const [publicationState, publicationAction, publishing] = useActionState(requestLayoutPublicationAction, initialLayoutActionState);
+  const [templateState, templateAction, templateSaving] = useActionState(saveLayoutTemplateAction, initialLayoutActionState);
+  const validation = useMemo(() => validateWorkspaceLayoutManifestV2(manifest), [manifest]);
+  const errors = validation.ok ? [] : validation.errors;
+  const dirty = JSON.stringify(manifest) !== JSON.stringify(baseManifest);
+  const activeTab = manifest.tabs.find((tab) => tab.id === activeTabId) ?? manifest.tabs[0];
+  const selectedNode = selection.kind === "node" ? findNode(manifest, selection.nodeId) : undefined;
+  const selectedRow = selection.kind === "row" || selection.kind === "column" || selection.kind === "node"
+    ? findRow(manifest, selection.rowId)
+    : undefined;
+  const selectedColumn = selection.kind === "column" || selection.kind === "node"
+    ? selectedRow?.columns.find((column) => column.id === selection.columnId)
+    : undefined;
+  const allAssets = [...sessionAssets, ...assets.filter((asset) => !sessionAssets.some((item) => item.id === asset.id))];
+
+  function commit(updater: (current: WorkspaceLayoutManifestV2) => WorkspaceLayoutManifestV2) {
+    setHistory((current) => {
+      const present = current.entries[current.index];
+      const next = updater(cloneWorkspaceLayoutManifestV2(present));
+      if (JSON.stringify(next) === JSON.stringify(present)) return current;
+      return { entries: [...current.entries.slice(0, current.index + 1), next], index: current.index + 1 };
+    });
+  }
+
+  function updateTab(tabId: WorkspaceTabId, updater: (tab: WorkspaceLayoutTabV2) => WorkspaceLayoutTabV2) {
+    commit((current) => ({ ...current, tabs: current.tabs.map((tab) => tab.id === tabId ? updater(tab) : tab) }));
+  }
+
+  function updateNode(nodeId: string, updater: (node: WorkspaceLayoutNodeV2) => WorkspaceLayoutNodeV2) {
+    commit((current) => mapManifestNodes(current, (node) => node.id === nodeId ? updater(node) : node));
+  }
+
+  function updateRow(rowId: string, updater: (row: WorkspaceLayoutRowV2) => WorkspaceLayoutRowV2) {
+    commit((current) => ({
+      ...current,
+      tabs: current.tabs.map((tab) => ({ ...tab, rows: tab.rows.map((row) => row.id === rowId ? updater(row) : row) })),
+    }));
+  }
+
+  function addBlock(component: WorkspaceCustomBlockKindV2, destination?: { columnId: string; rowId: string }) {
+    const node = createWorkspaceCustomNodeV2(component);
+    if (destination) {
+      updateRow(destination.rowId, (row) => ({ ...row, columns: row.columns.map((column) => column.id === destination.columnId ? { ...column, items: [...column.items, node] } : column) }));
+      setSelection({ columnId: destination.columnId, kind: "node", nodeId: node.id, rowId: destination.rowId, tabId: activeTabId });
+      return;
+    }
+    const row: WorkspaceLayoutRowV2 = {
+      columns: [{ id: createWorkspaceLayoutId("column"), items: [node], span: { desktop: 12, mobile: 12, tablet: 12 } }],
+      gap: "medium",
+      id: createWorkspaceLayoutId("row"),
+    };
+    updateTab(activeTabId, (tab) => ({ ...tab, rows: [...tab.rows, row] }));
+    setSelection({ columnId: row.columns[0].id, kind: "node", nodeId: node.id, rowId: row.id, tabId: activeTabId });
+  }
+
+  function addRow() {
+    const row: WorkspaceLayoutRowV2 = {
+      columns: [{ id: createWorkspaceLayoutId("column"), items: [], span: { desktop: 12, mobile: 12, tablet: 12 } }],
+      gap: "medium",
+      id: createWorkspaceLayoutId("row"),
+    };
+    updateTab(activeTabId, (tab) => ({ ...tab, rows: [...tab.rows, row] }));
+    setSelection({ kind: "row", rowId: row.id, tabId: activeTabId });
+  }
+
+  function addColumn(rowId: string) {
+    updateRow(rowId, (row) => {
+      if (row.columns.length >= 4) return row;
+      const span = row.columns.length === 1 ? 6 : row.columns.length === 2 ? 4 : 3;
+      return {
+        ...row,
+        columns: [
+          ...row.columns.map((column) => ({ ...column, span: { ...column.span, desktop: span as 3 | 4 | 6 } })),
+          { id: createWorkspaceLayoutId("column"), items: [], span: { desktop: span as 3 | 4 | 6, mobile: 12, tablet: 6 } },
+        ],
+      };
+    });
+  }
+
+  function removeNode(nodeId: string) {
+    const target = findNode(manifest, nodeId);
+    if (!target || isWorkspaceProductionNodeV2(target)) return;
+    commit((current) => ({
+      ...current,
+      tabs: current.tabs.map((tab) => ({
+        ...tab,
+        rows: tab.rows.map((row) => ({
+          ...row,
+          columns: row.columns.map((column) => ({ ...column, items: column.items.filter((node) => node.id !== nodeId) })),
+        })),
+      })),
+    }));
+    setSelection({ kind: "tab", tabId: activeTabId });
+  }
+
+  function moveNode(nodeId: string, destinationColumnId: string) {
+    commit((current) => {
+      const node = findNode(current, nodeId);
+      if (!node) return current;
+      const without = mapManifestColumns(current, (column) => ({ ...column, items: column.items.filter((item) => item.id !== nodeId) }));
+      return mapManifestColumns(without, (column) => column.id === destinationColumnId
+        ? { ...column, items: [...column.items, node] }
+        : column);
+    });
+  }
+
+  function moveNodeWithinColumn(columnId: string, nodeId: string, delta: -1 | 1) {
+    commit((current) => mapManifestColumns(current, (column) => {
+      if (column.id !== columnId) return column;
+      const index = column.items.findIndex((item) => item.id === nodeId);
+      const destination = index + delta;
+      if (index < 0 || destination < 0 || destination >= column.items.length) return column;
+      const items = [...column.items];
+      const [item] = items.splice(index, 1);
+      items.splice(destination, 0, item);
+      return { ...column, items };
+    }));
+  }
+
+  function moveRow(rowId: string, delta: -1 | 1) {
+    updateTab(activeTabId, (tab) => {
+      const index = tab.rows.findIndex((row) => row.id === rowId);
+      const destination = index + delta;
+      if (index < 0 || destination < 0 || destination >= tab.rows.length) return tab;
+      const rows = [...tab.rows];
+      const [row] = rows.splice(index, 1);
+      rows.splice(destination, 0, row);
+      return { ...tab, rows };
+    });
+  }
+
+  function applyTemplate(template: WorkspaceLayoutManifestV2) {
+    commit(() => cloneWorkspaceLayoutManifestV2(template));
+    setActiveTabId(template.settings.defaultTab);
+    setSelection({ kind: "workspace" });
+  }
+
+  async function uploadImage(file: File, alt: string, nodeId: string) {
+    setUploading(true);
+    setUploadError(null);
+    let bitmap: ImageBitmap | undefined;
+    try {
+      bitmap = await createImageBitmap(file);
+      const assetId = crypto.randomUUID();
+      const safeName = file.name.toLowerCase().replace(/[^a-z0-9.-]+/g, "-").slice(-90) || "image";
+      const blob = await upload(`layout-media/${safeName}`, file, {
+        access: "public",
+        clientPayload: JSON.stringify({
+          assetId,
+          alt,
+          contentType: file.type,
+          height: bitmap.height,
+          sizeBytes: file.size,
+          width: bitmap.width,
+        }),
+        handleUploadUrl: "/api/admin/layout-assets/upload",
+      });
+      const asset = {
+        alt,
+        contentType: blob.contentType,
+        height: bitmap.height,
+        id: assetId,
+        pathname: blob.pathname,
+        sizeBytes: file.size,
+        url: blob.url,
+        width: bitmap.width,
+      };
+      setSessionAssets((current) => [asset, ...current]);
+      attachAsset(nodeId, asset);
+    } catch (error) {
+      setUploadError(error instanceof Error ? error.message : "Image upload failed.");
+    } finally {
+      bitmap?.close();
+      setUploading(false);
+    }
+  }
+
+  function attachAsset(nodeId: string, asset: LayoutAssetSummary) {
+    updateNode(nodeId, (node) => isWorkspaceCustomNodeV2(node) ? {
+      ...node,
+      asset: {
+        alt: asset.alt,
+        assetId: asset.id,
+        height: asset.height,
+        url: asset.url,
+        width: asset.width,
+      },
+    } : node);
+  }
+
+  return (
+    <section className={styles.editor}>
+      <header className={styles.toolbar}>
+        <div className={styles.toolbarGroup}>
+          <button disabled={history.index === 0} onClick={() => setHistory((current) => ({ ...current, index: current.index - 1 }))} type="button"><Undo2 size={16} /> Undo</button>
+          <button disabled={history.index === history.entries.length - 1} onClick={() => setHistory((current) => ({ ...current, index: current.index + 1 }))} type="button"><Redo2 size={16} /> Redo</button>
+          <button disabled={!dirty} onClick={() => {
+            setHistory({ entries: [cloneWorkspaceLayoutManifestV2(baseManifest)], index: 0 });
+            setSelection({ kind: "workspace" });
+          }} type="button"><RotateCcw size={16} /> Reset</button>
+        </div>
+        <div aria-label="Preview width" className={styles.segmented} role="group">
+          {(["desktop", "tablet", "mobile"] as const).map((mode) => {
+            const Icon = mode === "desktop" ? Laptop : mode === "tablet" ? Tablet : Smartphone;
+            return <button aria-pressed={viewport === mode} key={mode} onClick={() => setViewport(mode)} type="button"><Icon size={16} /><span>{mode}</span></button>;
+          })}
+        </div>
+        <div className={styles.toolbarStatus}>
+          <span>{dirty ? "Unsaved changes" : "Up to date"}</span>
+          <span className={errors.length ? styles.errorBadge : styles.validBadge}>{errors.length ? `${errors.length} issue${errors.length === 1 ? "" : "s"}` : "Valid v2"}</span>
+        </div>
+      </header>
+      {uploadError && <p className={styles.errorMessage} role="alert"><TriangleAlert size={15} /> {uploadError}</p>}
+
+      <div className={styles.builderShell}>
+        <aside className={styles.library}>
+          <button className={styles.asideTitle} onClick={() => setLibraryOpen((value) => !value)} type="button">
+            <LayoutGrid size={17} /> Build <span>{libraryOpen ? <ChevronDown size={15} /> : <ChevronRight size={15} />}</span>
+          </button>
+          {libraryOpen && <>
+            <section>
+              <h2>Tabs</h2>
+              <div className={styles.tabList}>
+                {workspaceLayoutRegistryV2.map((tab) => {
+                  const configured = manifest.tabs.find((item) => item.id === tab.id)!;
+                  return (
+                    <button aria-pressed={activeTabId === tab.id} key={tab.id} onClick={() => {
+                      setActiveTabId(tab.id);
+                      setSelection({ kind: "tab", tabId: tab.id });
+                    }} type="button">
+                      <span>{tab.label}</span>
+                      {tab.required ? <LockKeyhole size={13} /> : configured.visible ? <Eye size={13} /> : <EyeOff size={13} />}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+            <section>
+              <h2>Content blocks</h2>
+              <div className={styles.blockPalette}>
+                {customBlocks.map((block) => (
+                  <button key={block.id} onClick={() => addBlock(block.id)} title={block.description} type="button">
+                    <Plus size={14} /><span><strong>{block.label}</strong><small>{block.description}</small></span>
+                  </button>
+                ))}
+              </div>
+            </section>
+            <section>
+              <h2>Starter layouts</h2>
+              <div className={styles.templateList}>
+                {workspaceStarterTemplates.map((template) => (
+                  <button key={template.id} onClick={() => applyTemplate(template.manifest)} type="button">
+                    <strong>{template.label}</strong><small>{template.description}</small>
+                  </button>
+                ))}
+                {templates.map((template) => (
+                  <button key={template.id} onClick={() => applyTemplate(template.manifest)} type="button">
+                    <strong>{template.name}</strong><small>{template.description || `Shared by ${template.actorEmail}`}</small>
+                  </button>
+                ))}
+              </div>
+            </section>
+          </>}
+        </aside>
+
+        <main className={styles.stage}>
+          <div className={styles.stageHeader}>
+            <div><span>Live-layout preview</span><h2>{workspaceLayoutRegistryV2.find((tab) => tab.id === activeTabId)?.label}</h2></div>
+            <button onClick={addRow} type="button"><Plus size={15} /> Add row</button>
+          </div>
+          <div className={`${styles.viewport} ${styles[viewport]}`} data-layout-accent={manifest.settings.accentColor} data-layout-theme={manifest.settings.theme}>
+            <div className={styles.sitePreviewHeader}>
+              <div className={styles.previewBrand}><span>CR</span><strong>Civic Result Maps</strong></div>
+              <div className={styles.previewMetrics}><span>Jurisdictions <strong>39</strong></span><span>Sources <strong>12</strong></span><span>Validation <strong>Pass</strong></span></div>
+            </div>
+            <div className={styles.previewTabs}>{manifest.tabs.filter((tab) => tab.visible).map((tab) => <span className={tab.id === activeTabId ? styles.activePreviewTab : ""} key={tab.id}>{workspaceLayoutRegistryV2.find((item) => item.id === tab.id)?.label}</span>)}</div>
+            <div className={styles.rows}>
+              {activeTab.rows.map((row, rowIndex) => (
+                <section
+                  aria-label={`Layout row ${rowIndex + 1}`}
+                  className={styles.row}
+                  data-selected={selection.kind === "row" && selection.rowId === row.id}
+                  key={row.id}
+                  onClick={() => setSelection({ kind: "row", rowId: row.id, tabId: activeTabId })}
+                  onKeyDown={(event) => { if (event.key === "Enter" || event.key === " ") setSelection({ kind: "row", rowId: row.id, tabId: activeTabId }); }}
+                  tabIndex={0}
+                >
+                  <div className={styles.rowControls}>
+                    <span>Row {rowIndex + 1}</span>
+                    <button aria-label="Move row up" disabled={rowIndex === 0} onClick={(event) => { event.stopPropagation(); moveRow(row.id, -1); }} type="button"><ArrowUp size={13} /></button>
+                    <button aria-label="Move row down" disabled={rowIndex === activeTab.rows.length - 1} onClick={(event) => { event.stopPropagation(); moveRow(row.id, 1); }} type="button"><ArrowDown size={13} /></button>
+                    <button onClick={(event) => { event.stopPropagation(); addColumn(row.id); }} type="button"><Columns3 size={13} /> Column</button>
+                  </div>
+                  <div className={styles.columns} data-gap={row.gap ?? "medium"}>
+                    {row.columns.map((column) => (
+                      <div
+                        aria-label={`Column ${column.id.slice(-4)}`}
+                        className={styles.column}
+                        data-empty={column.items.length === 0}
+                        data-selected={(selection.kind === "column" || selection.kind === "node") && selection.columnId === column.id}
+                        key={column.id}
+                        onClick={(event) => { event.stopPropagation(); setSelection({ columnId: column.id, kind: "column", rowId: row.id, tabId: activeTabId }); }}
+                        onDragOver={(event) => event.preventDefault()}
+                        onDrop={(event) => {
+                          event.preventDefault();
+                          if (draggedNodeId) moveNode(draggedNodeId, column.id);
+                          setDraggedNodeId(null);
+                        }}
+                        onKeyDown={(event) => { if (event.key === "Enter" || event.key === " ") setSelection({ columnId: column.id, kind: "column", rowId: row.id, tabId: activeTabId }); }}
+                        style={{ "--builder-span": column.span[viewport] } as CSSProperties}
+                        tabIndex={0}
+                      >
+                        {column.items.map((node) => (
+                          <BuilderNode
+                            key={node.id}
+                            node={node}
+                            onDragEnd={() => setDraggedNodeId(null)}
+                            onDragStart={() => setDraggedNodeId(node.id)}
+                            onSelect={() => setSelection({ columnId: column.id, kind: "node", nodeId: node.id, rowId: row.id, tabId: activeTabId })}
+                            selected={selection.kind === "node" && selection.nodeId === node.id}
+                          />
+                        ))}
+                        {!column.items.length && <button className={styles.emptyColumn} onClick={(event) => { event.stopPropagation(); addBlock("rich-text", { columnId: column.id, rowId: row.id }); }} type="button"><Plus size={15} /> Drop or add content</button>}
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              ))}
+              {!activeTab.rows.length && <button className={styles.emptyCanvas} onClick={addRow} type="button"><Plus /> Add the first row</button>}
+            </div>
+          </div>
+        </main>
+
+        <aside className={styles.inspector}>
+          <div className={styles.inspectorHeader}><Settings2 size={17} /><div><span>Configure</span><strong>{selectionLabel(selection, selectedNode)}</strong></div><button aria-label="Inspect workspace" onClick={() => setSelection({ kind: "workspace" })} type="button"><X size={15} /></button></div>
+          {selection.kind === "workspace" && <WorkspaceInspector manifest={manifest} onChange={(settings) => commit((current) => ({ ...current, settings }))} />}
+          {selection.kind === "tab" && <TabInspector tab={activeTab} required={workspaceLayoutRegistryV2.find((tab) => tab.id === activeTab.id)?.required ?? false} onChange={(tab) => updateTab(activeTab.id, () => tab)} />}
+          {selection.kind === "row" && selectedRow && <RowInspector row={selectedRow} onChange={(row) => updateRow(row.id, () => row)} />}
+          {selection.kind === "column" && selectedColumn && <ColumnInspector column={selectedColumn} viewport={viewport} onChange={(column) => updateRow(selection.rowId, (row) => ({ ...row, columns: row.columns.map((item) => item.id === column.id ? column : item) }))} />}
+          {selection.kind === "node" && selectedNode && <NodeInspector
+            assets={allAssets}
+            node={selectedNode}
+            onAttachAsset={(asset) => attachAsset(selectedNode.id, asset)}
+            onChange={(node) => updateNode(node.id, () => node)}
+            onRemove={() => removeNode(selectedNode.id)}
+            onMove={(delta) => moveNodeWithinColumn(selection.columnId, selectedNode.id, delta)}
+            onUpload={(file, alt) => uploadImage(file, alt, selectedNode.id)}
+            uploading={uploading}
+          />}
+        </aside>
+      </div>
+
+      <footer className={styles.operations}>
+        <section className={styles.operationCard}>
+          <div><Save size={18} /><span><strong>Save immutable revision</strong><small>Review validation, describe the change, then save.</small></span></div>
+          {errors.length > 0 && <ul className={styles.errorList}>{errors.slice(0, 8).map((error) => <li key={error}>{error}</li>)}</ul>}
+          <form action={saveAction}>
+            <input name="manifest" type="hidden" value={JSON.stringify(manifest)} />
+            <input name="parentRevisionId" type="hidden" value={parentRevisionId ?? ""} />
+            <label>Change summary<input minLength={5} maxLength={500} name="changeSummary" onChange={(event) => setChangeSummary(event.target.value)} placeholder="Describe what visitors will notice" value={changeSummary} /></label>
+            <button disabled={saving || errors.length > 0 || changeSummary.trim().length < 5 || !dirty} type="submit">{saving ? <LoaderCircle className={styles.spin} size={16} /> : <Save size={16} />} Save revision</button>
+          </form>
+          <ActionMessage state={saveState} />
+        </section>
+
+        <section className={styles.operationCard}>
+          <div><Copy size={18} /><span><strong>Save as shared template</strong><small>Reuse this complete workspace without publishing it.</small></span></div>
+          <form action={templateAction}>
+            <input name="manifest" type="hidden" value={JSON.stringify(manifest)} />
+            <label>Template name<input maxLength={80} minLength={3} name="name" placeholder="County review workspace" /></label>
+            <label>Description<input maxLength={240} name="description" placeholder="When this layout works best" /></label>
+            <button disabled={templateSaving || errors.length > 0} type="submit">{templateSaving ? <LoaderCircle className={styles.spin} size={16} /> : <Copy size={16} />} Save template</button>
+          </form>
+          <ActionMessage state={templateState} />
+        </section>
+
+        <section className={styles.operationCard}>
+          <div><Send size={18} /><span><strong>Preview and publish</strong><small>Saved revisions only; production confirmation is required.</small></span></div>
+          <form action={startLayoutDraftPreviewAction}>
+            <label>Revision<select name="revisionId" onChange={(event) => setSelectedRevisionId(event.target.value)} value={selectedRevisionId}>{revisions.map((revision) => <option key={revision.id} value={revision.id}>{revision.changeSummary} · {new Date(revision.createdAt).toLocaleString()}</option>)}</select></label>
+            <button disabled={!selectedRevisionId} type="submit"><MonitorSmartphone size={16} /> Preview revision</button>
+          </form>
+          <form action={publicationAction}>
+            <input name="requestKey" type="hidden" value={requestKey} />
+            <input name="revisionId" type="hidden" value={selectedRevisionId} />
+            <label>Environment<select name="environment" onChange={(event) => setEnvironment(event.target.value as "preview" | "production")} value={environment}><option value="preview">Preview</option><option value="production">Production</option></select></label>
+            <label>Action<select name="publicationAction"><option value="stage">Stage candidate</option><option value="promote">Promote stable</option><option value="rollback">Rollback stable</option></select></label>
+            {environment === "production" && <label className={styles.confirm}><input name="confirmProduction" type="checkbox" value="yes" /> I confirm this production change</label>}
+            <button disabled={!publisherEnabled || publishing || !selectedRevisionId} type="submit">{publishing ? <LoaderCircle className={styles.spin} size={16} /> : <Send size={16} />} Request publication</button>
+          </form>
+          {!publisherEnabled && <p className={styles.notice}><LockKeyhole size={14} /> Publishing workflow is currently queued-only.</p>}
+          {activeDraftRevisionId && <p className={styles.notice}><Eye size={14} /> Draft preview is active for {activeDraftRevisionId.slice(0, 8)}.</p>}
+          <ActionMessage state={publicationState} />
+        </section>
+
+        <section className={styles.operationCard}>
+          <div><History size={18} /><span><strong>Recent activity</strong><small>Revision and publication audit trail.</small></span></div>
+          <ol className={styles.historyList}>{revisions.slice(0, 8).map((revision) => <li key={revision.id}><strong>{revision.changeSummary}</strong><span>{revision.actorEmail} · {new Date(revision.createdAt).toLocaleString()}</span></li>)}</ol>
+          {publications.slice(0, 4).map((publication) => <p className={styles.publication} key={publication.id}><span>{publication.environment} / {publication.channel}</span><strong>{publication.status}</strong></p>)}
+        </section>
+      </footer>
+    </section>
+  );
+}
+
+function BuilderNode({ node, onDragEnd, onDragStart, onSelect, selected }: {
+  node: WorkspaceLayoutNodeV2;
+  onDragEnd: () => void;
+  onDragStart: () => void;
+  onSelect: () => void;
+  selected: boolean;
+}) {
+  const label = isWorkspaceProductionNodeV2(node) ? productionLabel(node) : customLabel(node);
+  return (
+    <article className={styles.builderNode} data-kind={node.kind} data-selected={selected} data-visible={node.visible} draggable onDragEnd={onDragEnd} onDragStart={onDragStart} onClick={(event) => { event.stopPropagation(); onSelect(); }}>
+      <div className={styles.nodeToolbar}>
+        <button aria-label={`Drag ${label}`} className={styles.dragHandle} type="button"><GripVertical size={16} /></button>
+        <span>{node.kind === "production" ? "Production" : "Content"}</span>
+        {!node.visible && <EyeOff size={13} />}
+        <button aria-label={`Configure ${label}`} onClick={onSelect} type="button"><Settings2 size={15} /></button>
+      </div>
+      <div className={styles.nodePreview}>
+        <strong>{label}</strong>
+        {isWorkspaceProductionNodeV2(node) ? <ProductionSketch node={node} /> : <CustomSketch node={node} />}
+      </div>
+    </article>
+  );
+}
+
+function ProductionSketch({ node }: { node: WorkspaceProductionNodeV2 }) {
+  if (node.component === "results-map") return <div className={styles.mapSketch}><span /><i /><i /><i /></div>;
+  if (node.component === "state-snapshot") return <div className={styles.metricSketch}><span>Candidate A</span><b /><span>Candidate B</span><b /></div>;
+  if (node.component === "source-provenance") return <div className={styles.textSketch}><span /><span /><span /></div>;
+  if (node.component === "review-center") return <div className={styles.pillSketch}><span>Overview</span><span>Tools</span><span>Indicators</span></div>;
+  return <div className={styles.textSketch}><span /><span /></div>;
+}
+
+function CustomSketch({ node }: { node: WorkspaceCustomNodeV2 }) {
+  if (node.component === "image") return node.asset ? <img alt={node.asset.alt} src={node.asset.url} /> : <div className={styles.imagePlaceholder}><FileImage size={24} /> Choose image</div>;
+  if (node.component === "divider") return <hr />;
+  if (node.component === "metric-strip") return <div className={styles.pillSketch}>{node.items?.map((item) => <span key={item.label}>{item.value || item.label}</span>)}</div>;
+  return <p>{node.body || node.document?.blocks[0]?.children.map((child) => child.text).join("") || "Configure this content with the gear."}</p>;
+}
+
+function WorkspaceInspector({ manifest, onChange }: { manifest: WorkspaceLayoutManifestV2; onChange: (settings: WorkspaceLayoutManifestV2["settings"]) => void }) {
+  const settings = manifest.settings;
+  const update = <K extends keyof typeof settings>(key: K, value: typeof settings[K]) => onChange({ ...settings, [key]: value });
+  return <div className={styles.inspectorBody}>
+    <fieldset><legend>Design system</legend>
+      <Select label="Theme" value={settings.theme} onChange={(value) => update("theme", value as typeof settings.theme)} options={["civic", "warm", "high-contrast"]} />
+      <Select label="Content width" value={settings.contentWidth} onChange={(value) => update("contentWidth", value as typeof settings.contentWidth)} options={["standard", "wide", "full"]} />
+      <Select label="Spacing" value={settings.spacingScale} onChange={(value) => update("spacingScale", value as typeof settings.spacingScale)} options={["tight", "standard", "relaxed"]} />
+      <Select label="Type scale" value={settings.typeScale} onChange={(value) => update("typeScale", value as typeof settings.typeScale)} options={["small", "standard", "large"]} />
+      <Select label="Corners" value={settings.radius} onChange={(value) => update("radius", value as typeof settings.radius)} options={["square", "subtle", "rounded"]} />
+      <Select label="Shadows" value={settings.shadow} onChange={(value) => update("shadow", value as typeof settings.shadow)} options={["none", "subtle", "raised"]} />
+      <Select label="Tab style" value={settings.tabStyle} onChange={(value) => update("tabStyle", value as typeof settings.tabStyle)} options={["bar", "pills"]} />
+      <label>Accent color<input aria-label="Accent color" type="color" value={settings.accentColor ?? "#18a77a"} onChange={(event) => update("accentColor", event.target.value)} /></label>
+    </fieldset>
+    <fieldset><legend>Defaults</legend>
+      <Select label="Default tab" value={settings.defaultTab} onChange={(value) => update("defaultTab", value as WorkspaceTabId)} options={manifest.tabs.filter((tab) => tab.visible).map((tab) => tab.id)} />
+      <Select label="Data notes" value={settings.notesDefault} onChange={(value) => update("notesDefault", value as typeof settings.notesDefault)} options={["collapsed", "expanded"]} />
+    </fieldset>
+  </div>;
+}
+
+function TabInspector({ tab, required, onChange }: { tab: WorkspaceLayoutTabV2; required: boolean; onChange: (tab: WorkspaceLayoutTabV2) => void }) {
+  return <div className={styles.inspectorBody}>
+    <fieldset><legend>Tab settings</legend>
+      <label className={styles.switchLabel}><input checked={tab.visible} disabled={required} onChange={(event) => onChange({ ...tab, visible: event.target.checked })} type="checkbox" /> Visible {required && <small>Required</small>}</label>
+      <Select label="Density" value={tab.settings?.density ?? "comfortable"} onChange={(value) => onChange({ ...tab, settings: { ...tab.settings, density: value as "compact" | "comfortable" | "spacious" } })} options={["compact", "comfortable", "spacious"]} />
+      <Select label="Data notes position" value={tab.settings?.notesPosition ?? "side"} onChange={(value) => onChange({ ...tab, settings: { ...tab.settings, notesPosition: value as "side" | "below" | "drawer" } })} options={["side", "below", "drawer"]} />
+    </fieldset>
+  </div>;
+}
+
+function RowInspector({ row, onChange }: { row: WorkspaceLayoutRowV2; onChange: (row: WorkspaceLayoutRowV2) => void }) {
+  return <div className={styles.inspectorBody}><fieldset><legend>Row layout</legend>
+    <Select label="Gap" value={row.gap ?? "medium"} onChange={(value) => onChange({ ...row, gap: value as "small" | "medium" | "large" })} options={["small", "medium", "large"]} />
+    <Select label="Vertical alignment" value={row.align ?? "stretch"} onChange={(value) => onChange({ ...row, align: value as "start" | "center" | "stretch" })} options={["start", "center", "stretch"]} />
+    <p>{row.columns.length} column{row.columns.length === 1 ? "" : "s"}; up to four are supported.</p>
+  </fieldset></div>;
+}
+
+function ColumnInspector({ column, viewport, onChange }: { column: WorkspaceLayoutColumnV2; viewport: Viewport; onChange: (column: WorkspaceLayoutColumnV2) => void }) {
+  const options = viewport === "desktop" ? [3, 4, 6, 8, 9, 12] : viewport === "tablet" ? [6, 12] : [12];
+  return <div className={styles.inspectorBody}><fieldset><legend>Responsive width</legend>
+    <label>{viewport} columns<select value={column.span[viewport]} onChange={(event) => onChange({ ...column, span: { ...column.span, [viewport]: Number(event.target.value) } as WorkspaceLayoutColumnV2["span"] })}>{options.map((span) => <option key={span} value={span}>{span} / 12</option>)}</select></label>
+    <div className={styles.breakpointSummary}><span>Desktop {column.span.desktop}/12</span><span>Tablet {column.span.tablet}/12</span><span>Mobile 12/12</span></div>
+  </fieldset></div>;
+}
+
+function NodeInspector({ assets, node, onAttachAsset, onChange, onMove, onRemove, onUpload, uploading }: {
+  assets: LayoutAssetSummary[];
+  node: WorkspaceLayoutNodeV2;
+  onAttachAsset: (asset: LayoutAssetSummary) => void;
+  onChange: (node: WorkspaceLayoutNodeV2) => void;
+  onRemove: () => void;
+  onMove: (delta: -1 | 1) => void;
+  onUpload: (file: File, alt: string) => Promise<void>;
+  uploading: boolean;
+}) {
+  const update = (patch: Partial<WorkspaceLayoutNodeV2>) => onChange({ ...node, ...patch } as WorkspaceLayoutNodeV2);
+  const protectedSurface = isWorkspaceProductionNodeV2(node) && workspaceLayoutRegistryV2.some(
+    (tab) => tab.components.some((component) => component.id === node.component && component.required),
+  );
+  return <div className={styles.inspectorBody}>
+    <fieldset><legend>Display</legend>
+      <label className={styles.switchLabel}><input checked={node.visible} disabled={protectedSurface} onChange={(event) => update({ visible: event.target.checked })} type="checkbox" /> Visible {protectedSurface && <small>Required trust surface</small>}</label>
+      <Select label="Surface" value={node.presentation?.surface ?? "panel"} onChange={(value) => update({ presentation: { ...node.presentation, surface: value as "panel" | "plain" | "muted" | "accent" } })} options={["panel", "plain", "muted", "accent"]} />
+      <Select label="Emphasis" value={node.presentation?.emphasis ?? "standard"} onChange={(value) => update({ presentation: { ...node.presentation, emphasis: value as "quiet" | "standard" | "prominent" } })} options={["quiet", "standard", "prominent"]} />
+      <Select label="Density" value={node.presentation?.density ?? "comfortable"} onChange={(value) => update({ presentation: { ...node.presentation, density: value as "compact" | "comfortable" | "spacious" } })} options={["compact", "comfortable", "spacious"]} />
+    </fieldset>
+    <fieldset><legend>Order in column</legend><div className={styles.breakpointSummary}>
+      <button onClick={() => onMove(-1)} type="button"><ArrowUp size={14} /> Earlier</button>
+      <button onClick={() => onMove(1)} type="button"><ArrowDown size={14} /> Later</button>
+    </div></fieldset>
+    {isWorkspaceProductionNodeV2(node)
+      ? <ProductionInspector node={node} onChange={onChange} />
+      : <CustomInspector assets={assets} key={`${node.id}:${node.asset?.assetId ?? ""}`} node={node} onAttachAsset={onAttachAsset} onChange={onChange} onUpload={onUpload} uploading={uploading} />}
+    {protectedSurface
+      ? <fieldset><legend>Visibility rules</legend><p>This required public-interest trust surface is always visible.</p></fieldset>
+      : <VisibilityInspector node={node} onChange={onChange} />}
+    {isWorkspaceCustomNodeV2(node) && <button className={styles.dangerButton} onClick={onRemove} type="button"><Trash2 size={15} /> Remove custom block</button>}
+  </div>;
+}
+
+function ProductionInspector({ node, onChange }: { node: WorkspaceProductionNodeV2; onChange: (node: WorkspaceLayoutNodeV2) => void }) {
+  const config = node.config ?? {};
+  const setConfig = (patch: Partial<typeof config>) => onChange({ ...node, config: { ...config, ...patch } });
+  return <fieldset><legend>Component variant</legend>
+    {node.component === "results-map" && <><Select label="Composition" value={config.mapComposition ?? "map-first"} onChange={(value) => setConfig({ mapComposition: value as "map-first" | "table-first" | "split" })} options={["map-first", "table-first", "split"]} /><Select label="Legend" value={config.legendPosition ?? "below"} onChange={(value) => setConfig({ legendPosition: value as "inline" | "below" })} options={["inline", "below"]} /></>}
+    {node.component === "coverage-context" && <Select label="Coverage display" value={config.coverageVariant ?? "list"} onChange={(value) => setConfig({ coverageVariant: value as "list" | "cards" | "compact" })} options={["list", "cards", "compact"]} />}
+    {node.component === "state-snapshot" && <Select label="Snapshot display" value={config.snapshotVariant ?? "bars"} onChange={(value) => setConfig({ snapshotVariant: value as "bars" | "metrics" | "table" })} options={["bars", "metrics", "table"]} />}
+    {node.component === "source-provenance" && <><Select label="Provenance display" value={config.provenanceVariant ?? "expanded"} onChange={(value) => setConfig({ provenanceVariant: value as "summary" | "expanded" | "accordion" })} options={["summary", "expanded", "accordion"]} /><Select label="Initial state" value={config.provenanceInitialState ?? "expanded"} onChange={(value) => setConfig({ provenanceInitialState: value as "collapsed" | "expanded" })} options={["collapsed", "expanded"]} /></>}
+    {node.component === "review-center" && <Select label="Navigation" value={config.navigationStyle ?? "tabs"} onChange={(value) => setConfig({ navigationStyle: value as "tabs" | "pills" | "sidebar" })} options={["tabs", "pills", "sidebar"]} />}
+    {!node.config && <p>This component uses its production-safe default variant.</p>}
+  </fieldset>;
+}
+
+function CustomInspector({ assets, node, onAttachAsset, onChange, onUpload, uploading }: {
+  assets: LayoutAssetSummary[];
+  node: WorkspaceCustomNodeV2;
+  onAttachAsset: (asset: LayoutAssetSummary) => void;
+  onChange: (node: WorkspaceLayoutNodeV2) => void;
+  onUpload: (file: File, alt: string) => Promise<void>;
+  uploading: boolean;
+}) {
+  const [alt, setAlt] = useState(node.asset?.alt ?? "");
+  const set = (patch: Partial<WorkspaceCustomNodeV2>) => onChange({ ...node, ...patch });
+  return <fieldset><legend>Content</legend>
+    {node.component !== "divider" && <label>Title<input maxLength={160} value={node.title ?? ""} onChange={(event) => set({ title: event.target.value })} /></label>}
+    {node.component === "rich-text" ? <LayoutRichTextEditor document={node.document ?? richTextDocumentFromPlainText(node.body ?? "")} key={node.id} onChange={(document) => set({ document })} /> : ["narrative", "callout", "heading", "button-group", "link-list"].includes(node.component) && <label>Body<textarea maxLength={2000} rows={5} value={node.body ?? ""} onChange={(event) => set({ body: event.target.value })} /></label>}
+    {node.component === "image" && <>
+      <label>Alternative text<input maxLength={240} onChange={(event) => { setAlt(event.target.value); if (node.asset) set({ asset: { ...node.asset, alt: event.target.value } }); }} value={alt} /></label>
+      <label className={styles.uploadButton}>{uploading ? <LoaderCircle className={styles.spin} size={16} /> : <FileImage size={16} />} Upload image<input accept="image/avif,image/jpeg,image/png,image/webp" disabled={uploading} onChange={(event) => { const file = event.target.files?.[0]; if (file) void onUpload(file, alt); }} type="file" /></label>
+      {assets.length > 0 && <div className={styles.assetGrid}>{assets.map((asset) => <button key={asset.id} onClick={() => onAttachAsset(asset)} type="button"><img alt={asset.alt} src={asset.url} /><span>{asset.alt || asset.pathname}</span></button>)}</div>}
+      <label>Caption<input maxLength={300} value={node.asset?.caption ?? ""} onChange={(event) => node.asset && set({ asset: { ...node.asset, caption: event.target.value } })} /></label>
+      <label className={styles.switchLabel}><input checked={node.asset?.decorative ?? false} disabled={!node.asset} onChange={(event) => node.asset && set({ asset: { ...node.asset, decorative: event.target.checked } })} type="checkbox" /> Decorative image</label>
+    </>}
+    {node.component === "video" && <><Select label="Provider" value={node.video?.provider ?? "youtube"} onChange={(value) => set({ video: { id: node.video?.id ?? "", provider: value as "youtube" | "vimeo", title: node.video?.title ?? node.title ?? "Video" } })} options={["youtube", "vimeo"]} /><label>Video ID<input value={node.video?.id ?? ""} onChange={(event) => set({ video: { id: event.target.value.replace(/[^a-zA-Z0-9_-]/g, ""), provider: node.video?.provider ?? "youtube", title: node.video?.title ?? node.title ?? "Video" } })} /></label></>}
+    {["metric-strip", "link-list", "button-group", "accordion"].includes(node.component) && <ItemsEditor node={node} onChange={set} />}
+  </fieldset>;
+}
+
+function ItemsEditor({ node, onChange }: { node: WorkspaceCustomNodeV2; onChange: (patch: Partial<WorkspaceCustomNodeV2>) => void }) {
+  const items = node.items ?? [];
+  return <div className={styles.itemsEditor}><span>Items</span>{items.map((item, index) => <div key={index}>
+    <input aria-label={`Item ${index + 1} label`} placeholder="Label" value={item.label} onChange={(event) => onChange({ items: items.map((entry, itemIndex) => itemIndex === index ? { ...entry, label: event.target.value } : entry) })} />
+    {node.component === "metric-strip" && <input aria-label={`Item ${index + 1} value`} placeholder="Value" value={item.value ?? ""} onChange={(event) => onChange({ items: items.map((entry, itemIndex) => itemIndex === index ? { ...entry, value: event.target.value } : entry) })} />}
+    {["link-list", "button-group"].includes(node.component) && <input aria-label={`Item ${index + 1} link`} placeholder="https:// or /path" value={item.href ?? ""} onChange={(event) => onChange({ items: items.map((entry, itemIndex) => itemIndex === index ? { ...entry, href: event.target.value } : entry) })} />}
+    {node.component === "accordion" && <textarea aria-label={`Item ${index + 1} body`} placeholder="Expanded content" value={item.body ?? ""} onChange={(event) => onChange({ items: items.map((entry, itemIndex) => itemIndex === index ? { ...entry, body: event.target.value } : entry) })} />}
+    <button aria-label={`Remove item ${index + 1}`} onClick={() => onChange({ items: items.filter((_, itemIndex) => itemIndex !== index) })} type="button"><Trash2 size={14} /></button>
+  </div>)}<button onClick={() => onChange({ items: [...items, { label: "New item", value: node.component === "metric-strip" ? "0" : undefined }] })} type="button"><Plus size={14} /> Add item</button></div>;
+}
+function initialVisibilityCondition(
+  fact: WorkspaceVisibilityConditionV1["fact"],
+): WorkspaceVisibilityConditionV1 {
+  if (fact === "data") return { fact, key: workspaceVisibilityDataKeys[0], operator: "available" };
+  if (fact === "capability") return { fact, key: workspaceVisibilityCapabilityKeys[0], operator: "available" };
+  if (fact === "year") return { fact, operator: "equals", value: 2024 };
+  if (fact === "validation") return { fact, operator: "equals", value: "passed" };
+  return { fact, operator: "equals", value: "" };
+}
+
+function visibilityRuleOptions(fact?: WorkspaceVisibilityConditionV1["fact"]): readonly string[] {
+  if (fact === "data") return workspaceVisibilityDataKeys;
+  if (fact === "capability") return workspaceVisibilityCapabilityKeys;
+  if (fact === "year") return ["2016", "2020", "2024"];
+  if (fact === "validation") return ["passed", "warning", "failed", "unknown"];
+  return [];
+}
+
+
+function VisibilityInspector({ node, onChange }: { node: WorkspaceLayoutNodeV2; onChange: (node: WorkspaceLayoutNodeV2) => void }) {
+  const visibility = node.visibility ?? { groups: [], operator: "all" as const, viewports: { desktop: true, mobile: true, tablet: true } };
+  const condition = visibility.groups?.[0]?.conditions[0];
+  const ruleOptions = visibilityRuleOptions(condition?.fact);
+  const updateViewports = (key: "desktop" | "mobile" | "tablet", value: boolean) => onChange({ ...node, visibility: { ...visibility, viewports: { ...visibility.viewports, [key]: value } } });
+  return <fieldset><legend>Visibility rules</legend>
+    <div className={styles.viewportChecks}>{(["desktop", "tablet", "mobile"] as const).map((key) => <label key={key}><input checked={visibility.viewports?.[key] !== false} onChange={(event) => updateViewports(key, event.target.checked)} type="checkbox" /> {key}</label>)}</div>
+    <label>Data rule<select value={condition?.fact ?? "always"} onChange={(event) => {
+      if (event.target.value === "always") return onChange({ ...node, visibility: { ...visibility, groups: [] } });
+      const fact = event.target.value as WorkspaceVisibilityConditionV1["fact"];
+      onChange({ ...node, visibility: { ...visibility, groups: [{ conditions: [initialVisibilityCondition(fact)], operator: "all" }] } });
+    }}><option value="always">Always</option><option value="state">State equals</option><option value="year">Year equals</option><option value="capability">Capability available</option><option value="data">Data available</option><option value="validation">Validation status</option></select></label>
+    {condition && <label>Rule value<input list={ruleOptions.length ? "layout-visibility-rule-options" : undefined} value={String(condition.key ?? condition.value ?? "")} onChange={(event) => {
+      const raw = event.target.value;
+      const next = condition.fact === "capability" || condition.fact === "data"
+        ? { ...condition, key: raw, operator: "available" as const, value: undefined }
+        : { ...condition, value: condition.fact === "year" ? Number(raw) || 0 : raw };
+      onChange({ ...node, visibility: { ...visibility, groups: [{ conditions: [next], operator: "all" }] } });
+    }} /></label>}
+    {ruleOptions.length > 0 && <datalist id="layout-visibility-rule-options">{ruleOptions.map((option) => <option key={option} value={option} />)}</datalist>}
+    <small>Rules use allowlisted state, year, capability, data, and validation facts. Required production components cannot be conditional.</small>
+  </fieldset>;
+}
+
+function Select({ label, onChange, options, value }: { label: string; onChange: (value: string) => void; options: readonly string[]; value: string }) {
+  return <label>{label}<select onChange={(event) => onChange(event.target.value)} value={value}>{options.map((option) => <option key={option} value={option}>{titleCase(option)}</option>)}</select></label>;
+}
+
+function ActionMessage({ state }: { state: LayoutActionState }) {
+  if (state.kind === "idle") return null;
+  const Icon = state.kind === "success" ? CheckCircle2 : TriangleAlert;
+  return <p className={state.kind === "success" ? styles.successMessage : styles.errorMessage} role="status"><Icon size={15} /> {state.message}</p>;
+}
+
+function mapManifestNodes(manifest: WorkspaceLayoutManifestV2, mapper: (node: WorkspaceLayoutNodeV2) => WorkspaceLayoutNodeV2) {
+  return mapManifestColumns(manifest, (column) => ({ ...column, items: column.items.map(mapper) }));
+}
+
+function mapManifestColumns(manifest: WorkspaceLayoutManifestV2, mapper: (column: WorkspaceLayoutColumnV2) => WorkspaceLayoutColumnV2) {
+  return {
+    ...manifest,
+    tabs: manifest.tabs.map((tab) => ({ ...tab, rows: tab.rows.map((row) => ({ ...row, columns: row.columns.map(mapper) })) })),
+  };
+}
+
+function findNode(manifest: WorkspaceLayoutManifestV2, nodeId: string) {
+  return manifest.tabs.flatMap(flattenWorkspaceNodes).find((node) => node.id === nodeId);
+}
+
+function findRow(manifest: WorkspaceLayoutManifestV2, rowId: string) {
+  return manifest.tabs.flatMap((tab) => tab.rows).find((row) => row.id === rowId);
+}
+
+function productionLabel(node: WorkspaceProductionNodeV2) {
+  for (const tab of workspaceLayoutRegistryV2) {
+    const component = tab.components.find((item) => item.id === node.component);
+    if (component) return component.label;
+  }
+  return titleCase(node.component);
+}
+
+function customLabel(node: WorkspaceCustomNodeV2) {
+  return node.title || titleCase(node.component);
+}
+
+function selectionLabel(selection: Selection, node?: WorkspaceLayoutNodeV2) {
+  if (selection.kind === "workspace") return "Workspace design";
+  if (selection.kind === "tab") return "Tab settings";
+  if (selection.kind === "row") return "Row";
+  if (selection.kind === "column") return "Column";
+  return node ? (isWorkspaceProductionNodeV2(node) ? productionLabel(node) : customLabel(node)) : "Component";
+}
+
+function titleCase(value: string) {
+  return value.replace(/-/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}

--- a/src/app/admin/layout/layout-editor.tsx
+++ b/src/app/admin/layout/layout-editor.tsx
@@ -1,4 +1,9 @@
 "use client";
 
-export { LayoutEditor } from "./layout-editor-v2";
-export type { LayoutPublicationSummary, LayoutRevisionSummary } from "./layout-editor-v2";
+export { LayoutEditor } from "./layout-editor-v3";
+export type {
+  LayoutAssetSummary,
+  LayoutPublicationSummary,
+  LayoutRevisionSummary,
+  LayoutTemplateSummary,
+} from "./layout-editor-v3";

--- a/src/app/admin/layout/layout-rich-text-editor.tsx
+++ b/src/app/admin/layout/layout-rich-text-editor.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { $createLinkNode, $isLinkNode, LinkNode, TOGGLE_LINK_COMMAND } from "@lexical/link";
+import {
+  $createListItemNode,
+  $createListNode,
+  $isListNode,
+  INSERT_ORDERED_LIST_COMMAND,
+  INSERT_UNORDERED_LIST_COMMAND,
+  ListItemNode,
+  ListNode,
+} from "@lexical/list";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
+import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
+import { ListPlugin } from "@lexical/react/LexicalListPlugin";
+import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
+import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $createHeadingNode, $isHeadingNode, HeadingNode } from "@lexical/rich-text";
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isElementNode,
+  $isTextNode,
+  FORMAT_TEXT_COMMAND,
+  type ElementNode,
+  type EditorState,
+  type LexicalNode,
+} from "lexical";
+import { Bold, Code2, Heading2, Italic, Link2, List, ListOrdered } from "lucide-react";
+import type {
+  WorkspaceRichTextBlockV1,
+  WorkspaceRichTextDocumentV1,
+  WorkspaceRichTextInlineV1,
+} from "@/lib/workspace-layout-v2";
+
+export function LayoutRichTextEditor({
+  document,
+  onChange,
+}: {
+  document: WorkspaceRichTextDocumentV1;
+  onChange: (document: WorkspaceRichTextDocumentV1) => void;
+}) {
+  const initialConfig = {
+    editorState: () => initializeEditor(document),
+    namespace: "CivicResultMapsLayoutEditor",
+    nodes: [HeadingNode, LinkNode, ListItemNode, ListNode],
+    onError(error: Error) {
+      throw error;
+    },
+    theme: {
+      link: "layout-rich-link",
+      paragraph: "layout-rich-paragraph",
+      text: { bold: "layout-rich-bold", code: "layout-rich-code", italic: "layout-rich-italic" },
+    },
+  };
+
+  return (
+    <LexicalComposer initialConfig={initialConfig}>
+      <div className="layout-rich-editor">
+        <RichTextToolbar />
+        <RichTextPlugin
+          contentEditable={<ContentEditable aria-label="Rich text content" className="layout-rich-content" />}
+          placeholder={<div className="layout-rich-placeholder">Write explanatory content…</div>}
+          ErrorBoundary={RichTextErrorBoundary}
+        />
+        <HistoryPlugin />
+        <LinkPlugin />
+        <ListPlugin />
+        <OnChangePlugin onChange={(state) => onChange(readEditorState(state))} />
+      </div>
+    </LexicalComposer>
+  );
+}
+
+function RichTextToolbar() {
+  const [editor] = useLexicalComposerContext();
+  const format = (name: "bold" | "code" | "italic") => editor.dispatchCommand(FORMAT_TEXT_COMMAND, name);
+  return (
+    <div aria-label="Text formatting" className="layout-rich-toolbar" role="toolbar">
+      <button aria-label="Bold" onClick={() => format("bold")} type="button"><Bold size={15} /></button>
+      <button aria-label="Italic" onClick={() => format("italic")} type="button"><Italic size={15} /></button>
+      <button aria-label="Inline code" onClick={() => format("code")} type="button"><Code2 size={15} /></button>
+      <button aria-label="Heading" onClick={() => editor.update(() => {
+        const first = $getRoot().getFirstChild();
+        if (!first) return;
+        if (!$isElementNode(first)) return;
+        const heading = $createHeadingNode("h2");
+        heading.append(...first.getChildren());
+        first.replace(heading);
+      })} type="button"><Heading2 size={15} /></button>
+      <button aria-label="Bulleted list" onClick={() => editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined)} type="button"><List size={15} /></button>
+      <button aria-label="Numbered list" onClick={() => editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined)} type="button"><ListOrdered size={15} /></button>
+      <button aria-label="Link" onClick={() => {
+        const href = window.prompt("Link URL (https://, mailto:, or a local /path)");
+        if (href) editor.dispatchCommand(TOGGLE_LINK_COMMAND, href);
+      }} type="button"><Link2 size={15} /></button>
+    </div>
+  );
+}
+
+function initializeEditor(document: WorkspaceRichTextDocumentV1) {
+  const root = $getRoot();
+  root.clear();
+  let currentList: ReturnType<typeof $createListNode> | null = null;
+  let currentListOrdered: boolean | undefined;
+
+  for (const block of document.blocks) {
+    if (block.type === "list-item") {
+      if (!currentList || currentListOrdered !== block.ordered) {
+        currentList = $createListNode(block.ordered ? "number" : "bullet");
+        currentListOrdered = block.ordered;
+        root.append(currentList);
+      }
+      const item = $createListItemNode();
+      appendInlineNodes(item, block.children);
+      currentList.append(item);
+      continue;
+    }
+
+    currentList = null;
+    currentListOrdered = undefined;
+    const element = block.type === "heading"
+      ? $createHeadingNode(block.level === 3 ? "h3" : "h2")
+      : $createParagraphNode();
+    appendInlineNodes(element, block.children);
+    root.append(element);
+  }
+  if (!root.getChildrenSize()) root.append($createParagraphNode());
+}
+
+function appendInlineNodes(element: ElementNode, children: WorkspaceRichTextInlineV1[]) {
+  for (const inline of children) {
+    const text = $createTextNode(inline.text);
+    inline.marks?.forEach((mark) => text.toggleFormat(mark));
+    if (inline.href) {
+      const link = $createLinkNode(inline.href);
+      link.append(text);
+      element.append(link);
+    } else {
+      element.append(text);
+    }
+  }
+}
+
+function readEditorState(state: EditorState): WorkspaceRichTextDocumentV1 {
+  return state.read(() => {
+    const blocks = $getRoot().getChildren().flatMap((node): WorkspaceRichTextBlockV1[] => {
+      const inlines = collectInlineNodes(node);
+      if (!inlines.length) inlines.push({ text: "", type: "text" });
+      if ($isHeadingNode(node)) {
+        return [{ children: inlines, level: node.getTag() === "h3" ? 3 : 2, type: "heading" }];
+      }
+      if ($isListNode(node)) {
+        return node.getChildren().map((item) => ({
+          children: collectInlineNodes(item),
+          ordered: node.getListType() === "number",
+          type: "list-item",
+        }));
+      }
+      return [{ children: inlines, type: "paragraph" }];
+    });
+    return { blocks: blocks.slice(0, 60), version: 1 };
+  });
+}
+
+function collectInlineNodes(node: LexicalNode): WorkspaceRichTextInlineV1[] {
+  if ($isTextNode(node)) {
+    const marks: WorkspaceRichTextInlineV1["marks"] = [];
+    if (node.hasFormat("bold")) marks.push("bold");
+    if (node.hasFormat("italic")) marks.push("italic");
+    if (node.hasFormat("code")) marks.push("code");
+    const parent = node.getParent();
+    return [{
+      href: parent && $isLinkNode(parent) ? parent.getURL() : undefined,
+      marks: marks.length ? marks : undefined,
+      text: node.getTextContent().slice(0, 1000),
+      type: "text",
+    }];
+  }
+  return $isElementNode(node) ? node.getChildren().flatMap(collectInlineNodes) : [];
+}
+
+function RichTextErrorBoundary({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/admin/layout/page.tsx
+++ b/src/app/admin/layout/page.tsx
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Metadata, Route } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { LayoutEditor, type LayoutPublicationSummary, type LayoutRevisionSummary } from "./layout-editor";
+import { LayoutEditor, type LayoutAssetSummary, type LayoutPublicationSummary, type LayoutRevisionSummary, type LayoutTemplateSummary } from "./layout-editor";
 import styles from "./layout-editor.module.css";
 import { readLayoutAdmin } from "@/lib/ui-layout-auth";
 import {
@@ -10,7 +10,11 @@ import {
   listLayoutPublications,
   listLayoutRevisions,
 } from "@/lib/ui-layout-repository";
-import { embeddedWorkspaceLayoutManifest } from "@/lib/workspace-layout";
+import {
+  embeddedWorkspaceLayoutManifestV2,
+  toWorkspaceLayoutManifestV2,
+} from "@/lib/workspace-layout-v2";
+import { listLayoutAssets, listLayoutTemplates } from "@/lib/ui-layout-v3-repository";
 import { WORKSPACE_LAYOUT_DRAFT_COOKIE } from "@/lib/workspace-layout-runtime";
 
 export const dynamic = "force-dynamic";
@@ -48,15 +52,17 @@ export default async function LayoutAdminPage() {
       <main className={styles.page}>
         <section className={styles.setupCard}>
           <h1>Layout database unavailable</h1>
-          <p>Configure <code>DATABASE_URL</code> or <code>POSTGRES_URL</code>, then apply migration 0004 and 0005 in the preview database.</p>
+          <p>Configure <code>DATABASE_URL</code> or <code>POSTGRES_URL</code>, then apply layout migrations through 0006 in the preview database.</p>
         </section>
       </main>
     );
   }
 
-  const [revisionRows, publicationRows, cookieStore] = await Promise.all([
+  const [revisionRows, publicationRows, assetRows, templateRows, cookieStore] = await Promise.all([
     listLayoutRevisions(),
     listLayoutPublications(),
+    listLayoutAssets(),
+    listLayoutTemplates(),
     cookies(),
   ]);
   const revisions: LayoutRevisionSummary[] = revisionRows.map((revision) => ({
@@ -64,7 +70,7 @@ export default async function LayoutAdminPage() {
     changeSummary: revision.changeSummary,
     createdAt: revision.createdAt.toISOString(),
     id: revision.id,
-    manifest: revision.manifest,
+    manifest: toWorkspaceLayoutManifestV2(revision.manifest),
     manifestDigest: revision.manifestDigest,
     parentRevisionId: revision.parentRevisionId,
   }));
@@ -79,6 +85,24 @@ export default async function LayoutAdminPage() {
     revisionId: publication.revisionId,
     status: publication.status,
   }));
+  const assets: LayoutAssetSummary[] = assetRows.map((asset) => ({
+    alt: asset.alt,
+    contentType: asset.contentType,
+    height: asset.height,
+    id: asset.id,
+    pathname: asset.pathname,
+    sizeBytes: asset.sizeBytes,
+    url: asset.url,
+    width: asset.width,
+  }));
+  const templates: LayoutTemplateSummary[] = templateRows.map((template) => ({
+    actorEmail: template.actorEmail,
+    description: template.description,
+    id: template.id,
+    manifest: template.manifest,
+    name: template.name,
+    updatedAt: template.updatedAt.toISOString(),
+  }));
   const latest = revisions[0];
 
   return (
@@ -90,19 +114,21 @@ export default async function LayoutAdminPage() {
           <span>Signed in as {admin.actor.email}. Build responsive layouts with protected public-interest trust surfaces.</span>
         </div>
         <div className={styles.statusRow}>
-          <span>Schema v1</span>
-          <span>Builder controls v2</span>
+          <span>Schema v2</span>
+          <span>Builder controls v3</span>
           <span>{process.env.EDGE_CONFIG ? "Edge Config connected" : "Embedded runtime fallback"}</span>
         </div>
       </header>
       <LayoutEditor
         activeDraftRevisionId={cookieStore.get(WORKSPACE_LAYOUT_DRAFT_COOKIE)?.value}
-        baseManifest={latest?.manifest ?? embeddedWorkspaceLayoutManifest}
+        assets={assets}
+        baseManifest={latest?.manifest ?? embeddedWorkspaceLayoutManifestV2}
         parentRevisionId={latest?.id ?? null}
         publications={publications}
         publisherEnabled={process.env.UI_LAYOUT_PUBLISH_WORKFLOW_ENABLED === "true"}
         requestKey={randomUUID()}
         revisions={revisions}
+        templates={templates}
       />
     </main>
   );

--- a/src/app/admin/layout/template-actions.ts
+++ b/src/app/admin/layout/template-actions.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type { LayoutActionState } from "./layout-action-state";
+import { requireLayoutAdmin } from "@/lib/ui-layout-auth";
+import {
+  createLayoutTemplate,
+  deleteLayoutTemplate,
+} from "@/lib/ui-layout-v3-repository";
+import { validateWorkspaceLayoutManifestV2 } from "@/lib/workspace-layout-v2";
+
+export async function saveLayoutTemplateAction(
+  _previous: LayoutActionState,
+  formData: FormData,
+): Promise<LayoutActionState> {
+  try {
+    const actor = await requireLayoutAdmin();
+    const manifest = JSON.parse(String(formData.get("manifest") ?? "")) as unknown;
+    const validation = validateWorkspaceLayoutManifestV2(manifest);
+    if (!validation.ok) return { kind: "error", message: validation.errors.join(" ") };
+    const template = await createLayoutTemplate({
+      actor,
+      description: String(formData.get("description") ?? ""),
+      manifest: validation.value,
+      name: String(formData.get("name") ?? ""),
+    });
+    revalidatePath("/admin/layout");
+    return { kind: "success", message: `Saved shared template “${template.name}”.` };
+  } catch (error) {
+    return { kind: "error", message: error instanceof Error ? error.message : "Unable to save the template." };
+  }
+}
+
+export async function deleteLayoutTemplateAction(formData: FormData) {
+  await requireLayoutAdmin();
+  const templateId = String(formData.get("templateId") ?? "");
+  if (!/^[0-9a-f-]{36}$/i.test(templateId)) throw new Error("Template ID is invalid.");
+  await deleteLayoutTemplate(templateId);
+  revalidatePath("/admin/layout");
+}

--- a/src/app/api/admin/layout-assets/upload/route.ts
+++ b/src/app/api/admin/layout-assets/upload/route.ts
@@ -1,0 +1,91 @@
+import { handleUpload, type HandleUploadBody } from "@vercel/blob/client";
+import { NextResponse } from "next/server";
+import { requireLayoutAdmin } from "@/lib/ui-layout-auth";
+import { createLayoutAsset } from "@/lib/ui-layout-v3-repository";
+
+export const runtime = "nodejs";
+
+const allowedContentTypes = ["image/avif", "image/jpeg", "image/png", "image/webp"] as const;
+const maxImageBytes = 5 * 1024 * 1024;
+
+type UploadMetadata = {
+  assetId: string;
+  actorEmail: string;
+  actorId: string;
+  alt: string;
+  contentType: (typeof allowedContentTypes)[number];
+  height: number;
+  sizeBytes: number;
+  width: number;
+};
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json() as HandleUploadBody;
+    const actor = body.type === "blob.generate-client-token"
+      ? await requireLayoutAdmin()
+      : null;
+    const result = await handleUpload({
+      body,
+      request,
+      onBeforeGenerateToken: async (pathname, clientPayload) => {
+        if (!actor) throw new Error("Sign in is required.");
+        if (!pathname.startsWith("layout-media/")) {
+          throw new Error("Uploads must use the layout-media namespace.");
+        }
+        const metadata = parseClientMetadata(clientPayload);
+        return {
+          addRandomSuffix: true,
+          allowedContentTypes: [...allowedContentTypes],
+          maximumSizeInBytes: maxImageBytes,
+          tokenPayload: JSON.stringify({ ...metadata, actorEmail: actor.email, actorId: actor.id }),
+        };
+      },
+      onUploadCompleted: async ({ blob, tokenPayload }) => {
+        const metadata = parseTokenMetadata(tokenPayload);
+        if (!allowedContentTypes.includes(blob.contentType as UploadMetadata["contentType"])) {
+          throw new Error("The uploaded file type is not allowed.");
+        }
+        await createLayoutAsset({
+          actor: { email: metadata.actorEmail, id: metadata.actorId },
+          alt: metadata.alt,
+          contentType: blob.contentType as UploadMetadata["contentType"],
+          id: metadata.assetId,
+          height: metadata.height,
+          pathname: blob.pathname,
+          sizeBytes: metadata.sizeBytes,
+          url: blob.url,
+          width: metadata.width,
+        });
+      },
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Image upload failed.";
+    const status = /authorized|sign in|required/i.test(message) ? 403 : 400;
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+
+function parseClientMetadata(value: string | null) {
+  if (!value) throw new Error("Image metadata is required.");
+  const parsed = JSON.parse(value) as Partial<UploadMetadata>;
+  const assetId = String(parsed.assetId ?? "");
+  const contentType = String(parsed.contentType ?? "") as UploadMetadata["contentType"];
+  const sizeBytes = Number(parsed.sizeBytes);
+  const width = Number(parsed.width);
+  const height = Number(parsed.height);
+  if (!allowedContentTypes.includes(contentType)) throw new Error("Only PNG, JPEG, WebP, and AVIF images are allowed.");
+  if (!Number.isInteger(sizeBytes) || sizeBytes < 1 || sizeBytes > maxImageBytes) throw new Error("Images must be 5 MB or smaller.");
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width < 1 || height < 1) throw new Error("Image dimensions are required.");
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(assetId)) throw new Error("Image asset ID is invalid.");
+  return { assetId, alt: String(parsed.alt ?? "").trim().slice(0, 300), contentType, height, sizeBytes, width };
+}
+
+function parseTokenMetadata(value: string | null | undefined): UploadMetadata {
+  if (!value) throw new Error("Signed image metadata is missing.");
+  const parsed = JSON.parse(value) as Partial<UploadMetadata>;
+  const safe = parseClientMetadata(JSON.stringify(parsed));
+  if (!parsed.actorId || !parsed.actorEmail) throw new Error("Signed uploader identity is missing.");
+  return { ...safe, actorEmail: parsed.actorEmail, actorId: parsed.actorId };
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { SiteFooter } from "./site-footer";
 import "./globals.css";
 
+import "./workspace-layout-v2.css";
 const siteUrl = "https://www.civicresultmaps.org";
 const siteDescription =
   "Explore source-linked 2016, 2020, and 2024 U.S. county election results, national flips, permanent county profiles, data confidence, releases, and public APIs.";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,8 @@ import { GlobalCountySearch } from "./global-county-search";
 import { NationalOverview } from "./national-overview";
 import { StateSwitcher } from "./state-switcher";
 import { WorkspaceTabs } from "./workspace-tabs";
-import { resolveVisibleWorkspaceTab } from "@/lib/workspace-layout";
+import { toWorkspaceLayoutManifestV2 } from "@/lib/workspace-layout-v2";
+import { resolveVisibleWorkspaceTabV2 } from "@/lib/workspace-layout-v2-runtime";
 import { resolveWorkspaceLayout } from "@/lib/workspace-layout-runtime";
 import {
   getCoverageSummary,
@@ -158,9 +159,9 @@ export async function generateMetadata({ searchParams }: HomeProps): Promise<Met
 export default async function Home({ searchParams }: HomeProps) {
   const params = await searchParams;
   const layoutResolution = await resolveWorkspaceLayout();
-  const layoutManifest = layoutResolution.envelope.manifest;
+  const layoutManifest = toWorkspaceLayoutManifestV2(layoutResolution.envelope.manifest);
   const selectedState = (params?.state ?? "WA").slice(0, 2).toUpperCase();
-  const activeTab = resolveVisibleWorkspaceTab(layoutManifest, params?.tab);
+  const activeTab = resolveVisibleWorkspaceTabV2(layoutManifest, params?.tab);
   const requestedYear = parseYear(params?.year);
   const selectedYear = activeTab === "map" ? requestedYear : 2024;
   const requestedMapMode = mapModes.has(params?.mode ?? "")

--- a/src/app/results-explorer.tsx
+++ b/src/app/results-explorer.tsx
@@ -2102,6 +2102,7 @@ export function ResultsExplorer({
               <label className="sort-select-label" htmlFor="result-sort">
                 <ArrowDownAZ aria-hidden size={16} />
                 <select
+                  aria-label="Sort results"
                   className="sort-select"
                   id="result-sort"
                   onChange={(event) => setSortKey(event.target.value as SortKey)}

--- a/src/app/workspace-layout-v2-blocks.tsx
+++ b/src/app/workspace-layout-v2-blocks.tsx
@@ -1,0 +1,190 @@
+import Image from "next/image";
+import type { CSSProperties, ReactNode } from "react";
+import {
+  workspaceViewportVisibilityAttributes,
+  type WorkspaceCustomNodeV2,
+  type WorkspaceRichTextBlockV1,
+  type WorkspaceRichTextInlineV1,
+} from "@/lib/workspace-layout-v2";
+import type { WorkspaceRuntimeCustomNode } from "@/lib/workspace-layout-v2-runtime";
+
+type WorkspaceLayoutBlockV2Props = {
+  item: WorkspaceRuntimeCustomNode;
+};
+
+export function WorkspaceLayoutBlockV2({ item }: WorkspaceLayoutBlockV2Props) {
+  const attributes = workspaceLayoutItemAttributesV2(item);
+  const label = item.title || blockLabel(item);
+
+  if (item.component === "divider") {
+    return (
+      <div aria-label={label} className="workspace-custom-block workspace-custom-divider" {...attributes} role="separator">
+        {item.title && <span>{item.title}</span>}
+      </div>
+    );
+  }
+
+  if (item.component === "heading") {
+    return (
+      <header aria-label={label} className="workspace-custom-block workspace-custom-heading" {...attributes}>
+        <h2>{item.title || "Section heading"}</h2>
+        {item.body && <p>{item.body}</p>}
+      </header>
+    );
+  }
+
+  if (item.component === "metric-strip") {
+    return (
+      <section aria-label={label} className="workspace-custom-block workspace-custom-metrics" {...attributes}>
+        {item.title && <h2>{item.title}</h2>}
+        <div>
+          {item.items?.map((metric, index) => (
+            <article key={`${metric.label}-${index}`}>
+              <span>{metric.label}</span>
+              <strong>{metric.value}</strong>
+              {metric.body && <small>{metric.body}</small>}
+            </article>
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (item.component === "link-list" || item.component === "button-group") {
+    return (
+      <nav aria-label={label} className={`workspace-custom-block workspace-custom-${item.component}`} {...attributes}>
+        {item.title && <h2>{item.title}</h2>}
+        {item.body && <p>{item.body}</p>}
+        <ul>
+          {item.items?.map((link, index) => (
+            <li key={`${link.label}-${index}`}>
+              <a href={link.href}>{link.label}</a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    );
+  }
+
+  if (item.component === "image" && item.asset) {
+    return (
+      <figure aria-label={label} className="workspace-custom-block workspace-custom-image" {...attributes}>
+        <Image
+          alt={item.asset.decorative ? "" : item.asset.alt}
+          height={item.asset.height}
+          sizes="(max-width: 760px) 100vw, (max-width: 1100px) 75vw, 1200px"
+          src={item.asset.url}
+          width={item.asset.width}
+        />
+        {(item.asset.caption || item.title) && <figcaption>{item.asset.caption || item.title}</figcaption>}
+      </figure>
+    );
+  }
+
+  if (item.component === "video" && item.video) {
+    const src = item.video.provider === "youtube"
+      ? `https://www.youtube-nocookie.com/embed/${item.video.id}`
+      : `https://player.vimeo.com/video/${item.video.id}`;
+    return (
+      <section aria-label={label} className="workspace-custom-block workspace-custom-video" {...attributes}>
+        {item.title && <h2>{item.title}</h2>}
+        <div className="workspace-video-frame">
+          <iframe
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            loading="lazy"
+            src={src}
+            title={item.video.title}
+          />
+        </div>
+      </section>
+    );
+  }
+
+  if (item.component === "accordion") {
+    return (
+      <section aria-label={label} className="workspace-custom-block workspace-custom-accordion" {...attributes}>
+        {item.title && <h2>{item.title}</h2>}
+        {item.items?.map((entry, index) => (
+          <details key={`${entry.label}-${index}`}>
+            <summary>{entry.label}</summary>
+            <p>{entry.body || entry.value}</p>
+          </details>
+        ))}
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-label={label}
+      className={[
+        "workspace-custom-block",
+        item.component === "callout" ? "workspace-custom-callout" : "workspace-custom-narrative",
+      ].join(" ")}
+      {...attributes}
+    >
+      {item.title && <h2>{item.title}</h2>}
+      {item.document ? <WorkspaceRichText blocks={item.document.blocks} /> : item.body && <p>{item.body}</p>}
+    </section>
+  );
+}
+
+function WorkspaceRichText({ blocks }: { blocks: WorkspaceRichTextBlockV1[] }) {
+  const content: ReactNode[] = [];
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index];
+    if (block.type !== "list-item") {
+      content.push(renderRichBlock(block, index));
+      continue;
+    }
+    const ordered = Boolean(block.ordered);
+    const items: WorkspaceRichTextBlockV1[] = [block];
+    while (blocks[index + 1]?.type === "list-item" && Boolean(blocks[index + 1].ordered) === ordered) {
+      items.push(blocks[index + 1]);
+      index += 1;
+    }
+    const children = items.map((item, itemIndex) => (
+      <li key={itemIndex}>{item.children.map((child, childIndex) => renderInline(child, childIndex))}</li>
+    ));
+    content.push(ordered ? <ol key={`list-${index}`}>{children}</ol> : <ul key={`list-${index}`}>{children}</ul>);
+  }
+  return <div className="workspace-rich-text">{content}</div>;
+}
+
+function renderRichBlock(block: WorkspaceRichTextBlockV1, index: number) {
+  const children = block.children.map((child, childIndex) => renderInline(child, childIndex));
+  if (block.type === "heading") {
+    return block.level === 3 ? <h3 key={index}>{children}</h3> : <h2 key={index}>{children}</h2>;
+  }
+  return <p key={index}>{children}</p>;
+}
+
+function renderInline(item: WorkspaceRichTextInlineV1, index: number) {
+  let child: ReactNode = item.text;
+  if (item.marks?.includes("code")) child = <code>{child}</code>;
+  if (item.marks?.includes("bold")) child = <strong>{child}</strong>;
+  if (item.marks?.includes("italic")) child = <em>{child}</em>;
+  if (item.href) child = <a href={item.href}>{child}</a>;
+  return <span key={index}>{child}</span>;
+}
+
+function workspaceLayoutItemAttributesV2(item: WorkspaceRuntimeCustomNode) {
+  return {
+    ...workspaceViewportVisibilityAttributes(item.visibility),
+    "data-layout-custom": item.id,
+    "data-layout-density": item.presentation?.density ?? "comfortable",
+    "data-layout-emphasis": item.presentation?.emphasis ?? "standard",
+    "data-layout-surface": item.presentation?.surface ?? "panel",
+    style: {
+      "--layout-span-desktop": item.span.desktop,
+      "--layout-span-mobile": item.span.mobile,
+      "--layout-span-tablet": item.span.tablet,
+      order: item.order,
+    } as CSSProperties,
+  };
+}
+
+function blockLabel(item: WorkspaceCustomNodeV2) {
+  return item.component.split("-").map((part) => part[0]?.toUpperCase() + part.slice(1)).join(" ");
+}

--- a/src/app/workspace-layout-v2.css
+++ b/src/app/workspace-layout-v2.css
@@ -1,0 +1,311 @@
+/* Workspace Builder v3 runtime tokens and rich-content variants. */
+.workspace-tabs {
+  --workspace-accent: #16a579;
+  --workspace-accent-foreground: #07110f;
+  --workspace-radius: 10px;
+  --workspace-shadow: 0 8px 26px rgba(4, 17, 13, 0.08);
+  accent-color: var(--workspace-accent);
+}
+
+.workspace-tabs[data-layout-radius="square"] { --workspace-radius: 0; }
+.workspace-tabs[data-layout-radius="rounded"] { --workspace-radius: 18px; }
+.workspace-tabs[data-layout-shadow="none"] { --workspace-shadow: none; }
+.workspace-tabs[data-layout-shadow="raised"] { --workspace-shadow: 0 15px 42px rgba(4, 17, 13, 0.17); }
+
+.workspace-tabs[data-layout-spacing="tight"] .tab-panel-content,
+.workspace-tabs[data-layout-spacing="tight"] .workspace-custom-grid { gap: 0.65rem; }
+.workspace-tabs[data-layout-spacing="relaxed"] .tab-panel-content,
+.workspace-tabs[data-layout-spacing="relaxed"] .workspace-custom-grid { gap: 1.45rem; }
+.workspace-tabs[data-layout-type-scale="small"] { font-size: 0.92rem; }
+.workspace-tabs[data-layout-type-scale="large"] { font-size: 1.08rem; }
+
+.workspace-tabs .panel,
+.workspace-tabs .workspace-custom-block,
+.workspace-tabs .map-shell,
+.workspace-tabs article {
+  border-radius: var(--workspace-radius);
+}
+
+.workspace-tabs .panel,
+.workspace-tabs .workspace-custom-block {
+  box-shadow: var(--workspace-shadow);
+}
+
+.workspace-tabs a,
+.workspace-tabs button:not(.tab-button) {
+  --focus-accent: var(--workspace-accent);
+}
+
+.workspace-tabs a:focus-visible,
+.workspace-tabs button:focus-visible,
+.workspace-tabs summary:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--workspace-accent) 70%, white);
+  outline-offset: 3px;
+}
+
+.workspace-tabs [data-layout-surface="accent"] {
+  background: color-mix(in srgb, var(--workspace-accent) 14%, var(--surface, white));
+  border-color: color-mix(in srgb, var(--workspace-accent) 38%, transparent);
+}
+
+.workspace-tabs .tab-button[aria-selected="true"] {
+  border-color: var(--workspace-accent);
+}
+.workspace-tab-list {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 6px;
+}
+.workspace-tabs .workspace-custom-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.workspace-custom-row {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+.workspace-custom-row[data-gap="small"] { gap: 0.65rem; }
+.workspace-custom-row[data-gap="large"] { gap: 1.5rem; }
+.workspace-custom-row[data-align="start"] { align-items: start; }
+.workspace-custom-row[data-align="center"] { align-items: center; }
+.workspace-custom-row[data-align="stretch"] { align-items: stretch; }
+
+
+.workspace-custom-column {
+  display: grid;
+  gap: 1rem;
+  grid-column: span var(--layout-span-desktop, 12);
+  min-width: 0;
+}
+
+.workspace-custom-column > .workspace-custom-block {
+  grid-column: auto;
+}
+
+
+.workspace-tabs .workspace-custom-button-group ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+}
+
+.workspace-tabs .workspace-custom-button-group a {
+  background: var(--workspace-accent);
+  border-radius: calc(var(--workspace-radius) * 0.7);
+  color: var(--workspace-accent-foreground);
+  display: inline-flex;
+  font-weight: 800;
+  padding: 0.7rem 0.95rem;
+  text-decoration: none;
+}
+
+.workspace-custom-heading {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  padding-inline: 0 !important;
+}
+
+.workspace-custom-heading h2 { margin-bottom: 0.25rem; }
+
+.workspace-custom-image {
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+.workspace-custom-image img {
+  display: block;
+  height: auto;
+  object-fit: cover;
+  width: 100%;
+}
+
+.workspace-custom-image figcaption {
+  color: var(--muted, #52635d);
+  font-size: 0.82rem;
+  padding: 0.65rem 0.8rem 0.8rem;
+}
+
+.workspace-video-frame {
+  aspect-ratio: 16 / 9;
+  border-radius: calc(var(--workspace-radius) * 0.75);
+  overflow: hidden;
+}
+
+.workspace-video-frame iframe {
+  border: 0;
+  height: 100%;
+  width: 100%;
+}
+
+.workspace-custom-accordion details {
+  border-top: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+  padding: 0.75rem 0;
+}
+
+.workspace-custom-accordion summary {
+  cursor: pointer;
+  font-weight: 750;
+}
+
+.workspace-rich-text > :first-child { margin-top: 0; }
+.workspace-rich-text > :last-child { margin-bottom: 0; }
+.workspace-rich-text code {
+  background: color-mix(in srgb, currentColor 8%, transparent);
+  border-radius: 4px;
+  padding: 0.1em 0.3em;
+}
+
+.review-subnav[data-layout-navigation="pills"] {
+  background: color-mix(in srgb, var(--workspace-accent) 8%, transparent);
+  border-radius: 999px;
+  padding: 0.35rem;
+}
+
+.review-subnav[data-layout-navigation="pills"] .review-subnav-button {
+  border-radius: 999px;
+}
+
+.review-subnav[data-layout-navigation="sidebar"] {
+  align-self: start;
+  display: grid;
+  float: left;
+  margin: 0 1rem 1rem 0;
+  max-width: 230px;
+}
+
+[data-layout-section][data-layout-map-composition="table-first"] .results-layout,
+[data-layout-section][data-layout-map-composition="table-first"] .map-results-layout {
+  direction: rtl;
+}
+
+[data-layout-section][data-layout-map-composition="table-first"] .results-layout > *,
+[data-layout-section][data-layout-map-composition="table-first"] .map-results-layout > * {
+  direction: ltr;
+}
+
+[data-layout-section][data-layout-map-composition="split"] .results-layout,
+[data-layout-section][data-layout-map-composition="split"] .map-results-layout {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.workspace-tabs [data-layout-legend-position="inline"] .map-legend {
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
+  border: 1px solid var(--line);
+  border-radius: calc(var(--workspace-radius) * 0.75);
+  margin: 0.75rem;
+  padding: 0.65rem 0.8rem;
+  width: fit-content;
+}
+
+.workspace-tabs [data-layout-provenance-variant="summary"] .source-list li:nth-child(n + 2) {
+  display: none;
+}
+
+.source-provenance-details {
+  border-top: 1px solid var(--line);
+  padding-top: 0.6rem;
+}
+
+.source-provenance-details summary {
+  cursor: pointer;
+  font-weight: 750;
+  margin-bottom: 0.5rem;
+}
+
+.workspace-tabs [data-layout-coverage-variant="cards"] .flag-list {
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.workspace-tabs [data-layout-coverage-variant="cards"] .flag-list li {
+  border: 1px solid var(--line);
+  border-radius: calc(var(--workspace-radius) * 0.65);
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.7rem;
+}
+
+.workspace-tabs [data-layout-coverage-variant="compact"] .flag-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.workspace-tabs [data-layout-coverage-variant="compact"] .flag-list li {
+  font-size: 0.78rem;
+  min-height: 0;
+  padding-block: 0.35rem;
+}
+
+.workspace-tabs [data-layout-snapshot-variant="metrics"] .candidate-bars {
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.workspace-tabs [data-layout-snapshot-variant="metrics"] .candidate-bar-row {
+  background: color-mix(in srgb, var(--workspace-accent) 7%, transparent);
+  border: 1px solid var(--line);
+  border-radius: calc(var(--workspace-radius) * 0.65);
+  padding: 0.75rem;
+}
+
+.workspace-tabs [data-layout-snapshot-variant="metrics"] .candidate-bar-row i,
+.workspace-tabs [data-layout-snapshot-variant="table"] .candidate-bar-row i {
+  display: none;
+}
+
+.workspace-tabs [data-layout-snapshot-variant="table"] .candidate-bar-row {
+  border-bottom: 1px solid var(--line);
+  padding-block: 0.55rem;
+}
+
+.workspace-tabs [data-layout-snapshot-variant="table"] .candidate-bar-row:last-child {
+  border-bottom: 0;
+}
+
+.workspace-body[data-layout-notes-position="drawer"],
+.workspace-body.notes-collapsed[data-layout-notes-position="drawer"] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.workspace-body[data-layout-notes-position="drawer"] .workspace-notes {
+  max-height: calc(100dvh - 2rem);
+  overflow-y: auto;
+  position: fixed;
+  right: max(1rem, env(safe-area-inset-right));
+  top: max(1rem, env(safe-area-inset-top));
+  width: min(420px, calc(100vw - 2rem));
+  z-index: 40;
+}
+
+.workspace-body[data-layout-notes-position="drawer"] .workspace-notes.is-collapsed {
+  width: 52px;
+}
+
+[data-layout-show-desktop="false"] { display: none !important; }
+
+@media (max-width: 980px) and (min-width: 641px) {
+  .workspace-custom-column { grid-column: span var(--layout-span-tablet, 12); }
+  [data-layout-show-desktop="false"] { display: revert !important; }
+  [data-layout-show-tablet="false"] { display: none !important; }
+}
+
+@media (max-width: 640px) {
+  .workspace-custom-column { grid-column: span var(--layout-span-mobile, 12); }
+  .workspace-tabs [data-layout-coverage-variant="cards"] .flag-list,
+  .workspace-tabs [data-layout-snapshot-variant="metrics"] .candidate-bars {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  [data-layout-show-desktop="false"] { display: revert !important; }
+  [data-layout-show-mobile="false"] { display: none !important; }
+  .workspace-tabs[data-layout-type-scale="large"] { font-size: 1rem; }
+  .review-subnav[data-layout-navigation="sidebar"] { float: none; margin: 0 0 1rem; max-width: none; }
+}

--- a/src/app/workspace-tabs.tsx
+++ b/src/app/workspace-tabs.tsx
@@ -30,17 +30,26 @@ import { useEffect, useMemo, useState } from "react";
 import { Eli5 } from "./eli5";
 import { GuidedTour, type TourStep } from "./guided-tour";
 import { ResultsExplorer } from "./results-explorer";
-import { WorkspaceLayoutBlock } from "./workspace-layout-blocks";
+import { WorkspaceLayoutBlockV2 } from "./workspace-layout-v2-blocks";
 import { rowsToCsv } from "@/lib/csv";
 import { equipmentClusterDiagnostics } from "@/lib/equipment-diagnostics";
 import {
-  workspaceCustomBlocks,
-  workspaceLayoutSettings,
-  workspaceSectionState,
-  type WorkspaceLayoutManifestV1,
   type WorkspaceSectionId,
   type WorkspaceTabId,
 } from "@/lib/workspace-layout";
+import {
+  workspaceAccentForeground,
+  workspaceViewportVisibilityAttributes,
+  type WorkspaceLayoutManifestV2,
+  type WorkspaceVisibilityContext,
+} from "@/lib/workspace-layout-v2";
+import {
+  reviewViewConfigurationV2,
+  workspaceCustomRowsV2 as workspaceCustomRows,
+  workspaceLayoutSettingsV2 as workspaceLayoutSettings,
+  workspaceProductionNodeV2,
+  workspaceSectionStateV2 as workspaceSectionState,
+} from "@/lib/workspace-layout-v2-runtime";
 import type {
   AnalysisIndicator,
   AdminSourceStatusSummary,
@@ -80,7 +89,7 @@ type WorkspaceTabsProps = {
   importRuns: ImportRunSummary[];
   indicators: AnalysisIndicator[];
   indicatorsEvaluated: boolean;
-  layoutManifest: WorkspaceLayoutManifestV1;
+  layoutManifest: WorkspaceLayoutManifestV2;
   reviewRows: ReviewRowSummary[];
   results: ResultRow[];
   statewideResultRows: ResultRow[];
@@ -2607,17 +2616,54 @@ function DataNotesPanel({
   );
 }
 
-function layoutSectionProps(
-  manifest: WorkspaceLayoutManifestV1,
+function SourceProvenanceList({ sources }: { sources: SourceSummary[] }) {
+  return (
+    <ul className="source-list">
+      {sources.map((source) => (
+        <li key={source.id}>
+          <strong>{source.title}</strong>
+          <span>{source.confidence}</span>
+          <span className="mono">{source.parser}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function SourceProvenanceDetails({
+  initiallyOpen,
+  sources,
+}: {
+  initiallyOpen: boolean;
+  sources: SourceSummary[];
+}) {
+  const [open, setOpen] = useState(initiallyOpen);
+  return (
+    <details className="source-provenance-details" onToggle={(event) => setOpen(event.currentTarget.open)} open={open}>
+      <summary>Source records</summary>
+      <SourceProvenanceList sources={sources} />
+    </details>
+  );
+}
+
+function buildLayoutSectionProps(
+  manifest: WorkspaceLayoutManifestV2,
   tabId: WorkspaceTabId,
   sectionId: WorkspaceSectionId,
+  context: WorkspaceVisibilityContext,
 ) {
-  const state = workspaceSectionState(manifest, tabId, sectionId);
+  const state = workspaceSectionState(manifest, tabId, sectionId, context);
   const span = state.presentation?.span;
   return {
+    ...workspaceViewportVisibilityAttributes(state.visibility),
     "data-layout-density": state.presentation?.density ?? "comfortable",
+    "data-layout-coverage-variant": state.config?.coverageVariant,
+    "data-layout-legend-position": state.config?.legendPosition,
+    "data-layout-provenance-initial": state.config?.provenanceInitialState,
+    "data-layout-provenance-variant": state.config?.provenanceVariant,
+    "data-layout-snapshot-variant": state.config?.snapshotVariant,
     "data-layout-emphasis": state.presentation?.emphasis ?? "standard",
-    "data-layout-map-height": state.presentation?.mapHeight,
+    "data-layout-map-composition": state.config?.mapComposition,
     "data-layout-section": `${tabId}:${sectionId}`,
     "data-layout-surface": state.presentation?.surface ?? "panel",
     hidden: !state.visible,
@@ -2679,11 +2725,10 @@ export function WorkspaceTabs({
     [layoutManifest],
   );
   const layoutReviewViewOptions = useMemo(() => {
-    const reviewSections = layoutManifest.tabs.find((tab) => tab.id === "review")?.sections ?? [];
-    return reviewSections
-      .filter((section) => section.visible && section.id in reviewViewBySectionId)
-      .map((section) => reviewViewOptions.find(
-        (option) => option.key === reviewViewBySectionId[section.id as keyof typeof reviewViewBySectionId],
+    const reviewConfiguration = reviewViewConfigurationV2(layoutManifest);
+    return reviewConfiguration.viewOrder
+      .map((sectionId) => reviewViewOptions.find(
+        (option) => option.key === reviewViewBySectionId[sectionId as keyof typeof reviewViewBySectionId],
       ))
       .filter((option): option is (typeof reviewViewOptions)[number] => Boolean(option));
   }, [layoutManifest]);
@@ -2717,7 +2762,33 @@ export function WorkspaceTabs({
   const activeLayoutTab = layoutManifest.tabs.find((tab) => tab.id === activeTab);
   const activeLayoutDensity = activeLayoutTab?.settings?.density ?? "comfortable";
   const activeNotesPosition = activeLayoutTab?.settings?.notesPosition ?? "side";
-  const activeCustomBlocks = workspaceCustomBlocks(layoutManifest, activeTab);
+  const layoutVisibilityContext = useMemo(() => ({
+    capabilities: booleanCapabilityFacts(selectedState?.capabilities ?? coverage?.capabilities),
+    data: {
+      equipment: equipmentRows.length > 0,
+      historical: historicalRows.length > 0,
+      indicators: indicators.length > 0,
+      results: results.length > 0,
+      review: reviewRows.length > 0,
+      sources: sources.length > 0,
+      turnout: turnoutRows.length > 0,
+    },
+    state: selectedStateCode,
+    validation: coverage?.validation.errors.length
+      ? "failed" as const
+      : coverage?.validation.warnings.length
+        ? "warning" as const
+        : coverage?.validation.passed ? "passed" as const : "unknown" as const,
+    year: electionYear,
+  }), [coverage, electionYear, equipmentRows.length, historicalRows.length, indicators.length, results.length, reviewRows.length, selectedState?.capabilities, selectedStateCode, sources.length, turnoutRows.length]);
+  const layoutSectionProps = (
+    manifest: WorkspaceLayoutManifestV2,
+    tabId: WorkspaceTabId,
+    sectionId: WorkspaceSectionId,
+  ) => buildLayoutSectionProps(manifest, tabId, sectionId, layoutVisibilityContext);
+
+  const activeCustomRows = workspaceCustomRows(layoutManifest, activeTab, layoutVisibilityContext);
+  const mapProvenanceConfig = workspaceProductionNodeV2(layoutManifest, "map", "source-provenance")?.config;
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -3886,26 +3957,40 @@ export function WorkspaceTabs({
       aria-label={`${stateName} workspace`}
       className="workspace-tabs"
       data-layout-content-width={layoutSettings.contentWidth}
+      data-layout-radius={layoutSettings.radius}
+      data-layout-shadow={layoutSettings.shadow}
+      data-layout-spacing={layoutSettings.spacingScale}
       data-layout-theme={layoutSettings.theme}
+      data-layout-type-scale={layoutSettings.typeScale}
       data-tour="workspace"
+      style={{
+        "--workspace-accent": layoutSettings.accentColor ?? "#16a579",
+        "--workspace-accent-foreground": workspaceAccentForeground(layoutSettings.accentColor),
+      } as CSSProperties}
     >
-      <nav
-        aria-label="Workspace sections"
+      <div
         className="tab-bar"
         data-layout-tab-style={layoutSettings.tabStyle}
         data-tour="tab-bar"
       >
         <GuidedTour activeTab={activeTab} onSelectTab={selectTab} onStepChange={syncReviewTourStep} steps={workspaceTourSteps} />
+        <nav
+          aria-label="Workspace sections"
+          className="workspace-tab-list"
+          role="tablist"
+        >
         {layoutTabs.map((tab) => {
           const Icon = tab.icon;
           return (
             <button
               aria-selected={activeTab === tab.key}
+              id={`workspace-tab-${tab.key}`}
               className="tab-button"
               data-tour={`tab-${tab.key}`}
               key={tab.key}
               onClick={() => selectTab(tab.key)}
               type="button"
+              role="tab"
             >
               <Icon aria-hidden size={16} />
               <span>{tab.label}</span>
@@ -3918,12 +4003,17 @@ export function WorkspaceTabs({
           );
         })}
       </nav>
+      </div>
       <div
         className={`workspace-body ${isDataNotesCollapsed ? "notes-collapsed" : ""}`}
         data-layout-density={activeLayoutDensity}
         data-layout-notes-position={activeNotesPosition}
       >
-        <main className="workspace-main">
+        <main
+          aria-labelledby={`workspace-tab-${activeTab}`}
+          className="workspace-main"
+          role="tabpanel"
+        >
           {activeTab === "map" && (
         <div className="tab-panel-content">
           <div className="content-grid">
@@ -3972,15 +4062,11 @@ export function WorkspaceTabs({
                     <FileCheck2 aria-hidden size={18} />
                   </div>
                 </div>
-                <ul className="source-list">
-                  {sources.map((source) => (
-                    <li key={source.id}>
-                      <strong>{source.title}</strong>
-                      <span>{source.confidence}</span>
-                      <span className="mono">{source.parser}</span>
-                    </li>
-                  ))}
-                </ul>
+                {mapProvenanceConfig?.provenanceVariant === "accordion" ? (
+                  <SourceProvenanceDetails initiallyOpen={mapProvenanceConfig.provenanceInitialState !== "collapsed"} sources={sources} />
+                ) : (
+                  <SourceProvenanceList sources={sources} />
+                )}
               </section>
 
               <section className="panel" aria-label="Coverage flags" {...layoutSectionProps(layoutManifest, "map", "coverage-context")}>
@@ -4081,7 +4167,13 @@ export function WorkspaceTabs({
                 <BarChart3 aria-hidden size={18} />
               </div>
             </div>
-            <div className="review-subnav" data-tour="review-subnav" role="tablist" aria-label="Review Center views">
+            <div
+              aria-label="Review Center views"
+              className="review-subnav"
+              data-layout-navigation={reviewViewConfigurationV2(layoutManifest).navigationStyle}
+              data-tour="review-subnav"
+              role="tablist"
+            >
               {layoutReviewViewOptions.map((option) => (
                 <button
                   aria-selected={reviewView === option.key}
@@ -6529,10 +6621,29 @@ export function WorkspaceTabs({
           </section>
         </div>
       )}
-          {activeCustomBlocks.length > 0 && (
+          {activeCustomRows.length > 0 && (
             <div aria-label="Custom workspace sections" className="workspace-custom-grid">
-              {activeCustomBlocks.map((block) => (
-                <WorkspaceLayoutBlock item={block} key={block.id} order={block.order} />
+              {activeCustomRows.map((row) => (
+                <div
+                  className="workspace-custom-row"
+                  data-align={row.align ?? "stretch"}
+                  data-gap={row.gap ?? "medium"}
+                  key={row.rowId}
+                >
+                  {row.columns.map((column) => (
+                    <div
+                      className="workspace-custom-column"
+                      key={column.columnId}
+                      style={{
+                        "--layout-span-desktop": column.span.desktop,
+                        "--layout-span-mobile": column.span.mobile,
+                        "--layout-span-tablet": column.span.tablet,
+                      } as CSSProperties}
+                    >
+                      {column.items.map((block) => <WorkspaceLayoutBlockV2 item={block} key={block.id} />)}
+                    </div>
+                  ))}
+                </div>
               ))}
             </div>
           )}
@@ -6548,4 +6659,15 @@ export function WorkspaceTabs({
       </div>
     </section>
   );
+}
+function booleanCapabilityFacts(value: StateSummary["capabilities"] | undefined) {
+  if (!value) return undefined;
+  return {
+    certifiedResults: value.certifiedResults,
+    historicalBaseline: value.historicalBaseline,
+    map: value.map,
+    reviewGraphs: value.reviewGraphs,
+    sourcePlanner: value.sourcePlanner,
+    turnout: value.turnout,
+  } satisfies Record<string, boolean>;
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,7 @@
 import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import * as schema from "./schema";
+import * as uiLayoutV3Schema from "./ui-layout-v3-schema";
 import { getDatabaseUrl } from "./url";
 
 type Database = ReturnType<typeof createDb>;
@@ -14,7 +15,7 @@ function createDb() {
     throw new Error("DATABASE_URL or POSTGRES_URL is not configured.");
   }
 
-  return drizzle(neon(databaseUrl), { schema });
+  return drizzle(neon(databaseUrl), { schema: { ...schema, ...uiLayoutV3Schema } });
 }
 
 export function getDb() {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -16,7 +16,7 @@ import {
   uuid,
   type AnyPgColumn,
 } from "drizzle-orm/pg-core";
-import type { WorkspaceLayoutManifestV1 } from "../lib/workspace-layout";
+import type { WorkspaceLayoutManifest } from "../lib/workspace-layout-v2";
 
 export const importStatus = pgEnum("import_status", [
   "staged",
@@ -50,7 +50,7 @@ export const uiLayoutRevisions = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     schemaVersion: integer("schema_version").notNull(),
     registryVersion: integer("registry_version").notNull(),
-    manifest: jsonb("manifest").$type<WorkspaceLayoutManifestV1>().notNull(),
+    manifest: jsonb("manifest").$type<WorkspaceLayoutManifest>().notNull(),
     manifestDigest: text("manifest_digest").notNull(),
     parentRevisionId: uuid("parent_revision_id").references((): AnyPgColumn => uiLayoutRevisions.id),
     changeSummary: text("change_summary").notNull(),
@@ -61,8 +61,8 @@ export const uiLayoutRevisions = pgTable(
   (table) => ({
     createdAtIndex: index("ui_layout_revisions_created_at_idx").on(table.createdAt),
     digestIndex: index("ui_layout_revisions_manifest_digest_idx").on(table.manifestDigest),
-    schemaVersionCheck: check("ui_layout_revisions_schema_version_check", sql`${table.schemaVersion} = 1`),
-    registryVersionCheck: check("ui_layout_revisions_registry_version_check", sql`${table.registryVersion} = 1`),
+    schemaVersionCheck: check("ui_layout_revisions_schema_version_check", sql`${table.schemaVersion} in (1, 2)`),
+    registryVersionCheck: check("ui_layout_revisions_registry_version_check", sql`${table.registryVersion} in (1, 2)`),
     parentRevisionUnique: unique("ui_layout_revisions_parent_revision_unique")
       .on(table.parentRevisionId)
       .nullsNotDistinct(),

--- a/src/db/ui-layout-v3-schema.ts
+++ b/src/db/ui-layout-v3-schema.ts
@@ -1,0 +1,87 @@
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import type { WorkspaceLayoutManifestV2 } from "../lib/workspace-layout-v2";
+import { uiLayoutRevisions } from "./schema";
+
+export const uiLayoutAssets = pgTable(
+  "ui_layout_assets",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    url: text("url").notNull(),
+    pathname: text("pathname").notNull(),
+    contentType: text("content_type").notNull(),
+    sizeBytes: integer("size_bytes").notNull(),
+    width: integer("width").notNull(),
+    height: integer("height").notNull(),
+    alt: text("alt").notNull().default(""),
+    actorId: text("actor_id").notNull(),
+    actorEmail: text("actor_email").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (table) => ({
+    createdAtIndex: index("ui_layout_assets_created_at_idx").on(table.createdAt),
+    dimensionsCheck: check("ui_layout_assets_dimensions_check", sql`${table.width} > 0 and ${table.height} > 0`),
+    pathnameUnique: uniqueIndex("ui_layout_assets_pathname_idx").on(table.pathname),
+    sizeCheck: check("ui_layout_assets_size_check", sql`${table.sizeBytes} > 0 and ${table.sizeBytes} <= 5242880`),
+    urlUnique: uniqueIndex("ui_layout_assets_url_idx").on(table.url),
+  }),
+);
+
+export const uiLayoutTemplates = pgTable(
+  "ui_layout_templates",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: text("name").notNull(),
+    description: text("description").notNull().default(""),
+    manifest: jsonb("manifest").$type<WorkspaceLayoutManifestV2>().notNull(),
+    isShared: boolean("is_shared").notNull().default(true),
+    actorId: text("actor_id").notNull(),
+    actorEmail: text("actor_email").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    createdAtIndex: index("ui_layout_templates_created_at_idx").on(table.createdAt),
+    nameIndex: index("ui_layout_templates_name_idx").on(table.name),
+  }),
+);
+
+export const uiLayoutRevisionAssets = pgTable(
+  "ui_layout_revision_assets",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    revisionId: uuid("revision_id").notNull().references(() => uiLayoutRevisions.id, { onDelete: "cascade" }),
+    assetId: uuid("asset_id").notNull().references(() => uiLayoutAssets.id, { onDelete: "restrict" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    revisionAssetUnique: uniqueIndex("ui_layout_revision_assets_unique_idx").on(table.revisionId, table.assetId),
+    revisionIndex: index("ui_layout_revision_assets_revision_idx").on(table.revisionId),
+  }),
+);
+
+export const uiLayoutTemplateAssets = pgTable(
+  "ui_layout_template_assets",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    templateId: uuid("template_id").notNull().references(() => uiLayoutTemplates.id, { onDelete: "cascade" }),
+    assetId: uuid("asset_id").notNull().references(() => uiLayoutAssets.id, { onDelete: "restrict" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    templateAssetUnique: uniqueIndex("ui_layout_template_assets_unique_idx").on(table.templateId, table.assetId),
+    templateIndex: index("ui_layout_template_assets_template_idx").on(table.templateId),
+  }),
+);

--- a/src/lib/ui-layout-repository.ts
+++ b/src/lib/ui-layout-repository.ts
@@ -8,13 +8,10 @@ import {
   uiLayoutPublications,
   uiLayoutRevisions,
 } from "../db/schema";
-import { workspaceLayoutDigest } from "./workspace-layout-digest";
-import {
-  WORKSPACE_LAYOUT_REGISTRY_VERSION,
-  WORKSPACE_LAYOUT_SCHEMA_VERSION,
-  validateWorkspaceLayoutManifest,
-  type WorkspaceLayoutManifestV1,
-} from "./workspace-layout";
+import { uiLayoutRevisionAssets } from "../db/ui-layout-v3-schema";
+import { validateWorkspaceLayoutManifestAny, workspaceLayoutDigest } from "./workspace-layout-digest";
+import type { WorkspaceLayoutManifest } from "./workspace-layout-v2";
+import { collectLayoutAssetIds } from "./ui-layout-v3-repository";
 
 export type LayoutActor = {
   id: string;
@@ -59,10 +56,10 @@ export async function getLayoutRevision(revisionId: string) {
 export async function createLayoutRevision(input: {
   actor: LayoutActor;
   changeSummary: string;
-  manifest: WorkspaceLayoutManifestV1;
+  manifest: WorkspaceLayoutManifest;
   parentRevisionId: string | null;
 }) {
-  const validation = validateWorkspaceLayoutManifest(input.manifest);
+  const validation = validateWorkspaceLayoutManifestAny(input.manifest);
   if (!validation.ok) {
     throw new Error(validation.errors.join(" "));
   }
@@ -85,12 +82,15 @@ export async function createLayoutRevision(input: {
   const id = randomUUID();
   const auditId = randomUUID();
   const manifestDigest = workspaceLayoutDigest(validation.value);
+  const assetIds = validation.value.schemaVersion === 2
+    ? collectLayoutAssetIds(validation.value)
+    : [];
   try {
     await db.batch([
       db.insert(uiLayoutRevisions).values({
         id,
-        schemaVersion: WORKSPACE_LAYOUT_SCHEMA_VERSION,
-        registryVersion: WORKSPACE_LAYOUT_REGISTRY_VERSION,
+        schemaVersion: validation.value.schemaVersion,
+        registryVersion: validation.value.registryVersion,
         manifest: validation.value,
         manifestDigest,
         parentRevisionId: input.parentRevisionId,
@@ -106,6 +106,11 @@ export async function createLayoutRevision(input: {
         revisionId: id,
         metadata: { changeSummary, manifestDigest, parentRevisionId: input.parentRevisionId },
       }),
+      ...assetIds.map((assetId) => db.insert(uiLayoutRevisionAssets).values({
+        assetId,
+        id: randomUUID(),
+        revisionId: id,
+      })),
     ]);
   } catch (error) {
     if (isUniqueViolation(error)) {

--- a/src/lib/ui-layout-v3-repository.ts
+++ b/src/lib/ui-layout-v3-repository.ts
@@ -1,0 +1,165 @@
+import "server-only";
+
+import { randomUUID } from "node:crypto";
+import { and, desc, eq, isNull } from "drizzle-orm";
+import { getDb, hasDatabase } from "../db";
+import {
+  uiLayoutAssets,
+  uiLayoutRevisionAssets,
+  uiLayoutTemplateAssets,
+  uiLayoutTemplates,
+} from "../db/ui-layout-v3-schema";
+import {
+  flattenWorkspaceNodes,
+  isSafeWorkspaceBlobUrl,
+  isWorkspaceCustomNodeV2,
+  validateWorkspaceLayoutManifestV2,
+  type WorkspaceLayoutManifestV2,
+} from "./workspace-layout-v2";
+import type { LayoutActor } from "./ui-layout-repository";
+
+export type LayoutAssetInput = {
+  id: string;
+  alt: string;
+  contentType: "image/avif" | "image/jpeg" | "image/png" | "image/webp";
+  height: number;
+  pathname: string;
+  sizeBytes: number;
+  url: string;
+  width: number;
+};
+
+export async function listLayoutAssets(limit = 80) {
+  if (!hasDatabase()) return [];
+  return getDb()
+    .select()
+    .from(uiLayoutAssets)
+    .where(isNull(uiLayoutAssets.deletedAt))
+    .orderBy(desc(uiLayoutAssets.createdAt))
+    .limit(Math.min(Math.max(limit, 1), 200));
+}
+
+export async function createLayoutAsset(input: LayoutAssetInput & { actor: LayoutActor }) {
+  validateAssetInput(input);
+  const [existing] = await getDb()
+    .select()
+    .from(uiLayoutAssets)
+    .where(eq(uiLayoutAssets.pathname, input.pathname))
+    .limit(1);
+  if (existing) return existing;
+  const [asset] = await getDb().insert(uiLayoutAssets).values({
+    id: input.id,
+    actorEmail: input.actor.email,
+    actorId: input.actor.id,
+    alt: input.alt.trim().slice(0, 300),
+    contentType: input.contentType,
+    height: input.height,
+    pathname: input.pathname,
+    sizeBytes: input.sizeBytes,
+    url: input.url,
+    width: input.width,
+  }).returning();
+  return asset;
+}
+
+export async function archiveLayoutAsset(assetId: string, actor: LayoutActor) {
+  const [usage] = await getDb()
+    .select({ id: uiLayoutRevisionAssets.id })
+    .from(uiLayoutRevisionAssets)
+    .where(eq(uiLayoutRevisionAssets.assetId, assetId))
+    .limit(1);
+  if (usage) throw new Error("This image is referenced by a saved layout revision and cannot be deleted.");
+  const [templateUsage] = await getDb()
+    .select({ id: uiLayoutTemplateAssets.id })
+    .from(uiLayoutTemplateAssets)
+    .where(eq(uiLayoutTemplateAssets.assetId, assetId))
+    .limit(1);
+  if (templateUsage) throw new Error("This image is referenced by a shared layout template and cannot be deleted.");
+
+  const [asset] = await getDb()
+    .update(uiLayoutAssets)
+    .set({ deletedAt: new Date(), actorEmail: actor.email, actorId: actor.id })
+    .where(and(eq(uiLayoutAssets.id, assetId), isNull(uiLayoutAssets.deletedAt)))
+    .returning();
+  return asset ?? null;
+}
+
+export async function listLayoutTemplates(limit = 40) {
+  if (!hasDatabase()) return [];
+  return getDb()
+    .select()
+    .from(uiLayoutTemplates)
+    .orderBy(desc(uiLayoutTemplates.updatedAt))
+    .limit(Math.min(Math.max(limit, 1), 100));
+}
+
+export async function createLayoutTemplate(input: {
+  actor: LayoutActor;
+  description: string;
+  manifest: WorkspaceLayoutManifestV2;
+  name: string;
+}) {
+  const validation = validateWorkspaceLayoutManifestV2(input.manifest);
+  if (!validation.ok) throw new Error(validation.errors.join(" "));
+  const name = input.name.trim();
+  if (name.length < 3 || name.length > 80) throw new Error("Template name must be between 3 and 80 characters.");
+  const id = randomUUID();
+  const db = getDb();
+  const assetIds = collectLayoutAssetIds(validation.value);
+  await db.batch([
+    db.insert(uiLayoutTemplates).values({
+      id,
+      actorEmail: input.actor.email,
+      actorId: input.actor.id,
+      description: input.description.trim().slice(0, 240),
+      manifest: validation.value,
+      name,
+    }),
+    ...assetIds.map((assetId) => db.insert(uiLayoutTemplateAssets).values({
+      assetId,
+      id: randomUUID(),
+      templateId: id,
+    })),
+  ]);
+  const [template] = await db.select().from(uiLayoutTemplates).where(eq(uiLayoutTemplates.id, id)).limit(1);
+  if (!template) throw new Error("The template was created but could not be reloaded.");
+  return template;
+}
+
+export async function deleteLayoutTemplate(templateId: string) {
+  const [template] = await getDb()
+    .delete(uiLayoutTemplates)
+    .where(eq(uiLayoutTemplates.id, templateId))
+    .returning();
+  return template ?? null;
+}
+
+export async function syncLayoutRevisionAssets(revisionId: string, manifest: WorkspaceLayoutManifestV2) {
+  const assetIds = collectLayoutAssetIds(manifest);
+  if (!assetIds.length) return;
+  await getDb().insert(uiLayoutRevisionAssets).values(assetIds.map((assetId) => ({
+    assetId,
+    id: randomUUID(),
+    revisionId,
+  }))).onConflictDoNothing();
+}
+
+export function collectLayoutAssetIds(manifest: WorkspaceLayoutManifestV2) {
+  return [...new Set(manifest.tabs.flatMap((tab) => flattenWorkspaceNodes(tab)
+    .filter(isWorkspaceCustomNodeV2)
+    .flatMap((node) => node.asset?.assetId ? [node.asset.assetId] : [])))];
+}
+
+function validateAssetInput(input: LayoutAssetInput) {
+  if (!isSafeWorkspaceBlobUrl(input.url)) throw new Error("Image URL must be a Vercel Blob URL.");
+  if (!input.pathname.startsWith("layout-media/")) throw new Error("Image path is outside the layout-media namespace.");
+  if (!["image/avif", "image/jpeg", "image/png", "image/webp"].includes(input.contentType)) {
+    throw new Error("Only PNG, JPEG, WebP, and AVIF images are allowed.");
+  }
+  if (!Number.isInteger(input.sizeBytes) || input.sizeBytes < 1 || input.sizeBytes > 5 * 1024 * 1024) {
+    throw new Error("Images must be 5 MB or smaller.");
+  }
+  if (!Number.isInteger(input.width) || !Number.isInteger(input.height) || input.width < 1 || input.height < 1) {
+    throw new Error("Image dimensions are required.");
+  }
+}

--- a/src/lib/workspace-layout-digest.ts
+++ b/src/lib/workspace-layout-digest.ts
@@ -5,28 +5,52 @@ import {
   WORKSPACE_LAYOUT_SCHEMA_VERSION,
   validateWorkspaceLayoutManifest,
 } from "./workspace-layout.ts";
+import {
+  WORKSPACE_LAYOUT_REGISTRY_VERSION_V2,
+  WORKSPACE_LAYOUT_SCHEMA_VERSION_V2,
+  validateWorkspaceLayoutManifestV2,
+  type WorkspaceLayoutEnvelope,
+  type WorkspaceLayoutEnvelopeV2,
+  type WorkspaceLayoutManifest,
+  type WorkspaceLayoutManifestV2,
+} from "./workspace-layout-v2.ts";
 
-export function workspaceLayoutDigest(manifest: WorkspaceLayoutManifestV1) {
+export function workspaceLayoutDigest(manifest: WorkspaceLayoutManifest) {
   return createHash("sha256").update(stableJsonStringify(manifest)).digest("hex");
 }
 
 export function createWorkspaceLayoutEnvelope(input: {
+  manifest: WorkspaceLayoutManifestV2;
+  publishedAt?: string;
+  revisionId: string;
+}): WorkspaceLayoutEnvelopeV2;
+export function createWorkspaceLayoutEnvelope(input: {
   manifest: WorkspaceLayoutManifestV1;
   publishedAt?: string;
   revisionId: string;
-}): WorkspaceLayoutEnvelopeV1 {
+}): WorkspaceLayoutEnvelopeV1;
+export function createWorkspaceLayoutEnvelope(input: {
+  manifest: WorkspaceLayoutManifest;
+  publishedAt?: string;
+  revisionId: string;
+}): WorkspaceLayoutEnvelope;
+export function createWorkspaceLayoutEnvelope(input: {
+  manifest: WorkspaceLayoutManifest;
+  publishedAt?: string;
+  revisionId: string;
+}): WorkspaceLayoutEnvelope {
   return {
-    schemaVersion: WORKSPACE_LAYOUT_SCHEMA_VERSION,
-    registryVersion: WORKSPACE_LAYOUT_REGISTRY_VERSION,
+    schemaVersion: input.manifest.schemaVersion,
+    registryVersion: input.manifest.registryVersion,
     revisionId: input.revisionId,
     manifestDigest: workspaceLayoutDigest(input.manifest),
     publishedAt: input.publishedAt ?? new Date().toISOString(),
     manifest: input.manifest,
-  };
+  } as WorkspaceLayoutEnvelope;
 }
 
 export type WorkspaceLayoutEnvelopeValidationResult =
-  | { ok: true; value: WorkspaceLayoutEnvelopeV1 }
+  | { ok: true; value: WorkspaceLayoutEnvelope }
   | { ok: false; errors: string[] };
 
 export function validateWorkspaceLayoutEnvelope(value: unknown): WorkspaceLayoutEnvelopeValidationResult {
@@ -35,11 +59,16 @@ export function validateWorkspaceLayoutEnvelope(value: unknown): WorkspaceLayout
   }
 
   const errors: string[] = [];
-  if (value.schemaVersion !== WORKSPACE_LAYOUT_SCHEMA_VERSION) {
-    errors.push(`Envelope schemaVersion must be ${WORKSPACE_LAYOUT_SCHEMA_VERSION}.`);
-  }
-  if (value.registryVersion !== WORKSPACE_LAYOUT_REGISTRY_VERSION) {
-    errors.push(`Envelope registryVersion must be ${WORKSPACE_LAYOUT_REGISTRY_VERSION}.`);
+  const versionPair = layoutVersionPair(value.manifest);
+  if (!versionPair) {
+    errors.push(`Envelope manifest schemaVersion must be ${WORKSPACE_LAYOUT_SCHEMA_VERSION} or ${WORKSPACE_LAYOUT_SCHEMA_VERSION_V2}.`);
+  } else {
+    if (value.schemaVersion !== versionPair.schemaVersion) {
+      errors.push(`Envelope schemaVersion must match manifest schemaVersion ${versionPair.schemaVersion}.`);
+    }
+    if (value.registryVersion !== versionPair.registryVersion) {
+      errors.push(`Envelope registryVersion must match manifest registryVersion ${versionPair.registryVersion}.`);
+    }
   }
   if (typeof value.revisionId !== "string" || !value.revisionId.trim()) {
     errors.push("Envelope revisionId is required.");
@@ -51,7 +80,7 @@ export function validateWorkspaceLayoutEnvelope(value: unknown): WorkspaceLayout
     errors.push("Envelope manifestDigest must be a SHA-256 hex digest.");
   }
 
-  const manifestResult = validateWorkspaceLayoutManifest(value.manifest);
+  const manifestResult = validateWorkspaceLayoutManifestAny(value.manifest);
   if (!manifestResult.ok) {
     errors.push(...manifestResult.errors);
   } else if (value.manifestDigest !== workspaceLayoutDigest(manifestResult.value)) {
@@ -60,11 +89,33 @@ export function validateWorkspaceLayoutEnvelope(value: unknown): WorkspaceLayout
 
   return errors.length
     ? { ok: false, errors }
-    : { ok: true, value: value as WorkspaceLayoutEnvelopeV1 };
+    : { ok: true, value: value as WorkspaceLayoutEnvelope };
+}
+
+export type WorkspaceLayoutManifestValidationResult =
+  | { ok: true; value: WorkspaceLayoutManifest }
+  | { ok: false; errors: string[] };
+
+export function validateWorkspaceLayoutManifestAny(value: unknown): WorkspaceLayoutManifestValidationResult {
+  if (isRecord(value) && value.schemaVersion === WORKSPACE_LAYOUT_SCHEMA_VERSION_V2) {
+    return validateWorkspaceLayoutManifestV2(value);
+  }
+  return validateWorkspaceLayoutManifest(value);
 }
 
 export function stableJsonStringify(value: unknown) {
   return JSON.stringify(canonicalize(value));
+}
+
+function layoutVersionPair(value: unknown) {
+  if (!isRecord(value)) return null;
+  if (value.schemaVersion === WORKSPACE_LAYOUT_SCHEMA_VERSION_V2 && value.registryVersion === WORKSPACE_LAYOUT_REGISTRY_VERSION_V2) {
+    return { registryVersion: WORKSPACE_LAYOUT_REGISTRY_VERSION_V2, schemaVersion: WORKSPACE_LAYOUT_SCHEMA_VERSION_V2 };
+  }
+  if (value.schemaVersion === WORKSPACE_LAYOUT_SCHEMA_VERSION && value.registryVersion === WORKSPACE_LAYOUT_REGISTRY_VERSION) {
+    return { registryVersion: WORKSPACE_LAYOUT_REGISTRY_VERSION, schemaVersion: WORKSPACE_LAYOUT_SCHEMA_VERSION };
+  }
+  return null;
 }
 
 function canonicalize(value: unknown): unknown {
@@ -76,6 +127,7 @@ function canonicalize(value: unknown): unknown {
       .map((key) => [key, canonicalize(value[key])]),
   );
 }
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/src/lib/workspace-layout-resolution.ts
+++ b/src/lib/workspace-layout-resolution.ts
@@ -2,15 +2,13 @@ import {
   createWorkspaceLayoutEnvelope,
   validateWorkspaceLayoutEnvelope,
 } from "./workspace-layout-digest.ts";
-import {
-  embeddedWorkspaceLayoutManifest,
-  type WorkspaceLayoutEnvelopeV1,
-} from "./workspace-layout.ts";
+import { embeddedWorkspaceLayoutManifest } from "./workspace-layout.ts";
+import type { WorkspaceLayoutEnvelope } from "./workspace-layout-v2.ts";
 
 export type WorkspaceLayoutSource = "draft" | "candidate" | "stable" | "embedded";
 
 export type WorkspaceLayoutResolution = {
-  envelope: WorkspaceLayoutEnvelopeV1;
+  envelope: WorkspaceLayoutEnvelope;
   fallbacks: string[];
   source: WorkspaceLayoutSource;
 };

--- a/src/lib/workspace-layout-v2-runtime.ts
+++ b/src/lib/workspace-layout-v2-runtime.ts
@@ -1,0 +1,204 @@
+import type { CSSProperties } from "react";
+import {
+  defaultWorkspaceLayoutSettingsV2,
+  evaluateWorkspaceVisibility,
+  findProductionNode,
+  flattenWorkspaceNodes,
+  isWorkspaceCustomNodeV2,
+  type WorkspaceCustomNodeV2,
+  type WorkspaceLayoutManifestV2,
+  type WorkspaceLayoutNodeV2,
+  type WorkspaceProductionComponentIdV2,
+  type WorkspaceVisibilityContext,
+} from "./workspace-layout-v2.ts";
+import type { WorkspaceSectionId, WorkspaceTabId } from "./workspace-layout.ts";
+
+export type WorkspaceRuntimeCustomNode = WorkspaceCustomNodeV2 & {
+  columnId: string;
+  order: number;
+  rowId: string;
+  span: { desktop: number; mobile: number; tablet: number };
+};
+
+export function visibleWorkspaceTabsV2(manifest: WorkspaceLayoutManifestV2) {
+  return manifest.tabs.filter((tab) => tab.visible);
+}
+
+export function resolveVisibleWorkspaceTabV2(
+  manifest: WorkspaceLayoutManifestV2,
+  requested?: string,
+): WorkspaceTabId {
+  const visibleTabs = visibleWorkspaceTabsV2(manifest);
+  const visible = new Set(visibleTabs.map((tab) => tab.id));
+  if (requested && visible.has(requested as WorkspaceTabId)) return requested as WorkspaceTabId;
+  if (visible.has(manifest.settings.defaultTab)) return manifest.settings.defaultTab;
+  return visible.has("map") ? "map" : visibleTabs[0]?.id ?? "map";
+}
+
+export function workspaceLayoutSettingsV2(manifest: WorkspaceLayoutManifestV2) {
+  return { ...defaultWorkspaceLayoutSettingsV2, ...manifest.settings };
+}
+
+export function workspaceSectionStateV2(
+  manifest: WorkspaceLayoutManifestV2,
+  tabId: WorkspaceTabId,
+  sectionId: WorkspaceSectionId | "review-center",
+  context?: WorkspaceVisibilityContext,
+) {
+  const tab = manifest.tabs.find((candidate) => candidate.id === tabId);
+  if (!tab) return missingState();
+  const wanted = tabId === "review" && isLegacyReviewSection(sectionId) ? "review-center" : sectionId;
+  let order = 0;
+  for (const row of tab.rows) {
+    for (const column of row.columns) {
+      for (const node of column.items) {
+        if (node.kind === "production" && node.component === wanted) {
+          const conditionallyVisible = context ? evaluateWorkspaceVisibility(node.visibility, context) : true;
+          return {
+            config: node.config,
+            order,
+            presentation: {
+              ...node.presentation,
+              span: column.span,
+            },
+            visibility: node.visibility,
+            visible: tab.visible && node.visible && conditionallyVisible,
+          };
+        }
+        order += 1;
+      }
+    }
+  }
+  return missingState();
+}
+
+export function workspaceProductionNodeV2(
+  manifest: WorkspaceLayoutManifestV2,
+  tabId: WorkspaceTabId,
+  component: WorkspaceProductionComponentIdV2,
+) {
+  const tab = manifest.tabs.find((candidate) => candidate.id === tabId);
+  return tab ? findProductionNode(tab, component) : undefined;
+}
+
+export function workspaceCustomBlocksV2(
+  manifest: WorkspaceLayoutManifestV2,
+  tabId: WorkspaceTabId,
+  context?: WorkspaceVisibilityContext,
+): WorkspaceRuntimeCustomNode[] {
+  const tab = manifest.tabs.find((candidate) => candidate.id === tabId);
+  if (!tab?.visible) return [];
+  let order = 0;
+  const result: WorkspaceRuntimeCustomNode[] = [];
+  for (const row of tab.rows) {
+    for (const column of row.columns) {
+      for (const node of column.items) {
+        const currentOrder = order;
+        order += 1;
+        if (!isWorkspaceCustomNodeV2(node) || !node.visible) continue;
+        if (context && !evaluateWorkspaceVisibility(node.visibility, context)) continue;
+        result.push({
+          ...node,
+          columnId: column.id,
+          order: currentOrder,
+          rowId: row.id,
+          span: column.span,
+        });
+      }
+    }
+  }
+  return result;
+}
+
+export type WorkspaceRuntimeCustomColumn = {
+  columnId: string;
+  items: WorkspaceRuntimeCustomNode[];
+  span: { desktop: number; mobile: number; tablet: number };
+};
+
+export type WorkspaceRuntimeCustomRow = {
+  align?: "center" | "start" | "stretch";
+  columns: WorkspaceRuntimeCustomColumn[];
+  gap?: "large" | "medium" | "small";
+  rowId: string;
+};
+
+export function workspaceCustomRowsV2(
+  manifest: WorkspaceLayoutManifestV2,
+  tabId: WorkspaceTabId,
+  context?: WorkspaceVisibilityContext,
+): WorkspaceRuntimeCustomRow[] {
+  const tab = manifest.tabs.find((candidate) => candidate.id === tabId);
+  if (!tab?.visible) return [];
+  const visibleNodes = new Map(
+    workspaceCustomBlocksV2(manifest, tabId, context).map((node) => [node.id, node]),
+  );
+  return tab.rows
+    .map((row) => ({
+      align: row.align,
+      columns: row.columns.map((column) => ({
+        columnId: column.id,
+        items: column.items.flatMap((node) => {
+          const visible = visibleNodes.get(node.id);
+          return visible ? [visible] : [];
+        }),
+        span: column.span,
+      })),
+      gap: row.gap,
+      rowId: row.id,
+    }))
+    .filter((row) => row.columns.some((column) => column.items.length > 0));
+}
+
+export function workspaceNodeStyleV2(
+  node: WorkspaceLayoutNodeV2,
+  span: { desktop: number; mobile: number; tablet: number },
+  order: number,
+): CSSProperties {
+  return {
+    "--layout-span-desktop": span.desktop,
+    "--layout-span-mobile": span.mobile,
+    "--layout-span-tablet": span.tablet,
+    order,
+  } as CSSProperties;
+}
+
+export function reviewViewConfigurationV2(manifest: WorkspaceLayoutManifestV2) {
+  const node = workspaceProductionNodeV2(manifest, "review", "review-center");
+  const viewOrder = node?.config?.viewOrder ?? ["overview", "evidence-tools", "screening", "indicators", "methodology"];
+  const visible = new Set(node?.config?.visibleViews ?? viewOrder);
+  return {
+    defaultView: node?.config?.defaultView ?? "overview",
+    navigationStyle: node?.config?.navigationStyle ?? "tabs",
+    viewOrder: viewOrder.filter((view) => visible.has(view)),
+  };
+}
+
+export function workspaceGridRowsV2(manifest: WorkspaceLayoutManifestV2, tabId: WorkspaceTabId) {
+  return manifest.tabs.find((tab) => tab.id === tabId)?.rows ?? [];
+}
+
+export function flattenVisibleWorkspaceNodesV2(
+  manifest: WorkspaceLayoutManifestV2,
+  tabId: WorkspaceTabId,
+  context?: WorkspaceVisibilityContext,
+) {
+  const tab = manifest.tabs.find((candidate) => candidate.id === tabId);
+  return tab
+    ? flattenWorkspaceNodes(tab).filter((node) => node.visible && (!context || evaluateWorkspaceVisibility(node.visibility, context)))
+    : [];
+}
+
+function missingState() {
+  return {
+    config: undefined,
+    order: Number.MAX_SAFE_INTEGER,
+    presentation: undefined,
+    visibility: undefined,
+    visible: false,
+  };
+}
+
+function isLegacyReviewSection(value: string) {
+  return ["overview", "evidence-tools", "screening", "indicators", "methodology"].includes(value);
+}

--- a/src/lib/workspace-layout-v2.ts
+++ b/src/lib/workspace-layout-v2.ts
@@ -1,0 +1,963 @@
+import { z } from "zod";
+import {
+  defaultWorkspaceLayoutSettings,
+  workspaceLayoutRegistry,
+  type WorkspaceCustomBlockKind,
+  type WorkspaceLayoutEmphasis,
+  type WorkspaceLayoutManifestV1,
+  type WorkspaceLayoutSurface,
+  type WorkspaceSectionId,
+  type WorkspaceTabId,
+} from "./workspace-layout.ts";
+
+export const WORKSPACE_LAYOUT_SCHEMA_VERSION_V2 = 2 as const;
+export const WORKSPACE_LAYOUT_REGISTRY_VERSION_V2 = 2 as const;
+export const WORKSPACE_LAYOUT_MAX_ROWS_PER_TAB = 20;
+export const WORKSPACE_LAYOUT_MAX_COLUMNS_PER_ROW = 4;
+export const workspaceVisibilityDataKeys = [
+  "equipment",
+  "historical",
+  "indicators",
+  "results",
+  "review",
+  "sources",
+  "turnout",
+] as const;
+
+export const workspaceVisibilityCapabilityKeys = [
+  "certifiedResults",
+  "historicalBaseline",
+  "map",
+  "reviewGraphs",
+  "sourcePlanner",
+  "turnout",
+] as const;
+
+export const WORKSPACE_LAYOUT_MAX_CUSTOM_BLOCKS_PER_TAB = 12;
+
+export type WorkspaceProductionComponentIdV2 =
+  | Exclude<
+    WorkspaceSectionId,
+    "overview" | "evidence-tools" | "screening" | "indicators" | "methodology"
+  >
+  | "review-center";
+
+export type WorkspaceCustomBlockKindV2 =
+  | WorkspaceCustomBlockKind
+  | "heading"
+  | "rich-text"
+  | "button-group"
+  | "image"
+  | "video"
+  | "accordion";
+
+export type WorkspaceLayoutDesktopSpanV2 = 3 | 4 | 6 | 8 | 9 | 12;
+export type WorkspaceLayoutTabletSpanV2 = 6 | 12;
+export type WorkspaceRichTextMarkV1 = "bold" | "italic" | "code";
+
+export type WorkspaceRichTextInlineV1 = {
+  href?: string;
+  marks?: WorkspaceRichTextMarkV1[];
+  text: string;
+  type: "text";
+};
+
+export type WorkspaceRichTextBlockV1 = {
+  children: WorkspaceRichTextInlineV1[];
+  level?: 2 | 3;
+  ordered?: boolean;
+  type: "paragraph" | "heading" | "list-item";
+};
+
+export type WorkspaceRichTextDocumentV1 = {
+  blocks: WorkspaceRichTextBlockV1[];
+  version: 1;
+};
+
+export type WorkspaceVisibilityFactV1 = "state" | "year" | "capability" | "data" | "validation";
+
+export type WorkspaceVisibilityConditionV1 = {
+  fact: WorkspaceVisibilityFactV1;
+  key?: string;
+  operator: "equals" | "not-equals" | "in" | "available" | "unavailable";
+  value?: boolean | number | string | string[];
+};
+
+export type WorkspaceVisibilityGroupV1 = {
+  conditions: WorkspaceVisibilityConditionV1[];
+  operator: "all" | "any";
+};
+
+export type WorkspaceVisibilityV1 = {
+  groups?: WorkspaceVisibilityGroupV1[];
+  operator?: "all" | "any";
+  viewports?: { desktop?: boolean; mobile?: boolean; tablet?: boolean };
+};
+
+export type WorkspaceNodePresentationV2 = {
+  density?: "compact" | "comfortable" | "spacious";
+  emphasis?: WorkspaceLayoutEmphasis;
+  surface?: WorkspaceLayoutSurface;
+};
+
+export type WorkspaceProductionConfigV2 = {
+  coverageVariant?: "list" | "cards" | "compact";
+  defaultView?: string;
+  legendPosition?: "inline" | "below";
+  mapComposition?: "map-first" | "table-first" | "split";
+  navigationStyle?: "tabs" | "pills" | "sidebar";
+  provenanceInitialState?: "collapsed" | "expanded";
+  provenanceVariant?: "summary" | "expanded" | "accordion";
+  snapshotVariant?: "bars" | "metrics" | "table";
+  viewOrder?: string[];
+  visibleViews?: string[];
+};
+
+export type WorkspaceProductionNodeV2 = {
+  component: WorkspaceProductionComponentIdV2;
+  config?: WorkspaceProductionConfigV2;
+  id: string;
+  kind: "production";
+  presentation?: WorkspaceNodePresentationV2;
+  visibility?: WorkspaceVisibilityV1;
+  visible: boolean;
+};
+
+export type WorkspaceCustomItemV2 = {
+  body?: string;
+  href?: string;
+  label: string;
+  value?: string;
+};
+
+export type WorkspaceCustomNodeV2 = {
+  asset?: {
+    alt: string;
+    assetId: string;
+    caption?: string;
+    decorative?: boolean;
+    height: number;
+    url: string;
+    width: number;
+  };
+  body?: string;
+  component: WorkspaceCustomBlockKindV2;
+  document?: WorkspaceRichTextDocumentV1;
+  id: string;
+  items?: WorkspaceCustomItemV2[];
+  kind: "custom";
+  presentation?: WorkspaceNodePresentationV2;
+  title?: string;
+  video?: { id: string; provider: "youtube" | "vimeo"; title: string };
+  visibility?: WorkspaceVisibilityV1;
+  visible: boolean;
+};
+
+export type WorkspaceLayoutNodeV2 = WorkspaceProductionNodeV2 | WorkspaceCustomNodeV2;
+
+export type WorkspaceLayoutColumnV2 = {
+  id: string;
+  items: WorkspaceLayoutNodeV2[];
+  span: { desktop: WorkspaceLayoutDesktopSpanV2; mobile: 12; tablet: WorkspaceLayoutTabletSpanV2 };
+};
+
+export type WorkspaceLayoutRowV2 = {
+  align?: "start" | "center" | "stretch";
+  columns: WorkspaceLayoutColumnV2[];
+  gap?: "small" | "medium" | "large";
+  id: string;
+};
+
+export type WorkspaceLayoutTabV2 = {
+  id: WorkspaceTabId;
+  rows: WorkspaceLayoutRowV2[];
+  settings?: {
+    density?: "compact" | "comfortable" | "spacious";
+    notesPosition?: "side" | "below" | "drawer";
+  };
+  visible: boolean;
+};
+
+export type WorkspaceLayoutManifestV2 = {
+  registryVersion: typeof WORKSPACE_LAYOUT_REGISTRY_VERSION_V2;
+  schemaVersion: typeof WORKSPACE_LAYOUT_SCHEMA_VERSION_V2;
+  settings: {
+    accentColor?: string;
+    contentWidth: "standard" | "wide" | "full";
+    defaultTab: WorkspaceTabId;
+    notesDefault: "collapsed" | "expanded";
+    radius: "square" | "subtle" | "rounded";
+    shadow: "none" | "subtle" | "raised";
+    spacingScale: "tight" | "standard" | "relaxed";
+    tabStyle: "bar" | "pills";
+    theme: "civic" | "high-contrast" | "warm";
+    typeScale: "small" | "standard" | "large";
+  };
+  tabs: WorkspaceLayoutTabV2[];
+};
+
+export type WorkspaceLayoutManifest = WorkspaceLayoutManifestV1 | WorkspaceLayoutManifestV2;
+
+export type WorkspaceLayoutEnvelopeV2 = {
+  manifest: WorkspaceLayoutManifestV2;
+  manifestDigest: string;
+  publishedAt: string;
+  registryVersion: typeof WORKSPACE_LAYOUT_REGISTRY_VERSION_V2;
+  revisionId: string;
+  schemaVersion: typeof WORKSPACE_LAYOUT_SCHEMA_VERSION_V2;
+};
+
+export type WorkspaceLayoutEnvelope = import("./workspace-layout.ts").WorkspaceLayoutEnvelopeV1 | WorkspaceLayoutEnvelopeV2;
+
+export type WorkspaceVisibilityContext = {
+  capabilities?: Record<string, boolean | undefined>;
+  data?: Record<string, boolean | undefined>;
+  state: string;
+  validation?: "passed" | "warning" | "failed" | "unknown";
+  year: number;
+};
+
+export type WorkspaceLayoutV2ValidationResult =
+  | { ok: true; value: WorkspaceLayoutManifestV2 }
+  | { errors: string[]; ok: false };
+
+const tabIds = workspaceLayoutRegistry.map((tab) => tab.id) as [WorkspaceTabId, ...WorkspaceTabId[]];
+const desktopSpans = [3, 4, 6, 8, 9, 12] as const;
+const tabletSpans = [6, 12] as const;
+const reviewViewIds = ["overview", "evidence-tools", "screening", "indicators", "methodology"] as const;
+const idSchema = z.string().regex(/^[a-z][a-z0-9-]{2,95}$/);
+const safeHrefSchema = z.string().max(240).refine(isSafeWorkspaceHrefV2, "Link must use /, https://, or mailto:.");
+
+const richTextInlineSchema = z.object({
+  href: safeHrefSchema.optional(),
+  marks: z.array(z.enum(["bold", "italic", "code"])).max(3).optional(),
+  text: z.string().max(1000),
+  type: z.literal("text"),
+}).strict();
+
+const richTextBlockSchema = z.object({
+  children: z.array(richTextInlineSchema).min(1).max(40),
+  level: z.union([z.literal(2), z.literal(3)]).optional(),
+  ordered: z.boolean().optional(),
+  type: z.enum(["paragraph", "heading", "list-item"]),
+}).strict();
+
+const richTextDocumentSchema = z.object({
+  blocks: z.array(richTextBlockSchema).min(1).max(100),
+  version: z.literal(1),
+}).strict().superRefine((document, context) => {
+  const plainTextLength = document.blocks.reduce(
+    (total, block) => total + block.children.reduce((sum, child) => sum + child.text.length, 0),
+    0,
+  );
+  if (plainTextLength > 10_000) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "Rich text may contain at most 10,000 characters." });
+  }
+});
+
+const visibilityConditionSchema = z.object({
+  fact: z.enum(["state", "year", "capability", "data", "validation"]),
+  key: z.string().max(60).optional(),
+  operator: z.enum(["equals", "not-equals", "in", "available", "unavailable"]),
+  value: z.union([z.boolean(), z.number(), z.string().max(120), z.array(z.string().max(120)).max(20)]).optional(),
+}).strict().superRefine((condition, context) => {
+  if (["capability", "data"].includes(condition.fact) && !condition.key?.trim()) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `${condition.fact} visibility rules require an allowlisted key.`,
+      path: ["key"],
+    });
+  }
+  if (condition.fact === "data" && condition.key
+    && !(workspaceVisibilityDataKeys as readonly string[]).includes(condition.key)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Unsupported data visibility key: ${condition.key}.`,
+      path: ["key"],
+    });
+  }
+  if (condition.fact === "capability" && condition.key
+    && !(workspaceVisibilityCapabilityKeys as readonly string[]).includes(condition.key)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Unsupported capability visibility key: ${condition.key}.`,
+      path: ["key"],
+    });
+  }
+  if (!["available", "unavailable"].includes(condition.operator)) {
+    const emptyArray = Array.isArray(condition.value) && condition.value.length === 0;
+    if (condition.value === undefined || condition.value === "" || emptyArray) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${condition.operator} visibility rules require a value.`,
+        path: ["value"],
+      });
+    }
+
+  }
+});
+const visibilitySchema = z.object({
+  groups: z.array(z.object({
+    conditions: z.array(visibilityConditionSchema).min(1).max(8),
+    operator: z.enum(["all", "any"]),
+  }).strict()).max(4).optional(),
+  operator: z.enum(["all", "any"]).optional(),
+  viewports: z.object({
+    desktop: z.boolean().optional(),
+    mobile: z.boolean().optional(),
+    tablet: z.boolean().optional(),
+  }).strict().optional(),
+}).strict().superRefine((visibility, context) => {
+  const count = visibility.groups?.reduce((total, group) => total + group.conditions.length, 0) ?? 0;
+  if (count > 8) context.addIssue({ code: z.ZodIssueCode.custom, message: "Visibility may use at most eight conditions." });
+});
+
+const presentationSchema = z.object({
+  density: z.enum(["compact", "comfortable", "spacious"]).optional(),
+  emphasis: z.enum(["quiet", "standard", "prominent"]).optional(),
+  surface: z.enum(["plain", "panel", "muted", "accent"]).optional(),
+}).strict().optional();
+
+const productionConfigSchema = z.object({
+  coverageVariant: z.enum(["list", "cards", "compact"]).optional(),
+  defaultView: z.string().max(60).optional(),
+  legendPosition: z.enum(["inline", "below"]).optional(),
+  mapComposition: z.enum(["map-first", "table-first", "split"]).optional(),
+  navigationStyle: z.enum(["tabs", "pills", "sidebar"]).optional(),
+  provenanceInitialState: z.enum(["collapsed", "expanded"]).optional(),
+  provenanceVariant: z.enum(["summary", "expanded", "accordion"]).optional(),
+  snapshotVariant: z.enum(["bars", "metrics", "table"]).optional(),
+  viewOrder: z.array(z.string().max(60)).max(8).optional(),
+  visibleViews: z.array(z.string().max(60)).max(8).optional(),
+}).strict();
+
+const productionNodeSchema = z.object({
+  component: z.string().min(1),
+  config: productionConfigSchema.optional(),
+  id: idSchema,
+  kind: z.literal("production"),
+  presentation: presentationSchema,
+  visibility: visibilitySchema.optional(),
+  visible: z.boolean(),
+}).strict();
+
+const customItemSchema = z.object({
+  body: z.string().max(600).optional(),
+  href: safeHrefSchema.optional(),
+  label: z.string().trim().min(1).max(80),
+  value: z.string().max(80).optional(),
+}).strict();
+
+const customNodeSchema = z.object({
+  asset: z.object({
+    alt: z.string().max(240),
+    assetId: z.string().uuid(),
+    caption: z.string().max(300).optional(),
+    decorative: z.boolean().optional(),
+    height: z.number().int().positive().max(20_000),
+    url: z.string().url().refine(isSafeWorkspaceBlobUrl, "Image must use a Vercel Blob layout-media path."),
+    width: z.number().int().positive().max(20_000),
+  }).strict().optional(),
+  body: z.string().max(2_000).optional(),
+  component: z.enum([
+    "narrative", "callout", "metric-strip", "link-list", "divider", "heading", "rich-text",
+    "button-group", "image", "video", "accordion",
+  ]),
+  document: richTextDocumentSchema.optional(),
+  id: idSchema,
+  items: z.array(customItemSchema).max(12).optional(),
+  kind: z.literal("custom"),
+  presentation: presentationSchema,
+  title: z.string().max(100).optional(),
+  video: z.object({
+    id: z.string().regex(/^[a-zA-Z0-9_-]{5,32}$/),
+    provider: z.enum(["youtube", "vimeo"]),
+    title: z.string().trim().min(1).max(160),
+  }).strict().optional(),
+  visibility: visibilitySchema.optional(),
+  visible: z.boolean(),
+}).strict().superRefine((node, context) => {
+  if (node.component === "rich-text" && !node.document) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "Rich text blocks require a document." });
+  }
+  if (node.component === "image" && !node.asset) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "Image blocks require a managed asset." });
+  }
+  if (node.component === "image" && node.asset && !node.asset.decorative && !node.asset.alt.trim()) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "Non-decorative images require alt text." });
+  }
+  if (node.component === "video" && !node.video) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "Video blocks require an approved provider video." });
+  }
+});
+
+const columnSchema = z.object({
+  id: idSchema,
+  items: z.array(z.union([productionNodeSchema, customNodeSchema])).min(1).max(20),
+  span: z.object({
+    desktop: z.number().refine((value) => desktopSpans.includes(value as WorkspaceLayoutDesktopSpanV2)),
+    mobile: z.literal(12),
+    tablet: z.number().refine((value) => tabletSpans.includes(value as WorkspaceLayoutTabletSpanV2)),
+  }).strict(),
+}).strict();
+
+const rowSchema = z.object({
+  align: z.enum(["start", "center", "stretch"]).optional(),
+  columns: z.array(columnSchema).min(1).max(WORKSPACE_LAYOUT_MAX_COLUMNS_PER_ROW),
+  gap: z.enum(["small", "medium", "large"]).optional(),
+  id: idSchema,
+}).strict();
+
+const manifestSchema = z.object({
+  registryVersion: z.literal(WORKSPACE_LAYOUT_REGISTRY_VERSION_V2),
+  schemaVersion: z.literal(WORKSPACE_LAYOUT_SCHEMA_VERSION_V2),
+  settings: z.object({
+    accentColor: z.string().regex(/^#[0-9a-f]{6}$/i).optional(),
+    contentWidth: z.enum(["standard", "wide", "full"]),
+    defaultTab: z.enum(tabIds),
+    notesDefault: z.enum(["collapsed", "expanded"]),
+    radius: z.enum(["square", "subtle", "rounded"]),
+    shadow: z.enum(["none", "subtle", "raised"]),
+    spacingScale: z.enum(["tight", "standard", "relaxed"]),
+    tabStyle: z.enum(["bar", "pills"]),
+    theme: z.enum(["civic", "high-contrast", "warm"]),
+    typeScale: z.enum(["small", "standard", "large"]),
+  }).strict(),
+  tabs: z.array(z.object({
+    id: z.enum(tabIds),
+    rows: z.array(rowSchema).min(1).max(WORKSPACE_LAYOUT_MAX_ROWS_PER_TAB),
+    settings: z.object({
+      density: z.enum(["compact", "comfortable", "spacious"]).optional(),
+      notesPosition: z.enum(["side", "below", "drawer"]).optional(),
+    }).strict().optional(),
+    visible: z.boolean(),
+  }).strict()).length(workspaceLayoutRegistry.length),
+}).strict();
+
+export const workspaceLayoutRegistryV2 = workspaceLayoutRegistry.map((tab) => ({
+  id: tab.id,
+  label: tab.label,
+  required: "required" in tab && tab.required === true,
+  components: tab.id === "review"
+    ? [{
+      allowedDesktopSpans: [8, 9, 12] as const,
+      id: "review-center" as const,
+      label: "Review Center",
+      required: true,
+    }]
+    : tab.sections.map((section) => ({
+      allowedDesktopSpans: allowedSpansForComponent(section.id),
+      id: section.id as WorkspaceProductionComponentIdV2,
+      label: section.label,
+      required: "required" in section && section.required === true,
+    })),
+}));
+
+export const defaultWorkspaceLayoutSettingsV2: WorkspaceLayoutManifestV2["settings"] = {
+  ...defaultWorkspaceLayoutSettings,
+  radius: "subtle",
+  shadow: "subtle",
+  spacingScale: "standard",
+  typeScale: "standard",
+};
+
+export const embeddedWorkspaceLayoutManifestV2: WorkspaceLayoutManifestV2 = {
+  registryVersion: WORKSPACE_LAYOUT_REGISTRY_VERSION_V2,
+  schemaVersion: WORKSPACE_LAYOUT_SCHEMA_VERSION_V2,
+  settings: defaultWorkspaceLayoutSettingsV2,
+  tabs: workspaceLayoutRegistryV2.map((tab) => defaultTabLayout(tab.id)),
+};
+
+export const workspaceStarterTemplates = [
+  {
+    description: "The current production hierarchy with a prominent map and supporting context.",
+    id: "balanced",
+    label: "Balanced",
+    manifest: embeddedWorkspaceLayoutManifestV2,
+  },
+  {
+    description: "A full-width result explorer followed by a three-card context row.",
+    id: "map-first",
+    label: "Map first",
+    manifest: createMapFirstTemplate(),
+  },
+  {
+    description: "Moves provenance and coverage ahead of the explorer for source-led review.",
+    id: "research",
+    label: "Research",
+    manifest: createResearchTemplate(),
+  },
+] as const;
+
+export function validateWorkspaceLayoutManifestV2(value: unknown): WorkspaceLayoutV2ValidationResult {
+  const parsed = manifestSchema.safeParse(value);
+  if (!parsed.success) {
+    return {
+      errors: parsed.error.issues.map((issue) => `${formatZodPath(issue.path)}${issue.message}`),
+      ok: false,
+    };
+  }
+  const manifest = parsed.data as WorkspaceLayoutManifestV2;
+  const errors = inspectStructuralRules(manifest);
+  return errors.length ? { errors, ok: false } : { ok: true, value: manifest };
+}
+
+export function toWorkspaceLayoutManifestV2(manifest: WorkspaceLayoutManifest): WorkspaceLayoutManifestV2 {
+  return manifest.schemaVersion === WORKSPACE_LAYOUT_SCHEMA_VERSION_V2
+    ? structuredClone(manifest)
+    : upgradeWorkspaceLayoutManifestV1(manifest);
+}
+
+export function upgradeWorkspaceLayoutManifestV1(manifest: WorkspaceLayoutManifestV1): WorkspaceLayoutManifestV2 {
+  const upgraded = structuredClone(embeddedWorkspaceLayoutManifestV2);
+  upgraded.settings = { ...defaultWorkspaceLayoutSettingsV2, ...manifest.settings };
+  upgraded.tabs = manifest.tabs.map((legacyTab) => {
+    const defaultTab = defaultTabLayout(legacyTab.id);
+    defaultTab.visible = legacyTab.visible;
+    defaultTab.settings = {
+      density: legacyTab.settings?.density,
+      notesPosition: legacyTab.settings?.notesPosition,
+    };
+
+    if (legacyTab.id === "review") {
+      const reviewNode = findProductionNode(defaultTab, "review-center");
+      const visibleViews = legacyTab.sections
+        .filter((section) => !("kind" in section) && section.visible)
+        .map((section) => section.id)
+        .filter((id): id is typeof reviewViewIds[number] => reviewViewIds.includes(id as typeof reviewViewIds[number]));
+      reviewNode.config = {
+        ...reviewNode.config,
+        defaultView: visibleViews[0] ?? "overview",
+        viewOrder: legacyTab.sections.filter((section) => !("kind" in section)).map((section) => section.id),
+        visibleViews,
+      };
+    } else {
+      const order = new Map(legacyTab.sections.map((section, index) => [section.id, index]));
+      const productionNodes = flattenWorkspaceNodes(defaultTab).filter(isWorkspaceProductionNodeV2);
+      for (const node of productionNodes) {
+        const legacy = legacyTab.sections.find((section) => section.id === node.component && !("kind" in section));
+        if (!legacy) continue;
+        node.visible = legacy.visible;
+        node.presentation = {
+          density: legacy.presentation?.density,
+          emphasis: legacy.presentation?.emphasis,
+          surface: legacy.presentation?.surface,
+        };
+      }
+      defaultTab.rows.sort((left, right) => {
+        const leftOrder = Math.min(...flattenRowNodes(left).map((node) => order.get(node.component) ?? Number.MAX_SAFE_INTEGER));
+        const rightOrder = Math.min(...flattenRowNodes(right).map((node) => order.get(node.component) ?? Number.MAX_SAFE_INTEGER));
+        return leftOrder - rightOrder;
+      });
+    }
+
+    for (const custom of legacyTab.sections.filter(
+      (section) => "kind" in section && section.kind === "custom",
+    ) as Array<Extract<(typeof legacyTab.sections)[number], { kind: "custom" }>>) {
+      defaultTab.rows.push({
+        columns: [{
+          id: stableId(`column-${legacyTab.id}-${custom.id}`),
+          items: [{
+            body: custom.body,
+            component: custom.component,
+            id: stableId(custom.id),
+            items: custom.items,
+            kind: "custom",
+            presentation: {
+              density: custom.presentation?.density,
+              emphasis: custom.presentation?.emphasis,
+              surface: custom.presentation?.surface,
+            },
+            title: custom.title,
+            visible: custom.visible,
+          }],
+          span: {
+            desktop: coerceDesktopSpan(custom.presentation?.span?.desktop),
+            mobile: 12,
+            tablet: custom.presentation?.span?.tablet === 6 ? 6 : 12,
+          },
+        }],
+        gap: "medium",
+        id: stableId(`row-${legacyTab.id}-${custom.id}`),
+      });
+    }
+    return defaultTab;
+  });
+  return upgraded;
+}
+
+export function cloneWorkspaceLayoutManifestV2(
+  manifest: WorkspaceLayoutManifestV2 = embeddedWorkspaceLayoutManifestV2,
+) {
+  return structuredClone(manifest);
+}
+
+export function flattenWorkspaceNodes(tab: WorkspaceLayoutTabV2) {
+  return tab.rows.flatMap((row) => flattenRowNodes(row));
+}
+
+export function flattenRowNodes(row: WorkspaceLayoutRowV2) {
+  return row.columns.flatMap((column) => column.items);
+}
+
+export function isWorkspaceProductionNodeV2(node: WorkspaceLayoutNodeV2): node is WorkspaceProductionNodeV2 {
+  return node.kind === "production";
+}
+
+export function isWorkspaceCustomNodeV2(node: WorkspaceLayoutNodeV2): node is WorkspaceCustomNodeV2 {
+  return node.kind === "custom";
+}
+
+export function findProductionNode(tab: WorkspaceLayoutTabV2, component: WorkspaceProductionComponentIdV2) {
+  const node = flattenWorkspaceNodes(tab).find(
+    (candidate): candidate is WorkspaceProductionNodeV2 => candidate.kind === "production" && candidate.component === component,
+  );
+  if (!node) throw new Error(`Production component ${component} is missing from ${tab.id}.`);
+  return node;
+}
+
+export function createWorkspaceCustomNodeV2(
+  component: WorkspaceCustomBlockKindV2,
+  id = createWorkspaceLayoutId(`custom-${component}`),
+): WorkspaceCustomNodeV2 {
+  const node: WorkspaceCustomNodeV2 = {
+    component,
+    id,
+    kind: "custom",
+    presentation: {
+      density: "comfortable",
+      emphasis: component === "callout" ? "prominent" : "standard",
+      surface: component === "divider" ? "plain" : "panel",
+    },
+    visible: true,
+  };
+  if (component === "heading") return { ...node, title: "Section heading" };
+  if (component === "rich-text") {
+    return { ...node, document: richTextDocumentFromPlainText("Add formatted orientation or source context."), title: "Rich text" };
+  }
+  if (component === "metric-strip") {
+    return {
+      ...node,
+      items: [
+        { label: "Metric one", value: "Value" },
+        { label: "Metric two", value: "Value" },
+        { label: "Metric three", value: "Value" },
+      ],
+      title: "Key figures",
+    };
+  }
+  if (component === "link-list" || component === "button-group") {
+    return { ...node, items: [{ href: "/", label: "Workspace home" }], title: "Related resources" };
+  }
+  if (component === "accordion") {
+    return { ...node, items: [{ body: "Add a concise, source-aware answer.", label: "Question" }], title: "Common questions" };
+  }
+  if (component === "divider") return { ...node, title: "Section" };
+  if (component === "image") return { ...node, title: "Image" };
+  if (component === "video") return { ...node, title: "Video" };
+  return {
+    ...node,
+    body: component === "callout" ? "Add an important caveat or next step." : "Add concise orientation or source context.",
+    title: component === "callout" ? "Important note" : "Section heading",
+  };
+}
+
+export function appendWorkspaceNodeAsRow(
+  tab: WorkspaceLayoutTabV2,
+  node: WorkspaceLayoutNodeV2,
+  span: WorkspaceLayoutDesktopSpanV2 = 12,
+) {
+  tab.rows.push({
+    columns: [{
+      id: createWorkspaceLayoutId("column"),
+      items: [node],
+      span: { desktop: span, mobile: 12, tablet: span === 3 || span === 4 ? 6 : 12 },
+    }],
+    gap: "medium",
+    id: createWorkspaceLayoutId("row"),
+  });
+}
+
+export function createWorkspaceLayoutId(prefix: string) {
+  const normalized = prefix.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 48) || "layout";
+  const suffix = typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID().replaceAll("-", "").slice(0, 12)
+    : `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  return `${normalized}-${suffix}`;
+}
+
+export function richTextDocumentFromPlainText(text: string): WorkspaceRichTextDocumentV1 {
+  return { blocks: [{ children: [{ text, type: "text" }], type: "paragraph" }], version: 1 };
+}
+
+export function evaluateWorkspaceVisibility(visibility: WorkspaceVisibilityV1 | undefined, context: WorkspaceVisibilityContext) {
+  if (!visibility?.groups?.length) return true;
+  const groupResults = visibility.groups.map((group) => {
+    const values = group.conditions.map((condition) => evaluateCondition(condition, context));
+    return group.operator === "any" ? values.some(Boolean) : values.every(Boolean);
+  });
+  return visibility.operator === "any" ? groupResults.some(Boolean) : groupResults.every(Boolean);
+}
+
+export function workspaceViewportVisibilityAttributes(visibility?: WorkspaceVisibilityV1) {
+  const viewports = visibility?.viewports;
+  return {
+    "data-layout-show-desktop": viewports?.desktop === false ? "false" : "true",
+    "data-layout-show-mobile": viewports?.mobile === false ? "false" : "true",
+    "data-layout-show-tablet": viewports?.tablet === false ? "false" : "true",
+  } as const;
+}
+
+export function workspaceAccentForeground(accent: string | undefined) {
+  if (!accent || !/^#[0-9a-f]{6}$/i.test(accent)) return "#07110f";
+  const [red, green, blue] = [accent.slice(1, 3), accent.slice(3, 5), accent.slice(5, 7)].map((value) => Number.parseInt(value, 16));
+  const luminance = [red, green, blue]
+    .map((value) => value / 255)
+    .map((value) => value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4)
+    .reduce((total, value, index) => total + value * [0.2126, 0.7152, 0.0722][index]!, 0);
+  const blackContrast = (luminance + 0.05) / 0.05;
+  const whiteContrast = 1.05 / (luminance + 0.05);
+  return blackContrast >= whiteContrast ? "#07110f" : "#ffffff";
+}
+
+export function isSafeWorkspaceBlobUrl(value: string) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:"
+      && url.hostname.endsWith(".public.blob.vercel-storage.com")
+      && url.pathname.startsWith("/layout-media/");
+  } catch {
+    return false;
+  }
+}
+
+function isSafeWorkspaceHrefV2(value: string) {
+  if (!value || value.length > 240 || /[\u0000-\u0020\u007f]/.test(value)) return false;
+  if (value.startsWith("/") && !value.startsWith("//") && !value.startsWith("/\\")) return true;
+  if (/^mailto:[^@?]+@[^@?]+\.[^@?]+(?:\?.*)?$/i.test(value)) return true;
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function inspectStructuralRules(manifest: WorkspaceLayoutManifestV2) {
+  const errors: string[] = [];
+  const seenTabs = new Set<WorkspaceTabId>();
+  const seenIds = new Set<string>();
+  for (const tab of manifest.tabs) {
+    if (seenTabs.has(tab.id)) errors.push(`Tab ${tab.id} appears more than once.`);
+    seenTabs.add(tab.id);
+    const registry = workspaceLayoutRegistryV2.find((candidate) => candidate.id === tab.id)!;
+    if (registry.required && !tab.visible) errors.push(`Required tab ${registry.label} cannot be hidden.`);
+    const nodes = flattenWorkspaceNodes(tab);
+    if (nodes.filter(isWorkspaceCustomNodeV2).length > WORKSPACE_LAYOUT_MAX_CUSTOM_BLOCKS_PER_TAB) {
+      errors.push(`Tab ${tab.id} may contain at most ${WORKSPACE_LAYOUT_MAX_CUSTOM_BLOCKS_PER_TAB} custom blocks.`);
+    }
+    for (const row of tab.rows) {
+      if (seenIds.has(row.id)) errors.push(`Layout id ${row.id} appears more than once.`);
+      seenIds.add(row.id);
+      for (const column of row.columns) {
+        if (seenIds.has(column.id)) errors.push(`Layout id ${column.id} appears more than once.`);
+        seenIds.add(column.id);
+        for (const node of column.items) {
+          if (seenIds.has(node.id)) errors.push(`Layout id ${node.id} appears more than once.`);
+          seenIds.add(node.id);
+          if (node.kind === "production" && node.visibility) {
+            const component = registry.components.find((candidate) => candidate.id === node.component);
+            if (component?.required) errors.push(`Required component ${component.label} cannot use visibility rules.`);
+          }
+        }
+      }
+    }
+    for (const component of registry.components) {
+      const matches = nodes.filter((node) => node.kind === "production" && node.component === component.id);
+      if (matches.length !== 1) errors.push(`Tab ${tab.id} must contain production component ${component.id} exactly once.`);
+      if (component.required && matches[0]?.visible !== true) errors.push(`Required component ${component.label} cannot be hidden.`);
+    }
+    const unknown = nodes.filter((node) => node.kind === "production"
+      && !registry.components.some((component) => component.id === node.component));
+    if (unknown.length) errors.push(`Tab ${tab.id} contains unsupported production components: ${unknown.map((node) => node.component).join(", ")}.`);
+    if (tab.visible && !nodes.some((node) => node.kind === "production" && node.visible && !node.visibility)) {
+      errors.push(`Visible tab ${tab.id} must retain an unconditional production component.`);
+    }
+  }
+  for (const registryTab of workspaceLayoutRegistryV2) {
+    if (!seenTabs.has(registryTab.id)) errors.push(`Tab ${registryTab.id} is missing.`);
+  }
+  if (!manifest.tabs.find((tab) => tab.id === manifest.settings.defaultTab)?.visible) {
+    errors.push("settings.defaultTab must reference a visible tab.");
+  }
+  return errors;
+}
+
+function defaultTabLayout(tabId: WorkspaceTabId): WorkspaceLayoutTabV2 {
+  const registry = workspaceLayoutRegistryV2.find((tab) => tab.id === tabId)!;
+  if (tabId === "map") {
+    return {
+      id: tabId,
+      rows: [{
+        align: "start",
+        columns: [
+          {
+            id: "column-map-primary",
+            items: [productionNode(tabId, "results-map")],
+            span: { desktop: 8, mobile: 12, tablet: 12 },
+          },
+          {
+            id: "column-map-context",
+            items: [
+              productionNode(tabId, "source-provenance"),
+              productionNode(tabId, "coverage-context"),
+              productionNode(tabId, "state-snapshot"),
+            ],
+            span: { desktop: 4, mobile: 12, tablet: 12 },
+          },
+        ],
+        gap: "medium",
+        id: "row-map-primary",
+      }],
+      settings: { density: "comfortable", notesPosition: "side" },
+      visible: true,
+    };
+  }
+  return {
+    id: tabId,
+    rows: registry.components.map((component, index) => ({
+      columns: [{
+        id: stableId(`column-${tabId}-${component.id}`),
+        items: [productionNode(tabId, component.id)],
+        span: { desktop: 12, mobile: 12, tablet: 12 },
+      }],
+      gap: "medium",
+      id: stableId(`row-${tabId}-${index + 1}`),
+    })),
+    settings: { density: "comfortable", notesPosition: "side" },
+    visible: true,
+  };
+}
+
+function productionNode(tabId: WorkspaceTabId, component: WorkspaceProductionComponentIdV2): WorkspaceProductionNodeV2 {
+  const config: WorkspaceProductionConfigV2 | undefined = component === "results-map"
+    ? { legendPosition: "below", mapComposition: "map-first" }
+    : component === "coverage-context"
+      ? { coverageVariant: "list" }
+      : component === "state-snapshot"
+        ? { snapshotVariant: "bars" }
+        : component === "source-provenance"
+          ? { provenanceInitialState: "expanded", provenanceVariant: "expanded" }
+          : component === "review-center"
+            ? {
+              defaultView: "overview",
+              navigationStyle: "tabs",
+              viewOrder: [...reviewViewIds],
+              visibleViews: [...reviewViewIds],
+            }
+            : undefined;
+  return {
+    component,
+    config,
+    id: stableId(`production-${tabId}-${component}`),
+    kind: "production",
+    presentation: { density: "comfortable", emphasis: "standard", surface: "panel" },
+    visible: true,
+  };
+}
+
+function createMapFirstTemplate() {
+  const manifest = cloneWorkspaceLayoutManifestV2(embeddedWorkspaceLayoutManifestV2);
+  const map = manifest.tabs.find((tab) => tab.id === "map")!;
+  const nodes = flattenWorkspaceNodes(map).filter(isWorkspaceProductionNodeV2);
+  map.rows = [
+    {
+      columns: [{
+        id: "column-map-first-explorer",
+        items: [nodes.find((node) => node.component === "results-map")!],
+        span: { desktop: 12, mobile: 12, tablet: 12 },
+      }],
+      gap: "medium",
+      id: "row-map-first-explorer",
+    },
+    {
+      columns: ["source-provenance", "coverage-context", "state-snapshot"].map((component, index) => ({
+        id: `column-map-first-context-${index + 1}`,
+        items: [nodes.find((node) => node.component === component)!],
+        span: { desktop: 4 as const, mobile: 12 as const, tablet: 6 as const },
+      })),
+      gap: "medium",
+      id: "row-map-first-context",
+    },
+  ];
+  return manifest;
+}
+
+function createResearchTemplate() {
+  const manifest = cloneWorkspaceLayoutManifestV2(embeddedWorkspaceLayoutManifestV2);
+  const map = manifest.tabs.find((tab) => tab.id === "map")!;
+  const nodes = flattenWorkspaceNodes(map).filter(isWorkspaceProductionNodeV2);
+  map.rows = [
+    {
+      columns: ["source-provenance", "coverage-context"].map((component, index) => ({
+        id: `column-research-context-${index + 1}`,
+        items: [nodes.find((node) => node.component === component)!],
+        span: { desktop: 6 as const, mobile: 12 as const, tablet: 6 as const },
+      })),
+      gap: "medium",
+      id: "row-research-context",
+    },
+    {
+      columns: [{
+        id: "column-research-explorer",
+        items: [nodes.find((node) => node.component === "results-map")!],
+        span: { desktop: 12, mobile: 12, tablet: 12 },
+      }],
+      gap: "medium",
+      id: "row-research-explorer",
+    },
+    {
+      columns: [{
+        id: "column-research-snapshot",
+        items: [nodes.find((node) => node.component === "state-snapshot")!],
+        span: { desktop: 12, mobile: 12, tablet: 12 },
+      }],
+      gap: "medium",
+      id: "row-research-snapshot",
+    },
+  ];
+  return manifest;
+}
+
+function evaluateCondition(condition: WorkspaceVisibilityConditionV1, context: WorkspaceVisibilityContext) {
+  const actual = condition.fact === "state"
+    ? context.state
+    : condition.fact === "year"
+      ? context.year
+      : condition.fact === "validation"
+        ? context.validation ?? "unknown"
+        : condition.fact === "capability"
+          ? context.capabilities?.[condition.key ?? ""]
+          : context.data?.[condition.key ?? ""];
+  if (condition.operator === "available") return actual === true;
+  if (condition.operator === "unavailable") return actual !== true;
+  if (condition.operator === "in") return Array.isArray(condition.value) && condition.value.map(String).includes(String(actual));
+  if (condition.operator === "not-equals") return String(actual) !== String(condition.value);
+  return String(actual) === String(condition.value);
+}
+
+function allowedSpansForComponent(component: WorkspaceSectionId) {
+  if (["results-map", "historical-charts", "screening", "indicators"].includes(component)) return [8, 9, 12] as const;
+  return [3, 4, 6, 8, 9, 12] as const;
+}
+
+function coerceDesktopSpan(value: number | undefined): WorkspaceLayoutDesktopSpanV2 {
+  return desktopSpans.includes(value as WorkspaceLayoutDesktopSpanV2) ? value as WorkspaceLayoutDesktopSpanV2 : 12;
+}
+
+function stableId(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 96);
+}
+
+function formatZodPath(path: PropertyKey[]) {
+  return path.length ? `${path.map(String).join(".")}: ` : "";
+}

--- a/tests/api/workspace-layout-admin-policy.test.mjs
+++ b/tests/api/workspace-layout-admin-policy.test.mjs
@@ -72,3 +72,20 @@ test("layout editor exposes a responsive constrained page builder", () => {
   assert.match(css, /\.compareGrid/);
   assert.match(css, /\.inspectorPanel/);
 });
+
+test("builder v3 exposes responsive rows, rich content, media, and publication controls", () => {
+  const editor = readFileSync("src/app/admin/layout/layout-editor-v3.tsx", "utf8");
+  const richText = readFileSync("src/app/admin/layout/layout-rich-text-editor.tsx", "utf8");
+  const runtime = readFileSync("src/lib/workspace-layout-v2-runtime.ts", "utf8");
+  const css = readFileSync("src/app/admin/layout/layout-editor-v3.module.css", "utf8");
+
+  assert.match(editor, /workspaceCustomRows|createWorkspaceCustomNodeV2/);
+  assert.match(editor, /desktop.*tablet.*mobile/s);
+  assert.match(editor, /layout-media\//);
+  assert.match(editor, /name="publicationAction"/);
+  assert.match(editor, /VisibilityInspector/);
+  assert.match(richText, /LexicalComposer/);
+  assert.match(runtime, /workspaceCustomRowsV2/);
+  assert.match(css, /\.columns/);
+  assert.match(css, /\.inspector/);
+});

--- a/tests/api/workspace-layout-v2.test.mjs
+++ b/tests/api/workspace-layout-v2.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cloneWorkspaceLayoutManifestV2,
+  createWorkspaceCustomNodeV2,
+  embeddedWorkspaceLayoutManifestV2,
+  evaluateWorkspaceVisibility,
+  isSafeWorkspaceBlobUrl,
+  toWorkspaceLayoutManifestV2,
+  validateWorkspaceLayoutManifestV2,
+  workspaceStarterTemplates,
+} from "../../src/lib/workspace-layout-v2.ts";
+import { embeddedWorkspaceLayoutManifest } from "../../src/lib/workspace-layout.ts";
+import {
+  createWorkspaceLayoutEnvelope,
+  validateWorkspaceLayoutEnvelope,
+} from "../../src/lib/workspace-layout-digest.ts";
+import {
+  workspaceCustomRowsV2,
+  workspaceSectionStateV2,
+} from "../../src/lib/workspace-layout-v2-runtime.ts";
+
+test("the embedded v2 manifest and every starter template are structurally valid", () => {
+  assert.equal(validateWorkspaceLayoutManifestV2(embeddedWorkspaceLayoutManifestV2).ok, true);
+  assert.equal(workspaceStarterTemplates.length, 3);
+  for (const template of workspaceStarterTemplates) {
+    const validation = validateWorkspaceLayoutManifestV2(template.manifest);
+    assert.equal(validation.ok, true, validation.ok ? "" : validation.errors.join("\n"));
+  }
+});
+
+test("v1 revisions upgrade deterministically without mutating the original", () => {
+  const legacy = structuredClone(embeddedWorkspaceLayoutManifest);
+  const snapshot = JSON.stringify(legacy);
+  const upgraded = toWorkspaceLayoutManifestV2(legacy);
+  assert.equal(upgraded.schemaVersion, 2);
+  assert.equal(upgraded.registryVersion, 2);
+  assert.equal(validateWorkspaceLayoutManifestV2(upgraded).ok, true);
+  assert.equal(JSON.stringify(legacy), snapshot);
+  assert.equal(upgraded.tabs.find((tab) => tab.id === "review")?.rows[0].columns[0].items[0].component, "review-center");
+});
+
+test("required production components cannot be hidden or made conditional", () => {
+  const hidden = cloneWorkspaceLayoutManifestV2(embeddedWorkspaceLayoutManifestV2);
+  const map = hidden.tabs.find((tab) => tab.id === "map");
+  const resultMap = map.rows[0].columns[0].items[0];
+  resultMap.visible = false;
+  const hiddenValidation = validateWorkspaceLayoutManifestV2(hidden);
+  assert.equal(hiddenValidation.ok, false);
+  assert.match(hiddenValidation.errors.join(" "), /required|visible/i);
+
+  const conditional = cloneWorkspaceLayoutManifestV2(embeddedWorkspaceLayoutManifestV2);
+  conditional.tabs.find((tab) => tab.id === "map").rows[0].columns[0].items[0].visibility = {
+    groups: [{ conditions: [{ fact: "state", operator: "equals", value: "WA" }], operator: "all" }],
+  };
+  const conditionalValidation = validateWorkspaceLayoutManifestV2(conditional);
+  assert.equal(conditionalValidation.ok, false);
+  assert.match(conditionalValidation.errors.join(" "), /visibility rules|condition/i);
+});
+
+test("visibility groups evaluate allowlisted public data facts", () => {
+  const visibility = {
+    groups: [
+      {
+        conditions: [
+          { fact: "state", operator: "in", value: ["WA", "OR"] },
+          { fact: "data", key: "turnout", operator: "available" },
+        ],
+        operator: "all",
+      },
+    ],
+    operator: "all",
+  };
+  assert.equal(evaluateWorkspaceVisibility(visibility, {
+    data: { turnout: true },
+    state: "WA",
+    year: 2024,
+  }), true);
+  assert.equal(evaluateWorkspaceVisibility(visibility, {
+    data: { turnout: false },
+    state: "WA",
+    year: 2024,
+  }), false);
+  const manifest = cloneWorkspaceLayoutManifestV2(embeddedWorkspaceLayoutManifestV2);
+  const coverage = manifest.tabs.find((tab) => tab.id === "map").rows[0].columns[1].items
+    .find((node) => node.component === "coverage-context");
+  coverage.visibility = visibility;
+  assert.equal(workspaceSectionStateV2(manifest, "map", "coverage-context", {
+    data: { turnout: false },
+    state: "WA",
+    year: 2024,
+  }).visible, false);
+  assert.equal(workspaceSectionStateV2(manifest, "map", "coverage-context", {
+    data: { turnout: true },
+    state: "WA",
+    year: 2024,
+  }).visible, true);
+});
+
+test("visibility rules reject unknown public-data keys", () => {
+  const manifest = cloneWorkspaceLayoutManifestV2(embeddedWorkspaceLayoutManifestV2);
+  const custom = createWorkspaceCustomNodeV2("callout");
+  custom.visibility = {
+    groups: [{ conditions: [{ fact: "data", key: "private-record", operator: "available" }], operator: "all" }],
+  };
+  manifest.tabs.find((tab) => tab.id === "map").rows[0].columns[1].items.push(custom);
+  const validation = validateWorkspaceLayoutManifestV2(manifest);
+  assert.equal(validation.ok, false);
+  assert.match(validation.errors.join(" "), /unsupported data visibility key/i);
+});
+
+test("managed image URLs are restricted to the layout-media Blob namespace", () => {
+  assert.equal(isSafeWorkspaceBlobUrl("https://example.public.blob.vercel-storage.com/layout-media/map.webp"), true);
+  assert.equal(isSafeWorkspaceBlobUrl("https://example.public.blob.vercel-storage.com/other/map.webp"), false);
+  assert.equal(isSafeWorkspaceBlobUrl("https://example.com/layout-media/map.webp"), false);
+});
+
+test("custom runtime rows preserve column placement and conditional visibility", () => {
+  const manifest = cloneWorkspaceLayoutManifestV2(embeddedWorkspaceLayoutManifestV2);
+  const mapRow = manifest.tabs.find((tab) => tab.id === "map").rows[0];
+  const custom = createWorkspaceCustomNodeV2("callout");
+  custom.visibility = {
+    groups: [{ conditions: [{ fact: "data", key: "historical", operator: "available" }], operator: "all" }],
+  };
+  mapRow.columns[1].items.push(custom);
+
+  assert.equal(workspaceCustomRowsV2(manifest, "map", {
+    data: { historical: false },
+    state: "WA",
+    year: 2024,
+  }).length, 0);
+
+  const rows = workspaceCustomRowsV2(manifest, "map", {
+    data: { historical: true },
+    state: "WA",
+    year: 2024,
+  });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].columns.length, mapRow.columns.length);
+  assert.equal(rows[0].columns[0].items.length, 0);
+  assert.equal(rows[0].columns[1].items[0].id, custom.id);
+});
+
+test("v2 envelopes retain version metadata and detect tampering", () => {
+  const envelope = createWorkspaceLayoutEnvelope({
+    manifest: embeddedWorkspaceLayoutManifestV2,
+    publishedAt: "2026-07-16T00:00:00.000Z",
+    revisionId: "v2-test",
+  });
+  assert.equal(envelope.schemaVersion, 2);
+  assert.equal(validateWorkspaceLayoutEnvelope(envelope).ok, true);
+  const tampered = structuredClone(envelope);
+  tampered.manifest.settings.theme = "warm";
+  assert.equal(validateWorkspaceLayoutEnvelope(tampered).ok, false);
+});

--- a/tests/e2e/workspace-layout-v3.spec.ts
+++ b/tests/e2e/workspace-layout-v3.spec.ts
@@ -1,0 +1,55 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test("schema-v2 design tokens reach the public workspace at desktop and mobile widths", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  await page.goto("/?state=WA&tab=map");
+  const workspace = page.getByRole("region", { name: /Washington workspace/i });
+  await expect(workspace).toBeVisible();
+  await expect(workspace).toHaveAttribute("data-layout-theme", "civic");
+  await expect(workspace).toHaveAttribute("data-layout-radius", "subtle");
+  await expect(workspace).toHaveAttribute("data-layout-shadow", "subtle");
+  await expect(workspace).toHaveAttribute("data-layout-spacing", "standard");
+  await expect(workspace).toHaveAttribute("data-layout-type-scale", "standard");
+  await expect(workspace.getByRole("tab", { name: "Map", exact: true })).toBeVisible();
+
+  const accessibility = await new AxeBuilder({ page }).include(".workspace-tabs").analyze();
+  expect(accessibility.violations
+    .filter((violation) => violation.impact === "critical")
+    .map((violation) => ({ id: violation.id, targets: violation.nodes.map((node) => node.target) })))
+    .toEqual([]);
+
+  await page.setViewportSize({ height: 844, width: 390 });
+  await expect(workspace).toBeVisible();
+  const box = await workspace.boundingBox();
+  expect(box?.width ?? 999).toBeLessThanOrEqual(390);
+  await expect(page.locator("[data-nextjs-dialog], .nextjs-error-overlay, #webpack-dev-server-client-overlay")).toHaveCount(0);
+  expect(errors).toEqual([]);
+});
+
+test("layout media upload tokens fail closed without an authenticated admin", async ({ request }) => {
+  const response = await request.post("/api/admin/layout-assets/upload", {
+    data: {
+      payload: {
+        clientPayload: JSON.stringify({
+          assetId: "aee694fd-a7fe-4895-b2e7-80d8b47466ee",
+          alt: "Test image",
+          contentType: "image/png",
+          height: 10,
+          sizeBytes: 100,
+          width: 10,
+        }),
+        multipart: false,
+        pathname: "layout-media/test.png",
+      },
+      type: "blob.generate-client-token",
+    },
+  });
+  expect(response.status()).toBe(403);
+  await expect(response.json()).resolves.toMatchObject({ error: expect.stringMatching(/sign in|required/i) });
+});

--- a/tests/e2e/workspace-layout.spec.ts
+++ b/tests/e2e/workspace-layout.spec.ts
@@ -22,13 +22,13 @@ test("public workspace uses the safe embedded layout and durable visitor cookie"
 
   const workspace = page.getByRole("region", { name: /Washington workspace/i });
   await expect(workspace).toBeVisible();
-  await expect(workspace.getByRole("button", { name: "Map", exact: true })).toBeVisible();
-  await expect(workspace.getByRole("button", { name: "Review Center", exact: true })).toBeVisible();
-  await expect(workspace.getByRole("button", { name: "Data & Sources", exact: true })).toBeVisible();
+  await expect(workspace.getByRole("tab", { name: "Map", exact: true })).toBeVisible();
+  await expect(workspace.getByRole("tab", { name: "Review Center", exact: true })).toBeVisible();
+  await expect(workspace.getByRole("tab", { name: "Data & Sources", exact: true })).toBeVisible();
   await workspace.getByRole("button", { name: /^Data Notes/ }).click();
   await expect(page.getByRole("heading", { name: "Data Notes", exact: true })).toBeVisible();
 
-  await workspace.getByRole("button", { name: "History", exact: true }).click();
+  await workspace.getByRole("tab", { name: "History", exact: true }).click();
   await expect(page).toHaveURL(/tab=history/);
   await expect(page.getByRole("heading", { name: "Historical Baselines", exact: true })).toBeVisible();
 


### PR DESCRIPTION
## What changed

- adds Workspace Builder v3 with responsive rows and columns, native drag-and-drop, desktop/tablet/mobile previews, design tokens, variants, visibility rules, templates, rich text, managed media, undo/redo, drafts, publishing, and revision history
- renders schema-v2 layouts on the public workspace while preserving schema-v1 compatibility
- adds the authenticated Vercel Blob upload route and persistent asset/template references
- adds Drizzle migration 0006 for schema-v2 constraints and layout asset/template tables
- expands the operator documentation and automated layout/e2e coverage

## Why

The prior editor primarily supported ordering and hiding tabs. This makes layout changes closer to editing the actual production composition and gives operators reusable, responsive controls without requiring a code deployment for each layout adjustment.

## Validation

- `npm run typecheck`
- `npm run test:layout`
- `npm run test:e2e` — 5 passed, including the critical Axe accessibility scan and unauthenticated upload policy
- `npm run build`
- `git diff --cached --check`

The broader `npm test` still contains the pre-existing Windows CRLF/LF failure in the deterministic Georgia historical-review CSV test; this change does not touch that data path.

## Deployment notes

- migration 0006 has been applied to the linked Neon database and its required tables, indexes, and schema-version constraints were verified
- a public Vercel Blob store named `civicresultmaps-layout-assets` is linked to production, preview, and development
- Builder image uploads remain restricted to authenticated allowlisted admins and validated PNG/JPEG/WebP/AVIF files up to 5 MB