### PR TITLE
Fix workspace builder preview and undo

### DIFF
--- a/src/app/admin/layout/layout-editor-v3.module.css
+++ b/src/app/admin/layout/layout-editor-v3.module.css
@@ -245,18 +245,83 @@
   margin: 0.14rem 0 0;
 }
 
+.canvasStage,
+.canvasFrame {
+  min-width: 0;
+  width: 100%;
+}
+
+.canvasFrame {
+  margin: 0 auto;
+}
+
+.canvasLabel {
+  background: #1f2220;
+  border: 1px solid #2c302e;
+  border-bottom: 0;
+  border-radius: 9px 9px 0 0;
+  color: #35c7a3;
+  display: inline-block;
+  font-size: 0.63rem;
+  font-weight: 850;
+  letter-spacing: 0.09em;
+  padding: 0.42rem 0.62rem;
+  text-transform: uppercase;
+}
+
+.compareGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(540px, 1fr));
+  min-width: 1100px;
+}
+
 .viewport {
-  --preview-scale: 1;
-  background: #f3f7f5;
-  border: 1px solid rgba(210, 235, 227, 0.23);
+  --preview-accent: #16a579;
+  --preview-background: #101112;
+  --preview-foreground: #f4f1ea;
+  --preview-line: #2c302e;
+  --preview-muted: #a9aaa4;
+  --preview-panel: #171918;
+  --preview-panel-strong: #1f2220;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--preview-accent) 5%, transparent), transparent 260px),
+    radial-gradient(circle at 15% 0%, rgba(240, 195, 106, 0.06), transparent 250px),
+    var(--preview-background);
+  border: 1px solid var(--preview-line);
   border-radius: 14px;
   box-shadow: 0 20px 70px rgba(0, 0, 0, 0.34);
-  color: #10211d;
+  color: var(--preview-foreground);
   margin: 0 auto;
   min-height: 650px;
   overflow: hidden;
   transition: max-width 180ms ease;
 }
+
+.viewport[data-layout-theme="warm"] {
+  --preview-panel: #211d18;
+  --preview-panel-strong: #2a241d;
+}
+
+.viewport[data-layout-theme="high-contrast"] {
+  --preview-line: #71817e;
+  --preview-muted: #d6dfdd;
+  --preview-panel: #070909;
+  --preview-panel-strong: #111616;
+}
+
+.viewport[data-layout-shadow="none"] .builderNode { box-shadow: none; }
+.viewport[data-layout-shadow="raised"] .builderNode { box-shadow: 0 12px 28px rgba(0, 0, 0, 0.32); }
+.viewport[data-layout-radius="square"] :is(.row, .column, .builderNode, .nodeToolbar, .mapSketch) { border-radius: 0; }
+.viewport[data-layout-radius="rounded"] :is(.row, .column, .builderNode, .mapSketch) { border-radius: 16px; }
+.viewport[data-layout-spacing="tight"] .rows { gap: 0.45rem; padding: 0.6rem; }
+.viewport[data-layout-spacing="relaxed"] .rows { gap: 1.15rem; padding: 1.35rem; }
+.viewport[data-layout-type-scale="small"] .nodePreview { font-size: 0.9em; }
+.viewport[data-layout-type-scale="large"] .nodePreview { font-size: 1.12em; }
+.viewport[data-layout-content-width="standard"] .rows { margin-inline: auto; max-width: 920px; }
+.viewport[data-layout-tab-style="pills"] .previewTabs { background: transparent; border: 0; gap: 0.35rem; padding-block: 0.4rem; }
+.viewport[data-layout-tab-style="pills"] .previewTabs span { border: 1px solid var(--preview-line); border-radius: 999px; padding: 0.38rem 0.55rem; }
+.viewport[data-layout-tab-style="pills"] .previewTabs .activePreviewTab { border-color: var(--preview-accent); }
 
 .desktop { max-width: 1180px; }
 .tablet { max-width: 760px; }
