### PR TITLE
Prioritize workspace controls and map

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6156,6 +6156,15 @@ td {
   border-color: var(--accent);
 }
 
+.workspace-context-notices {
+  display: grid;
+  gap: 8px;
+}
+
+.workspace-context-notices .historical-map-note {
+  margin: 0;
+}
+
 .historical-map-note {
   margin: 0 0 16px;
   padding: 12px 14px;
@@ -6610,6 +6619,7 @@ td {
 /* Primary navigation hierarchy and responsive state rail. */
 .workspace {
   grid-template-columns: auto minmax(0, 1fr);
+  padding-top: clamp(12px, 1.5vw, 20px);
 }
 
 .state-rail {
@@ -6814,4 +6824,18 @@ td {
   .state-rail .state-list {
     max-height: none;
   }
+}
+.workspace-supporting-tools {
+  display: grid;
+  gap: 18px;
+  margin-top: 28px;
+}
+
+.workspace-supporting-tools .workspace-county-jump {
+  margin: 0;
+  max-width: none;
+}
+
+.workspace-supporting-tools .national-overview {
+  margin-bottom: 0;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,6 @@ import type { Metadata } from "next";
 import {
   Archive,
   Braces,
-  CheckCircle2,
-  CircleDashed,
   Database,
   GitCompareArrows,
   MapPin,
@@ -303,9 +301,6 @@ export default async function Home({ searchParams }: HomeProps) {
           map: historicalCoverageReady,
         },
       };
-  const coveragePassed = selectedYear === 2024
-    ? Boolean(displayCoverage?.validation.passed)
-    : historicalCoverageReady;
 
   return (
     <main className="app-shell">
@@ -372,78 +367,6 @@ export default async function Home({ searchParams }: HomeProps) {
         </StateRail>
 
         <section className="main-panel">
-          <NationalOverview report={completenessReport} year={2024} />
-
-          <section aria-labelledby="county-profile-jump-title" className="workspace-county-jump">
-            <div className="workspace-county-jump-copy">
-              <span aria-hidden className="workspace-county-jump-icon"><MapPin size={18} /></span>
-              <div>
-                <div className="workspace-county-jump-heading">
-                  <p className="section-label">County profiles</p>
-                  <span>Separate page</span>
-                </div>
-                <h2 id="county-profile-jump-title">Open a county profile</h2>
-                <p>Search nationwide by county name or five-digit FIPS. This opens a separate county history page and does not filter the state map.</p>
-              </div>
-            </div>
-            <GlobalCountySearch
-              className="workspace-county-search"
-              defaultState={selectedStateCode}
-              key={"county-profile-search-" + selectedStateCode}
-              label="County or FIPS"
-              placeholder="Enter county name, alias, or five-digit FIPS"
-            />
-          </section>
-
-          <div className="dashboard-head">
-            <div>
-              <p className="section-label">{selectedYear} President</p>
-              <h1>{selected?.name ?? selectedStateCode}</h1>
-            </div>
-            <div className="head-status">
-              {coveragePassed ? (
-                <CheckCircle2 aria-hidden size={18} />
-              ) : (
-                <CircleDashed aria-hidden size={18} />
-              )}
-              <span>{coveragePassed ? "Validated canonical coverage" : "Coverage gap"}</span>
-            </div>
-          </div>
-
-          {selectedYear !== 2024 && (
-            <p className="historical-map-note">
-              Historical mode shows canonical county presidential rows. {indicatorsEvaluated
-                ? "Same-year advisory indicators are overlaid from loaded President-versus-comparison-contest rows."
-                : "Advisory indicators are not evaluated for this state-year because same-grain comparison rows are not loaded."}{" "}
-              Vote methods, equipment, and administration records remain 2024 context and are not overlaid.
-            </p>
-          )}
-          {selectedYear !== 2024 && indicatorEvaluation.broadSignalWarning && (
-            <p className="historical-map-note historical-map-warning" role="status">
-              <strong>Broad-signal caution.</strong>{" "}
-              {indicatorEvaluation.broadSignalWarning}
-            </p>
-          )}
-
-          <section className="metrics-grid" aria-label="Platform metrics">
-            <div className="metric">
-              <span>Jurisdictions</span>
-              <strong>{displayCoverage?.loadedJurisdictions ?? results.length}</strong>
-            </div>
-            <div className="metric">
-              <span>Total votes</span>
-              <strong>{totalVotes.toLocaleString()}</strong>
-            </div>
-            <div className="metric">
-              <span>Sources</span>
-              <strong>{sources.length}</strong>
-            </div>
-            <div className="metric">
-              <span>Validation</span>
-              <strong>{coveragePassed ? "Pass" : "Gap"}</strong>
-            </div>
-          </section>
-
           <WorkspaceTabs
             adminSourceStatus={adminSourceStatuses.states[0]}
             coverage={displayCoverage}
@@ -453,6 +376,7 @@ export default async function Home({ searchParams }: HomeProps) {
             electronicIntegrityRequests={electronicIntegrityRequests}
             equipmentRows={equipmentRows}
             historicalRows={historicalRows}
+            historicalBroadSignalWarning={indicatorEvaluation.broadSignalWarning ?? undefined}
             importRuns={importRuns}
             indicators={indicators}
             indicatorsEvaluated={indicatorsEvaluated}
@@ -475,6 +399,31 @@ export default async function Home({ searchParams }: HomeProps) {
             voteMethodRows={voteMethodRows}
             securityIncidents={securityIncidents}
           />
+
+          <section aria-label="Additional workspace tools" className="workspace-supporting-tools">
+            <section aria-labelledby="county-profile-jump-title" className="workspace-county-jump">
+              <div className="workspace-county-jump-copy">
+                <span aria-hidden className="workspace-county-jump-icon"><MapPin size={18} /></span>
+                <div>
+                  <div className="workspace-county-jump-heading">
+                    <p className="section-label">County profiles</p>
+                    <span>Separate page</span>
+                  </div>
+                  <h2 id="county-profile-jump-title">Open a county profile</h2>
+                  <p>Search nationwide by county name or five-digit FIPS. This opens a separate county history page and does not filter the state map.</p>
+                </div>
+              </div>
+              <GlobalCountySearch
+                className="workspace-county-search"
+                defaultState={selectedStateCode}
+                key={"county-profile-search-" + selectedStateCode}
+                label="County or FIPS"
+                placeholder="Enter county name, alias, or five-digit FIPS"
+              />
+            </section>
+
+            <NationalOverview report={completenessReport} year={2024} />
+          </section>
         </section>
       </div>
     </main>

--- a/src/app/workspace-context-bar.tsx
+++ b/src/app/workspace-context-bar.tsx
@@ -138,7 +138,9 @@ export function WorkspaceContextBar({
         <SlidersHorizontal aria-hidden size={18} />
         <div>
           <span>Current context</span>
-          <strong>{selectedStateName} · {electionYear} President</strong>
+          <h1>
+            {selectedStateName} · <small>{electionYear} President</small>
+          </h1>
         </div>
       </div>
 
@@ -175,9 +177,11 @@ export function WorkspaceContextBar({
           </select>
         </label>
 
-        <div className="workspace-context-readonly">
+        <div className="workspace-context-control">
           <span>Contest</span>
-          <strong>President</strong>
+          <div className="workspace-context-readonly">
+            <strong>President</strong>
+          </div>
         </div>
 
         <label className="workspace-context-control is-wide">

--- a/src/app/workspace-layout-v2.css
+++ b/src/app/workspace-layout-v2.css
@@ -335,17 +335,15 @@
   flex: 0 0 auto;
 }
 
-.workspace-context-summary div,
-.workspace-context-control,
-.workspace-context-readonly {
+.workspace-context-summary > div,
+.workspace-context-control {
   display: grid;
   gap: 5px;
   min-width: 0;
 }
 
-.workspace-context-summary span,
-.workspace-context-control span,
-.workspace-context-readonly span {
+.workspace-context-summary > div > span,
+.workspace-context-control > span {
   color: var(--quiet);
   font-size: 10px;
   font-weight: 850;
@@ -353,10 +351,17 @@
   text-transform: uppercase;
 }
 
-.workspace-context-summary strong {
+.workspace-context-summary h1 {
+  font-size: 15px;
+  margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.workspace-context-summary h1 small {
+  color: var(--muted);
+  font: inherit;
 }
 
 .workspace-context-controls {
@@ -391,8 +396,8 @@
 }
 
 .workspace-context-readonly {
-  align-content: center;
-  gap: 1px;
+  align-items: center;
+  display: flex;
   padding: 5px 11px;
 }
 

--- a/src/app/workspace-tabs.tsx
+++ b/src/app/workspace-tabs.tsx
@@ -97,6 +97,7 @@ type WorkspaceTabsProps = {
   equipmentRows: EquipmentRowSummary[];
   securityIncidents: SecurityIncidentSummary[];
   historicalRows: HistoricalResultRowSummary[];
+  historicalBroadSignalWarning?: string;
   initialFips?: string;
   initialMapMode?: "winner" | "margin" | "volume" | "method" | "equipment" | "security";
   initialTab?: string;
@@ -2730,6 +2731,7 @@ export function WorkspaceTabs({
   equipmentRows,
   securityIncidents,
   historicalRows,
+  historicalBroadSignalWarning,
   initialFips,
   initialMapMode,
   initialTab,
@@ -4141,6 +4143,22 @@ export function WorkspaceTabs({
         states={states}
         voteMethodAvailable={voteMethodRows.length > 0}
       />
+      {activeTab === "map" && electionYear !== 2024 && (
+        <div className="workspace-context-notices">
+          <p className="historical-map-note">
+            Historical mode shows canonical county presidential rows. {indicatorsEvaluated
+              ? "Same-year advisory indicators are overlaid from loaded President-versus-comparison-contest rows."
+              : "Advisory indicators are not evaluated for this state-year because same-grain comparison rows are not loaded."}{" "}
+            Vote methods, equipment, and administration records remain 2024 context and are not overlaid.
+          </p>
+          {historicalBroadSignalWarning && (
+            <p className="historical-map-note historical-map-warning" role="status">
+              <strong>Broad-signal caution.</strong>{" "}
+              {historicalBroadSignalWarning}
+            </p>
+          )}
+        </div>
+      )}
       <div
         className="tab-bar"
         data-layout-tab-style={layoutDesignSettings.tabStyle}

--- a/tests/api/historical-indicators.test.mjs
+++ b/tests/api/historical-indicators.test.mjs
@@ -7,6 +7,7 @@ const schema = readFileSync("src/db/schema.ts", "utf8");
 const dataAccess = readFileSync("src/lib/data-access.ts", "utf8");
 const page = readFileSync("src/app/page.tsx", "utf8");
 const explorer = readFileSync("src/app/results-explorer.tsx", "utf8");
+const workspaceTabs = readFileSync("src/app/workspace-tabs.tsx", "utf8");
 const pipeline = readFileSync("civic_etl/pipeline.py", "utf8");
 
 test("historical promotion replaces only explicitly loaded review years", () => {
@@ -57,7 +58,8 @@ test("historical maps load same-year indicators and distinguish not evaluated", 
   assert.match(page, /indicatorsEvaluated/);
   assert.match(page, /not been evaluated for advisory indicators/);
   assert.match(page, /indicatorEvaluation\.broadSignalWarning/);
-  assert.match(page, /Broad-signal caution/);
+  assert.match(workspaceTabs, /historicalBroadSignalWarning/);
+  assert.match(workspaceTabs, /Broad-signal caution/);
   assert.match(explorer, /mapIndicatorsByTag/);
   assert.match(explorer, /indicatorsByTag/);
   assert.match(explorer, /Advisory indicators are not evaluated for this state-year/);

--- a/tests/e2e/workspace-layout.spec.ts
+++ b/tests/e2e/workspace-layout.spec.ts
@@ -29,6 +29,26 @@ test("public workspace uses the safe embedded layout and durable visitor cookie"
   await expect(workspaceContext.getByText("President", { exact: true })).toBeVisible();
   await expect(workspaceContext.getByLabel("Workspace geography")).toHaveValue("53033");
   await expect(workspaceContext.getByLabel("Workspace map layer")).toHaveValue("margin");
+  await expect(workspaceContext.getByRole("heading", { level: 1, name: /Washington/i })).toBeVisible();
+  await expect(workspaceContext.locator(".workspace-context-control")).toHaveCount(5);
+  await expect(workspaceContext.locator(".workspace-context-readonly")).toHaveText("President");
+
+  const mapPanel = page.locator('[aria-label="WA county map"]');
+  const supportingTools = page.getByRole("region", { name: "Additional workspace tools" });
+  await expect(mapPanel).toBeVisible();
+  await expect(supportingTools).toBeVisible();
+  const [contextBounds, mapBounds, supportingBounds] = await Promise.all([
+    workspaceContext.boundingBox(),
+    mapPanel.boundingBox(),
+    supportingTools.boundingBox(),
+  ]);
+  if (!contextBounds || !mapBounds || !supportingBounds) {
+    throw new Error("Expected workspace priority surfaces to have measurable bounds.");
+  }
+  expect(contextBounds.y).toBeLessThan(mapBounds.y);
+  expect(mapBounds.y).toBeLessThan(supportingBounds.y);
+  expect(mapBounds.y).toBeLessThan(page.viewportSize()?.height ?? 720);
+
   await expect(workspace.getByRole("tab", { name: "Map", exact: true })).toBeVisible();
   await expect(workspace.getByRole("tab", { name: "Review Center", exact: true })).toBeVisible();
   await expect(workspace.getByRole("tab", { name: "Data & Sources", exact: true })).toBeVisible();


### PR DESCRIPTION
## What changed

- moves Current Context, workspace navigation, and the active workspace ahead of county search and national overview tools
- places the selected state/year in the page heading and gives Contest the same label/value structure as every other context control
- keeps historical-mode cautions adjacent to the Map workspace
- adds browser assertions for context → map → supporting-tools order, consistent control labels, and an above-the-fold map

## Why

Reviewer feedback showed that the sticky context controls were separated from the header, the map required scrolling to discover, Data Notes appeared after the page content, and Contest was labeled inconsistently.

This code change is paired with saved layout draft version 8 (not published), which removes the redundant Map “Start here” stack, moves snapshot and coverage context beside the map, and sets Map Data Notes to the side.

## User impact

The primary path is now header → Current Context → workspace navigation → map. County-profile search and the national overview remain available below the main workspace.

## Validation

- `npm run typecheck`
- `npm run test:layout`
- `npm run build` (Next.js 16 Turbopack production build)
- `playwright test workspace-layout.spec.ts --project=chromium`: primary desktop layout test and four other flows passed; one mobile navigation timeout under six-worker load passed immediately when rerun alone with one worker
- manual production-server Chromium check: no framework overlay or page exception; map starts at y=449 in a 900px viewport; the only local console 404 is the expected Vercel Web Analytics script outside Vercel

## Notes

The repository currently has no ESLint 9 flat configuration, so the focused ESLint command cannot start. TypeScript, production build, layout tests, and browser verification all pass.