### PR TITLE
Render layout manifests in the public workspace

### DIFF
--- a/src/app/admin/layout/actions.ts
+++ b/src/app/admin/layout/actions.ts
@@ -5,6 +5,7 @@ import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { requireLayoutAdmin } from "@/lib/ui-layout-auth";
+import { getLayoutDraft } from "@/lib/ui-layout-v4-repository";
 import type { LayoutActionState } from "./layout-action-state";
 import {
   createLayoutPublication,
@@ -56,9 +57,18 @@ export async function saveLayoutRevisionAction(
 
 export async function startLayoutDraftPreviewAction(formData: FormData) {
   await requireLayoutAdmin();
-  const revisionId = String(formData.get("revisionId") ?? "");
-  if (!(await getLayoutRevision(revisionId))) throw new Error("Layout revision not found.");
-  (await cookies()).set(WORKSPACE_LAYOUT_DRAFT_COOKIE, revisionId, {
+  const draftId = String(formData.get("draftId") ?? "").trim();
+  const revisionId = String(formData.get("revisionId") ?? "").trim();
+  let previewTarget: string;
+  if (draftId) {
+    const draft = await getLayoutDraft(draftId);
+    if (!draft || draft.archivedAt) throw new Error("Named layout draft not found.");
+    previewTarget = `draft:${draft.id}`;
+  } else {
+    if (!(await getLayoutRevision(revisionId))) throw new Error("Layout revision not found.");
+    previewTarget = `revision:${revisionId}`;
+  }
+  (await cookies()).set(WORKSPACE_LAYOUT_DRAFT_COOKIE, previewTarget, {
     httpOnly: true,
     maxAge: WORKSPACE_LAYOUT_DRAFT_MAX_AGE,
     path: "/",

--- a/src/app/admin/layout/layout-editor-v4-operations.tsx
+++ b/src/app/admin/layout/layout-editor-v4-operations.tsx
@@ -32,6 +32,7 @@ import styles from "./layout-editor-v4.module.css";
 
 export function LayoutV4Operations({
   activeDraftRevisionId,
+  activeNamedDraft,
   dirty,
   errors,
   manifest,
@@ -43,6 +44,7 @@ export function LayoutV4Operations({
   testMode = false,
 }: {
   activeDraftRevisionId?: string;
+  activeNamedDraft?: { id: string; name: string; version: number };
   dirty: boolean;
   errors: string[];
   manifest: WorkspaceLayoutManifestV3;
@@ -104,6 +106,15 @@ export function LayoutV4Operations({
 
       <section className={base.operationCard}>
         <div><Send size={18} /><span><strong>Preview, schedule, and publish</strong><small>Every release uses the protected GitHub workflow and production approval gate.</small></span></div>
+        {activeNamedDraft && (
+          <form action={startLayoutDraftPreviewAction}>
+            <input name="draftId" type="hidden" value={activeNamedDraft.id} />
+            <p className={styles.noticeText}>
+              Preview the saved version {activeNamedDraft.version} of <strong>{activeNamedDraft.name}</strong>.
+            </p>
+            <button disabled={testMode} type="submit"><MonitorSmartphone size={16} /> Open named draft preview</button>
+          </form>
+        )}
         <form action={startLayoutDraftPreviewAction}>
           <label>Saved revision<select name="revisionId" onChange={(event) => setSelectedRevisionId(event.target.value)} value={selectedRevisionId}>{revisions.map((revision) => <option key={revision.id} value={revision.id}>{revision.changeSummary} - {new Date(revision.createdAt).toLocaleString()}</option>)}</select></label>
           <button disabled={testMode || !selectedRevisionId} type="submit"><MonitorSmartphone size={16} /> Open revision preview</button>

--- a/src/app/admin/layout/layout-editor-v4.tsx
+++ b/src/app/admin/layout/layout-editor-v4.tsx
@@ -599,7 +599,19 @@ export function LayoutEditorV4({
         </div>
       </DragDropProvider>
 
-      <LayoutV4Operations activeDraftRevisionId={activeDraftRevisionId} dirty={dirty} errors={errors} manifest={manifest} parentRevisionId={parentRevisionId} publications={publications} publisherEnabled={publisherEnabled} requestKey={requestKey} revisions={revisions} testMode={testMode} />
+      <LayoutV4Operations
+        activeDraftRevisionId={activeDraftRevisionId}
+        activeNamedDraft={activeDraft ? { id: activeDraft.id, name: activeDraft.name, version: activeDraft.version } : undefined}
+        dirty={dirty}
+        errors={errors}
+        manifest={manifest}
+        parentRevisionId={parentRevisionId}
+        publications={publications}
+        publisherEnabled={publisherEnabled}
+        requestKey={requestKey}
+        revisions={revisions}
+        testMode={testMode}
+      />
     </section>
   );
 

--- a/src/app/workspace-layout-v3-groups.tsx
+++ b/src/app/workspace-layout-v3-groups.tsx
@@ -1,10 +1,30 @@
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import type { WorkspaceProductionNodeV3 } from "@/lib/workspace-layout-v3";
 import type { WorkspaceRuntimeGroupV3 } from "@/lib/workspace-layout-v3-runtime";
 import { WorkspaceLayoutBlockV2 } from "./workspace-layout-v2-blocks";
 
-export function WorkspaceLayoutGroupsV3({ groups }: { groups: WorkspaceRuntimeGroupV3[] }) {
+type WorkspaceLayoutGroupsV3Props = {
+  groups: WorkspaceRuntimeGroupV3[];
+  renderProduction: (node: WorkspaceProductionNodeV3) => ReactNode | null;
+};
+
+export function WorkspaceLayoutGroupsV3({ groups, renderProduction }: WorkspaceLayoutGroupsV3Props) {
+  const landmarks = groups.filter((group) => Boolean(group.heading));
+
   return (
-    <div aria-label="Custom workspace groups" className="workspace-layout-groups">
+    <div aria-label="Configured workspace layout" className="workspace-layout-groups">
+      {landmarks.length > 1 && (
+        <nav aria-label="On this page" className="workspace-layout-local-nav">
+          <span>On this page</span>
+          <ul>
+            {landmarks.map((group) => (
+              <li key={group.id}>
+                <a href={`#workspace-group-${group.id}`}>{group.heading}</a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
       {groups.map((group) => (
         <section
           aria-label={group.heading || group.name}
@@ -13,6 +33,7 @@ export function WorkspaceLayoutGroupsV3({ groups }: { groups: WorkspaceRuntimeGr
           data-show-divider={group.presentation.showDivider ? "true" : "false"}
           data-spacing={group.presentation.spacing}
           data-surface={group.presentation.surface}
+          id={`workspace-group-${group.id}`}
           key={group.id}
         >
           {(group.heading || group.description) && (
@@ -38,17 +59,31 @@ export function WorkspaceLayoutGroupsV3({ groups }: { groups: WorkspaceRuntimeGr
                     "--layout-span-tablet": column.span.tablet,
                   } as CSSProperties}
                 >
-                  {column.items.map((block, index) => (
-                    <WorkspaceLayoutBlockV2
-                      item={{
-                        ...block,
-                        columnId: column.id,
-                        order: index,
-                        rowId: row.id,
-                        span: column.span,
-                      }}
-                      key={block.id}
-                    />
+                  {column.items.map((node, index) => (
+                    <div
+                      className="workspace-layout-node"
+                      data-layout-component={node.component}
+                      data-layout-density={node.presentation?.density ?? "comfortable"}
+                      data-layout-emphasis={node.presentation?.emphasis ?? "standard"}
+                      data-layout-height={node.presentation?.height ?? "auto"}
+                      data-layout-node-kind={node.kind}
+                      data-layout-surface={node.presentation?.surface ?? "panel"}
+                      key={node.id}
+                    >
+                      {node.kind === "production"
+                        ? renderProduction(node)
+                        : (
+                            <WorkspaceLayoutBlockV2
+                              item={{
+                                ...node,
+                                columnId: column.id,
+                                order: index,
+                                rowId: row.id,
+                                span: column.span,
+                              }}
+                            />
+                          )}
+                    </div>
                   ))}
                 </div>
               ))}

--- a/src/app/workspace-layout-v3.css
+++ b/src/app/workspace-layout-v3.css
@@ -1,7 +1,43 @@
 .workspace-layout-groups {
   display: grid;
   gap: 24px;
-  margin-top: 22px;
+}
+
+.workspace-layout-local-nav {
+  align-items: center;
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 18px;
+  padding: 10px 14px;
+}
+
+.workspace-layout-local-nav > span {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.workspace-layout-local-nav ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.workspace-layout-local-nav a {
+  color: var(--foreground);
+  font-size: 0.88rem;
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  text-underline-offset: 3px;
 }
 
 .workspace-layout-group {
@@ -101,6 +137,58 @@
   grid-column: span var(--layout-span-desktop, 12);
   grid-template-columns: minmax(0, 1fr);
   min-width: 0;
+}
+
+.workspace-layout-node {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+
+.workspace-layout-node[data-layout-node-kind="production"][data-layout-surface="panel"] {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  box-shadow: var(--shadow);
+  padding: var(--layout-node-padding, 18px);
+}
+
+.workspace-layout-node[data-layout-node-kind="production"]:has(> .panel),
+.workspace-layout-node[data-layout-node-kind="production"]:has(> .tab-panel-content) {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+}
+
+.workspace-layout-node[data-layout-height="compact"] {
+  min-height: 0;
+}
+
+.workspace-layout-node[data-layout-height="standard"] {
+  min-height: 300px;
+}
+
+.workspace-layout-node[data-layout-height="tall"] {
+  min-height: 480px;
+}
+
+.workspace-layout-node[data-layout-density="compact"] {
+  --layout-node-padding: 12px;
+}
+
+.workspace-layout-node[data-layout-density="spacious"] {
+  --layout-node-padding: 24px;
+}
+
+.workspace-layout-node[data-layout-surface="muted"] > [data-layout-section],
+.workspace-layout-node[data-layout-surface="muted"] > .workspace-custom-block {
+  background: color-mix(in srgb, var(--panel) 84%, var(--muted));
+}
+
+.workspace-layout-node[data-layout-emphasis="prominent"] > [data-layout-section],
+.workspace-layout-node[data-layout-emphasis="prominent"] > .workspace-custom-block {
+  border-color: var(--accent);
 }
 
 .workspace-custom-column > .workspace-custom-block {

--- a/src/app/workspace-tabs.tsx
+++ b/src/app/workspace-tabs.tsx
@@ -27,8 +27,8 @@ import {
   TriangleAlert,
   X,
 } from "lucide-react";
-import type { ComponentType, CSSProperties, SVGProps } from "react";
-import { useEffect, useMemo, useState } from "react";
+import type { ComponentType, CSSProperties, ReactNode, SVGProps } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { Eli5 } from "./eli5";
 import { GuidedTour, type TourStep } from "./guided-tour";
 import { ResultsExplorer } from "./results-explorer";
@@ -54,7 +54,10 @@ import {
   workspaceProductionNodeV2,
   workspaceSectionStateV2 as workspaceSectionState,
 } from "@/lib/workspace-layout-v2-runtime";
-import type { WorkspaceLayoutManifestV3 } from "@/lib/workspace-layout-v3";
+import type {
+  WorkspaceLayoutManifestV3,
+  WorkspaceProductionNodeV3,
+} from "@/lib/workspace-layout-v3";
 import {
   workspaceLayoutSettingsV3,
   workspaceRuntimeGroupsV3,
@@ -4067,6 +4070,23 @@ export function WorkspaceTabs({
   const trendY = (trend: { intercept: number; slope: number } | null, x: number) =>
     trend ? scatterY(clamp(trend.intercept + trend.slope * x, 0, 100)) : null;
 
+  const capturedProduction = new Map<string, ReactNode[]>();
+  const captureProduction = (component: string, content: ReactNode) => {
+    const captured = capturedProduction.get(component);
+    if (captured) {
+      captured.push(content);
+    } else {
+      capturedProduction.set(component, [content]);
+    }
+    return content;
+  };
+  const renderCapturedProduction = (node: WorkspaceProductionNodeV3) => {
+    const content = capturedProduction.get(node.component);
+    return content?.length
+      ? <>{content.map((item, index) => <Fragment key={`${node.id}-${index}`}>{item}</Fragment>)}</>
+      : null;
+  };
+
   return (
     <section
       aria-label={`${stateName} workspace`}
@@ -4163,10 +4183,13 @@ export function WorkspaceTabs({
           className="workspace-main"
           role="tabpanel"
         >
+          {(() => {
+            const legacyContent = (
+              <>
           {activeTab === "map" && (
         <div className="tab-panel-content">
           <div className="content-grid">
-            <div {...layoutSectionProps(layoutManifest, "map", "results-map")}>
+            {captureProduction("results-map", (<div {...layoutSectionProps(layoutManifest, "map", "results-map")}>
             <ResultsExplorer
               countyLabel={countyLabel}
               electionYear={electionYear}
@@ -4182,7 +4205,7 @@ export function WorkspaceTabs({
               sources={sources}
               voteMethodRows={voteMethodRows}
             />
-            </div>
+            </div>))}
             <div
               className="detail-stack"
               style={{
@@ -4193,7 +4216,7 @@ export function WorkspaceTabs({
                 ),
               }}
             >
-              <section className="panel" aria-label="Provenance" {...layoutSectionProps(layoutManifest, "map", "source-provenance")}>
+              {captureProduction("source-provenance", (<section className="panel" aria-label="Provenance" {...layoutSectionProps(layoutManifest, "map", "source-provenance")}>
                 <div className="panel-header">
                   <div>
                     <h2>Source Provenance</h2>
@@ -4216,9 +4239,9 @@ export function WorkspaceTabs({
                 ) : (
                   <SourceProvenanceList sources={sources} />
                 )}
-              </section>
+              </section>))}
 
-              <section className="panel" aria-label="Coverage flags" {...layoutSectionProps(layoutManifest, "map", "coverage-context")}>
+              {captureProduction("coverage-context", (<section className="panel" aria-label="Coverage flags" {...layoutSectionProps(layoutManifest, "map", "coverage-context")}>
                 <div className="panel-header">
                   <div>
                     <h2>Coverage</h2>
@@ -4245,9 +4268,9 @@ export function WorkspaceTabs({
                       </li>
                     ))}
                 </ul>
-              </section>
+              </section>))}
 
-              <section className="panel" aria-label="Statewide vote breakdown" {...layoutSectionProps(layoutManifest, "map", "state-snapshot")}>
+              {captureProduction("state-snapshot", (<section className="panel" aria-label="Statewide vote breakdown" {...layoutSectionProps(layoutManifest, "map", "state-snapshot")}>
                 <div className="panel-header">
                   <div>
                     <h2>State Snapshot</h2>
@@ -4287,13 +4310,13 @@ export function WorkspaceTabs({
                     </div>
                   ))}
                 </div>
-              </section>
+              </section>))}
             </div>
           </div>
         </div>
       )}
 
-      {activeTab === "review" && (
+      {activeTab === "review" && captureProduction("review-center", (
         <div className="tab-panel-content">
           <section className="panel review-center-panel" data-tour="review-panel">
             <div className="panel-header review-center-header">
@@ -5129,11 +5152,11 @@ export function WorkspaceTabs({
             )}
           </section>
         </div>
-      )}
+      ))}
       {activeTab === "history" && (
         <div className="tab-panel-content">
           <section className="panel layout-section-container">
-            <div className="panel-header">
+            {captureProduction("historical-summary", (<div className="panel-header">
               <div>
                 <h2>Historical Baselines</h2>
                 <span>
@@ -5157,10 +5180,10 @@ export function WorkspaceTabs({
                 />
                 <History aria-hidden size={18} />
               </div>
-            </div>
+            </div>))}
             {historicalRows.length ? (
               <>
-                <div className="layout-section-stack" {...layoutSectionProps(layoutManifest, "history", "historical-summary")}>
+                {captureProduction("historical-summary", (<div className="layout-section-stack" {...layoutSectionProps(layoutManifest, "history", "historical-summary")}>
                 <div className="history-controls" aria-label="Historical year toggles">
                   <span>Show years</span>
                   {historicalYears.map((year) => (
@@ -5229,8 +5252,8 @@ export function WorkspaceTabs({
                     </article>
                   ))}
                 </div>
-                </div>
-                <div className="layout-section-stack" {...layoutSectionProps(layoutManifest, "history", "historical-charts")}>
+                </div>))}
+                {captureProduction("historical-charts", (<div className="layout-section-stack" {...layoutSectionProps(layoutManifest, "history", "historical-charts")}>
                 <div className="history-chart-grid" data-tour="history-charts">
                   {enabledHistoricalGraphs.includes("share") && (
                     <article className="history-chart-card">
@@ -5535,16 +5558,18 @@ export function WorkspaceTabs({
                     historical API for the full selected-state extract.
                   </div>
                 )}
-                </div>
+                </div>))}
               </>
             ) : (
-              <div className="empty-panel" {...layoutSectionProps(layoutManifest, "history", "historical-summary")}>
+              <>
+              {captureProduction("historical-summary", (<div className="empty-panel" {...layoutSectionProps(layoutManifest, "history", "historical-summary")}>
                 <strong>No historical baseline rows loaded for {stateName}</strong>
                 <span>
                   The importer looks for historicalBaseline.series rows in the legacy state bundle. Current repo data
                   only exposes populated historical series for a subset of states.
                 </span>
-              </div>
+              </div>))}
+              </>
             )}
           </section>
         </div>
@@ -5554,7 +5579,7 @@ export function WorkspaceTabs({
       {activeTab === "electronic" && (
         <div className="tab-panel-content">
           <section className="panel electronic-integrity-panel layout-section-container" data-tour="electronic-integrity">
-            {requestGuideOpen && (
+            {requestGuideOpen && captureProduction("integrity-context", (
               <div
                 aria-labelledby="request-guide-title"
                 aria-modal="true"
@@ -5624,8 +5649,8 @@ export function WorkspaceTabs({
                   </div>
                 </div>
               </div>
-            )}
-            <div className="layout-section-stack" {...layoutSectionProps(layoutManifest, "electronic", "integrity-context")}>
+            ))}
+            {captureProduction("integrity-context", (<div className="layout-section-stack" {...layoutSectionProps(layoutManifest, "electronic", "integrity-context")}>
             <div className="panel-header">
               <div>
                 <h2>Electronic Integrity</h2>
@@ -5704,8 +5729,8 @@ export function WorkspaceTabs({
                 input unless row-level data supports it.
               </span>
             </div>
-            </div>
-            {sourceRecordsRequestRows.length > 0 && (
+            </div>))}
+            {captureProduction("source-records-request", (
               <div className="source-records-request-section" data-tour="source-records-request-draft" {...layoutSectionProps(layoutManifest, "electronic", "source-records-request")}>
                 <div className="planner-note source-records-separation">
                   <strong>Separate source-records requests</strong>
@@ -5768,7 +5793,8 @@ export function WorkspaceTabs({
                     </div>
                   </div>
                 )}
-                <div className="table-wrap">
+                {sourceRecordsRequestRows.length > 0 ? (
+                  <div className="table-wrap">
                   <table>
                     <thead>
                       <tr>
@@ -5793,10 +5819,16 @@ export function WorkspaceTabs({
                       ))}
                     </tbody>
                   </table>
-                </div>
+                  </div>
+                ) : (
+                  <div className="planner-note" data-layout-empty-state="source-records-request">
+                    <strong>No separate source-records requests are queued</strong>
+                    <span>This area will list prepared requests when the source inventory identifies a records gap.</span>
+                  </div>
+                )}
               </div>
-            )}
-            <div className="layout-section-stack" {...layoutSectionProps(layoutManifest, "electronic", "cvr-requests")}>
+            ))}
+            {captureProduction("cvr-requests", (<div className="layout-section-stack" {...layoutSectionProps(layoutManifest, "electronic", "cvr-requests")}>
             {electronicIntegrityStatus ? (
               <>
                 <div className="admin-source-grid" aria-label={`${stateName} electronic integrity status`}>
@@ -5946,12 +5978,12 @@ export function WorkspaceTabs({
                 <span>Start by registering certified results, local reporting-unit results, CVR availability, audit output, and custody/log sources.</span>
               </div>
             )}
-            </div>
+            </div>))}
           </section>
         </div>
       )}
 
-      {activeTab === "planner" && (
+      {activeTab === "planner" && captureProduction("source-plan", (
         <div className="tab-panel-content">
           <section className="panel" data-tour="source-planner" {...layoutSectionProps(layoutManifest, "planner", "source-plan")}>
             <div className="panel-header">
@@ -6055,12 +6087,12 @@ export function WorkspaceTabs({
             </div>
           </section>
         </div>
-      )}
+      ))}
 
       {activeTab === "data" && (
         <div className="tab-panel-content">
           <section className="panel layout-section-container" data-tour="data-sources">
-            <div className="panel-header" {...layoutSectionProps(layoutManifest, "data", "source-provenance")}>
+            {captureProduction("source-provenance", (<div className="panel-header" {...layoutSectionProps(layoutManifest, "data", "source-provenance")}>
               <div>
                 <h2>Data & Sources</h2>
                 <span>{sources.length} source document records</span>
@@ -6079,8 +6111,8 @@ export function WorkspaceTabs({
                 </a>
                 <FileCheck2 aria-hidden size={18} />
               </div>
-            </div>
-            <div className="source-links-panel" data-tour="source-links" {...layoutSectionProps(layoutManifest, "data", "source-provenance")}>
+            </div>))}
+            {captureProduction("source-provenance", (<div className="source-links-panel" data-tour="source-links" {...layoutSectionProps(layoutManifest, "data", "source-provenance")}>
               <div>
                 <strong>Official Source Links</strong>
                 <span>
@@ -6114,8 +6146,8 @@ export function WorkspaceTabs({
                   </li>
                 ))}
               </ul>
-            </div>
-            <div className="vote-method-panel" data-tour="vote-method-summary" {...layoutSectionProps(layoutManifest, "data", "vote-methods")}>
+            </div>))}
+            {captureProduction("vote-methods", (<div className="vote-method-panel" data-tour="vote-method-summary" {...layoutSectionProps(layoutManifest, "data", "vote-methods")}>
               <div className="vote-method-head">
                 <div>
                   <strong>Vote Methods</strong>
@@ -6205,8 +6237,8 @@ export function WorkspaceTabs({
                   <span>Current normalized EAC method coverage is available for MI, MN, OH, PA, and WI.</span>
                 </div>
               )}
-            </div>
-            <div className="vote-method-caveat" data-tour="candidate-method-note" {...layoutSectionProps(layoutManifest, "data", "vote-methods")}>
+            </div>))}
+            {captureProduction("vote-methods", (<div className="vote-method-caveat" data-tour="candidate-method-note" {...layoutSectionProps(layoutManifest, "data", "vote-methods")}>
               <div>
                 <strong>Candidate by Method</strong>
                 <span>
@@ -6215,8 +6247,8 @@ export function WorkspaceTabs({
                 </span>
               </div>
               <span className="pending">Source required</span>
-            </div>
-            <div className="vote-method-panel" data-tour="equipment-context" {...layoutSectionProps(layoutManifest, "data", "equipment-context")}>
+            </div>))}
+            {captureProduction("equipment-context", (<div className="vote-method-panel" data-tour="equipment-context" {...layoutSectionProps(layoutManifest, "data", "equipment-context")}>
               <div className="vote-method-head">
                 <div>
                   <strong>Equipment Context</strong>
@@ -6358,8 +6390,8 @@ export function WorkspaceTabs({
                   <span>Use the admin source status endpoint to confirm whether the Verifier source is loaded or blocked for this state.</span>
                 </div>
               )}
-            </div>
-            <div className="source-card-grid" {...layoutSectionProps(layoutManifest, "data", "source-provenance")}>
+            </div>))}
+            {captureProduction("source-provenance", (<div className="source-card-grid" {...layoutSectionProps(layoutManifest, "data", "source-provenance")}>
               {sources.map((source) => (
                 <article className="source-card" key={source.id}>
                   <span>{source.category}</span>
@@ -6384,7 +6416,7 @@ export function WorkspaceTabs({
                   )}
                 </article>
               ))}
-            </div>
+            </div>))}
           </section>
         </div>
       )}
@@ -6392,7 +6424,7 @@ export function WorkspaceTabs({
       {activeTab === "methodology" && (
         <div className="tab-panel-content methodology-grid">
           <section className="panel text-panel layout-section-container" data-tour="methodology">
-            <div className="panel-header" {...layoutSectionProps(layoutManifest, "methodology", "introduction")}>
+            {captureProduction("introduction", (<div className="panel-header" {...layoutSectionProps(layoutManifest, "methodology", "introduction")}>
               <div>
                 <h2>Review Guide</h2>
                 <span>How to review this release responsibly</span>
@@ -6404,8 +6436,8 @@ export function WorkspaceTabs({
                 </Eli5>
                 <BookOpen aria-hidden size={18} />
               </div>
-            </div>
-            <div className="responsible-review-panel" data-tour="reviewer-checklist" {...layoutSectionProps(layoutManifest, "methodology", "responsible-review")}>
+            </div>))}
+            {captureProduction("responsible-review", (<div className="responsible-review-panel" data-tour="reviewer-checklist" {...layoutSectionProps(layoutManifest, "methodology", "responsible-review")}>
               <article>
                 <span className="section-label">How to Review Responsibly</span>
                 <strong>Use this site to find records worth checking, not to make claims by itself.</strong>
@@ -6426,8 +6458,8 @@ export function WorkspaceTabs({
                   ))}
                 </ul>
               </article>
-            </div>
-            <div className="guided-workflow-panel" data-tour="guided-workflows" {...layoutSectionProps(layoutManifest, "methodology", "guided-workflows")}>
+            </div>))}
+            {captureProduction("guided-workflows", (<div className="guided-workflow-panel" data-tour="guided-workflows" {...layoutSectionProps(layoutManifest, "methodology", "guided-workflows")}>
               <div>
                 <span className="section-label">Guided Workflows</span>
                 <strong>Common reviewer paths</strong>
@@ -6440,8 +6472,8 @@ export function WorkspaceTabs({
                   </article>
                 ))}
               </div>
-            </div>
-            <div className="glossary-panel" {...layoutSectionProps(layoutManifest, "methodology", "glossary")}>
+            </div>))}
+            {captureProduction("glossary", (<div className="glossary-panel" {...layoutSectionProps(layoutManifest, "methodology", "glossary")}>
               <div>
                 <span className="section-label">Glossary</span>
                 <strong>Terms used across charts, tables, and source notes</strong>
@@ -6454,8 +6486,8 @@ export function WorkspaceTabs({
                   </div>
                 ))}
               </dl>
-            </div>
-            <div className="method-list" {...layoutSectionProps(layoutManifest, "methodology", "introduction")}>
+            </div>))}
+            {captureProduction("introduction", (<div className="method-list" {...layoutSectionProps(layoutManifest, "methodology", "introduction")}>
               {methodologyGuides.map((guide) => {
                 return (
                   <details className="methodology-card" key={guide.id}>
@@ -6499,8 +6531,8 @@ export function WorkspaceTabs({
                   </details>
                 );
               })}
-            </div>
-            <div className="validation-list" {...layoutSectionProps(layoutManifest, "methodology", "responsible-review")}>
+            </div>))}
+            {captureProduction("responsible-review", (<div className="validation-list" {...layoutSectionProps(layoutManifest, "methodology", "responsible-review")}>
               {validationChecks.map((check) => (
                 <article className={check.passed ? "validation-pass" : "validation-warn"} key={check.label}>
                   {check.passed ? <CheckCircle2 aria-hidden size={17} /> : <TriangleAlert aria-hidden size={17} />}
@@ -6510,7 +6542,7 @@ export function WorkspaceTabs({
                   </div>
                 </article>
               ))}
-            </div>
+            </div>))}
           </section>
         </div>
       )}
@@ -6518,7 +6550,7 @@ export function WorkspaceTabs({
       {activeTab === "exports" && (
         <div className="tab-panel-content">
           <section className="panel layout-section-container" data-tour="exports">
-            <div className="panel-header">
+            {captureProduction("review-packet", (<div className="panel-header">
               <div>
                 <h2>Exports & API</h2>
                 <span>Download selected state data or use public read endpoints</span>
@@ -6530,8 +6562,8 @@ export function WorkspaceTabs({
                 </Eli5>
                 <Database aria-hidden size={18} />
               </div>
-            </div>
-            <div className="export-grid" style={{ order: Math.min(workspaceSectionState(layoutManifest, "exports", "downloads").order, workspaceSectionState(layoutManifest, "exports", "review-packet").order) }}>
+            </div>))}
+            {captureProduction("downloads", (<div className="export-grid" style={{ order: Math.min(workspaceSectionState(layoutManifest, "exports", "downloads").order, workspaceSectionState(layoutManifest, "exports", "review-packet").order) }}>
               <button onClick={exportResults} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
                 <Download aria-hidden size={16} />
                 Results CSV
@@ -6576,12 +6608,14 @@ export function WorkspaceTabs({
                 <Download aria-hidden size={16} />
                 Import Summary JSON
               </button>
+            </div>))}
+            {captureProduction("review-packet", (<div className="export-grid">
               <button data-tour="export-review-packet" onClick={exportReviewPackage} type="button" {...layoutSectionProps(layoutManifest, "exports", "review-packet")}>
                 <Download aria-hidden size={16} />
                 Review Packet ZIP (All Files ZIP)
               </button>
-            </div>
-            <div className="export-summary-grid" {...layoutSectionProps(layoutManifest, "exports", "review-packet")}>
+            </div>))}
+            {captureProduction("review-packet", (<div className="export-summary-grid" {...layoutSectionProps(layoutManifest, "exports", "review-packet")}>
               <article>
                 <span>Rows</span>
                 <strong>{results.length}</strong>
@@ -6610,8 +6644,8 @@ export function WorkspaceTabs({
                 <span>Total votes</span>
                 <strong>{totalVotes.toLocaleString()}</strong>
               </article>
-            </div>
-            <ul className="api-list" {...layoutSectionProps(layoutManifest, "exports", "api-links")}>
+            </div>))}
+            {captureProduction("api-links", (<ul className="api-list" {...layoutSectionProps(layoutManifest, "exports", "api-links")}>
               <li className="api-helper">
                 <Eli5>
                   Each API row is like a vending-machine button. Change the state code or limit in the URL, and the app
@@ -6670,12 +6704,12 @@ export function WorkspaceTabs({
                 <strong>Completeness</strong>
                 <code>/api/completeness?year=2024</code>
               </li>
-            </ul>
+            </ul>))}
           </section>
         </div>
       )}
 
-      {activeTab === "imports" && (
+      {activeTab === "imports" && captureProduction("import-history", (
         <div className="tab-panel-content">
           <section className="panel" data-tour="import-runs" {...layoutSectionProps(layoutManifest, "imports", "import-history")}>
             <div className="panel-header">
@@ -6715,9 +6749,9 @@ export function WorkspaceTabs({
             </ul>
           </section>
         </div>
-      )}
+      ))}
 
-      {activeTab === "support" && (
+      {activeTab === "support" && captureProduction("support-actions", (
         <div className="tab-panel-content support-grid">
           <section className="panel support-panel" {...layoutSectionProps(layoutManifest, "support", "support-actions")}>
             <div className="panel-header">
@@ -6755,9 +6789,9 @@ export function WorkspaceTabs({
             </div>
           </section>
         </div>
-      )}
+      ))}
 
-      {activeTab === "contact" && (
+      {activeTab === "contact" && captureProduction("contact-options", (
         <div className="tab-panel-content contact-grid">
           <section className="panel contact-panel" {...layoutSectionProps(layoutManifest, "contact", "contact-options")}>
             <div className="panel-header">
@@ -6783,9 +6817,28 @@ export function WorkspaceTabs({
             </div>
           </section>
         </div>
-      )}
-          {layoutManifestV3 && activeLayoutGroups.length > 0 && <WorkspaceLayoutGroupsV3 groups={activeLayoutGroups} />}
-          {!layoutManifestV3 && activeCustomRows.length > 0 && (
+      ))}
+              </>
+            );
+            const productionNodes = activeLayoutGroups.flatMap((group) => group.rows.flatMap(
+              (row) => row.columns.flatMap((column) => column.items.filter(
+                (node): node is WorkspaceProductionNodeV3 => node.kind === "production",
+              )),
+            ));
+            const rendererComplete = Boolean(layoutManifestV3)
+              && productionNodes.every((node) => capturedProduction.has(node.component));
+            if (layoutManifestV3 && rendererComplete) {
+              return (
+                <WorkspaceLayoutGroupsV3
+                  groups={activeLayoutGroups}
+                  renderProduction={renderCapturedProduction}
+                />
+              );
+            }
+            return (
+              <>
+                {legacyContent}
+          {activeCustomRows.length > 0 && (
             <div aria-label="Custom workspace sections" className="workspace-custom-grid">
               {activeCustomRows.map((row) => (
                 <div
@@ -6811,6 +6864,9 @@ export function WorkspaceTabs({
               ))}
             </div>
           )}
+              </>
+            );
+          })()}
         </main>
         <DataNotesPanel
           dataIssueUrl={dataIssueUrl}

--- a/src/lib/workspace-layout-runtime.ts
+++ b/src/lib/workspace-layout-runtime.ts
@@ -5,6 +5,7 @@ import { cookies } from "next/headers";
 import { evaluate } from "flags/next";
 import { workspaceLayoutCandidate, workspaceLayoutRuntimeV3 } from "@/flags";
 import { readLayoutAdmin } from "./ui-layout-auth";
+import { getLayoutDraft } from "./ui-layout-v4-repository";
 import { getLayoutRevision } from "./ui-layout-repository";
 import { createWorkspaceLayoutEnvelope } from "./workspace-layout-digest";
 import { resolveWorkspaceLayoutCandidates } from "./workspace-layout-resolution";
@@ -24,13 +25,26 @@ function getEdgeConfigClient() {
 }
 
 async function readDraftEnvelope() {
-  const revisionId = (await cookies()).get(WORKSPACE_LAYOUT_DRAFT_COOKIE)?.value;
-  if (!revisionId || !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(revisionId)) {
-    return undefined;
-  }
+  const value = (await cookies()).get(WORKSPACE_LAYOUT_DRAFT_COOKIE)?.value;
+  if (!value) return undefined;
   const admin = await readLayoutAdmin();
   if (admin.status !== "ready") return undefined;
-  const revision = await getLayoutRevision(revisionId);
+
+  const [kind, id] = value.includes(":") ? value.split(":", 2) : ["revision", value];
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id)) {
+    return undefined;
+  }
+  if (kind === "draft") {
+    const draft = await getLayoutDraft(id);
+    if (!draft || draft.archivedAt) return undefined;
+    return createWorkspaceLayoutEnvelope({
+      manifest: draft.manifest,
+      publishedAt: draft.updatedAt.toISOString(),
+      revisionId: draft.id,
+    });
+  }
+  if (kind !== "revision") return undefined;
+  const revision = await getLayoutRevision(id);
   if (!revision) return undefined;
   return createWorkspaceLayoutEnvelope({
     manifest: revision.manifest,
@@ -81,6 +95,9 @@ export async function resolveWorkspaceLayout() {
     candidateEnabled,
     stable: edgeLayouts.stable,
   });
+  if (resolution.source === "draft" && resolution.envelope.schemaVersion === 3) {
+    runtimeV3Enabled = true;
+  }
   console.info(JSON.stringify({
     event: "workspace_layout_resolved",
     source: resolution.source,

--- a/src/lib/workspace-layout-v3-runtime.ts
+++ b/src/lib/workspace-layout-v3-runtime.ts
@@ -1,6 +1,5 @@
 import {
   evaluateWorkspaceVisibility,
-  isWorkspaceCustomNodeV2,
   type WorkspaceVisibilityContext,
 } from "./workspace-layout-v2.ts";
 import {
@@ -25,7 +24,7 @@ export type WorkspaceRuntimeGroupV3 = {
     align: "start" | "center" | "stretch";
     columns: Array<{
       id: string;
-      items: Array<Extract<WorkspaceLayoutNodeV3, { kind: "custom" }>>;
+      items: WorkspaceLayoutNodeV3[];
       span: { desktop: number; mobile: number; tablet: number };
     }>;
     gap: "small" | "medium" | "large";
@@ -47,7 +46,7 @@ export function workspaceRuntimeGroupsV3(
   return tab.groups.flatMap((group) => {
     const rows = group.rows.flatMap((row) => {
       const columns = row.columns.flatMap((column) => {
-        const items = column.items.filter((node) => isVisibleCustomNode(node, context));
+        const items = column.items.filter((node) => isVisibleWorkspaceNode(node, context));
         return items.length ? [{ id: column.id, items, span: column.span }] : [];
       });
       return columns.length ? [{
@@ -88,11 +87,10 @@ export function workspaceProductionGroupIdV3(
   return undefined;
 }
 
-function isVisibleCustomNode(
+function isVisibleWorkspaceNode(
   node: WorkspaceLayoutNodeV3,
   context?: WorkspaceVisibilityContext,
-): node is Extract<WorkspaceLayoutNodeV3, { kind: "custom" }> {
-  return isWorkspaceCustomNodeV2(node)
-    && node.visible
+): boolean {
+  return node.visible
     && (!context || evaluateWorkspaceVisibility(node.visibility, context));
 }

--- a/tests/api/workspace-layout-admin-policy.test.mjs
+++ b/tests/api/workspace-layout-admin-policy.test.mjs
@@ -99,6 +99,9 @@ test("builder v3 exposes responsive rows, rich content, media, and publication c
 
 test("builder v4 exposes grouped editing, recovery, scheduling, and safety controls", () => {
   const editor = readFileSync("src/app/admin/layout/layout-editor-v4.tsx", "utf8");
+  const operations = readFileSync("src/app/admin/layout/layout-editor-v4-operations.tsx", "utf8");
+  const actions = readFileSync("src/app/admin/layout/actions.ts", "utf8");
+  const workspaceRuntime = readFileSync("src/lib/workspace-layout-runtime.ts", "utf8");
   const canvas = readFileSync("src/app/admin/layout/layout-editor-v4-canvas.tsx", "utf8");
   const inspector = readFileSync("src/app/admin/layout/layout-editor-v4-inspector.tsx", "utf8");
   const scheduler = readFileSync("src/lib/ui-layout-scheduler.ts", "utf8");
@@ -113,6 +116,10 @@ test("builder v4 exposes grouped editing, recovery, scheduling, and safety contr
   assert.match(editor, /RECOVERY_KEY/);
   assert.match(editor, /saveLayoutDraftAction/);
   assert.match(editor, /workspaceStarterGroupTemplatesV3/);
+  assert.match(operations, /Open named draft preview/);
+  assert.match(actions, /draft:\$\{draft\.id\}/);
+  assert.match(workspaceRuntime, /getLayoutDraft/);
+  assert.match(workspaceRuntime, /source === "draft"/);
   assert.match(canvas, /layout-group/);
   assert.match(canvas, /layout-row/);
   assert.match(canvas, /layout-column/);

--- a/tests/api/workspace-layout-v3.test.mjs
+++ b/tests/api/workspace-layout-v3.test.mjs
@@ -58,7 +58,7 @@ test("weak design-token contrast and unknown fields fail closed", () => {
   assert.match(shape.errors.join(" "), /unsupported fields/i);
 });
 
-test("starter groups remain custom-only and public runtime projection keeps headings", () => {
+test("runtime projection retains production and custom nodes in manifest order", () => {
   assert.equal(workspaceStarterGroupTemplatesV3.every((template) => isWorkspaceGroupCustomOnlyV3(template.group)), true);
   const manifest = cloneWorkspaceLayoutManifestV3();
   const group = structuredClone(workspaceStarterGroupTemplatesV3[0].group);
@@ -66,6 +66,16 @@ test("starter groups remain custom-only and public runtime projection keeps head
   manifest.tabs.find((tab) => tab.id === "map").groups.push(group);
   const runtime = workspaceRuntimeGroupsV3(manifest, "map", { state: "WA", year: 2024 });
   assert.equal(runtime.some((item) => item.heading === "How to read this view"), true);
+  assert.deepEqual(
+    runtime[0].rows[0].columns.flatMap((column) => column.items.map((node) => node.component)),
+    ["results-map", "source-provenance", "coverage-context", "state-snapshot"],
+  );
+  assert.equal(
+    runtime.at(-1).rows.flatMap((row) => row.columns.flatMap((column) => column.items)).every(
+      (node) => node.kind === "custom",
+    ),
+    true,
+  );
 });
 
 test("schema v3 envelopes retain version metadata and detect tampering", () => {

--- a/tests/e2e/workspace-layout-v3.spec.ts
+++ b/tests/e2e/workspace-layout-v3.spec.ts
@@ -18,6 +18,12 @@ test("schema-v2 design tokens reach the public workspace at desktop and mobile w
   await expect(workspace).toHaveAttribute("data-layout-type-scale", "standard");
   await expect(workspace.getByRole("tab", { name: "Map", exact: true })).toBeVisible();
 
+  const productionNodes = workspace.locator('[data-layout-node-kind="production"]');
+  await expect(productionNodes).toHaveCount(4);
+  await expect(page.locator('[data-layout-section="map:results-map"]')).toHaveCount(1);
+  expect(await productionNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute("data-layout-component"))))
+    .toEqual(["results-map", "source-provenance", "coverage-context", "state-snapshot"]);
+
   const accessibility = await new AxeBuilder({ page }).include(".workspace-tabs").analyze();
   expect(accessibility.violations
     .filter((violation) => violation.impact === "critical")
@@ -29,6 +35,38 @@ test("schema-v2 design tokens reach the public workspace at desktop and mobile w
   const box = await workspace.boundingBox();
   expect(box?.width ?? 999).toBeLessThanOrEqual(390);
   await expect(page.locator("[data-nextjs-dialog], .nextjs-error-overlay, #webpack-dev-server-client-overlay")).toHaveCount(0);
+  expect(errors).toEqual([]);
+});
+
+test("schema-v3 renderer keeps multi-segment production content in one manifest slot", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  await page.goto("/?state=WA&tab=data");
+  const workspace = page.getByRole("region", { name: /Washington workspace/i });
+  const productionNodes = workspace.locator('[data-layout-node-kind="production"]');
+  await expect(productionNodes).toHaveCount(3);
+  await expect(productionNodes.nth(0)).toHaveAttribute("data-layout-component", "source-provenance");
+  await expect(productionNodes.nth(0).locator('[data-layout-section="data:source-provenance"]')).toHaveCount(3);
+  expect(errors).toEqual([]);
+});
+
+test("schema-v3 renderer preserves the Electronic layout when source requests are empty", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  await page.goto("/?state=WA&tab=electronic");
+  const workspace = page.getByRole("region", { name: /Washington workspace/i });
+  const productionNodes = workspace.locator('[data-layout-node-kind="production"]');
+  await expect(productionNodes).toHaveCount(3);
+  await expect(workspace.locator('[data-layout-component="source-records-request"]')).toBeVisible();
+  await expect(workspace.locator('[data-layout-empty-state="source-records-request"]')).toBeVisible();
   expect(errors).toEqual([]);
 });
 


### PR DESCRIPTION
## Scope
- render schema-v3 production and custom nodes in exact group, row, column, and item order
- preserve responsive spans and safe density, surface, emphasis, and minimum-height presentation
- add an authenticated preview path for mutable named drafts without creating an immutable revision
- fail closed to the legacy tab renderer if a production renderer is unavailable
- preserve the Electronic manifest renderer when its source-request queue is empty

## Validation
- `npm run typecheck`
- `npm run test:layout`
- `npm run build`
- focused Playwright: Map layout and accessibility assertions
- focused Playwright: Data multi-segment manifest slot
- focused Playwright: Electronic empty source-request state
- `git diff --check`

## Display paths checked
- public Map tab on desktop and mobile
- public Data tab source-provenance composition
- public Electronic tab with no queued source-record requests
- authenticated named-draft preview policy and server wiring

## Data and safety
- no election data, ETL config, migration, revision, publication, staging, or production promotion changes
- draft preview remains layout-admin gated and rejects missing, archived, or malformed targets

## Review
A bounded read-only review found one blocking Electronic empty-state fallback. The implementation now always captures that production slot and includes a browser regression. No remaining blocking issue was reported.

## Caveat
A full `npm test` run reaches the existing Georgia historical-review CSV assertion and fails only on its pre-existing CRLF-versus-LF expectation; the layout-specific suite passes in full.