@@ -264,8 +329,9 @@
 
 .sitePreviewHeader {
   align-items: center;
-  background: #091815;
-  color: #eaf9f4;
+  background: rgba(16, 17, 18, 0.92);
+  border-bottom: 1px solid var(--preview-line);
+  color: var(--preview-foreground);
   display: flex;
   gap: 1rem;
   justify-content: space-between;
@@ -282,7 +348,7 @@
 
 .previewBrand > span {
   align-items: center;
-  background: #1bb082;
+  background: var(--preview-accent);
   border-radius: 8px;
   color: #061510;
   display: inline-flex;
@@ -290,22 +356,23 @@
   font-weight: 900;
   height: 28px;
   justify-content: center;
+  transition: background-color 120ms ease;
   width: 28px;
 }
 
 .previewMetrics {
-  color: #91aaa1;
+  color: var(--preview-muted);
   font-size: 0.62rem;
 }
 
 .previewMetrics strong {
-  color: #fff;
+  color: var(--preview-foreground);
   display: block;
 }
 
 .previewTabs {
-  background: #fff;
-  border-bottom: 1px solid #dbe5e1;
+  background: var(--preview-panel);
+  border-bottom: 1px solid var(--preview-line);
   overflow: hidden;
   padding: 0 0.85rem;
   white-space: nowrap;
@@ -313,14 +380,14 @@
 
 .previewTabs span {
   border-bottom: 2px solid transparent;
-  color: #65736f;
+  color: var(--preview-muted);
   font-size: 0.58rem;
   padding: 0.62rem 0.2rem;
 }
 
 .previewTabs .activePreviewTab {
-  border-color: #138d68;
-  color: #0a3d30;
+  border-color: var(--preview-accent);
+  color: var(--preview-accent);
   font-weight: 800;
 }
 
@@ -331,15 +398,20 @@
 }
 
 .row {
-  border: 1px dashed rgba(28, 111, 86, 0.36);
+  border: 1px dashed color-mix(in srgb, var(--preview-accent) 36%, transparent);
   border-radius: 10px;
   padding: 1.7rem 0.55rem 0.55rem;
   position: relative;
 }
 
+.viewport[data-read-only="true"] .row {
+  border-color: transparent;
+  padding: 0.55rem;
+}
+
 .row[data-selected="true"] {
-  border-color: #15956e;
-  box-shadow: 0 0 0 2px rgba(21, 149, 110, 0.1);
+  border-color: var(--preview-accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--preview-accent) 14%, transparent);
 }
 
 .rowControls {
@@ -352,7 +424,7 @@
 }
 
 .rowControls span {
-  color: #55736a;
+  color: var(--preview-muted);
   font-size: 0.57rem;
   font-weight: 800;
   margin-right: 0.2rem;
@@ -360,9 +432,9 @@
 }
 
 .rowControls button {
-  background: #edf4f1;
-  border-color: #d0ded9;
-  color: #315049;
+  background: var(--preview-panel-strong);
+  border-color: var(--preview-line);
+  color: var(--preview-foreground);
   font-size: 0.55rem;
   min-height: 20px;
   padding: 0.15rem 0.3rem;
@@ -391,23 +463,23 @@
 
 .column[data-empty="true"],
 .column[data-selected="true"] {
-  background: rgba(23, 135, 101, 0.035);
-  border-color: rgba(23, 135, 101, 0.25);
+  background: color-mix(in srgb, var(--preview-accent) 4%, transparent);
+  border-color: color-mix(in srgb, var(--preview-accent) 30%, transparent);
 }
 
 .builderNode {
-  background: #fff;
-  border: 1px solid #d4e1dc;
+  background: var(--preview-panel);
+  border: 1px solid var(--preview-line);
   border-radius: 9px;
-  box-shadow: 0 5px 16px rgba(25, 55, 46, 0.07);
+  box-shadow: 0 5px 16px rgba(0, 0, 0, 0.2);
   cursor: default;
   min-width: 0;
   overflow: hidden;
 }
 
 .builderNode[data-selected="true"] {
-  border-color: #0e9368;
-  box-shadow: 0 0 0 2px rgba(14, 147, 104, 0.17);
+  border-color: var(--preview-accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--preview-accent) 20%, transparent);
 }
 
 .builderNode[data-visible="false"] {
@@ -416,9 +488,9 @@
 
 .nodeToolbar {
   align-items: center;
-  background: #edf5f2;
-  border-bottom: 1px solid #d9e7e2;
-  color: #527068;
+  background: var(--preview-panel-strong);
+  border-bottom: 1px solid var(--preview-line);
+  color: var(--preview-muted);
   display: flex;
   font-size: 0.56rem;
   gap: 0.35rem;
@@ -432,7 +504,7 @@
 .nodeToolbar button {
   background: transparent;
   border: 0;
-  color: #3b5f55;
+  color: var(--preview-muted);
   cursor: pointer;
   display: inline-flex;
   padding: 0.1rem;
@@ -446,14 +518,14 @@
 }
 
 .nodePreview > strong {
-  color: #16352d;
+  color: var(--preview-foreground);
   display: block;
   font-size: 0.7rem;
   margin-bottom: 0.4rem;
 }
 
 .nodePreview p {
-  color: #597069;
+  color: var(--preview-muted);
   font-size: 0.62rem;
   line-height: 1.45;
   margin: 0;
@@ -469,7 +541,8 @@
 }
 
 .mapSketch {
-  background: linear-gradient(145deg, #d8eee5, #c6ded7);
+  background: linear-gradient(145deg, var(--preview-panel-strong), var(--preview-background));
+  border: 1px solid var(--preview-line);
   border-radius: 7px;
   height: 140px;
   overflow: hidden;
@@ -477,14 +550,15 @@
 }
 
 .mapSketch span {
-  background: rgba(18, 142, 104, 0.7);
+  background: color-mix(in srgb, var(--preview-accent) 78%, transparent);
   clip-path: polygon(9% 8%, 82% 0, 100% 43%, 73% 100%, 18% 83%, 0 41%);
   inset: 18% 22%;
   position: absolute;
+  transition: background-color 120ms ease;
 }
 
 .mapSketch i {
-  background: #fff;
+  background: var(--preview-foreground);
   border-radius: 999px;
   height: 8px;
   position: absolute;
@@ -503,7 +577,7 @@
 
 .textSketch span,
 .metricSketch b {
-  background: #dce8e4;
+  background: var(--preview-panel-strong);
   border-radius: 999px;
   display: block;
   height: 5px;
@@ -513,7 +587,7 @@
 .textSketch span:nth-child(3) { width: 52%; }
 
 .metricSketch span {
-  color: #648078;
+  color: var(--preview-muted);
   font-size: 0.55rem;
 }
 
@@ -527,9 +601,10 @@
 }
 
 .pillSketch span {
-  background: #e3efeb;
+  background: color-mix(in srgb, var(--preview-accent) 14%, var(--preview-panel));
+  border: 1px solid color-mix(in srgb, var(--preview-accent) 32%, transparent);
   border-radius: 999px;
-  color: #3a5c52;
+  color: var(--preview-accent);
   font-size: 0.5rem;
   padding: 0.24rem 0.38rem;
 }
@@ -538,7 +613,7 @@
 .emptyColumn,
 .emptyCanvas {
   align-items: center;
-  color: #6a817a;
+  color: var(--preview-muted);
   display: flex;
   flex-direction: column;
   font-size: 0.6rem;

--- a/src/app/admin/layout/layout-editor-v3.tsx
+++ b/src/app/admin/layout/layout-editor-v3.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronRight,
+  Columns2,
   Columns3,
   Copy,
   Eye,
@@ -66,6 +67,14 @@ import {
   type WorkspaceVisibilityConditionV1,
 } from "@/lib/workspace-layout-v2";
 import type { WorkspaceTabId } from "@/lib/workspace-layout";
+import {
+  closeWorkspaceLayoutHistoryGroup,
+  commitWorkspaceLayoutHistory,
+  createWorkspaceLayoutHistory,
+  redoWorkspaceLayoutHistory,
+  undoWorkspaceLayoutHistory,
+} from "@/lib/workspace-layout-history";
+import type { BuilderCompareMode } from "./layout-builder-types";
 import styles from "./layout-editor-v3.module.css";
 
 export type LayoutRevisionSummary = {
@@ -155,11 +164,12 @@ export function LayoutEditor({
   revisions,
   templates,
 }: LayoutEditorProps) {
-  const [history, setHistory] = useState(() => ({ entries: [cloneWorkspaceLayoutManifestV2(baseManifest)], index: 0 }));
+  const [history, setHistory] = useState(() => createWorkspaceLayoutHistory(baseManifest));
   const manifest = history.entries[history.index];
   const [activeTabId, setActiveTabId] = useState<WorkspaceTabId>(() => manifest.settings.defaultTab);
   const [selection, setSelection] = useState<Selection>({ kind: "workspace" });
   const [viewport, setViewport] = useState<Viewport>("desktop");
+  const [compareMode, setCompareMode] = useState<BuilderCompareMode>("draft");
   const [changeSummary, setChangeSummary] = useState("");
   const [environment, setEnvironment] = useState<"preview" | "production">("preview");
   const [selectedRevisionId, setSelectedRevisionId] = useState(parentRevisionId ?? revisions[0]?.id ?? "");
@@ -184,13 +194,11 @@ export function LayoutEditor({
     : undefined;
   const allAssets = [...sessionAssets, ...assets.filter((asset) => !sessionAssets.some((item) => item.id === asset.id))];
 
-  function commit(updater: (current: WorkspaceLayoutManifestV2) => WorkspaceLayoutManifestV2) {
-    setHistory((current) => {
-      const present = current.entries[current.index];
-      const next = updater(cloneWorkspaceLayoutManifestV2(present));
-      if (JSON.stringify(next) === JSON.stringify(present)) return current;
-      return { entries: [...current.entries.slice(0, current.index + 1), next], index: current.index + 1 };
-    });
+  function commit(
+    updater: (current: WorkspaceLayoutManifestV2) => WorkspaceLayoutManifestV2,
+    groupKey?: string,
+  ) {
+    setHistory((current) => commitWorkspaceLayoutHistory(current, updater, groupKey));
   }
 
   function updateTab(tabId: WorkspaceTabId, updater: (tab: WorkspaceLayoutTabV2) => WorkspaceLayoutTabV2) {
@@ -363,10 +371,10 @@ export function LayoutEditor({
     <section className={styles.editor}>
       <header className={styles.toolbar}>
         <div className={styles.toolbarGroup}>
-          <button disabled={history.index === 0} onClick={() => setHistory((current) => ({ ...current, index: current.index - 1 }))} type="button"><Undo2 size={16} /> Undo</button>
-          <button disabled={history.index === history.entries.length - 1} onClick={() => setHistory((current) => ({ ...current, index: current.index + 1 }))} type="button"><Redo2 size={16} /> Redo</button>
+          <button disabled={history.index === 0} onClick={() => setHistory(undoWorkspaceLayoutHistory)} type="button"><Undo2 size={16} /> Undo</button>
+          <button disabled={history.index === history.entries.length - 1} onClick={() => setHistory(redoWorkspaceLayoutHistory)} type="button"><Redo2 size={16} /> Redo</button>
           <button disabled={!dirty} onClick={() => {
-            setHistory({ entries: [cloneWorkspaceLayoutManifestV2(baseManifest)], index: 0 });
+            setHistory(createWorkspaceLayoutHistory(baseManifest));
             setSelection({ kind: "workspace" });
           }} type="button"><RotateCcw size={16} /> Reset</button>
         </div>
@@ -375,6 +383,11 @@ export function LayoutEditor({
             const Icon = mode === "desktop" ? Laptop : mode === "tablet" ? Tablet : Smartphone;
             return <button aria-pressed={viewport === mode} key={mode} onClick={() => setViewport(mode)} type="button"><Icon size={16} /><span>{mode}</span></button>;
           })}
+        </div>
+        <div aria-label="Comparison mode" className={styles.segmented} role="group">
+          <button aria-pressed={compareMode === "baseline"} onClick={() => setCompareMode("baseline")} type="button">Before</button>
+          <button aria-pressed={compareMode === "draft"} onClick={() => setCompareMode("draft")} type="button">After</button>
+          <button aria-pressed={compareMode === "split"} onClick={() => setCompareMode("split")} type="button"><Columns2 size={16} /> Compare</button>
         </div>
         <div className={styles.toolbarStatus}>
           <span>{dirty ? "Unsaved changes" : "Up to date"}</span>
@@ -437,74 +450,89 @@ export function LayoutEditor({
         <main className={styles.stage}>
           <div className={styles.stageHeader}>
             <div><span>Live-layout preview</span><h2>{workspaceLayoutRegistryV2.find((tab) => tab.id === activeTabId)?.label}</h2></div>
-            <button onClick={addRow} type="button"><Plus size={15} /> Add row</button>
+            <button disabled={compareMode === "baseline"} onClick={addRow} type="button"><Plus size={15} /> Add row</button>
           </div>
-          <div className={`${styles.viewport} ${styles[viewport]}`} data-layout-accent={manifest.settings.accentColor} data-layout-theme={manifest.settings.theme}>
-            <div className={styles.sitePreviewHeader}>
-              <div className={styles.previewBrand}><span>CR</span><strong>Civic Result Maps</strong></div>
-              <div className={styles.previewMetrics}><span>Jurisdictions <strong>39</strong></span><span>Sources <strong>12</strong></span><span>Validation <strong>Pass</strong></span></div>
-            </div>
-            <div className={styles.previewTabs}>{manifest.tabs.filter((tab) => tab.visible).map((tab) => <span className={tab.id === activeTabId ? styles.activePreviewTab : ""} key={tab.id}>{workspaceLayoutRegistryV2.find((item) => item.id === tab.id)?.label}</span>)}</div>
-            <div className={styles.rows}>
-              {activeTab.rows.map((row, rowIndex) => (
-                <section
-                  aria-label={`Layout row ${rowIndex + 1}`}
-                  className={styles.row}
-                  data-selected={selection.kind === "row" && selection.rowId === row.id}
-                  key={row.id}
-                  onClick={() => setSelection({ kind: "row", rowId: row.id, tabId: activeTabId })}
-                  onKeyDown={(event) => { if (event.key === "Enter" || event.key === " ") setSelection({ kind: "row", rowId: row.id, tabId: activeTabId }); }}
-                  tabIndex={0}
-                >
-                  <div className={styles.rowControls}>
-                    <span>Row {rowIndex + 1}</span>
-                    <button aria-label="Move row up" disabled={rowIndex === 0} onClick={(event) => { event.stopPropagation(); moveRow(row.id, -1); }} type="button"><ArrowUp size={13} /></button>
-                    <button aria-label="Move row down" disabled={rowIndex === activeTab.rows.length - 1} onClick={(event) => { event.stopPropagation(); moveRow(row.id, 1); }} type="button"><ArrowDown size={13} /></button>
-                    <button onClick={(event) => { event.stopPropagation(); addColumn(row.id); }} type="button"><Columns3 size={13} /> Column</button>
-                  </div>
-                  <div className={styles.columns} data-gap={row.gap ?? "medium"}>
-                    {row.columns.map((column) => (
-                      <div
-                        aria-label={`Column ${column.id.slice(-4)}`}
-                        className={styles.column}
-                        data-empty={column.items.length === 0}
-                        data-selected={(selection.kind === "column" || selection.kind === "node") && selection.columnId === column.id}
-                        key={column.id}
-                        onClick={(event) => { event.stopPropagation(); setSelection({ columnId: column.id, kind: "column", rowId: row.id, tabId: activeTabId }); }}
-                        onDragOver={(event) => event.preventDefault()}
-                        onDrop={(event) => {
-                          event.preventDefault();
-                          if (draggedNodeId) moveNode(draggedNodeId, column.id);
-                          setDraggedNodeId(null);
-                        }}
-                        onKeyDown={(event) => { if (event.key === "Enter" || event.key === " ") setSelection({ columnId: column.id, kind: "column", rowId: row.id, tabId: activeTabId }); }}
-                        style={{ "--builder-span": column.span[viewport] } as CSSProperties}
-                        tabIndex={0}
-                      >
-                        {column.items.map((node) => (
-                          <BuilderNode
-                            key={node.id}
-                            node={node}
-                            onDragEnd={() => setDraggedNodeId(null)}
-                            onDragStart={() => setDraggedNodeId(node.id)}
-                            onSelect={() => setSelection({ columnId: column.id, kind: "node", nodeId: node.id, rowId: row.id, tabId: activeTabId })}
-                            selected={selection.kind === "node" && selection.nodeId === node.id}
-                          />
-                        ))}
-                        {!column.items.length && <button className={styles.emptyColumn} onClick={(event) => { event.stopPropagation(); addBlock("rich-text", { columnId: column.id, rowId: row.id }); }} type="button"><Plus size={15} /> Drop or add content</button>}
-                      </div>
-                    ))}
-                  </div>
-                </section>
-              ))}
-              {!activeTab.rows.length && <button className={styles.emptyCanvas} onClick={addRow} type="button"><Plus /> Add the first row</button>}
-            </div>
+          <div className={compareMode === "split" ? styles.compareGrid : styles.canvasStage}>
+            {compareMode === "baseline" && (
+              <BuilderCanvas
+                activeTabId={activeTabId}
+                draggedNodeId={draggedNodeId}
+                label="Before - saved revision"
+                manifest={baseManifest}
+                onAddBlock={addBlock}
+                onAddColumn={addColumn}
+                onAddRow={addRow}
+                onMoveNode={moveNode}
+                onMoveRow={moveRow}
+                onSelect={setSelection}
+                onSetDraggedNodeId={setDraggedNodeId}
+                readOnly
+                selection={selection}
+                viewport={viewport}
+              />
+            )}
+            {compareMode === "draft" && (
+              <BuilderCanvas
+                activeTabId={activeTabId}
+                draggedNodeId={draggedNodeId}
+                label="After - current draft"
+                manifest={manifest}
+                onAddBlock={addBlock}
+                onAddColumn={addColumn}
+                onAddRow={addRow}
+                onMoveNode={moveNode}
+                onMoveRow={moveRow}
+                onSelect={setSelection}
+                onSetDraggedNodeId={setDraggedNodeId}
+                selection={selection}
+                viewport={viewport}
+              />
+            )}
+            {compareMode === "split" && (
+              <>
+                <BuilderCanvas
+                  activeTabId={activeTabId}
+                  draggedNodeId={draggedNodeId}
+                  label="Before"
+                  manifest={baseManifest}
+                  onAddBlock={addBlock}
+                  onAddColumn={addColumn}
+                  onAddRow={addRow}
+                  onMoveNode={moveNode}
+                  onMoveRow={moveRow}
+                  onSelect={setSelection}
+                  onSetDraggedNodeId={setDraggedNodeId}
+                  readOnly
+                  selection={selection}
+                  viewport={viewport}
+                />
+                <BuilderCanvas
+                  activeTabId={activeTabId}
+                  draggedNodeId={draggedNodeId}
+                  label="After"
+                  manifest={manifest}
+                  onAddBlock={addBlock}
+                  onAddColumn={addColumn}
+                  onAddRow={addRow}
+                  onMoveNode={moveNode}
+                  onMoveRow={moveRow}
+                  onSelect={setSelection}
+                  onSetDraggedNodeId={setDraggedNodeId}
+                  selection={selection}
+                  viewport={viewport}
+                />
+              </>
+            )}
           </div>
         </main>
 
         <aside className={styles.inspector}>
           <div className={styles.inspectorHeader}><Settings2 size={17} /><div><span>Configure</span><strong>{selectionLabel(selection, selectedNode)}</strong></div><button aria-label="Inspect workspace" onClick={() => setSelection({ kind: "workspace" })} type="button"><X size={15} /></button></div>
-          {selection.kind === "workspace" && <WorkspaceInspector manifest={manifest} onChange={(settings) => commit((current) => ({ ...current, settings }))} />}
+          {selection.kind === "workspace" && <WorkspaceInspector
+            manifest={manifest}
+            onChange={(settings, groupKey) => commit((current) => ({ ...current, settings }), groupKey)}
+            onFinishChange={() => setHistory(closeWorkspaceLayoutHistoryGroup)}
+          />}
           {selection.kind === "tab" && <TabInspector tab={activeTab} required={workspaceLayoutRegistryV2.find((tab) => tab.id === activeTab.id)?.required ?? false} onChange={(tab) => updateTab(activeTab.id, () => tab)} />}
           {selection.kind === "row" && selectedRow && <RowInspector row={selectedRow} onChange={(row) => updateRow(row.id, () => row)} />}
           {selection.kind === "column" && selectedColumn && <ColumnInspector column={selectedColumn} viewport={viewport} onChange={(column) => updateRow(selection.rowId, (row) => ({ ...row, columns: row.columns.map((item) => item.id === column.id ? column : item) }))} />}
@@ -574,22 +602,164 @@ export function LayoutEditor({
   );
 }
 
-function BuilderNode({ node, onDragEnd, onDragStart, onSelect, selected }: {
+type BuilderCanvasProps = {
+  activeTabId: WorkspaceTabId;
+  draggedNodeId: string | null;
+  label: string;
+  manifest: WorkspaceLayoutManifestV2;
+  onAddBlock: (component: WorkspaceCustomBlockKindV2, destination?: { columnId: string; rowId: string }) => void;
+  onAddColumn: (rowId: string) => void;
+  onAddRow: () => void;
+  onMoveNode: (nodeId: string, destinationColumnId: string) => void;
+  onMoveRow: (rowId: string, delta: -1 | 1) => void;
+  onSelect: (selection: Selection) => void;
+  onSetDraggedNodeId: (nodeId: string | null) => void;
+  readOnly?: boolean;
+  selection: Selection;
+  viewport: Viewport;
+};
+
+function BuilderCanvas({
+  activeTabId,
+  draggedNodeId,
+  label,
+  manifest,
+  onAddBlock,
+  onAddColumn,
+  onAddRow,
+  onMoveNode,
+  onMoveRow,
+  onSelect,
+  onSetDraggedNodeId,
+  readOnly = false,
+  selection,
+  viewport,
+}: BuilderCanvasProps) {
+  const activeTab = manifest.tabs.find((tab) => tab.id === activeTabId) ?? manifest.tabs[0];
+  const previewStyle = {
+    "--preview-accent": manifest.settings.accentColor ?? "#16a579",
+  } as CSSProperties;
+
+  return (
+    <section className={styles.canvasFrame}>
+      <span className={styles.canvasLabel}>{label}</span>
+      <div
+        aria-label={`${label}, ${workspaceLayoutRegistryV2.find((tab) => tab.id === activeTab.id)?.label ?? activeTab.id} preview`}
+        className={`${styles.viewport} ${styles[viewport]}`}
+        data-layout-content-width={manifest.settings.contentWidth}
+        data-layout-radius={manifest.settings.radius}
+        data-layout-shadow={manifest.settings.shadow}
+        data-layout-spacing={manifest.settings.spacingScale}
+        data-layout-tab-style={manifest.settings.tabStyle}
+        data-layout-theme={manifest.settings.theme}
+        data-layout-type-scale={manifest.settings.typeScale}
+        data-read-only={readOnly}
+        role="region"
+        style={previewStyle}
+      >
+        <div className={styles.sitePreviewHeader}>
+          <div className={styles.previewBrand}><span>CR</span><strong>Civic Result Maps</strong></div>
+          <div className={styles.previewMetrics}><span>Jurisdictions <strong>39</strong></span><span>Sources <strong>12</strong></span><span>Validation <strong>Pass</strong></span></div>
+        </div>
+        <div className={styles.previewTabs}>{manifest.tabs.filter((tab) => tab.visible).map((tab) => <span className={tab.id === activeTabId ? styles.activePreviewTab : ""} key={tab.id}>{workspaceLayoutRegistryV2.find((item) => item.id === tab.id)?.label}</span>)}</div>
+        <div className={styles.rows}>
+          {activeTab.rows.map((row, rowIndex) => (
+            <section
+              aria-label={`Layout row ${rowIndex + 1}`}
+              className={styles.row}
+              data-selected={!readOnly && selection.kind === "row" && selection.rowId === row.id}
+              key={row.id}
+              onClick={readOnly ? undefined : () => onSelect({ kind: "row", rowId: row.id, tabId: activeTabId })}
+              onKeyDown={readOnly ? undefined : (event) => {
+                if (event.key === "Enter" || event.key === " ") onSelect({ kind: "row", rowId: row.id, tabId: activeTabId });
+              }}
+              tabIndex={readOnly ? undefined : 0}
+            >
+              {!readOnly && <div className={styles.rowControls}>
+                <span>Row {rowIndex + 1}</span>
+                <button aria-label="Move row up" disabled={rowIndex === 0} onClick={(event) => { event.stopPropagation(); onMoveRow(row.id, -1); }} type="button"><ArrowUp size={13} /></button>
+                <button aria-label="Move row down" disabled={rowIndex === activeTab.rows.length - 1} onClick={(event) => { event.stopPropagation(); onMoveRow(row.id, 1); }} type="button"><ArrowDown size={13} /></button>
+                <button onClick={(event) => { event.stopPropagation(); onAddColumn(row.id); }} type="button"><Columns3 size={13} /> Column</button>
+              </div>}
+              <div className={styles.columns} data-gap={row.gap ?? "medium"}>
+                {row.columns.map((column) => (
+                  <div
+                    aria-label={`Column ${column.id.slice(-4)}`}
+                    className={styles.column}
+                    data-empty={column.items.length === 0}
+                    data-selected={!readOnly && (selection.kind === "column" || selection.kind === "node") && selection.columnId === column.id}
+                    key={column.id}
+                    onClick={readOnly ? undefined : (event) => {
+                      event.stopPropagation();
+                      onSelect({ columnId: column.id, kind: "column", rowId: row.id, tabId: activeTabId });
+                    }}
+                    onDragOver={readOnly ? undefined : (event) => event.preventDefault()}
+                    onDrop={readOnly ? undefined : (event) => {
+                      event.preventDefault();
+                      if (draggedNodeId) onMoveNode(draggedNodeId, column.id);
+                      onSetDraggedNodeId(null);
+                    }}
+                    onKeyDown={readOnly ? undefined : (event) => {
+                      if (event.key === "Enter" || event.key === " ") onSelect({ columnId: column.id, kind: "column", rowId: row.id, tabId: activeTabId });
+                    }}
+                    style={{ "--builder-span": column.span[viewport] } as CSSProperties}
+                    tabIndex={readOnly ? undefined : 0}
+                  >
+                    {column.items.map((node) => (
+                      <BuilderNode
+                        key={node.id}
+                        node={node}
+                        onDragEnd={() => onSetDraggedNodeId(null)}
+                        onDragStart={() => onSetDraggedNodeId(node.id)}
+                        onSelect={() => onSelect({ columnId: column.id, kind: "node", nodeId: node.id, rowId: row.id, tabId: activeTabId })}
+                        readOnly={readOnly}
+                        selected={!readOnly && selection.kind === "node" && selection.nodeId === node.id}
+                      />
+                    ))}
+                    {!column.items.length && (readOnly
+                      ? <div className={styles.emptyColumn}>Empty column</div>
+                      : <button className={styles.emptyColumn} onClick={(event) => { event.stopPropagation(); onAddBlock("rich-text", { columnId: column.id, rowId: row.id }); }} type="button"><Plus size={15} /> Drop or add content</button>)}
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+          {!activeTab.rows.length && (readOnly
+            ? <div className={styles.emptyCanvas}>No rows in this tab</div>
+            : <button className={styles.emptyCanvas} onClick={onAddRow} type="button"><Plus /> Add the first row</button>)}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function BuilderNode({ node, onDragEnd, onDragStart, onSelect, readOnly = false, selected }: {
   node: WorkspaceLayoutNodeV2;
   onDragEnd: () => void;
   onDragStart: () => void;
   onSelect: () => void;
+  readOnly?: boolean;
   selected: boolean;
 }) {
   const label = isWorkspaceProductionNodeV2(node) ? productionLabel(node) : customLabel(node);
   return (
-    <article className={styles.builderNode} data-kind={node.kind} data-selected={selected} data-visible={node.visible} draggable onDragEnd={onDragEnd} onDragStart={onDragStart} onClick={(event) => { event.stopPropagation(); onSelect(); }}>
-      <div className={styles.nodeToolbar}>
+    <article
+      className={styles.builderNode}
+      data-kind={node.kind}
+      data-read-only={readOnly}
+      data-selected={selected}
+      data-visible={node.visible}
+      draggable={!readOnly}
+      onClick={readOnly ? undefined : (event) => { event.stopPropagation(); onSelect(); }}
+      onDragEnd={readOnly ? undefined : onDragEnd}
+      onDragStart={readOnly ? undefined : onDragStart}
+    >
+      {!readOnly && <div className={styles.nodeToolbar}>
         <button aria-label={`Drag ${label}`} className={styles.dragHandle} type="button"><GripVertical size={16} /></button>
         <span>{node.kind === "production" ? "Production" : "Content"}</span>
         {!node.visible && <EyeOff size={13} />}
         <button aria-label={`Configure ${label}`} onClick={onSelect} type="button"><Settings2 size={15} /></button>
-      </div>
+      </div>}
       <div className={styles.nodePreview}>
         <strong>{label}</strong>
         {isWorkspaceProductionNodeV2(node) ? <ProductionSketch node={node} /> : <CustomSketch node={node} />}
@@ -613,9 +783,13 @@ function CustomSketch({ node }: { node: WorkspaceCustomNodeV2 }) {
   return <p>{node.body || node.document?.blocks[0]?.children.map((child) => child.text).join("") || "Configure this content with the gear."}</p>;
 }
 
-function WorkspaceInspector({ manifest, onChange }: { manifest: WorkspaceLayoutManifestV2; onChange: (settings: WorkspaceLayoutManifestV2["settings"]) => void }) {
+function WorkspaceInspector({ manifest, onChange, onFinishChange }: {
+  manifest: WorkspaceLayoutManifestV2;
+  onChange: (settings: WorkspaceLayoutManifestV2["settings"], groupKey?: string) => void;
+  onFinishChange: () => void;
+}) {
   const settings = manifest.settings;
-  const update = <K extends keyof typeof settings>(key: K, value: typeof settings[K]) => onChange({ ...settings, [key]: value });
+  const update = <K extends keyof typeof settings>(key: K, value: typeof settings[K], groupKey?: string) => onChange({ ...settings, [key]: value }, groupKey);
   return <div className={styles.inspectorBody}>
     <fieldset><legend>Design system</legend>
       <Select label="Theme" value={settings.theme} onChange={(value) => update("theme", value as typeof settings.theme)} options={["civic", "warm", "high-contrast"]} />
@@ -625,7 +799,7 @@ function WorkspaceInspector({ manifest, onChange }: { manifest: WorkspaceLayoutM
       <Select label="Corners" value={settings.radius} onChange={(value) => update("radius", value as typeof settings.radius)} options={["square", "subtle", "rounded"]} />
       <Select label="Shadows" value={settings.shadow} onChange={(value) => update("shadow", value as typeof settings.shadow)} options={["none", "subtle", "raised"]} />
       <Select label="Tab style" value={settings.tabStyle} onChange={(value) => update("tabStyle", value as typeof settings.tabStyle)} options={["bar", "pills"]} />
-      <label>Accent color<input aria-label="Accent color" type="color" value={settings.accentColor ?? "#18a77a"} onChange={(event) => update("accentColor", event.target.value)} /></label>
+      <label>Accent color<input aria-label="Accent color" type="color" value={settings.accentColor ?? "#16a579"} onBlur={onFinishChange} onChange={(event) => update("accentColor", event.target.value, "workspace:accent-color")} /></label>
     </fieldset>
     <fieldset><legend>Defaults</legend>
       <Select label="Default tab" value={settings.defaultTab} onChange={(value) => update("defaultTab", value as WorkspaceTabId)} options={manifest.tabs.filter((tab) => tab.visible).map((tab) => tab.id)} />

--- a/src/lib/workspace-layout-history.ts
+++ b/src/lib/workspace-layout-history.ts
@@ -1,0 +1,73 @@
+import {
+  cloneWorkspaceLayoutManifestV2,
+  type WorkspaceLayoutManifestV2,
+} from "./workspace-layout-v2.ts";
+
+export type WorkspaceLayoutHistory = {
+  entries: WorkspaceLayoutManifestV2[];
+  groupKey: string | null;
+  index: number;
+};
+
+export function createWorkspaceLayoutHistory(
+  manifest: WorkspaceLayoutManifestV2,
+): WorkspaceLayoutHistory {
+  return {
+    entries: [cloneWorkspaceLayoutManifestV2(manifest)],
+    groupKey: null,
+    index: 0,
+  };
+}
+
+export function commitWorkspaceLayoutHistory(
+  history: WorkspaceLayoutHistory,
+  updater: (manifest: WorkspaceLayoutManifestV2) => WorkspaceLayoutManifestV2,
+  groupKey?: string,
+): WorkspaceLayoutHistory {
+  const present = history.entries[history.index];
+  const next = updater(cloneWorkspaceLayoutManifestV2(present));
+  if (JSON.stringify(next) === JSON.stringify(present)) return history;
+
+  const entries = history.entries.slice(0, history.index + 1);
+  if (
+    groupKey
+    && history.groupKey === groupKey
+    && history.index > 0
+    && history.index === history.entries.length - 1
+  ) {
+    entries[history.index] = next;
+    return { entries, groupKey, index: history.index };
+  }
+
+  return {
+    entries: [...entries, next],
+    groupKey: groupKey ?? null,
+    index: entries.length,
+  };
+}
+
+export function closeWorkspaceLayoutHistoryGroup(
+  history: WorkspaceLayoutHistory,
+): WorkspaceLayoutHistory {
+  return history.groupKey ? { ...history, groupKey: null } : history;
+}
+
+export function undoWorkspaceLayoutHistory(
+  history: WorkspaceLayoutHistory,
+): WorkspaceLayoutHistory {
+  return {
+    ...history,
+    groupKey: null,
+    index: Math.max(0, history.index - 1),
+  };
+}
+
+export function redoWorkspaceLayoutHistory(
+  history: WorkspaceLayoutHistory,
+): WorkspaceLayoutHistory {
+  return {
+    ...history,
+    groupKey: null,
+    index: Math.min(history.entries.length - 1, history.index + 1),
+  };
+}

--- a/tests/api/workspace-layout-admin-policy.test.mjs
+++ b/tests/api/workspace-layout-admin-policy.test.mjs
@@ -84,8 +84,15 @@ test("builder v3 exposes responsive rows, rich content, media, and publication c
   assert.match(editor, /layout-media\//);
   assert.match(editor, /name="publicationAction"/);
   assert.match(editor, /VisibilityInspector/);
+  assert.match(editor, /aria-label="Comparison mode"/);
+  assert.match(editor, /Before - saved revision/);
+  assert.match(editor, /workspace:accent-color/);
+  assert.match(editor, /--preview-accent/);
   assert.match(richText, /LexicalComposer/);
   assert.match(runtime, /workspaceCustomRowsV2/);
   assert.match(css, /\.columns/);
+  assert.match(css, /--preview-background: #101112/);
+  assert.match(css, /var\(--preview-accent\)/);
+  assert.match(css, /\.compareGrid/);
   assert.match(css, /\.inspector/);
 });

--- a/tests/api/workspace-layout-v2.test.mjs
+++ b/tests/api/workspace-layout-v2.test.mjs
@@ -12,6 +12,13 @@ import {
 } from "../../src/lib/workspace-layout-v2.ts";
 import { embeddedWorkspaceLayoutManifest } from "../../src/lib/workspace-layout.ts";
 import {
+  closeWorkspaceLayoutHistoryGroup,
+  commitWorkspaceLayoutHistory,
+  createWorkspaceLayoutHistory,
+  redoWorkspaceLayoutHistory,
+  undoWorkspaceLayoutHistory,
+} from "../../src/lib/workspace-layout-history.ts";
+import {
   createWorkspaceLayoutEnvelope,
   validateWorkspaceLayoutEnvelope,
 } from "../../src/lib/workspace-layout-digest.ts";
@@ -19,6 +26,37 @@ import {
   workspaceCustomRowsV2,
   workspaceSectionStateV2,
 } from "../../src/lib/workspace-layout-v2-runtime.ts";
+
+test("continuous color updates are one undoable history action", () => {
+  let history = createWorkspaceLayoutHistory(embeddedWorkspaceLayoutManifestV2);
+  history = commitWorkspaceLayoutHistory(history, (manifest) => ({
+    ...manifest,
+    settings: { ...manifest.settings, accentColor: "#123456" },
+  }), "workspace:accent-color");
+  history = commitWorkspaceLayoutHistory(history, (manifest) => ({
+    ...manifest,
+    settings: { ...manifest.settings, accentColor: "#abcdef" },
+  }), "workspace:accent-color");
+
+  assert.equal(history.entries.length, 2);
+  assert.equal(history.index, 1);
+  assert.equal(history.entries[history.index].settings.accentColor, "#abcdef");
+
+  history = closeWorkspaceLayoutHistoryGroup(history);
+  history = undoWorkspaceLayoutHistory(history);
+  assert.equal(history.index, 0);
+  assert.equal(history.entries[history.index].settings.accentColor, undefined);
+
+  history = redoWorkspaceLayoutHistory(history);
+  assert.equal(history.index, 1);
+  assert.equal(history.entries[history.index].settings.accentColor, "#abcdef");
+
+  history = commitWorkspaceLayoutHistory(history, (manifest) => ({
+    ...manifest,
+    settings: { ...manifest.settings, accentColor: "#fedcba" },
+  }), "workspace:accent-color");
+  assert.equal(history.entries.length, 3);
+});
 
 test("the embedded v2 manifest and every starter template are structurally valid", () => {
   assert.equal(validateWorkspaceLayoutManifestV2(embeddedWorkspaceLayoutManifestV2).ok, true);


### PR DESCRIPTION
## What changed

- restores the **Before**, **After**, and **Compare** workspace-builder modes
- makes the saved **Before** canvas read-only while keeping the draft canvas editable
- aligns the builder preview with the live site's civic background, panel, border, foreground, and muted color tokens
- wires the selected accent color into the preview so tabs, highlights, map fixtures, and pills update immediately
- coalesces native color-picker updates into one history transaction so a single Undo restores the prior accent and field value
- adds focused history and builder-surface regression coverage

## Root cause

Builder v3 dropped the comparison toolbar while replacing the v2 canvas. Its accent was rendered only as a data attribute that no CSS rule consumed. The color input also committed every intermediate native color-picker event as a separate history entry, making Undo appear endless and ineffective.

## User impact

The preview now matches production's dark civic surfaces, accent edits are immediately visible, one color edit takes one Undo, and operators can compare saved versus draft layouts again.

## Validation

- `npm run typecheck`
- `npm run test:layout`
- `npm run test:e2e` — 5 passed
- `npm run build`
- `git diff --check`

The broader `npm test` reaches a pre-existing Windows CRLF/LF mismatch in the deterministic Georgia historical-review CSV test. This hotfix does not touch that data path.