### PR TITLE
Fix protected layout publisher

### DIFF
--- a/scripts/publish-ui-layout.ts
+++ b/scripts/publish-ui-layout.ts
@@ -112,12 +112,12 @@ function disableCandidateFlag(target: Environment) {
 }
 
 async function updateEdgeConfig(items: Array<{ key: string; value: unknown }>) {
-  const operations = await Promise.all(items.map(async (item) => ({
-    operation: await edgeItemExists(item.key) ? "update" : "create",
+  const operations = items.map((item) => ({
+    operation: "upsert",
     key: item.key,
     value: item.value,
     description: "Versioned Civic Result Maps workspace layout envelope",
-  })));
+  }));
   const response = await fetch(edgeUrl(`/v1/edge-config/${edgeConfigId}/items`), {
     method: "PATCH",
     headers: {
@@ -129,14 +129,6 @@ async function updateEdgeConfig(items: Array<{ key: string; value: unknown }>) {
   if (!response.ok) throw new Error(`Edge Config write failed (${response.status}): ${(await response.text()).slice(0, 500)}`);
 }
 
-async function edgeItemExists(key: string) {
-  const response = await fetch(edgeUrl(`/v1/edge-config/${edgeConfigId}/item/${encodeURIComponent(key)}`), {
-    headers: { Authorization: `Bearer ${vercelToken}` },
-  });
-  if (response.status === 404) return false;
-  if (!response.ok) throw new Error(`Edge Config item lookup failed (${response.status}).`);
-  return true;
-}
 
 async function readEdgeDigest() {
   const response = await fetch(edgeUrl(`/v1/edge-config/${edgeConfigId}`), {

--- a/scripts/publish-ui-layout.ts
+++ b/scripts/publish-ui-layout.ts
@@ -101,7 +101,7 @@ function disableCandidateFlag(target: Environment) {
       "--environment",
       target,
       "--variant",
-      "off",
+      "false",
       "--token",
       vercelToken,
       "--no-color",

--- a/tests/api/workspace-layout-publisher-policy.test.mjs
+++ b/tests/api/workspace-layout-publisher-policy.test.mjs
@@ -40,3 +40,10 @@ test("protected workflow does not interpolate dispatch inputs into shell syntax"
   assert.doesNotMatch(editor, /useId/);
   assert.match(page, /requestKey=\{randomUUID\(\)\}/);
 });
+
+test("publisher disables the candidate flag with the boolean off variant", () => {
+  const publisher = readFileSync("scripts/publish-ui-layout.ts", "utf8");
+
+  assert.match(publisher, /"--variant",\s*"false"/);
+  assert.doesNotMatch(publisher, /"--variant",\s*"off"/);
+});

--- a/tests/api/workspace-layout-publisher-policy.test.mjs
+++ b/tests/api/workspace-layout-publisher-policy.test.mjs
@@ -47,3 +47,11 @@ test("publisher disables the candidate flag with the boolean off variant", () =>
   assert.match(publisher, /"--variant",\s*"false"/);
   assert.doesNotMatch(publisher, /"--variant",\s*"off"/);
 });
+
+test("publisher upserts Edge Config items without an existence race", () => {
+  const publisher = readFileSync("scripts/publish-ui-layout.ts", "utf8");
+
+  assert.match(publisher, /operation: "upsert"/);
+  assert.doesNotMatch(publisher, /edgeItemExists/);
+  assert.doesNotMatch(publisher, /await Promise\.all\(items\.map/);
+});


### PR DESCRIPTION
## What changed

- use the Boolean Vercel Flag variant ID `false` when disabling the layout candidate flag
- atomically `upsert` Edge Config layout envelopes instead of probing and choosing `create` or `update`
- add regression coverage for both publishing failures

## Why

The protected preview publisher exposed two integration mismatches:

1. the project’s Boolean flag exposes `false` and `true`, while the script requested a nonexistent `off` variant
2. the Edge Config existence probe could classify a missing key as present, causing an `update` operation to fail; `upsert` is the supported atomic operation and removes that race

## Validation

- `npm run test:layout`
- `tsc --noEmit`
- focused publisher-policy tests
- protected preview workflow retries (no production promotion)

This change does not publish or promote a production layout. It only repairs the protected publishing workflow.