### PR TITLE
Fix workspace content-block deletion

### DIFF
--- a/src/app/admin/layout/layout-editor-v4-canvas.tsx
+++ b/src/app/admin/layout/layout-editor-v4-canvas.tsx
@@ -9,6 +9,7 @@ import {
   LockKeyhole,
   Plus,
   Settings2,
+  Trash2,
 } from "lucide-react";
 import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
 import type { WorkspaceTabId } from "@/lib/workspace-layout";
@@ -35,6 +36,7 @@ import styles from "./layout-editor-v4.module.css";
 type CanvasCallbacks = {
   onAddColumn: (rowId: string) => void;
   onAddRow: (groupId: string) => void;
+  onRemoveNode: (nodeId: string) => void;
   onResizeColumn: (columnId: string, delta: -1 | 1) => void;
   onSelect: (selection: LayoutSelection, event?: ReactMouseEvent) => void;
 };
@@ -164,6 +166,7 @@ export function LayoutV4Canvas({
   manifest,
   onAddColumn,
   onAddRow,
+  onRemoveNode,
   onResizeColumn,
   onSelect,
   readOnly = false,
@@ -220,7 +223,7 @@ export function LayoutV4Canvas({
         <div className={base.rows}>
           {tab.groups.map((group, groupIndex) => (
             <SortableGroup
-              callbacks={{ onAddColumn, onAddRow, onResizeColumn, onSelect }}
+              callbacks={{ onAddColumn, onAddRow, onRemoveNode, onResizeColumn, onSelect }}
               group={group}
               index={groupIndex}
               key={group.id}
@@ -499,6 +502,18 @@ function SortableNode({
           {!node.visible && <EyeOff size={13} />}
           {locked && <LockKeyhole size={12} />}
           <button aria-label={`Configure ${label}`} onClick={(event) => callbacks.onSelect({ columnId: column.id, groupId: group.id, kind: "node", nodeId: node.id, rowId: row.id, tabId }, event)} type="button"><Settings2 size={15} /></button>
+          {node.kind === "custom" && (
+            <button
+              aria-label={"Delete " + label}
+              className={styles.nodeDelete}
+              disabled={locked}
+              onClick={() => callbacks.onRemoveNode(node.id)}
+              title={locked ? "Unlock this content block before deleting it" : "Delete content block"}
+              type="button"
+            >
+              <Trash2 size={15} />
+            </button>
+          )}
         </div>
       )}
       <div

--- a/src/app/admin/layout/layout-editor-v4-inspector.tsx
+++ b/src/app/admin/layout/layout-editor-v4-inspector.tsx
@@ -59,6 +59,7 @@ type Commit = (
 export function LayoutV4Inspector({
   assets,
   clipboard,
+  canRemove,
   closeHistoryGroup,
   commit,
   manifest,
@@ -74,6 +75,7 @@ export function LayoutV4Inspector({
 }: {
   assets: LayoutAssetSummary[];
   clipboard: LayoutSettingsClipboard | null;
+  canRemove: boolean;
   closeHistoryGroup: () => void;
   commit: Commit;
   manifest: WorkspaceLayoutManifestV3;
@@ -135,7 +137,7 @@ export function LayoutV4Inspector({
       {selection.kind !== "workspace" && selection.kind !== "tab" && (
         <div className={styles.inspectorActions}>
           <button onClick={onDuplicate} type="button"><Copy size={13} /> Duplicate</button>
-          <button className={styles.dangerButton} onClick={onRemove} type="button"><Trash2 size={13} /> Delete</button>
+          <button className={styles.dangerButton} disabled={!canRemove} onClick={onRemove} title={canRemove ? "Delete this selection" : "Only unlocked custom content can be deleted"} type="button"><Trash2 size={13} /> Delete {selection.kind === "node" ? "block" : selection.kind}</button>
         </div>
       )}
       <p className={styles.shortcutHint}>Shortcuts: Ctrl/Cmd+Z undo, Shift+Ctrl/Cmd+Z redo, Ctrl/Cmd+D duplicate, Delete remove custom content, Ctrl/Cmd+S save the named draft.</p>

--- a/src/app/admin/layout/layout-editor-v4-model.ts
+++ b/src/app/admin/layout/layout-editor-v4-model.ts
@@ -263,17 +263,6 @@ export function appendColumn(manifest: WorkspaceLayoutManifestV3, rowId: string)
   }));
 }
 
-export function removeCustomNode(manifest: WorkspaceLayoutManifestV3, nodeId: string) {
-  const source = findNodeLocation(manifest, nodeId);
-  if (!source || source.node.kind !== "custom" || source.node.locked
-    || source.group.locked || source.row.locked || source.column.locked
-    || source.column.items.length <= 1) return manifest;
-  return updateColumn(manifest, source.column.id, (column) => ({
-    ...column,
-    items: column.items.filter((item) => item.id !== nodeId),
-  }));
-}
-
 export function removeCustomRow(manifest: WorkspaceLayoutManifestV3, rowId: string) {
   const row = findRow(manifest, rowId);
   if (!row || row.locked || !rowIsCustomOnly(row)) return manifest;

--- a/src/app/admin/layout/layout-editor-v4.module.css
+++ b/src/app/admin/layout/layout-editor-v4.module.css
@@ -266,6 +266,9 @@
   color: #ffb7b7 !important;
 }
 
+.nodeDelete { color: #ffb7b7 !important; }
+.nodeDelete:disabled { cursor: not-allowed !important; opacity: 0.42; }
+
 .inlineGrid {
   display: grid;
   gap: 0.45rem;

--- a/src/app/admin/layout/layout-editor-v4.tsx
+++ b/src/app/admin/layout/layout-editor-v4.tsx
@@ -59,7 +59,6 @@ import {
   mapNodes,
   nodeLabel,
   removeCustomColumn,
-  removeCustomNode,
   removeCustomRow,
   requiredProductionNode,
   resizeColumn,
@@ -92,6 +91,7 @@ import {
   moveWorkspaceNodeV3,
   moveWorkspaceRowV3,
   removeWorkspaceGroupV3,
+  removeWorkspaceNodeV3,
   setWorkspaceNodeLockV3,
   workspaceLayoutEditorReducer,
 } from "@/lib/workspace-layout-editor-reducer";
@@ -127,6 +127,14 @@ const customBlocks: Array<{ description: string; id: WorkspaceCustomBlockKindV2;
   { description: "Expandable detail rows", id: "accordion", label: "Accordion" },
   { description: "A visual section break", id: "divider", label: "Divider" },
 ];
+
+function removeLayoutSelection(manifest: WorkspaceLayoutManifestV3, selection: LayoutSelection) {
+  if (selection.kind === "node") return removeWorkspaceNodeV3(manifest, selection.nodeId);
+  if (selection.kind === "row") return removeCustomRow(manifest, selection.rowId);
+  if (selection.kind === "column") return removeCustomColumn(manifest, selection.columnId);
+  if (selection.kind === "group") return removeWorkspaceGroupV3(manifest, selection.groupId);
+  return manifest;
+}
 
 type RecoverySnapshot = {
   draftId: string | null;
@@ -184,6 +192,8 @@ export function LayoutEditorV4({
   const activeGroupId = selection.kind !== "workspace" && "groupId" in selection
     ? selection.groupId
     : activeTab?.groups[0]?.id;
+  const removal = useMemo(() => removeLayoutSelection(manifest, selection), [manifest, selection]);
+  const canRemove = JSON.stringify(removal) !== JSON.stringify(manifest);
 
   function commit(
     updater: (current: WorkspaceLayoutManifestV3) => WorkspaceLayoutManifestV3,
@@ -250,10 +260,24 @@ export function LayoutEditorV4({
   }
 
   function removeSelection() {
-    if (selection.kind === "node") commit((current) => removeCustomNode(current, selection.nodeId));
-    if (selection.kind === "row") commit((current) => removeCustomRow(current, selection.rowId));
-    if (selection.kind === "column") commit((current) => removeCustomColumn(current, selection.columnId));
-    if (selection.kind === "group") commit((current) => removeWorkspaceGroupV3(current, selection.groupId));
+    if (!canRemove) return;
+    commit(() => removal);
+    setSelection({ kind: "workspace" });
+    setSelectedNodeIds(new Set());
+    setOperationNotice("Deleted " + (selection.kind === "node" ? "content block" : selection.kind) + ". Use Undo to restore it.");
+  }
+
+  function removeNode(nodeId: string) {
+    const next = removeWorkspaceNodeV3(manifest, nodeId);
+    if (JSON.stringify(next) === JSON.stringify(manifest)) return;
+    commit(() => next);
+    if (selection.kind === "node" && selection.nodeId === nodeId) setSelection({ kind: "workspace" });
+    setSelectedNodeIds((current) => {
+      const copy = new Set(current);
+      copy.delete(nodeId);
+      return copy;
+    });
+    setOperationNotice("Deleted content block. Use Undo to restore it.");
   }
 
   function copySelectionSettings() {
@@ -480,6 +504,7 @@ export function LayoutEditorV4({
         event.preventDefault();
         void persistDraft();
       } else if (event.key === "Delete" || event.key === "Backspace") {
+        if (canRemove) event.preventDefault();
         removeSelection();
       } else if (event.key === "Escape") {
         setSelection({ kind: "workspace" });
@@ -561,14 +586,14 @@ export function LayoutEditorV4({
           <section aria-labelledby="layout-v4-stage-heading" className={base.stage}>
             <div className={base.stageHeader}><div><span>Production-shaped preview</span><h2 id="layout-v4-stage-heading">{activeTab ? tabLabel(activeTab.id) : "Workspace"}</h2></div><button disabled={!activeTab} onClick={() => addGroup()} type="button"><Plus size={15} /> Add group</button></div>
             <div className={compareMode === "split" ? base.compareGrid : base.canvasStage}>
-              {(compareMode === "baseline" || compareMode === "split") && <LayoutV4Canvas activeTabId={activeTabId} label={compareMode === "split" ? "Before" : "Before - saved draft"} manifest={editor.baseline} onAddColumn={() => undefined} onAddRow={() => undefined} onResizeColumn={() => undefined} onSelect={() => undefined} readOnly selectedNodeIds={new Set()} selection={{ kind: "workspace" }} viewport={viewport} />}
-              {(compareMode === "draft" || compareMode === "split") && <LayoutV4Canvas activeTabId={activeTabId} label={compareMode === "split" ? "After" : "After - current draft"} manifest={manifest} onAddColumn={(rowId) => commit((current) => appendColumn(current, rowId))} onAddRow={(groupId) => commit((current) => appendRow(current, groupId))} onResizeColumn={(columnId, delta) => commit((current) => resizeColumn(current, columnId, viewport, delta))} onSelect={handleSelection} selectedNodeIds={selectedNodeIds} selection={selection} viewport={viewport} />}
+              {(compareMode === "baseline" || compareMode === "split") && <LayoutV4Canvas activeTabId={activeTabId} label={compareMode === "split" ? "Before" : "Before - saved draft"} manifest={editor.baseline} onAddColumn={() => undefined} onAddRow={() => undefined} onRemoveNode={() => undefined} onResizeColumn={() => undefined} onSelect={() => undefined} readOnly selectedNodeIds={new Set()} selection={{ kind: "workspace" }} viewport={viewport} />}
+              {(compareMode === "draft" || compareMode === "split") && <LayoutV4Canvas activeTabId={activeTabId} label={compareMode === "split" ? "After" : "After - current draft"} manifest={manifest} onAddColumn={(rowId) => commit((current) => appendColumn(current, rowId))} onAddRow={(groupId) => commit((current) => appendRow(current, groupId))} onRemoveNode={removeNode} onResizeColumn={(columnId, delta) => commit((current) => resizeColumn(current, columnId, viewport, delta))} onSelect={handleSelection} selectedNodeIds={selectedNodeIds} selection={selection} viewport={viewport} />}
             </div>
           </section>
 
           <aside className={base.inspector}>
             <div className={base.inspectorHeader}><Settings2 size={17} /><div><span>Configure</span><strong>{selectionLabel(manifest, selection)}</strong></div><button aria-label="Inspect workspace" onClick={() => handleSelection({ kind: "workspace" })} type="button"><X size={15} /></button></div>
-            <LayoutV4Inspector assets={allAssets} clipboard={clipboard} closeHistoryGroup={() => dispatch({ type: "close-group" })} commit={commit} manifest={manifest} onCopy={copySelectionSettings} onDuplicate={duplicateSelection} onPaste={pasteSelectionSettings} onRemove={removeSelection} onSaveGroupTemplate={(name, description) => void saveGroupTemplate(name, description)} onUploadImage={uploadImage} selection={selection} uploading={uploading} viewport={viewport} />
+            <LayoutV4Inspector assets={allAssets} canRemove={canRemove} clipboard={clipboard} closeHistoryGroup={() => dispatch({ type: "close-group" })} commit={commit} manifest={manifest} onCopy={copySelectionSettings} onDuplicate={duplicateSelection} onPaste={pasteSelectionSettings} onRemove={removeSelection} onSaveGroupTemplate={(name, description) => void saveGroupTemplate(name, description)} onUploadImage={uploadImage} selection={selection} uploading={uploading} viewport={viewport} />
             <div className={base.inspectorBody}><fieldset><legend>Accessibility checks</legend><ul className={styles.contrastList}>{contrast.map((item) => <li data-valid={item.ok} key={item.label}><span>{item.label}</span><strong>{item.ratio.toFixed(2)}:1 / {item.threshold}:1</strong></li>)}</ul></fieldset></div>
           </aside>
         </div>

--- a/src/lib/workspace-layout-editor-reducer.ts
+++ b/src/lib/workspace-layout-editor-reducer.ts
@@ -198,6 +198,34 @@ export function moveWorkspaceNodeV3(
   });
 }
 
+export function removeWorkspaceNodeV3(manifest: WorkspaceLayoutManifestV3, nodeId: string) {
+  const source = findNodeLocation(manifest, nodeId);
+  if (!source || source.node.kind !== "custom" || isWorkspaceNodeLockedV3(source.node)
+    || source.group.locked || source.row.locked || source.column.locked) {
+    return manifest;
+  }
+
+  const tab = manifest.tabs.find((candidate) => candidate.id === source.tabId);
+  if (!tab) return manifest;
+
+  const groups = tab.groups.flatMap((group) => {
+    if (group.id !== source.group.id) return [group];
+    const rows = group.rows.flatMap((row) => {
+      if (row.id !== source.row.id) return [row];
+      const columns = row.columns.flatMap((column) => {
+        if (column.id !== source.column.id) return [column];
+        const items = column.items.filter((node) => node.id !== nodeId);
+        return items.length ? [{ ...column, items }] : [];
+      });
+      return columns.length ? [{ ...row, columns }] : [];
+    });
+    return rows.length ? [{ ...group, rows }] : [];
+  });
+
+  if (!groups.length || groups.every((group) => group.rows.length === 0)) return manifest;
+  return mapTab(manifest, source.tabId, (current) => ({ ...current, groups }));
+}
+
 export function duplicateWorkspaceNodeV3(manifest: WorkspaceLayoutManifestV3, nodeId: string) {
   const location = findNodeLocation(manifest, nodeId);
   if (!location || location.node.kind !== "custom" || location.node.locked

--- a/tests/api/workspace-layout-editor-reducer.test.mjs
+++ b/tests/api/workspace-layout-editor-reducer.test.mjs
@@ -8,12 +8,14 @@ import {
   moveWorkspaceGroupV3,
   moveWorkspaceRowV3,
   moveWorkspaceNodeV3,
+  removeWorkspaceNodeV3,
   setWorkspaceNodeLockV3,
   workspaceLayoutEditorReducer,
 } from "../../src/lib/workspace-layout-editor-reducer.ts";
 import {
   cloneWorkspaceLayoutManifestV3,
   embeddedWorkspaceLayoutManifestV3,
+  validateWorkspaceLayoutManifestV3,
 } from "../../src/lib/workspace-layout-v3.ts";
 import { createWorkspaceCustomNodeV2 } from "../../src/lib/workspace-layout-v2.ts";
 
@@ -84,6 +86,52 @@ test("only custom components duplicate", () => {
   const duplicated = duplicateWorkspaceNodeV3(manifest, custom.id);
   assert.equal(duplicated.tabs.find((tab) => tab.id === "map").groups[0].rows[0].columns[0].items.length, column.items.length + 1);
 });
+
+test("deleting a sole custom block prunes its empty containers and remains undoable", () => {
+  const manifest = cloneWorkspaceLayoutManifestV3();
+  const map = manifest.tabs.find((tab) => tab.id === "map");
+  const custom = createWorkspaceCustomNodeV2("rich-text", "custom-delete-test");
+  map.groups.push({
+    id: "custom-delete-group",
+    name: "Delete test",
+    rows: [{
+      columns: [{
+        id: "custom-delete-column",
+        items: [custom],
+        span: { desktop: 12, mobile: 12, tablet: 12 },
+      }],
+      id: "custom-delete-row",
+    }],
+  });
+
+  let state = createWorkspaceLayoutEditorState(manifest);
+  state = commit(state, (current) => removeWorkspaceNodeV3(current, custom.id));
+  assert.equal(
+    state.present.tabs.find((tab) => tab.id === "map").groups.some((group) => group.id === "custom-delete-group"),
+    false,
+  );
+  assert.equal(validateWorkspaceLayoutManifestV3(state.present).ok, true);
+  assert.equal(state.past.length, 1);
+
+  state = workspaceLayoutEditorReducer(state, { type: "undo" });
+  assert.equal(
+    state.present.tabs.find((tab) => tab.id === "map").groups.some((group) => group.id === "custom-delete-group"),
+    true,
+  );
+});
+
+test("production and locked content cannot be deleted", () => {
+  const manifest = cloneWorkspaceLayoutManifestV3();
+  const map = manifest.tabs.find((tab) => tab.id === "map");
+  const production = map.groups[0].rows[0].columns[0].items[0];
+  assert.deepEqual(removeWorkspaceNodeV3(manifest, production.id), manifest);
+
+  const custom = createWorkspaceCustomNodeV2("callout", "custom-locked-delete-test");
+  custom.locked = true;
+  map.groups[0].rows[0].columns[0].items.push(custom);
+  assert.deepEqual(removeWorkspaceNodeV3(manifest, custom.id), manifest);
+});
+
 test("invalid drag destinations never remove source content", () => {
   const manifest = cloneWorkspaceLayoutManifestV3();
   const map = manifest.tabs.find((tab) => tab.id === "map");

--- a/tests/e2e/workspace-builder-v4.spec.ts
+++ b/tests/e2e/workspace-builder-v4.spec.ts
@@ -29,6 +29,12 @@ test("workspace builder v4 supports live tokens, finite undo, responsive compari
   await expect(page.getByRole("button", { name: /New group/ }).first()).toBeVisible();
   await expect(undo).toBeEnabled();
 
+  await page.getByRole("button", { name: "Delete Rich text" }).click();
+  await expect(page.getByRole("button", { name: /New group/ })).toHaveCount(0);
+  await expect(page.getByText("Deleted content block. Use Undo to restore it.")).toBeVisible();
+  await undo.click();
+  await expect(page.getByRole("button", { name: /New group/ }).first()).toBeVisible();
+
   await page.getByRole("button", { name: /mobile/i }).first().click();
   await expect.poll(async () => (await after.boundingBox())?.width ?? 999).toBeLessThanOrEqual(392);
 


### PR DESCRIPTION
## What changed

- adds a clearly labeled trash control to each custom content block
- makes the inspector Delete action reflect whether the selection is removable
- removes an empty custom column, row, or group after deleting its final block
- keeps production and locked content protected
- preserves one-step Undo restoration

## Root cause

The editor rejected deletion whenever a custom block was the only item in its column. The Delete control remained enabled, so the action silently did nothing and Undoing the earlier add was the only apparent way to remove the block.

## User impact

Custom content blocks can now be deleted directly from the production-shaped canvas or the inspector. Deleting the final block in a custom group also removes the now-empty layout containers without creating an invalid manifest.

## Validation

- npm run test:layout
- npm run typecheck
- npx playwright test tests/e2e/workspace-builder-v4.spec.ts --project=chromium
- npm run build