### PR TITLE
Allow layout drafts to collapse provenance

### DIFF
--- a/src/lib/workspace-layout-agent-operations.ts
+++ b/src/lib/workspace-layout-agent-operations.ts
@@ -173,7 +173,7 @@ const productionConfigKeysByComponent: Record<string, readonly string[]> = {
   "coverage-context": ["coverageVariant"],
   "results-map": ["legendPosition", "mapComposition"],
   "review-center": ["navigationStyle"],
-  "source-provenance": ["provenanceVariant"],
+  "source-provenance": ["provenanceInitialState", "provenanceVariant"],
   "state-snapshot": ["snapshotVariant"],
 };
 

--- a/tests/api/workspace-layout-agent-operations.test.mjs
+++ b/tests/api/workspace-layout-agent-operations.test.mjs
@@ -209,6 +209,58 @@ test("layout agent protects required production components and contrast rules", 
   );
 });
 
+test("layout agent scopes provenance initial state configuration to source provenance", () => {
+  const mapTab = embeddedWorkspaceLayoutManifestV3.tabs.find((tab) => tab.id === "map");
+  const sourceProvenance = flattenWorkspaceNodesV3(mapTab)
+    .find((node) => node.kind === "production" && node.component === "source-provenance");
+  assert.ok(sourceProvenance);
+
+  const collapsed = applyWorkspaceLayoutAgentOperations(embeddedWorkspaceLayoutManifestV3, [{
+    nodeId: sourceProvenance.id,
+    operationId: "collapse-map-provenance",
+    patch: {
+      config: {
+        provenanceInitialState: "collapsed",
+        provenanceVariant: "accordion",
+      },
+    },
+    type: "update_block",
+  }]);
+  const collapsedNode = flattenWorkspaceNodesV3(collapsed.manifest.tabs.find((tab) => tab.id === "map"))
+    .find((node) => node.id === sourceProvenance.id);
+  assert.equal(collapsedNode?.kind, "production");
+  assert.equal(collapsedNode?.config?.provenanceInitialState, "collapsed");
+  assert.equal(collapsedNode?.config?.provenanceVariant, "accordion");
+  assert.equal(validateWorkspaceLayoutManifestV3(collapsed.manifest).ok, true);
+
+  const initialStateOnly = applyWorkspaceLayoutAgentOperations(embeddedWorkspaceLayoutManifestV3, [{
+    nodeId: sourceProvenance.id,
+    operationId: "preserve-provenance-variant",
+    patch: { config: { provenanceInitialState: "collapsed" } },
+    type: "update_block",
+  }]);
+  const preservedNode = flattenWorkspaceNodesV3(initialStateOnly.manifest.tabs.find((tab) => tab.id === "map"))
+    .find((node) => node.id === sourceProvenance.id);
+  assert.equal(preservedNode?.config?.provenanceInitialState, "collapsed");
+  assert.equal(preservedNode?.config?.provenanceVariant, sourceProvenance.config?.provenanceVariant);
+
+  const unrelatedProductionNodes = embeddedWorkspaceLayoutManifestV3.tabs
+    .flatMap((tab) => flattenWorkspaceNodesV3(tab))
+    .filter((node) => node.kind === "production" && node.component !== "source-provenance");
+  assert.ok(unrelatedProductionNodes.length > 0);
+  for (const [index, node] of unrelatedProductionNodes.entries()) {
+    assert.throws(
+      () => applyWorkspaceLayoutAgentOperations(embeddedWorkspaceLayoutManifestV3, [{
+        nodeId: node.id,
+        operationId: `reject-provenance-${index}`,
+        patch: { config: { provenanceInitialState: "collapsed" } },
+        type: "update_block",
+      }]),
+      /does not support configuration: provenanceInitialState/i,
+    );
+  }
+});
+
 test("layout agent operation failures identify their batch position", () => {
   assert.throws(
     () => applyWorkspaceLayoutAgentOperations(embeddedWorkspaceLayoutManifestV3, [{


### PR DESCRIPTION
## What changed

- Allow the guarded layout agent to set `provenanceInitialState` on `source-provenance` production blocks.
- Keep the configuration rejected for every unrelated production component.
- Add regression coverage for accordion/collapsed configuration, partial config merging, manifest validation, and cross-component rejection.

## Why

The layout schema, MCP input schema, and Map renderer already support collapsed provenance, but the per-component agent allowlist omitted `provenanceInitialState`. That prevented the Navigation-first UX draft from reducing the initially visible source-detail load on the Map tab.

## Impact

After merge and deployment, the Civic Layout Control plugin can preview and save a Map provenance block as an initially collapsed accordion. This PR does not modify a layout draft, create a revision, or publish a layout.

The allowlist is component-scoped, so Data & Sources' `source-provenance` node also accepts the field; that renderer currently ignores it. The review agent classified this as a non-blocking follow-up because it creates no runtime or guardrail regression.

## Validation

- `node --experimental-strip-types --test tests/api/workspace-layout-agent-operations.test.mjs`
- `npm run test:layout`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Review agent: approved with no P0 or P1 findings.