### PR TITLE
Improve workspace navigation and result hierarchy

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6606,3 +6606,204 @@ td {
     grid-column: span var(--layout-span-mobile, 12);
   }
 }
+
+/* Primary navigation hierarchy and responsive state rail. */
+.workspace {
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.state-rail {
+  width: clamp(260px, 23vw, 340px);
+  transition: width 180ms ease;
+}
+
+.state-rail-heading {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.state-rail-heading .section-label {
+  margin: 0;
+}
+
+.state-rail-collapse-button,
+.state-rail-mobile-close {
+  align-items: center;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  cursor: pointer;
+  display: inline-flex;
+  height: 36px;
+  justify-content: center;
+  width: 36px;
+}
+
+.state-rail-collapse-button:hover,
+.state-rail-collapse-button:focus-visible,
+.state-rail-mobile-close:hover,
+.state-rail-mobile-close:focus-visible {
+  border-color: var(--accent-line);
+  color: var(--accent);
+  outline: 0;
+}
+
+.state-rail-mobile-trigger,
+.state-rail-backdrop,
+.state-rail-mobile-close,
+.state-rail-collapsed-summary {
+  display: none;
+}
+
+.state-rail.is-collapsed {
+  width: 64px;
+}
+
+.state-rail.is-collapsed .sidebar-header {
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+.state-rail.is-collapsed .state-rail-heading,
+.state-rail.is-collapsed .state-rail-content {
+  display: none;
+}
+
+.state-rail.is-collapsed .state-rail-collapsed-summary {
+  align-items: center;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: var(--foreground);
+  cursor: pointer;
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+  padding: 12px 6px;
+  width: 100%;
+}
+
+.state-rail-collapsed-summary:hover,
+.state-rail-collapsed-summary:focus-visible {
+  border-color: var(--accent-line);
+  color: var(--accent);
+  outline: 0;
+}
+
+.state-rail-collapsed-summary span {
+  color: var(--quiet);
+  font-size: 10px;
+}
+
+.review-direction-notice {
+  border-top: 0;
+}
+
+.review-direction-notice summary {
+  color: var(--foreground);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.review-direction-notice summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.review-direction-notice-body {
+  display: grid;
+  gap: 8px;
+  padding-top: 10px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .state-rail {
+    transition: none;
+  }
+}
+
+@media (max-width: 980px) {
+  .state-rail-mobile-trigger {
+    align-items: center;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    color: var(--foreground);
+    cursor: pointer;
+    display: flex;
+    gap: 10px;
+    min-height: 44px;
+    padding: 0 14px;
+    width: 100%;
+  }
+
+  .state-rail-mobile-trigger span {
+    flex: 1;
+    text-align: left;
+  }
+
+  .state-rail-mobile-trigger strong {
+    color: var(--accent);
+    font-family: var(--font-code);
+    font-size: 12px;
+  }
+
+  .state-rail-backdrop {
+    background: rgba(3, 8, 12, 0.72);
+    border: 0;
+    display: block;
+    inset: 0;
+    position: fixed;
+    z-index: 79;
+  }
+
+  .sidebar.state-rail,
+  .sidebar.state-rail.is-collapsed {
+    background: var(--background);
+    border-right: 1px solid var(--line);
+    box-shadow: 24px 0 60px rgba(0, 0, 0, 0.38);
+    height: 100dvh;
+    inset: 0 auto 0 0;
+    overflow-y: auto;
+    padding: 18px;
+    position: fixed;
+    top: 0;
+    transform: translateX(-105%);
+    transition:
+      transform 180ms ease,
+      visibility 180ms ease;
+    visibility: hidden;
+    width: min(92vw, 380px);
+    z-index: 80;
+  }
+
+  .sidebar.state-rail.is-mobile-open {
+    transform: translateX(0);
+    visibility: visible;
+  }
+
+  .state-rail.is-collapsed .sidebar-header {
+    justify-content: space-between;
+  }
+
+  .state-rail.is-collapsed .state-rail-heading,
+  .state-rail.is-collapsed .state-rail-content {
+    display: grid;
+  }
+
+  .state-rail-collapse-button,
+  .state-rail-collapsed-summary {
+    display: none !important;
+  }
+
+  .state-rail-mobile-close {
+    display: inline-flex;
+  }
+
+  .state-rail .state-list {
+    max-height: none;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import {
 import { BrandMark } from "./brand-mark";
 import { GlobalCountySearch } from "./global-county-search";
 import { NationalOverview } from "./national-overview";
+import { StateRail } from "./state-rail";
 import { StateSwitcher } from "./state-switcher";
 import { WorkspaceTabs } from "./workspace-tabs";
 import {
@@ -344,18 +345,14 @@ export default async function Home({ searchParams }: HomeProps) {
       </header>
 
       <div className="workspace">
-        <aside className="sidebar" data-tour="state-sidebar" aria-label="State coverage">
-          <div className="sidebar-header">
-            <p className="section-label">States</p>
-            <span>{states.length} loaded</span>
-          </div>
+        <StateRail loadedCount={states.length} selectedState={selectedStateCode}>
           <StateSwitcher
             completenessReport={completenessReport}
             securityIncidentStates={securityIncidentStateSummaries}
             selectedState={selectedStateCode}
             states={states}
           />
-        </aside>
+        </StateRail>
 
         <section className="main-panel">
           <NationalOverview report={completenessReport} year={2024} />

--- a/src/app/results-explorer.tsx
+++ b/src/app/results-explorer.tsx
@@ -667,7 +667,7 @@ export function ResultsExplorer({
   const [pinnedMapName, setPinnedMapName] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [showFlaggedOnly, setShowFlaggedOnly] = useState(false);
-  const [sortKey, setSortKey] = useState<SortKey>("margin");
+  const [sortKey, setSortKey] = useState<SortKey>("jurisdiction");
   const [isPanning, setIsPanning] = useState(false);
   const mapWrapRef = useRef<HTMLDivElement | null>(null);
   const mapSvgRef = useRef<SVGSVGElement | null>(null);
@@ -2069,24 +2069,6 @@ export function ResultsExplorer({
         </div>
         {results.length > 0 ? (
           <>
-            <div className="review-direction-notice" role="note">
-              <strong>About the directional review column</strong>
-              <p>
-                The column below is not a finding that interference occurred, and it does not prove that any candidate
-                actually received extra votes. It is a rough advisory screen from the loaded review indicators. For
-                down-ballot comparison flags, the app compares same-party presidential votes against a comparison race
-                such as U.S. Senate or Governor, then labels the direction with the larger relative gap. Governor-only
-                comparisons are marked low confidence because they can mostly reflect ordinary race-specific ticket
-                splitting. When the comparison is U.S. House, the column names presidential-over-House dropoff direction
-                instead of candidate benefit because House races are district- and candidate-specific controls.
-              </p>
-              <p>
-                That direction can be affected by split-ticket voting, incumbency, local candidate strength, undervotes,
-                uncontested races, one-sided comparison races, reporting-unit definitions, missing comparison rows, or ordinary political geography.
-                Treat it as "if this pattern needs review, this is the side the math points toward," not as a causal claim
-                or a conclusion.
-              </p>
-            </div>
             <div className="table-tools">
               <label className="table-search" htmlFor="result-search">
                 <Search aria-hidden size={16} />
@@ -2108,10 +2090,10 @@ export function ResultsExplorer({
                   onChange={(event) => setSortKey(event.target.value as SortKey)}
                   value={sortKey}
                 >
-                  <option value="margin">Margin</option>
-                  <option value="total">Total votes</option>
-                  <option value="jurisdiction">Jurisdiction</option>
-                  <option value="winner">Winner</option>
+                  <option value="jurisdiction">Jurisdiction A-Z</option>
+                  <option value="margin">Margin (high to low)</option>
+                  <option value="total">Total votes (high to low)</option>
+                  <option value="winner">Winner A-Z</option>
                 </select>
               </label>
               <label className="toggle-label" htmlFor="flagged-only">
@@ -2124,6 +2106,26 @@ export function ResultsExplorer({
                 Flagged only
               </label>
             </div>
+            <details className="review-direction-notice">
+              <summary>About the directional review column</summary>
+              <div className="review-direction-notice-body">
+                <p>
+                  The column below is not a finding that interference occurred, and it does not prove that any candidate
+                  actually received extra votes. It is a rough advisory screen from the loaded review indicators. For
+                  down-ballot comparison flags, the app compares same-party presidential votes against a comparison race
+                  such as U.S. Senate or Governor, then labels the direction with the larger relative gap. Governor-only
+                  comparisons are marked low confidence because they can mostly reflect ordinary race-specific ticket
+                  splitting. When the comparison is U.S. House, the column names presidential-over-House dropoff direction
+                  instead of candidate benefit because House races are district- and candidate-specific controls.
+                </p>
+                <p>
+                  That direction can be affected by split-ticket voting, incumbency, local candidate strength, undervotes,
+                  uncontested races, one-sided comparison races, reporting-unit definitions, missing comparison rows, or ordinary political geography.
+                  Treat it as "if this pattern needs review, this is the side the math points toward," not as a causal claim
+                  or a conclusion.
+                </p>
+              </div>
+            </details>
             {pinnedMapName && pinnedMapResult && (
               <div className="selected-result-callout" role="status">
                 <div>

--- a/src/app/state-rail.tsx
+++ b/src/app/state-rail.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { MapPinned, PanelLeftClose, PanelLeftOpen, X } from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useId, useState } from "react";
+
+const stateRailStorageKey = "crm-state-rail-collapsed";
+
+type StateRailProps = {
+  children: ReactNode;
+  loadedCount: number;
+  selectedState: string;
+};
+
+export function StateRail({ children, loadedCount, selectedState }: StateRailProps) {
+  const contentId = useId();
+  const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    setCollapsed(window.localStorage.getItem(stateRailStorageKey) === "true");
+  }, []);
+
+  useEffect(() => {
+    if (!mobileOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMobileOpen(false);
+    };
+
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [mobileOpen]);
+
+  const toggleCollapsed = () => {
+    setCollapsed((current) => {
+      const next = !current;
+      window.localStorage.setItem(stateRailStorageKey, String(next));
+      return next;
+    });
+  };
+
+  return (
+    <>
+      <button
+        aria-controls={contentId}
+        aria-expanded={mobileOpen}
+        className="state-rail-mobile-trigger"
+        onClick={() => setMobileOpen(true)}
+        type="button"
+      >
+        <PanelLeftOpen aria-hidden size={17} />
+        <span>Choose a state</span>
+        <strong>{selectedState}</strong>
+      </button>
+
+      {mobileOpen && (
+        <button
+          aria-label="Close state selector"
+          className="state-rail-backdrop"
+          onClick={() => setMobileOpen(false)}
+          type="button"
+        />
+      )}
+
+      <aside
+        aria-label="State coverage"
+        className={`sidebar state-rail ${collapsed ? "is-collapsed" : ""} ${mobileOpen ? "is-mobile-open" : ""}`}
+        data-tour="state-sidebar"
+      >
+        <div className="sidebar-header">
+          <div className="state-rail-heading">
+            <p className="section-label">States</p>
+            <span>{loadedCount} loaded</span>
+          </div>
+          <button
+            aria-controls={contentId}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? "Expand state selector" : "Collapse state selector"}
+            className="state-rail-collapse-button"
+            onClick={toggleCollapsed}
+            title={collapsed ? "Expand states" : "Collapse states"}
+            type="button"
+          >
+            {collapsed ? <PanelLeftOpen aria-hidden size={17} /> : <PanelLeftClose aria-hidden size={17} />}
+          </button>
+          <button
+            aria-label="Close state selector"
+            className="state-rail-mobile-close"
+            onClick={() => setMobileOpen(false)}
+            type="button"
+          >
+            <X aria-hidden size={18} />
+          </button>
+        </div>
+
+        <button
+          aria-label={`Expand state selector. ${selectedState} is selected.`}
+          className="state-rail-collapsed-summary"
+          onClick={toggleCollapsed}
+          type="button"
+        >
+          <MapPinned aria-hidden size={19} />
+          <strong>{selectedState}</strong>
+          <span>{loadedCount}</span>
+        </button>
+
+        <div className="state-rail-content" id={contentId}>
+          {children}
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/src/app/workspace-layout-v2.css
+++ b/src/app/workspace-layout-v2.css
@@ -309,3 +309,194 @@
   .workspace-tabs[data-layout-type-scale="large"] { font-size: 1rem; }
   .review-subnav[data-layout-navigation="sidebar"] { float: none; margin: 0 0 1rem; max-width: none; }
 }
+
+/* Task-first workspace navigation. */
+.workspace-tabs .tab-bar {
+  overflow: visible;
+}
+
+
+.workspace-tabs .workspace-tab-list {
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  gap: 6px;
+  min-width: 0;
+}
+
+.workspace-primary-tabs {
+  align-items: center;
+  display: flex;
+  gap: 6px;
+  min-width: 0;
+}
+
+.workspace-more-menu {
+  flex: 0 0 auto;
+  position: relative;
+}
+
+.workspace-more-menu > summary {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--muted);
+  cursor: pointer;
+  display: inline-flex;
+  gap: 7px;
+  min-height: 38px;
+  padding: 0 11px;
+  user-select: none;
+}
+
+.workspace-more-menu > summary::-webkit-details-marker {
+  display: none;
+}
+
+.workspace-more-menu > summary:hover,
+.workspace-more-menu > summary:focus-visible,
+.workspace-more-menu[open] > summary,
+.workspace-more-menu.is-active > summary {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+  color: var(--accent);
+  outline: 0;
+}
+
+.workspace-more-chevron {
+  transition: transform 160ms ease;
+}
+
+.workspace-more-menu[open] .workspace-more-chevron {
+  transform: rotate(180deg);
+}
+
+.workspace-more-panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: 0 22px 55px rgba(0, 0, 0, 0.34);
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(150px, 1fr));
+  padding: 12px;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  width: min(680px, calc(100vw - 48px));
+  z-index: 45;
+}
+
+.workspace-more-group {
+  align-content: start;
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.workspace-more-group-label {
+  color: var(--quiet);
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  padding: 6px 10px 3px;
+  text-transform: uppercase;
+}
+
+.workspace-more-panel .tab-button {
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.workspace-more-panel .tab-button[aria-current="page"] {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+  color: var(--accent);
+}
+
+.workspace-tab-select,
+.review-view-select {
+  display: none;
+}
+
+.workspace-tab-select span,
+.review-view-select span {
+  color: var(--quiet);
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.workspace-tab-select select,
+.review-view-select select {
+  appearance: none;
+  background: var(--panel-strong);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--foreground);
+  font: inherit;
+  min-height: 42px;
+  padding: 0 38px 0 12px;
+  width: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-more-chevron {
+    transition: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .workspace-tabs .tab-bar {
+    flex-wrap: wrap;
+    overflow: visible;
+  }
+
+  .workspace-tabs .workspace-tab-list {
+    display: none;
+  }
+
+  .workspace-tab-select {
+    display: grid;
+    flex: 1 1 220px;
+    gap: 5px;
+    min-width: 0;
+    position: relative;
+  }
+
+  .workspace-tab-select::after,
+  .review-view-select::after {
+    border-bottom: 2px solid currentColor;
+    border-right: 2px solid currentColor;
+    bottom: 18px;
+    color: var(--muted);
+    content: "";
+    height: 7px;
+    pointer-events: none;
+    position: absolute;
+    right: 15px;
+    transform: rotate(45deg);
+    width: 7px;
+  }
+
+  .workspace-tabs .review-center-panel .review-subnav {
+    display: none;
+  }
+
+  .review-view-select {
+    background: rgba(255, 255, 255, 0.018);
+    border-bottom: 1px solid var(--line);
+    display: grid;
+    gap: 5px;
+    padding: 12px 16px;
+    position: relative;
+  }
+}
+
+@media (max-width: 520px) {
+  .workspace-tabs .tour-launch {
+    width: 100%;
+  }
+}

--- a/src/app/workspace-tabs.tsx
+++ b/src/app/workspace-tabs.tsx
@@ -5,6 +5,7 @@ import {
   BarChart3,
   BellRing,
   BookOpen,
+  ChevronDown,
   CheckCircle2,
   Copy,
   Database,
@@ -17,6 +18,7 @@ import {
   ListChecks,
   Mail,
   MapIcon,
+  MoreHorizontal,
   Megaphone,
   Search,
   Send,
@@ -265,6 +267,22 @@ const tabs: Array<{ icon: ComponentType<SVGProps<SVGSVGElement> & { size?: numbe
   { icon: GitBranch, key: "imports", label: "Import Runs" },
   { icon: HeartHandshake, key: "support", label: "Support" },
   { icon: Mail, key: "contact", label: "Contact" },
+];
+
+const primaryWorkspaceTabOrder: TabKey[] = ["map", "review", "history", "data"];
+const secondaryWorkspaceTabGroups: Array<{ label: string; tabKeys: TabKey[] }> = [
+  {
+    label: "Learn & investigate",
+    tabKeys: ["methodology", "electronic", "planner"],
+  },
+  {
+    label: "Use the data",
+    tabKeys: ["exports", "imports"],
+  },
+  {
+    label: "Help",
+    tabKeys: ["support", "contact"],
+  },
 ];
 
 const reviewViewOptions: Array<{ key: ReviewView; label: string; summary: string }> = [
@@ -2734,6 +2752,32 @@ export function WorkspaceTabs({
       .filter((tab): tab is (typeof tabs)[number] => Boolean(tab)),
     [layoutManifest],
   );
+  const workspaceNavigation = useMemo(() => {
+    const tabByKey = new Map(layoutTabs.map((tab) => [tab.key, tab] as const));
+    const primary = primaryWorkspaceTabOrder
+      .map((key) => tabByKey.get(key))
+      .filter((tab): tab is (typeof tabs)[number] => Boolean(tab));
+    const groups = secondaryWorkspaceTabGroups
+      .map((group) => ({
+        label: group.label,
+        tabs: group.tabKeys
+          .map((key) => tabByKey.get(key))
+          .filter((tab): tab is (typeof tabs)[number] => Boolean(tab)),
+      }))
+      .filter((group) => group.tabs.length > 0);
+    const assignedKeys = new Set([...primary.map((tab) => tab.key), ...groups.flatMap((group) => group.tabs.map((tab) => tab.key))]);
+    const ungrouped = layoutTabs.filter((tab) => !assignedKeys.has(tab.key));
+
+    if (ungrouped.length) {
+      groups.push({ label: "More", tabs: ungrouped });
+    }
+
+    return {
+      all: [...primary, ...groups.flatMap((group) => group.tabs)],
+      groups,
+      primary,
+    };
+  }, [layoutTabs]);
   const layoutReviewViewOptions = useMemo(() => {
     const reviewConfiguration = reviewViewConfigurationV2(layoutManifest);
     return reviewConfiguration.viewOrder
@@ -2746,6 +2790,9 @@ export function WorkspaceTabs({
     ? initialTab as TabKey
     : "map";
   const [activeTab, setActiveTab] = useState<TabKey>(requestedTab);
+  const activeSecondaryTab = workspaceNavigation.groups
+    .flatMap((group) => group.tabs)
+    .find((tab) => tab.key === activeTab);
   const [copiedElectronicDraft, setCopiedElectronicDraft] = useState(false);
   const [copiedSourceRecordsDraft, setCopiedSourceRecordsDraft] = useState(false);
   const [enabledScreeningGraphs, setEnabledScreeningGraphs] = useState<ScreeningGraphType[]>([
@@ -2849,15 +2896,20 @@ export function WorkspaceTabs({
 
   const filteredIndicators = useMemo(() => {
     const query = reviewQuery.trim().toLowerCase();
-    return indicators.filter((indicator) => {
-      const typeMatches = reviewType === "all" || indicator.type === reviewType;
-      const queryMatches =
-        !query ||
-        indicator.jurisdictionName.toLowerCase().includes(query) ||
-        indicator.label.toLowerCase().includes(query) ||
-        indicator.summary.toLowerCase().includes(query);
-      return typeMatches && queryMatches;
-    });
+    return indicators
+      .filter((indicator) => {
+        const typeMatches = reviewType === "all" || indicator.type === reviewType;
+        const queryMatches =
+          !query ||
+          indicator.jurisdictionName.toLowerCase().includes(query) ||
+          indicator.label.toLowerCase().includes(query) ||
+          indicator.summary.toLowerCase().includes(query);
+        return typeMatches && queryMatches;
+      })
+      .sort(
+        (left, right) =>
+          right.severity - left.severity || left.jurisdictionName.localeCompare(right.jurisdictionName),
+      );
   }, [indicators, reviewQuery, reviewType]);
 
   const countyIndicators = useMemo(() => indicators.filter((indicator) => indicator.level === "county"), [indicators]);
@@ -3222,6 +3274,36 @@ export function WorkspaceTabs({
   const sourceRecordsRequestRows = sourceRecordsRequests.requests;
   const sourceRecordsRequestQueueCount = sourceRecordsRequestRows.length;
   const totalRecordsRequestQueueCount = electronicRequestQueueCount + sourceRecordsRequestQueueCount;
+
+  const renderWorkspaceTabButton = (
+    tab: (typeof tabs)[number],
+    presentation: "menu" | "tab" = "tab",
+  ) => {
+    const Icon = tab.icon;
+    const selected = activeTab === tab.key;
+    return (
+      <button
+        aria-current={presentation === "menu" && selected ? "page" : undefined}
+        aria-selected={presentation === "tab" ? selected : undefined}
+        className="tab-button"
+        data-tour={`tab-${tab.key}`}
+        id={`workspace-tab-${tab.key}`}
+        key={tab.key}
+        onClick={() => selectTab(tab.key)}
+        role={presentation === "tab" ? "tab" : undefined}
+        type="button"
+      >
+        <Icon aria-hidden size={16} />
+        <span>{tab.label}</span>
+        {tab.key === "electronic" && totalRecordsRequestQueueCount > 0 && (
+          <span className="tab-alert-badge" aria-label={`${totalRecordsRequestQueueCount} records requests need review`}>
+            {totalRecordsRequestQueueCount}
+          </span>
+        )}
+      </button>
+    );
+  };
+
   const sourceRecordsDraftFiles = sourceRecordsRequests.summary.draftFiles;
   const sourceRecordsStateDraft = sourceRecordsDraftFiles.find((draft) => draft.state === selectedStateCode);
   const sourceRecordsRequestStatusCounts = sourceRecordsRequestRows.reduce<Record<string, number>>((counts, request) => {
@@ -3994,35 +4076,48 @@ export function WorkspaceTabs({
         data-tour="tab-bar"
       >
         <GuidedTour activeTab={activeTab} onSelectTab={selectTab} onStepChange={syncReviewTourStep} steps={workspaceTourSteps} />
-        <nav
-          aria-label="Workspace sections"
-          className="workspace-tab-list"
-          role="tablist"
-        >
-        {layoutTabs.map((tab) => {
-          const Icon = tab.icon;
-          return (
-            <button
-              aria-selected={activeTab === tab.key}
-              id={`workspace-tab-${tab.key}`}
-              className="tab-button"
-              data-tour={`tab-${tab.key}`}
-              key={tab.key}
-              onClick={() => selectTab(tab.key)}
-              type="button"
-              role="tab"
-            >
-              <Icon aria-hidden size={16} />
-              <span>{tab.label}</span>
-              {tab.key === "electronic" && totalRecordsRequestQueueCount > 0 && (
-                <span className="tab-alert-badge" aria-label={`${totalRecordsRequestQueueCount} records requests need review`}>
-                  {totalRecordsRequestQueueCount}
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </nav>
+        <nav aria-label="Workspace sections" className="workspace-tab-list">
+          <div className="workspace-primary-tabs" role="tablist">
+            {workspaceNavigation.primary.map((tab) => renderWorkspaceTabButton(tab))}
+          </div>
+          {workspaceNavigation.groups.length > 0 && (
+            <details className={`workspace-more-menu ${activeSecondaryTab ? "is-active" : ""}`}>
+              <summary
+                aria-label={
+                  activeSecondaryTab
+                    ? `More workspace sections. Current section: ${activeSecondaryTab.label}`
+                    : "More workspace sections"
+                }
+              >
+                <MoreHorizontal aria-hidden size={16} />
+                <span>{activeSecondaryTab ? `More: ${activeSecondaryTab.label}` : "More"}</span>
+                <ChevronDown aria-hidden className="workspace-more-chevron" size={14} />
+              </summary>
+              <div className="workspace-more-panel">
+                {workspaceNavigation.groups.map((group) => (
+                  <div className="workspace-more-group" key={group.label}>
+                    <span className="workspace-more-group-label">{group.label}</span>
+                    {group.tabs.map((tab) => renderWorkspaceTabButton(tab, "menu"))}
+                  </div>
+                ))}
+              </div>
+            </details>
+          )}
+        </nav>
+        <label className="workspace-tab-select">
+          <span>Workspace section</span>
+          <select
+            aria-label="Workspace section"
+            onChange={(event) => selectTab(event.target.value as TabKey)}
+            value={activeTab}
+          >
+            {workspaceNavigation.all.map((tab) => (
+              <option key={tab.key} value={tab.key}>
+                {tab.label}
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
       <div
         className={`workspace-body ${isDataNotesCollapsed ? "notes-collapsed" : ""}`}
@@ -4187,6 +4282,20 @@ export function WorkspaceTabs({
                 <BarChart3 aria-hidden size={18} />
               </div>
             </div>
+            <label className="review-view-select">
+              <span>Review view</span>
+              <select
+                aria-label="Review Center view"
+                onChange={(event) => setReviewView(event.target.value as ReviewView)}
+                value={reviewView}
+              >
+                {layoutReviewViewOptions.map((option) => (
+                  <option key={option.key} value={option.key}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
             <div
               aria-label="Review Center views"
               className="review-subnav"
@@ -4289,8 +4398,8 @@ export function WorkspaceTabs({
                     </div>
                     <div className="review-action-stack">
                       <button onClick={() => setReviewView("tools")} type="button">Evidence Tools<span>Explain readiness, source gaps, and top flags.</span></button>
-                      <button onClick={() => setReviewView("screening")} type="button">Screening<span>Review charts, caveats, and ticket-splitting proxy.</span></button>
                       <button onClick={() => setReviewView("indicators")} type="button">Indicators<span>Search, filter, and inspect advisory rows.</span></button>
+                      <button onClick={() => setReviewView("screening")} type="button">Screening<span>Review charts, caveats, and ticket-splitting proxy.</span></button>
                       <button onClick={() => setReviewView("methodology")} type="button">Methodology<span>Check formulas, thresholds, and common explanations.</span></button>
                     </div>
                   </article>

--- a/tests/e2e/workspace-layout.spec.ts
+++ b/tests/e2e/workspace-layout.spec.ts
@@ -25,6 +25,25 @@ test("public workspace uses the safe embedded layout and durable visitor cookie"
   await expect(workspace.getByRole("tab", { name: "Map", exact: true })).toBeVisible();
   await expect(workspace.getByRole("tab", { name: "Review Center", exact: true })).toBeVisible();
   await expect(workspace.getByRole("tab", { name: "Data & Sources", exact: true })).toBeVisible();
+  const moreSections = workspace.locator('summary[aria-label="More workspace sections"]');
+  await expect(moreSections).toBeVisible();
+  await moreSections.click();
+  await expect(workspace.getByRole("button", { name: "Support", exact: true })).toBeVisible();
+  await moreSections.click();
+
+  const stateRail = page.getByRole("complementary", { name: "State coverage" });
+  await page.locator(".state-rail-collapse-button").click();
+  await expect(stateRail).toHaveClass(/is-collapsed/);
+  await page.locator(".state-rail-collapse-button").click();
+  await expect(stateRail).not.toHaveClass(/is-collapsed/);
+
+  await expect(page.getByLabel("Sort results")).toHaveValue("jurisdiction");
+  const jurisdictionNames = await page
+    .getByRole("region", { name: "WA county results table" })
+    .locator("tbody tr td:first-child")
+    .allTextContents();
+  expect(jurisdictionNames.length).toBeGreaterThan(0);
+  expect(jurisdictionNames).toEqual([...jurisdictionNames].sort((left, right) => left.localeCompare(right)));
   await workspace.getByRole("button", { name: /^Data Notes/ }).click();
   await expect(page.getByRole("heading", { name: "Data Notes", exact: true })).toBeVisible();
 
@@ -37,6 +56,33 @@ test("public workspace uses the safe embedded layout and durable visitor cookie"
   expect(cookie?.httpOnly).toBe(true);
   expect(cookie?.sameSite).toBe("Lax");
   expect(cookie?.value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+});
+
+test("workspace navigation and state selector adapt on small screens", async ({ page }) => {
+  await page.setViewportSize({ height: 844, width: 390 });
+  await page.goto("/?state=WA&tab=map");
+
+  const stateTrigger = page.getByRole("button", { name: /Choose a state/i });
+  await expect(stateTrigger).toBeVisible();
+  await stateTrigger.click();
+
+  const stateRail = page.getByRole("complementary", { name: "State coverage" });
+  await expect(stateRail).toHaveClass(/is-mobile-open/);
+  await stateRail.getByRole("button", { name: "Close state selector" }).click();
+  await expect(stateRail).not.toHaveClass(/is-mobile-open/);
+
+  const workspaceSection = page.getByLabel("Workspace section", { exact: true });
+  await expect(workspaceSection).toBeVisible();
+  await workspaceSection.selectOption("support");
+  await expect(page).toHaveURL(/tab=support/);
+  await expect(workspaceSection).toHaveValue("support");
+
+  await workspaceSection.selectOption("review");
+  await expect(page).toHaveURL(/tab=review/);
+  const reviewView = page.getByLabel("Review Center view", { exact: true });
+  await expect(reviewView).toBeVisible();
+  await reviewView.selectOption("indicators");
+  await expect(reviewView).toHaveValue("indicators");
 });
 
 test("layout administration fails safely when Clerk is not configured", async ({ page }) => {


### PR DESCRIPTION
## What changed

- adds a collapsible desktop state rail and an off-canvas state selector on small screens
- keeps Map, Review Center, History, and Data & Sources as the primary workspace destinations
- groups specialized areas into a labeled More menu and provides a compact mobile section selector
- replaces the five large Review Center navigation cards with a mobile review-view selector
- sorts Review Center indicators by severity and jurisdiction
- defaults county results to jurisdiction A–Z, moves table controls ahead of explanatory copy, and makes the directional-screen explanation expandable
- adds desktop and mobile browser coverage for navigation, rail behavior, section selection, and result sorting

## Why

User feedback indicated that election data and tools felt scattered and difficult to navigate. This creates a clearer task hierarchy while preserving source provenance, caveats, advisory-language guardrails, and all existing data surfaces.

## Related production fix

The private layout editor was not loading named database drafts because the `workspace-builder-v4` Vercel flag did not exist. The flag has now been created and enabled for production, so authorized admins can see the agent-created `Navigation-first UX concept` draft after refreshing `/admin/layout`.

## Validation

- `npm run typecheck`
- `npm run test:layout`
- `npx playwright test tests/e2e/workspace-layout.spec.ts` — 4 passed
- `npm run build`
- manual desktop visual verification of primary tabs, grouped menu, and collapsed rail
- `npx vercel flags inspect workspace-builder-v4` — production On

Note: the existing `npm run lint` script invokes `next lint`, which is not available in the installed Next.js version; this PR does not change that script.