### PR TITLE
Add equipment social previews by state

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "equipment:claims:state": "node scripts/set-equipment-claim-editorial-state.mjs",
     "validate:equipment-editorial": "node scripts/validate-equipment-editorial-workflow.mjs",
     "validate:equipment-catalog": "node scripts/validate-equipment-catalog.mjs",
-    "test:equipment-catalog": "npm run validate:equipment-editorial && npm run validate:equipment-catalog && npm run equipment:usage:coverage && node tests/api/equipment-catalog.test.mjs && node tests/api/equipment-usage.test.mjs && node --experimental-strip-types tests/api/equipment-explorer-config.test.mts && node tests/api/equipment-editorial-state.test.mjs"
+    "test:equipment-catalog": "npm run validate:equipment-editorial && npm run validate:equipment-catalog && npm run equipment:usage:coverage && node tests/api/equipment-catalog.test.mjs && node tests/api/equipment-usage.test.mjs && node tests/api/equipment-social-preview.test.mjs && node --experimental-strip-types tests/api/equipment-explorer-config.test.mts && node tests/api/equipment-editorial-state.test.mjs"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.5.18",

--- a/scripts/build-equipment-usage-index.mjs
+++ b/scripts/build-equipment-usage-index.mjs
@@ -244,7 +244,8 @@ async function buildIndex() {
 const output = `${JSON.stringify(await buildIndex(), null, 2)}\n`;
 if (process.argv.includes("--check")) {
   const current = await readFile(outputPath, "utf8").catch(() => "");
-  if (current !== output) throw new Error(`${outputPath} is stale. Run npm run equipment:usage:build.`);
+  const normalizedCurrent = current.replace(/\r\n?/g, "\n");
+  if (normalizedCurrent !== output) throw new Error(`${outputPath} is stale. Run npm run equipment:usage:build.`);
   console.log(`${outputPath} is current.`);
 } else {
   await writeFile(outputPath, output);

--- a/src/app/api/equipment-social-card/route.tsx
+++ b/src/app/api/equipment-social-card/route.tsx
@@ -1,0 +1,414 @@
+import { ImageResponse } from "next/og";
+import type { NextRequest } from "next/server";
+
+import {
+  buildEquipmentIndexSocialPreview,
+  buildEquipmentMachineSocialPreview,
+  buildEquipmentStateSocialPreview,
+  type EquipmentMachineSocialPreview,
+  type EquipmentNetworkPreviewStatus,
+  type EquipmentStateSocialPreview,
+} from "@/lib/equipment-social-preview";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const size = { width: 1200, height: 630 };
+const colors = {
+  background: "#071619",
+  card: "#0d2427",
+  cardDark: "#091d20",
+  border: "#274548",
+  text: "#edf8f6",
+  muted: "#9db9b6",
+  accent: "#67d9cc",
+  optional: "#f0c36a",
+  context: "#9db9b6",
+};
+
+function BrandMark() {
+  return (
+    <svg height="42" viewBox="0 0 512 512" width="42">
+      <path d="M 261 253 L 397 331 Q 402 334 397 337 L 261 415 Q 256 418 251 415 L 115 337 Q 110 334 115 331 L 251 253 Q 256 250 261 253 Z" fill="#35c7a3" opacity="0.92" />
+      <path d="M 261 173 L 397 251 Q 402 254 397 257 L 261 335 Q 256 338 251 335 L 115 257 Q 110 254 115 251 L 251 173 Q 256 170 261 173 Z" fill="#ff8f7e" opacity="0.96" />
+      <path d="M 261 93 L 397 171 Q 402 174 397 177 L 261 255 Q 256 258 251 255 L 115 177 Q 110 174 115 171 L 251 93 Q 256 90 261 93 Z" fill="#f4f1ea" />
+      <path d="M 179 174 C 217 119 295 119 333 174 C 295 229 217 229 179 174 Z" fill="#061111" />
+      <circle cx="256" cy="174" fill="#35c7a3" r="25" />
+      <circle cx="256" cy="174" fill="#061111" r="13" />
+      <circle cx="270" cy="160" fill="#f4f1ea" r="7" />
+    </svg>
+  );
+}
+
+function BrandHeader({ label }: { label: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 13 }}>
+      <div
+        style={{
+          width: 48,
+          height: 48,
+          border: `1px solid ${colors.border}`,
+          borderRadius: 10,
+          background: colors.card,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <BrandMark />
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <div style={{ display: "flex", color: colors.text, fontSize: 22, fontWeight: 900 }}>Civic Result Maps</div>
+        <div style={{ display: "flex", color: colors.muted, fontSize: 14 }}>{label}</div>
+      </div>
+    </div>
+  );
+}
+
+function statusColors(status: EquipmentNetworkPreviewStatus) {
+  if (status === "optional") {
+    return { background: "rgba(240,195,106,0.13)", border: "#715f38", text: colors.optional };
+  }
+  if (status === "documented") {
+    return { background: "rgba(103,217,204,0.12)", border: "#356d69", text: colors.accent };
+  }
+  return { background: "rgba(157,185,182,0.08)", border: colors.border, text: "#bdd0ce" };
+}
+
+function NetworkPill({
+  label,
+  status,
+}: {
+  label: string;
+  status: EquipmentNetworkPreviewStatus;
+}) {
+  const palette = statusColors(status);
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "8px 11px",
+        border: `1px solid ${palette.border}`,
+        borderRadius: 999,
+        background: palette.background,
+        color: palette.text,
+        fontSize: 14,
+        fontWeight: 800,
+      }}
+    >
+      <div style={{ display: "flex", width: 8, height: 8, borderRadius: 999, background: palette.text }} />
+      {label}
+    </div>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        minWidth: 142,
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        padding: "12px 14px",
+        border: `1px solid ${colors.border}`,
+        borderRadius: 10,
+        background: colors.cardDark,
+      }}
+    >
+      <div style={{ display: "flex", color: colors.muted, fontSize: 12, textTransform: "uppercase", letterSpacing: "0.08em" }}>{label}</div>
+      <div style={{ display: "flex", color: colors.text, fontSize: 20, fontWeight: 900 }}>{value}</div>
+    </div>
+  );
+}
+
+function machineCard(preview: EquipmentMachineSocialPreview, origin: string) {
+  const imageUrl = preview.referenceImage
+    ? new URL(preview.referenceImage.assetUrl, origin).toString()
+    : null;
+  const palette = statusColors(preview.network.status);
+  const response = new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          padding: "38px 44px",
+          display: "flex",
+          gap: 30,
+          background: colors.background,
+          color: colors.text,
+          fontFamily: "Geist, Inter, Segoe UI, Arial, sans-serif",
+        }}
+      >
+        <div style={{ width: 700, display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 25 }}>
+            <BrandHeader label="Source-linked U.S. election equipment" />
+            <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+              <div style={{ display: "flex", color: colors.accent, fontSize: 17, fontWeight: 900, letterSpacing: "0.08em", textTransform: "uppercase" }}>
+                Equipment dossier
+              </div>
+              <div style={{ display: "flex", fontSize: 42, fontWeight: 900, lineHeight: 1.04, letterSpacing: "-0.035em" }}>
+                {preview.displayName}
+              </div>
+              <div style={{ display: "flex", color: colors.muted, fontSize: 20, lineHeight: 1.32 }}>
+                {preview.deviceRole}
+              </div>
+            </div>
+            <div style={{ display: "flex", gap: 10 }}>
+              <Fact label="Components" value={String(preview.componentCount)} />
+              <Fact label="Change records" value={String(preview.changeRecordCount)} />
+              <Fact label="Sources" value={String(preview.sourceCount)} />
+              <Fact label="System" value={preview.systemVersion} />
+            </div>
+          </div>
+          <div style={{ display: "flex", color: colors.muted, fontSize: 14, lineHeight: 1.35 }}>
+            Certified and test documentation is not a live inspection or proof of a jurisdiction's field configuration.
+          </div>
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+            padding: 16,
+            border: `1px solid ${colors.border}`,
+            borderRadius: 16,
+            background: colors.card,
+          }}
+        >
+          {imageUrl ? (
+            <div
+              style={{
+                height: 244,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                overflow: "hidden",
+                borderRadius: 11,
+                background: "#e9eceb",
+              }}
+            >
+              <img
+                alt={preview.referenceImage?.alt ?? ""}
+                height="244"
+                src={imageUrl}
+                style={{ width: "100%", height: "100%", objectFit: "contain" }}
+              />
+            </div>
+          ) : null}
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "space-between",
+              padding: "3px 2px 1px",
+            }}
+          >
+            <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+              <div style={{ display: "flex", color: colors.muted, fontSize: 12, fontWeight: 800, letterSpacing: "0.09em", textTransform: "uppercase" }}>
+                Networking in the reviewed dossier
+              </div>
+              <div style={{ display: "flex" }}>
+                <NetworkPill label={preview.network.shortLabel} status={preview.network.status} />
+              </div>
+              <div style={{ display: "flex", color: colors.text, fontSize: 16, fontWeight: 800, lineHeight: 1.32 }}>
+                {preview.network.label}
+              </div>
+              <div style={{ display: "flex", color: colors.muted, fontSize: 13, lineHeight: 1.35 }}>
+                {preview.network.detail}
+              </div>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                paddingTop: 10,
+                borderTop: `1px solid ${palette.border}`,
+                color: palette.text,
+                fontSize: 12,
+                lineHeight: 1.3,
+              }}
+            >
+              {preview.network.caveat}
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+  return setCache(response);
+}
+
+function stateCard(preview: EquipmentStateSocialPreview) {
+  const response = new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          padding: "34px 42px 30px",
+          display: "flex",
+          flexDirection: "column",
+          background: colors.background,
+          color: colors.text,
+          fontFamily: "Geist, Inter, Segoe UI, Arial, sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 30 }}>
+          <BrandHeader label="2024 source-linked equipment records" />
+          <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+            <Fact label="Tracked dossiers" value={String(preview.systems.length)} />
+            <Fact label="Named families" value={String(preview.namedFamilySystemCount)} />
+            <Fact label="Source records" value={String(preview.sourceCount)} />
+          </div>
+        </div>
+
+        <div style={{ marginTop: 18, marginBottom: 14, display: "flex", alignItems: "baseline", gap: 13 }}>
+          <div style={{ display: "flex", color: colors.accent, fontSize: 22, fontWeight: 900 }}>{preview.stateCode}</div>
+          <div style={{ display: "flex", fontSize: 38, fontWeight: 900, letterSpacing: "-0.035em" }}>{preview.stateName} equipment records</div>
+        </div>
+
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 7 }}>
+          {preview.systems.map((system) => {
+            const exactFamily = system.usage.deviceFamilyRecords > 0;
+            return (
+              <div
+                key={system.slug}
+                style={{
+                  minHeight: 62,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 14,
+                  padding: "9px 13px",
+                  border: `1px solid ${colors.border}`,
+                  borderLeft: `4px solid ${exactFamily ? colors.accent : colors.context}`,
+                  borderRadius: 10,
+                  background: colors.card,
+                }}
+              >
+                <div style={{ width: 356, display: "flex", flexDirection: "column", gap: 2 }}>
+                  <div style={{ display: "flex", color: colors.text, fontSize: 18, fontWeight: 900 }}>{system.deviceName}</div>
+                  <div style={{ display: "flex", color: colors.muted, fontSize: 12 }}>{system.manufacturer}</div>
+                </div>
+                <div style={{ width: 254, display: "flex", flexDirection: "column", gap: 3 }}>
+                  <div style={{ display: "flex", color: exactFamily ? colors.accent : "#c1d1cf", fontSize: 13, fontWeight: 850 }}>
+                    {system.evidenceShortLabel}
+                  </div>
+                  <div style={{ display: "flex", color: colors.muted, fontSize: 11 }}>{system.evidenceLabel}</div>
+                </div>
+                <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
+                  <NetworkPill label={system.network.shortLabel} status={system.network.status} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div style={{ marginTop: 12, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 20 }}>
+          <div style={{ display: "flex", maxWidth: 850, color: colors.muted, fontSize: 12, lineHeight: 1.28 }}>{preview.caveat}</div>
+          <div style={{ display: "flex", color: colors.accent, fontSize: 13, fontWeight: 850 }}>civicresultmaps.org/equipment</div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+  return setCache(response);
+}
+
+function indexCard() {
+  const preview = buildEquipmentIndexSocialPreview();
+  const response = new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          padding: "38px 44px",
+          display: "flex",
+          flexDirection: "column",
+          background: colors.background,
+          color: colors.text,
+          fontFamily: "Geist, Inter, Segoe UI, Arial, sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+          <BrandHeader label="Source-linked U.S. election equipment" />
+          <div style={{ display: "flex", gap: 9 }}>
+            <Fact label="Dossiers" value={String(preview.systems.length)} />
+            <Fact label="Network capability" value={String(preview.documentedCount)} />
+            <Fact label="Optional networking" value={String(preview.optionalCount)} />
+          </div>
+        </div>
+        <div style={{ marginTop: 21, display: "flex", flexDirection: "column", gap: 7 }}>
+          <div style={{ display: "flex", fontSize: 42, fontWeight: 900, letterSpacing: "-0.04em" }}>U.S. Election Equipment Explorer</div>
+          <div style={{ display: "flex", color: colors.muted, fontSize: 18 }}>
+            Certified-configuration quick facts, components, change records, networking evidence, and jurisdiction context.
+          </div>
+        </div>
+        <div style={{ flex: 1, marginTop: 20, display: "flex", flexWrap: "wrap", gap: 10 }}>
+          {preview.systems.map((system) => (
+            <div
+              key={system.slug}
+              style={{
+                width: 547,
+                height: 104,
+                padding: "13px 15px",
+                border: `1px solid ${colors.border}`,
+                borderRadius: 12,
+                background: colors.card,
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "space-between",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12 }}>
+                <div style={{ display: "flex", color: colors.text, fontSize: 19, fontWeight: 900 }}>{system.deviceName}</div>
+                <div style={{ display: "flex", color: colors.muted, fontSize: 12 }}>{system.systemName} {system.systemVersion}</div>
+              </div>
+              <div style={{ display: "flex" }}>
+                <NetworkPill label={system.network.shortLabel} status={system.network.status} />
+              </div>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: "flex", color: colors.muted, fontSize: 12 }}>
+          Network capability in a reviewed dossier does not prove a jurisdiction connected, enabled, configured, or used it.
+        </div>
+      </div>
+    ),
+    size,
+  );
+  return setCache(response);
+}
+
+function setCache(response: ImageResponse) {
+  response.headers.set("Cache-Control", "public, max-age=0, s-maxage=900, stale-while-revalidate=86400");
+  response.headers.set("CDN-Cache-Control", "public, s-maxage=900, stale-while-revalidate=86400");
+  response.headers.set("Vercel-CDN-Cache-Control", "public, s-maxage=900, stale-while-revalidate=86400");
+  return response;
+}
+
+export async function GET(request: NextRequest) {
+  const slug = request.nextUrl.searchParams.get("slug");
+  if (slug) {
+    const preview = buildEquipmentMachineSocialPreview(slug);
+    if (!preview) return new Response("Equipment dossier not found", { status: 404 });
+    return machineCard(preview, request.nextUrl.origin);
+  }
+
+  const state = request.nextUrl.searchParams.get("state");
+  if (state) {
+    const preview = buildEquipmentStateSocialPreview(state);
+    if (!preview) return new Response("Tracked state equipment not found", { status: 404 });
+    return stateCard(preview);
+  }
+
+  return indexCard();
+}

--- a/src/app/equipment/[slug]/page.tsx
+++ b/src/app/equipment/[slug]/page.tsx
@@ -22,6 +22,10 @@ import {
 } from "@/lib/equipment-catalog";
 import { isEquipmentExplorerEnabled } from "@/lib/equipment-explorer-config";
 import {
+  buildEquipmentMachineSocialPreview,
+  equipmentSocialCardPath,
+} from "@/lib/equipment-social-preview";
+import {
   defaultEquipmentUsageEvidence,
   equipmentUsageMetadata,
   getEquipmentUsageSource,
@@ -45,12 +49,30 @@ type PageProps = {
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
   const system = getEquipmentSystem(slug);
-  if (!system) return {};
+  const preview = buildEquipmentMachineSocialPreview(slug);
+  if (!system || !preview) return {};
+  const canonical = `/equipment/${system.slug}`;
+  const image = equipmentSocialCardPath({ slug: system.slug });
+  const imageAlt = `${system.displayName} quick facts and sourced networking status`;
   return {
-    title: `${system.displayName} Equipment Dossier`,
-    description: system.summary,
-    alternates: { canonical: `/equipment/${system.slug}` },
+    title: preview.title,
+    description: preview.description,
+    alternates: { canonical },
     robots: { index: true, follow: true },
+    openGraph: {
+      type: "website",
+      siteName: "Civic Result Maps",
+      url: canonical,
+      title: preview.title,
+      description: preview.description,
+      images: [{ url: image, width: 1200, height: 630, alt: imageAlt }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: preview.title,
+      description: preview.description,
+      images: [{ url: image, alt: imageAlt }],
+    },
   };
 }
 

--- a/src/app/equipment/equipment-share-button.client.tsx
+++ b/src/app/equipment/equipment-share-button.client.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Share2 } from "lucide-react";
+
+export function EquipmentShareButton({ title }: { title: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function share() {
+    const url = window.location.href;
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, url });
+        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+      }
+    }
+
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(url);
+    } else {
+      const textArea = document.createElement("textarea");
+      textArea.value = url;
+      textArea.style.position = "fixed";
+      textArea.style.opacity = "0";
+      document.body.append(textArea);
+      textArea.select();
+      document.execCommand("copy");
+      textArea.remove();
+    }
+    setCopied(true);
+  }
+
+  return (
+    <button className="equipment-share-button" onClick={share} type="button">
+      {copied ? <Check aria-hidden size={15} /> : <Share2 aria-hidden size={15} />}
+      {copied ? "Link copied" : "Share this state page"}
+    </button>
+  );
+}

--- a/src/app/equipment/equipment.module.css
+++ b/src/app/equipment/equipment.module.css
@@ -2787,3 +2787,430 @@
     grid-template-columns: 1fr;
   }
 }
+
+.statePickerPanel {
+  margin-top: 40px;
+  padding: 22px;
+  border: 1px solid var(--equipment-border);
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(14, 47, 50, 0.88), rgba(7, 27, 30, 0.92));
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.65fr);
+  gap: 28px;
+  align-items: end;
+}
+
+.statePickerPanel h2,
+.statePickerPanel p {
+  margin: 0;
+}
+
+.statePickerPanel h2 {
+  font-size: clamp(1.35rem, 2.5vw, 2rem);
+  letter-spacing: -0.025em;
+}
+
+.statePickerPanel > div > p:last-child {
+  max-width: 760px;
+  margin-top: 10px;
+  color: var(--equipment-muted);
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+.statePickerForm {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: end;
+}
+
+.statePickerForm label {
+  grid-column: 1 / -1;
+  color: var(--equipment-muted);
+  font-size: 0.72rem;
+  font-weight: 780;
+}
+
+.statePickerForm select,
+.statePickerForm button {
+  min-height: 42px;
+  border: 1px solid var(--equipment-border);
+  border-radius: 9px;
+  font: inherit;
+}
+
+.statePickerForm select {
+  min-width: 0;
+  padding: 0 10px;
+  color: #edf8f6;
+  background: #0b2023;
+}
+
+.statePickerForm button {
+  padding: 0 15px;
+  color: #051615;
+  background: var(--equipment-accent);
+  cursor: pointer;
+  font-weight: 850;
+}
+
+.networkQuickFact {
+  padding: 12px;
+  border: 1px solid rgba(103, 217, 204, 0.22);
+  border-radius: 11px;
+  background: rgba(103, 217, 204, 0.065);
+  color: var(--equipment-accent);
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.networkQuickFact[data-network-status="optional"] {
+  border-color: rgba(240, 195, 106, 0.28);
+  background: rgba(240, 195, 106, 0.07);
+  color: #f0c36a;
+}
+
+.networkQuickFact[data-network-status="reviewed_without_attachment"] {
+  border-color: rgba(157, 185, 182, 0.2);
+  background: rgba(157, 185, 182, 0.05);
+  color: #bdd0ce;
+}
+
+.networkQuickFact div {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.networkQuickFact span {
+  color: currentColor;
+  font-size: 0.68rem;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.networkQuickFact strong {
+  color: #edf8f6;
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.networkQuickFact small {
+  color: var(--equipment-muted);
+  font-size: 0.7rem;
+  line-height: 1.45;
+}
+
+.equipmentBreadcrumb {
+  margin-bottom: 28px;
+  color: var(--equipment-muted);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.78rem;
+}
+
+.equipmentBreadcrumb a {
+  color: var(--equipment-accent);
+  text-decoration: none;
+}
+
+.stateHero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.68fr);
+  gap: 36px;
+  align-items: end;
+}
+
+.stateHero h1 {
+  max-width: 920px;
+  margin: 0;
+  font-size: clamp(2.25rem, 5vw, 4.8rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.shareActions {
+  margin-top: 17px;
+  display: grid;
+  gap: 8px;
+}
+
+.shareActions :global(.equipment-share-button),
+.shareActions a {
+  min-height: 38px;
+  padding: 0 12px;
+  border: 1px solid rgba(103, 217, 204, 0.24);
+  border-radius: 9px;
+  color: #8be6db;
+  background: rgba(103, 217, 204, 0.07);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+}
+
+.stateBoundaryNote {
+  margin-top: 22px;
+  padding: 15px 17px;
+  border-left: 3px solid #f0c36a;
+  border-radius: 0 10px 10px 0;
+  background: rgba(240, 195, 106, 0.065);
+  display: grid;
+  gap: 5px;
+}
+
+.stateBoundaryNote strong {
+  color: #f0c36a;
+}
+
+.stateBoundaryNote p {
+  margin: 0;
+  color: var(--equipment-muted);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.stateSystemGrid {
+  display: grid;
+  gap: 16px;
+}
+
+.stateSystemCard {
+  overflow: hidden;
+  border: 1px solid var(--equipment-border);
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(16, 43, 46, 0.9), rgba(7, 26, 29, 0.94));
+  display: grid;
+  grid-template-columns: 290px minmax(0, 1fr);
+}
+
+.stateSystemCard[data-evidence="device-family"] {
+  border-left: 4px solid var(--equipment-accent);
+}
+
+.stateSystemCard[data-evidence="manufacturer-context"] {
+  border-left: 4px solid #819b98;
+}
+
+.stateSystemImage {
+  position: relative;
+  min-height: 100%;
+  padding: 16px;
+  background: rgba(4, 20, 23, 0.86);
+  display: grid;
+  align-content: center;
+  gap: 9px;
+}
+
+.stateSystemImage img {
+  width: 100%;
+  max-height: 235px;
+  object-fit: contain;
+  border-radius: 10px;
+  background: #e9eceb;
+}
+
+.stateSystemImage span {
+  color: var(--equipment-muted);
+  font-size: 0.68rem;
+  text-align: center;
+}
+
+.stateSystemBody {
+  min-width: 0;
+  padding: 21px;
+  display: grid;
+  gap: 14px;
+}
+
+.stateSystemBody h3,
+.stateSystemBody > p {
+  margin: 0;
+}
+
+.stateSystemBody h3 {
+  font-size: 1.35rem;
+}
+
+.stateSystemBody > p {
+  color: var(--equipment-muted);
+  font-size: 0.82rem;
+}
+
+.namedEvidenceBadge,
+.contextEvidenceBadge {
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-weight: 820;
+}
+
+.namedEvidenceBadge {
+  color: #8be6db;
+  background: rgba(103, 217, 204, 0.11);
+}
+
+.contextEvidenceBadge {
+  color: #c0d0ce;
+  background: rgba(157, 185, 182, 0.09);
+}
+
+.stateQuickFacts {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.stateQuickFacts div {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid rgba(154, 211, 205, 0.13);
+  border-radius: 9px;
+  background: rgba(5, 21, 24, 0.65);
+}
+
+.stateQuickFacts dt {
+  color: var(--equipment-muted);
+  font-size: 0.65rem;
+}
+
+.stateQuickFacts dd {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.stateNetworkFact {
+  padding: 13px;
+  border: 1px solid rgba(103, 217, 204, 0.22);
+  border-radius: 11px;
+  color: var(--equipment-accent);
+  background: rgba(103, 217, 204, 0.055);
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.stateNetworkFact[data-network-status="optional"] {
+  border-color: rgba(240, 195, 106, 0.27);
+  color: #f0c36a;
+  background: rgba(240, 195, 106, 0.055);
+}
+
+.stateNetworkFact[data-network-status="reviewed_without_attachment"] {
+  border-color: rgba(157, 185, 182, 0.2);
+  color: #bdd0ce;
+  background: rgba(157, 185, 182, 0.045);
+}
+
+.stateNetworkFact > div {
+  display: grid;
+  gap: 4px;
+}
+
+.stateNetworkFact span {
+  font-size: 0.66rem;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stateNetworkFact strong {
+  color: #edf8f6;
+  font-size: 0.86rem;
+}
+
+.stateNetworkFact p,
+.stateNetworkFact small {
+  margin: 0;
+  color: var(--equipment-muted);
+  line-height: 1.45;
+}
+
+.stateNetworkFact p {
+  font-size: 0.75rem;
+}
+
+.stateNetworkFact small {
+  font-size: 0.68rem;
+}
+
+.reportedContext {
+  padding: 11px 13px;
+  border: 1px dashed rgba(157, 185, 182, 0.25);
+  border-radius: 10px;
+  display: grid;
+  gap: 4px;
+}
+
+.reportedContext strong {
+  color: #c7d7d5;
+  font-size: 0.74rem;
+}
+
+.reportedContext span,
+.reportedContext small {
+  color: var(--equipment-muted);
+  font-size: 0.71rem;
+  line-height: 1.45;
+}
+
+.stateSystemLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.stateSystemLinks a {
+  min-height: 34px;
+  padding: 0 11px;
+  border: 1px solid rgba(103, 217, 204, 0.23);
+  border-radius: 999px;
+  color: #8be6db;
+  font-size: 0.72rem;
+  font-weight: 780;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+@media (max-width: 900px) {
+  .statePickerPanel,
+  .stateHero {
+    grid-template-columns: 1fr;
+  }
+
+  .stateSystemCard {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .stateQuickFacts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .statePickerForm,
+  .stateSystemCard {
+    grid-template-columns: 1fr;
+  }
+
+  .statePickerForm button {
+    min-height: 44px;
+  }
+
+  .stateSystemImage {
+    min-height: 220px;
+  }
+}

--- a/src/app/equipment/page.tsx
+++ b/src/app/equipment/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { Box, ChevronRight, Database, ExternalLink, FileCheck2 } from "lucide-react";
+import { Box, ChevronRight, Database, ExternalLink, FileCheck2, Network } from "lucide-react";
 import { notFound } from "next/navigation";
 
 import { RouteTour } from "../route-tour";
@@ -8,16 +8,47 @@ import { SiteHeader } from "../site-header";
 import { equipmentIndexTourSteps } from "../tour-manifests";
 import { equipmentCatalogMetadata, listEquipmentSystemTiles } from "@/lib/equipment-catalog";
 import { isEquipmentExplorerEnabled } from "@/lib/equipment-explorer-config";
+import {
+  buildEquipmentIndexSocialPreview,
+  equipmentSocialCardPath,
+  getEquipmentNetworkQuickFact,
+  listTrackedEquipmentStates,
+} from "@/lib/equipment-social-preview";
 import { listEquipmentUsageSummaries } from "@/lib/equipment-usage";
 import styles from "./equipment.module.css";
 
 export const dynamic = "force-dynamic";
 
+const equipmentIndexPreview = buildEquipmentIndexSocialPreview();
+const equipmentIndexSocialImage = equipmentSocialCardPath();
+
 export const metadata: Metadata = {
-  title: "U.S. Election Equipment Explorer",
-  description: "Source-linked certified configurations, hardware change records, version observations, findings, jurisdiction context, and evidence gaps for reviewed election systems.",
+  title: equipmentIndexPreview.title,
+  description: equipmentIndexPreview.description,
   alternates: { canonical: "/equipment" },
   robots: { index: true, follow: true },
+  openGraph: {
+    type: "website",
+    siteName: "Civic Result Maps",
+    url: "/equipment",
+    title: equipmentIndexPreview.title,
+    description: equipmentIndexPreview.description,
+    images: [{
+      url: equipmentIndexSocialImage,
+      width: 1200,
+      height: 630,
+      alt: "Six reviewed U.S. election equipment dossiers and their sourced networking status",
+    }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: equipmentIndexPreview.title,
+    description: equipmentIndexPreview.description,
+    images: [{
+      url: equipmentIndexSocialImage,
+      alt: "Six reviewed U.S. election equipment dossiers and their sourced networking status",
+    }],
+  },
 };
 
 export default function EquipmentIndexPage() {
@@ -25,6 +56,7 @@ export default function EquipmentIndexPage() {
   if (!equipmentEnabled) notFound();
   const systems = listEquipmentSystemTiles();
   const usageBySlug = new Map(listEquipmentUsageSummaries().map((summary) => [summary.slug, summary]));
+  const stateOptions = listTrackedEquipmentStates();
 
   return (
     <main className={styles.shell}>
@@ -62,6 +94,27 @@ export default function EquipmentIndexPage() {
           <article><Box aria-hidden size={20} /><strong>Illustrative 3D</strong><span>An accessible selection aid, never a teardown, proprietary CAD drawing, or field inventory.</span></article>
         </section>
 
+        <section className={styles.statePickerPanel} aria-labelledby="equipment-state-picker-heading">
+          <div>
+            <p className={styles.eyebrow}>State equipment share pages</p>
+            <h2 id="equipment-state-picker-heading">Select a state to build a source-bounded preview</h2>
+            <p>
+              Each state URL lists every connected dossier, distinguishes named product-family evidence from
+              manufacturer-only context, and includes dossier-level networking status in its social link preview.
+            </p>
+          </div>
+          <form action="/equipment/state" className={styles.statePickerForm} method="get">
+            <label htmlFor="equipment-state">State</label>
+            <select defaultValue="" id="equipment-state" name="state" required>
+              <option disabled value="">Choose a tracked state</option>
+              {stateOptions.map((option) => (
+                <option key={option.stateCode} value={option.stateCode}>{option.stateName} ({option.stateCode})</option>
+              ))}
+            </select>
+            <button type="submit">View state equipment</button>
+          </form>
+        </section>
+
         <section className={styles.catalogSection} aria-labelledby="catalog-heading" data-tour="equipment-catalog">
           <div className={styles.sectionHead}>
             <div><p className={styles.eyebrow}>Reviewed systems</p><h2 id="catalog-heading">Available equipment dossiers</h2></div>
@@ -70,6 +123,7 @@ export default function EquipmentIndexPage() {
           <div className={styles.systemGrid}>
             {systems.map((system) => {
               const usageSummary = usageBySlug.get(system.slug);
+              const network = getEquipmentNetworkQuickFact(system.slug);
               return (
                 <article className={styles.systemCard} key={system.slug}>
                   {system.referenceImage ? (
@@ -118,6 +172,12 @@ export default function EquipmentIndexPage() {
                     <div><dt>Change records</dt><dd>{system.coverage.configurationChangeCount}</dd></div>
                     <div><dt>Sources</dt><dd>{system.coverage.sourceCount}</dd></div>
                   </dl>
+                  {network ? (
+                    <div className={styles.networkQuickFact} data-network-status={network.status}>
+                      <Network aria-hidden size={17} />
+                      <div><span>Networking</span><strong>{network.label}</strong><small>{network.caveat}</small></div>
+                    </div>
+                  ) : null}
                   {usageSummary ? (
                     <div className={styles.usageSummary} data-tour="equipment-usage-summary">
                       {usageSummary.deviceFamilyRecords > 0 ? (

--- a/src/app/equipment/state/[state]/page.tsx
+++ b/src/app/equipment/state/[state]/page.tsx
@@ -1,0 +1,224 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import { ChevronRight, ExternalLink, MapPinned, Network, Share2 } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+
+import { SiteHeader } from "../../../site-header";
+import { EquipmentShareButton } from "../../equipment-share-button.client";
+import { equipmentCatalogMetadata } from "@/lib/equipment-catalog";
+import { isEquipmentExplorerEnabled } from "@/lib/equipment-explorer-config";
+import {
+  buildEquipmentStateSocialPreview,
+  equipmentSocialCardPath,
+  listTrackedEquipmentStates,
+  type EquipmentStateSocialPreviewSystem,
+} from "@/lib/equipment-social-preview";
+import { getEquipmentUsageSource } from "@/lib/equipment-usage";
+import styles from "../../equipment.module.css";
+
+export const dynamic = "force-dynamic";
+
+type PageProps = {
+  params: Promise<{ state: string }>;
+};
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { state } = await params;
+  const preview = buildEquipmentStateSocialPreview(state);
+  if (!preview) return {};
+  const canonical = `/equipment/state/${preview.stateCode}`;
+  const image = equipmentSocialCardPath({ state: preview.stateCode });
+  const imageAlt = `${preview.stateName} tracked election equipment and dossier-level networking status`;
+
+  return {
+    title: preview.title,
+    description: preview.description,
+    alternates: { canonical },
+    robots: { index: true, follow: true },
+    openGraph: {
+      type: "website",
+      siteName: "Civic Result Maps",
+      url: canonical,
+      title: preview.title,
+      description: preview.description,
+      images: [{ url: image, width: 1200, height: 630, alt: imageAlt }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: preview.title,
+      description: preview.description,
+      images: [{ url: image, alt: imageAlt }],
+    },
+  };
+}
+
+function reportedNames(system: EquipmentStateSocialPreviewSystem) {
+  const names = system.usage.reportedSystemNames.slice(0, 3);
+  const remaining = system.usage.reportedSystemNames.length - names.length;
+  return `${names.join("; ")}${remaining > 0 ? `; +${remaining} more` : ""}`;
+}
+
+function StateSystemCard({ system }: { system: EquipmentStateSocialPreviewSystem }) {
+  const source = system.usage.sourceIds
+    .map((sourceId) => getEquipmentUsageSource(sourceId))
+    .find((entry) => Boolean(entry));
+  const namedFamily = system.usage.deviceFamilyRecords > 0;
+
+  return (
+    <article className={styles.stateSystemCard} data-evidence={namedFamily ? "device-family" : "manufacturer-context"}>
+      {system.referenceImage ? (
+        <div className={styles.stateSystemImage}>
+          <Image
+            alt={system.referenceImage.alt}
+            height={system.referenceImage.height}
+            sizes="(max-width: 760px) 90vw, 300px"
+            src={system.referenceImage.assetUrl}
+            width={system.referenceImage.width}
+          />
+          <span>Source reference image</span>
+        </div>
+      ) : null}
+      <div className={styles.stateSystemBody}>
+        <div className={styles.cardTopline}>
+          <span className={namedFamily ? styles.namedEvidenceBadge : styles.contextEvidenceBadge}>
+            {system.evidenceShortLabel}
+          </span>
+          <span>{system.evidenceLabel}</span>
+        </div>
+        <h3>{system.displayName}</h3>
+        <p>{system.deviceRole}</p>
+
+        <dl className={styles.stateQuickFacts}>
+          <div><dt>System</dt><dd>{system.systemName} {system.systemVersion}</dd></div>
+          <div><dt>Components</dt><dd>{system.componentCount} source-linked</dd></div>
+          <div><dt>Changes</dt><dd>{system.changeRecordCount} reviewed records</dd></div>
+          <div><dt>Sources</dt><dd>{system.sourceCount} archived</dd></div>
+        </dl>
+
+        <div className={styles.stateNetworkFact} data-network-status={system.network.status}>
+          <Network aria-hidden size={18} />
+          <div>
+            <span>Dossier networking</span>
+            <strong>{system.network.label}</strong>
+            <p>{system.network.detail}</p>
+            <small>{system.network.caveat}</small>
+          </div>
+        </div>
+
+        {!namedFamily && system.usage.reportedSystemNames.length > 0 ? (
+          <div className={styles.reportedContext}>
+            <strong>What the state records actually name</strong>
+            <span>{reportedNames(system)}</span>
+            <small>These names provide manufacturer context only and do not identify this dossier&apos;s exact model.</small>
+          </div>
+        ) : null}
+
+        <div className={styles.stateSystemLinks}>
+          <a href={system.detailHref}>Open the state-filtered dossier <ChevronRight aria-hidden size={14} /></a>
+          {source ? (
+            <a href={source.sourceUrl} rel="noreferrer" target="_blank">
+              Open {source.authority} source <ExternalLink aria-hidden size={13} />
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default async function EquipmentStatePage({ params }: PageProps) {
+  const equipmentEnabled = isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady });
+  if (!equipmentEnabled) notFound();
+  const { state } = await params;
+  const preview = buildEquipmentStateSocialPreview(state);
+  if (!preview) notFound();
+  if (state !== preview.stateCode) redirect(`/equipment/state/${preview.stateCode}`);
+
+  const stateOptions = listTrackedEquipmentStates();
+  const namedSystems = preview.systems.filter((system) => system.usage.deviceFamilyRecords > 0);
+  const contextSystems = preview.systems.filter((system) => system.usage.deviceFamilyRecords === 0);
+  const socialImage = equipmentSocialCardPath({ state: preview.stateCode });
+
+  return (
+    <main className={styles.shell}>
+      <SiteHeader
+        activePage="equipment"
+        equipmentEnabled={equipmentEnabled}
+        subtitle="U.S. election equipment evidence"
+      />
+
+      <div className={styles.page}>
+        <nav aria-label="Breadcrumb" className={styles.equipmentBreadcrumb}>
+          <a href="/equipment">U.S. Equipment</a><ChevronRight aria-hidden size={14} /><span>{preview.stateName}</span>
+        </nav>
+
+        <section className={styles.stateHero}>
+          <div>
+            <p className={styles.eyebrow}><MapPinned aria-hidden size={15} /> 2024 tracked equipment records</p>
+            <h1>{preview.stateName} election equipment records</h1>
+            <p className={styles.lede}>
+              See every reviewed dossier connected to a {preview.stateName}{" "}source row, with exact product-family
+              evidence kept separate from manufacturer-only context. Networking labels come from the dossier&apos;s
+              certification, test, or model-family sources—not from an assumed state configuration.
+            </p>
+          </div>
+          <aside className={styles.scopeCard}>
+            <span>State share preview</span>
+            <strong>{preview.systems.length} tracked {preview.systems.length === 1 ? "dossier" : "dossiers"}</strong>
+            <p>{preview.namedFamilySystemCount} named product-family; {preview.manufacturerContextOnlySystemCount} manufacturer-context only.</p>
+            <div className={styles.shareActions}>
+              <EquipmentShareButton title={preview.title} />
+              <a href={socialImage} rel="noreferrer" target="_blank"><Share2 aria-hidden size={14} /> Open preview image</a>
+            </div>
+          </aside>
+        </section>
+
+        <section className={styles.statePickerPanel} aria-labelledby="state-picker-heading">
+          <div>
+            <p className={styles.eyebrow}>Choose another state</p>
+            <h2 id="state-picker-heading">Create a state-specific share link</h2>
+            <p>The destination URL has its own Open Graph and X/Twitter preview listing tracked dossiers and their sourced networking status.</p>
+          </div>
+          <form action="/equipment/state" className={styles.statePickerForm} method="get">
+            <label htmlFor="equipment-state">State</label>
+            <select defaultValue={preview.stateCode} id="equipment-state" name="state">
+              {stateOptions.map((option) => (
+                <option key={option.stateCode} value={option.stateCode}>{option.stateName} ({option.stateCode})</option>
+              ))}
+            </select>
+            <button type="submit">View state equipment</button>
+          </form>
+        </section>
+
+        <section className={styles.stateBoundaryNote}>
+          <strong>How to read this page</strong>
+          <p>{preview.caveat}</p>
+        </section>
+
+        {namedSystems.length > 0 ? (
+          <section className={styles.dossierSection} aria-labelledby="named-equipment-heading">
+            <div className={styles.sectionHead}>
+              <div><p className={styles.eyebrow}>Stronger match</p><h2 id="named-equipment-heading">Named product-family records</h2></div>
+              <p>The source row explicitly names this product family. It still does not prove internal parts, firmware, networking state, or configuration of a particular unit.</p>
+            </div>
+            <div className={styles.stateSystemGrid}>
+              {namedSystems.map((system) => <StateSystemCard key={system.slug} system={system} />)}
+            </div>
+          </section>
+        ) : null}
+
+        {contextSystems.length > 0 ? (
+          <section className={styles.dossierSection} aria-labelledby="context-equipment-heading">
+            <div className={styles.sectionHead}>
+              <div><p className={styles.eyebrow}>Related context</p><h2 id="context-equipment-heading">Manufacturer context only</h2></div>
+              <p>The source row names the manufacturer but not this dossier&apos;s exact model or configuration. These cards are leads for review, not exact-machine deployment claims.</p>
+            </div>
+            <div className={styles.stateSystemGrid}>
+              {contextSystems.map((system) => <StateSystemCard key={system.slug} system={system} />)}
+            </div>
+          </section>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/src/app/equipment/state/page.tsx
+++ b/src/app/equipment/state/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+import { buildEquipmentStateSocialPreview } from "@/lib/equipment-social-preview";
+
+type SearchValue = string | string[] | undefined;
+
+export default async function EquipmentStateRedirectPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, SearchValue>>;
+}) {
+  const requested = await searchParams;
+  const value = Array.isArray(requested.state) ? requested.state[0] : requested.state;
+  const state = value?.trim().toUpperCase() ?? "";
+  if (buildEquipmentStateSocialPreview(state)) redirect(`/equipment/state/${state}`);
+  redirect("/equipment");
+}

--- a/src/app/guided-tour.tsx
+++ b/src/app/guided-tour.tsx
@@ -3,7 +3,7 @@
 import { ChevronLeft, ChevronRight, HelpCircle, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { tourStartEventName } from "./tour-launch-button";
+import { consumePendingTourStart, tourStartEventName } from "./tour-launch-button";
 
 export type TourTabKey =
   | "map"
@@ -192,9 +192,14 @@ export function GuidedTour({
   }, [sessionKey]);
 
   useEffect(() => {
-    const handleStart = () => startTour();
-    window.addEventListener(tourStartEventName(tourId), handleStart);
-    return () => window.removeEventListener(tourStartEventName(tourId), handleStart);
+    const eventName = tourStartEventName(tourId);
+    const handleStart = () => {
+      consumePendingTourStart(tourId);
+      startTour();
+    };
+    window.addEventListener(eventName, handleStart);
+    if (consumePendingTourStart(tourId)) startTour();
+    return () => window.removeEventListener(eventName, handleStart);
   }, [startTour, tourId]);
 
   useEffect(() => {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,9 @@
 import type { MetadataRoute } from "next";
+import {
+  equipmentCatalogMetadata,
+  listEquipmentSystemSlugs,
+} from "@/lib/equipment-catalog";
+import { listTrackedEquipmentStates } from "@/lib/equipment-social-preview";
 import { getCanonicalJurisdictionRegistry } from "@/lib/jurisdiction-tags";
 
 const siteUrl = "https://www.civicresultmaps.org";
@@ -8,6 +13,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const staticRouteConfig = [
     { path: "", changeFrequency: "daily", priority: 1 },
     { path: "/compare", changeFrequency: "daily", priority: 0.95 },
+    { path: "/equipment", changeFrequency: "weekly", priority: 0.9 },
     { path: "/security", changeFrequency: "weekly", priority: 0.85 },
     { path: "/readiness", changeFrequency: "daily", priority: 0.8 },
     { path: "/evidence", changeFrequency: "weekly", priority: 0.7 },
@@ -31,5 +37,22 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.45,
     }));
 
-  return [...staticRoutes, ...countyRoutes];
+  const equipmentRoutes: MetadataRoute.Sitemap = equipmentCatalogMetadata.productionReady
+    ? [
+        ...listEquipmentSystemSlugs().map((slug) => ({
+          url: `${siteUrl}/equipment/${slug}`,
+          lastModified: now,
+          changeFrequency: "monthly" as const,
+          priority: 0.72,
+        })),
+        ...listTrackedEquipmentStates().map(({ stateCode }) => ({
+          url: `${siteUrl}/equipment/state/${stateCode}`,
+          lastModified: now,
+          changeFrequency: "monthly" as const,
+          priority: 0.62,
+        })),
+      ]
+    : [];
+
+  return [...staticRoutes, ...equipmentRoutes, ...countyRoutes];
 }

--- a/src/app/tour-launch-button.tsx
+++ b/src/app/tour-launch-button.tsx
@@ -4,13 +4,24 @@ import { CircleHelp } from "lucide-react";
 
 export const tourStartEventName = (tourId: string) => `civicresultmaps:start-tour:${tourId}`;
 
+const pendingTourStarts = new Set<string>();
+
+export function requestTourStart(tourId: string) {
+  pendingTourStarts.add(tourId);
+  window.dispatchEvent(new CustomEvent(tourStartEventName(tourId)));
+}
+
+export function consumePendingTourStart(tourId: string) {
+  return pendingTourStarts.delete(tourId);
+}
+
 export function TourLaunchButton({ tourId }: { tourId: string }) {
   return (
     <button
       aria-label="Start a guided tour of this page"
       className="site-tour-launch"
       data-tour="tour-launch"
-      onClick={() => window.dispatchEvent(new CustomEvent(tourStartEventName(tourId)))}
+      onClick={() => requestTourStart(tourId)}
       type="button"
     >
       <CircleHelp aria-hidden size={15} />

--- a/src/lib/equipment-social-preview.ts
+++ b/src/lib/equipment-social-preview.ts
@@ -1,0 +1,269 @@
+import {
+  getEquipmentSystem,
+  listEquipmentSystems,
+  type EquipmentSystem,
+} from "./equipment-catalog";
+import {
+  getEquipmentUsageStateSummary,
+  listEquipmentUsageStateCodes,
+  type EquipmentUsageStateSystemSummary,
+} from "./equipment-usage";
+import { stateNameForCode } from "./us-states";
+
+export const equipmentSocialCardVersion = "equipment-v1";
+
+export type EquipmentNetworkPreviewStatus = "documented" | "optional" | "reviewed_without_attachment";
+
+export type EquipmentNetworkQuickFact = {
+  status: EquipmentNetworkPreviewStatus;
+  label: string;
+  shortLabel: string;
+  detail: string;
+  caveat: string;
+  sourceIds: string[];
+};
+
+type EquipmentNetworkQuickFactDefinition = Omit<EquipmentNetworkQuickFact, "sourceIds">;
+
+const networkQuickFacts: Record<string, EquipmentNetworkQuickFactDefinition> = {
+  "clear-ballot-clearvote-25-clearaccess": {
+    status: "reviewed_without_attachment",
+    label: "No network attachment in the reviewed station configuration",
+    shortLabel: "Local peripherals only",
+    detail:
+      "The reviewed station uses local peripherals. Clear Ballot's published policy says its certified products are not attached to modems, the Internet, Wi-Fi, or Bluetooth.",
+    caveat:
+      "This describes the reviewed certified configuration and manufacturer policy, not an inspection of a fielded unit.",
+  },
+  "clear-ballot-clearvote-25-clearcount": {
+    status: "documented",
+    label: "Closed wired Ethernet system documented",
+    shortLabel: "Closed wired LAN",
+    detail:
+      "The certified configuration links CountServer, ScanStations, and CountStations through an approved Ethernet-switch alternative on a closed, isolated network.",
+    caveat:
+      "The certification record does not establish a jurisdiction's live cabling, switch settings, or current installation.",
+  },
+  "dominion-democracy-suite-517-imagecast-central": {
+    status: "optional",
+    label: "Optional isolated-LAN infrastructure documented",
+    shortLabel: "Optional isolated LAN",
+    detail:
+      "The scanner attaches locally to its workstation by USB. Reviewed state documentation makes the workstation's closed data-center Ethernet path conditional.",
+    caveat:
+      "The optional infrastructure is part of the reviewed documentation; a jurisdiction connection or field network state is not established.",
+  },
+  "dominion-democracy-suite-517-imagecast-x": {
+    status: "documented",
+    label: "Built-in Ethernet capability documented",
+    shortLabel: "Ethernet interface",
+    detail:
+      "The certified hardware profile includes a physical 10/100 RJ-45 interface, while the evaluated system used no public network or wireless technology.",
+    caveat:
+      "A physical interface is not evidence that an external peer was connected, enabled, or used in a jurisdiction.",
+  },
+  "ess-evs-6400-ds200": {
+    status: "optional",
+    label: "Optional cellular modem hardware documented historically",
+    shortLabel: "Optional cellular modem",
+    detail:
+      "Historical federal and state records identify optional MultiTech cellular-modem alternatives for the DS200 hardware family.",
+    caveat:
+      "Those records do not establish inclusion in EVS 6.4.0.0 certification, modem firmware, activation, or use in a particular fielded unit.",
+  },
+  "ess-evs-6400-ds950": {
+    status: "documented",
+    label: "Closed-LAN result path documented in testing",
+    shortLabel: "Closed-LAN test path",
+    detail:
+      "The EVS 6.4.0.0 Pro V&V report documents DS950 result transmission to the EMS through a closed local area network during accuracy testing.",
+    caveat:
+      "A laboratory test path does not establish a jurisdiction's switch, connection, settings, or field use.",
+  },
+};
+
+export type EquipmentMachineSocialPreview = {
+  kind: "machine";
+  slug: string;
+  title: string;
+  description: string;
+  displayName: string;
+  deviceName: string;
+  deviceRole: string;
+  manufacturer: string;
+  systemName: string;
+  systemVersion: string;
+  certificationId: string;
+  certifiedOn: string;
+  componentCount: number;
+  changeRecordCount: number;
+  sourceCount: number;
+  referenceImage: EquipmentSystem["scene"]["referenceImages"][number] | null;
+  network: EquipmentNetworkQuickFact;
+};
+
+export type EquipmentStateSocialPreviewSystem = EquipmentMachineSocialPreview & {
+  usage: EquipmentUsageStateSystemSummary;
+  evidenceLabel: string;
+  evidenceShortLabel: string;
+  detailHref: string;
+};
+
+export type EquipmentStateSocialPreview = {
+  kind: "state";
+  stateCode: string;
+  stateName: string;
+  title: string;
+  description: string;
+  systems: EquipmentStateSocialPreviewSystem[];
+  namedFamilySystemCount: number;
+  manufacturerContextOnlySystemCount: number;
+  sourceCount: number;
+  caveat: string;
+};
+
+function uniqueNetworkSourceIds(system: EquipmentSystem) {
+  return [...new Set(system.networkEvidence.configurations.flatMap((configuration) => configuration.sourceIds))];
+}
+
+export function getEquipmentNetworkQuickFact(slug: string): EquipmentNetworkQuickFact | null {
+  const system = getEquipmentSystem(slug);
+  const definition = networkQuickFacts[slug];
+  if (!system || !definition) return null;
+  return { ...definition, sourceIds: uniqueNetworkSourceIds(system) };
+}
+
+function machineDescription(system: EquipmentSystem, network: EquipmentNetworkQuickFact) {
+  return [
+    `${system.deviceName}: ${system.deviceRole}.`,
+    `${network.label}.`,
+    `${system.coverage.componentCount} sourced components and ${system.coverage.sourceCount} archived sources in the reviewed ${system.systemName} ${system.systemVersion} dossier.`,
+  ].join(" ");
+}
+
+function buildMachinePreview(system: EquipmentSystem): EquipmentMachineSocialPreview {
+  const network = getEquipmentNetworkQuickFact(system.slug);
+  if (!network) {
+    throw new Error(`Missing reviewed social-preview network fact for ${system.slug}`);
+  }
+
+  return {
+    kind: "machine",
+    slug: system.slug,
+    title: `${system.displayName} equipment dossier`,
+    description: machineDescription(system, network),
+    displayName: system.displayName,
+    deviceName: system.deviceName,
+    deviceRole: system.deviceRole,
+    manufacturer: system.manufacturer,
+    systemName: system.systemName,
+    systemVersion: system.systemVersion,
+    certificationId: system.certification.certificationId,
+    certifiedOn: system.certification.certifiedOn,
+    componentCount: system.coverage.componentCount,
+    changeRecordCount: system.coverage.configurationChangeCount,
+    sourceCount: system.coverage.sourceCount,
+    referenceImage: system.scene.referenceImages[0] ?? null,
+    network,
+  };
+}
+
+export function buildEquipmentMachineSocialPreview(slug: string): EquipmentMachineSocialPreview | null {
+  const system = getEquipmentSystem(slug);
+  return system ? buildMachinePreview(system) : null;
+}
+
+function evidenceLabels(usage: EquipmentUsageStateSystemSummary) {
+  if (usage.deviceFamilyRecords > 0) {
+    return {
+      label: `${usage.deviceFamilyRecords.toLocaleString("en-US")} named product-family ${usage.deviceFamilyRecords === 1 ? "record" : "records"}`,
+      shortLabel: "Named product family",
+    };
+  }
+  return {
+    label: `${usage.manufacturerContextRecords.toLocaleString("en-US")} manufacturer-context ${usage.manufacturerContextRecords === 1 ? "record" : "records"}`,
+    shortLabel: "Manufacturer context only",
+  };
+}
+
+export function buildEquipmentStateSocialPreview(state: string): EquipmentStateSocialPreview | null {
+  const stateCode = state.trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(stateCode)) return null;
+
+  const usageBySlug = new Map(getEquipmentUsageStateSummary(stateCode).map((usage) => [usage.slug, usage]));
+  const systems = listEquipmentSystems().flatMap((summary) => {
+    const usage = usageBySlug.get(summary.slug);
+    const system = getEquipmentSystem(summary.slug);
+    if (!usage || !system) return [];
+    const labels = evidenceLabels(usage);
+    const evidenceKind = usage.deviceFamilyRecords > 0 ? "device_family" : "manufacturer_context";
+    return [{
+      ...buildMachinePreview(system),
+      usage,
+      evidenceLabel: labels.label,
+      evidenceShortLabel: labels.shortLabel,
+      detailHref: `/equipment/${system.slug}?usageEvidence=${evidenceKind}&usageState=${stateCode}#equipment-usage`,
+    }];
+  });
+  if (systems.length === 0) return null;
+
+  const stateName = stateNameForCode(stateCode);
+  const namedFamilySystemCount = systems.filter((system) => system.usage.deviceFamilyRecords > 0).length;
+  const manufacturerContextOnlySystemCount = systems.length - namedFamilySystemCount;
+  const sourceCount = new Set(systems.flatMap((system) => system.usage.sourceIds)).size;
+  const evidenceSummary = [
+    namedFamilySystemCount
+      ? `${namedFamilySystemCount} named product-family ${namedFamilySystemCount === 1 ? "match" : "matches"}`
+      : null,
+    manufacturerContextOnlySystemCount
+      ? `${manufacturerContextOnlySystemCount} manufacturer-context ${manufacturerContextOnlySystemCount === 1 ? "dossier" : "dossiers"}`
+      : null,
+  ].filter(Boolean).join(" and ");
+
+  return {
+    kind: "state",
+    stateCode,
+    stateName,
+    title: `${stateName} tracked election equipment`,
+    description:
+      `2024 source records connect ${systems.length} reviewed equipment ${systems.length === 1 ? "dossier" : "dossiers"} to ${stateName}: ${evidenceSummary}. Each card identifies documented or optional networking separately.`,
+    systems,
+    namedFamilySystemCount,
+    manufacturerContextOnlySystemCount,
+    sourceCount,
+    caveat:
+      "State records identify a product family or manufacturer at the reported grain. Dossier network capability does not establish a state or local connection, configuration, activation, or use.",
+  };
+}
+
+export function buildEquipmentIndexSocialPreview() {
+  const systems = listEquipmentSystems().map((summary) => {
+    const system = getEquipmentSystem(summary.slug);
+    if (!system) throw new Error(`Missing equipment system ${summary.slug}`);
+    return buildMachinePreview(system);
+  });
+  const documentedCount = systems.filter((system) => system.network.status === "documented").length;
+  const optionalCount = systems.filter((system) => system.network.status === "optional").length;
+
+  return {
+    title: "U.S. Election Equipment Explorer",
+    description:
+      `${systems.length} source-linked equipment dossiers with certified-configuration facts, components, change records, and documented or optional network capability.`,
+    systems,
+    documentedCount,
+    optionalCount,
+  };
+}
+
+export function listTrackedEquipmentStates() {
+  return listEquipmentUsageStateCodes()
+    .map((stateCode) => ({ stateCode, stateName: stateNameForCode(stateCode) }))
+    .sort((left, right) => left.stateName.localeCompare(right.stateName));
+}
+
+export function equipmentSocialCardPath(input: { slug?: string; state?: string } = {}) {
+  const parameters = new URLSearchParams({ v: equipmentSocialCardVersion });
+  if (input.slug) parameters.set("slug", input.slug);
+  if (input.state) parameters.set("state", input.state.toUpperCase());
+  return `/api/equipment-social-card?${parameters.toString()}`;
+}

--- a/src/lib/equipment-usage.ts
+++ b/src/lib/equipment-usage.ts
@@ -58,6 +58,17 @@ export type EquipmentUsageSummary = {
   unavailableMapLinks: number;
 };
 
+export type EquipmentUsageStateSystemSummary = {
+  slug: string;
+  state: string;
+  totalRecords: number;
+  deviceFamilyRecords: number;
+  manufacturerContextRecords: number;
+  sourceIds: string[];
+  reportedSystemNames: string[];
+  reportedVendors: string[];
+};
+
 type EquipmentUsageIndex = {
   schemaVersion: number;
   generatedOn: string;
@@ -114,6 +125,63 @@ export function listEquipmentUsageStates(slug: string, evidenceKind?: EquipmentU
     .filter((record) => !evidenceKind || record.evidenceKind === evidenceKind)
     .map((record) => record.state))]
     .sort();
+}
+
+export function listEquipmentUsageStateCodes() {
+  return [...new Set(index.records
+    .filter((record) => record.matches.length > 0)
+    .map((record) => record.state))]
+    .sort();
+}
+
+export function getEquipmentUsageStateSummary(state: string): EquipmentUsageStateSystemSummary[] {
+  const normalizedState = state.trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(normalizedState)) return [];
+
+  type MutableSummary = Omit<
+    EquipmentUsageStateSystemSummary,
+    "sourceIds" | "reportedSystemNames" | "reportedVendors"
+  > & {
+    sourceIds: Set<string>;
+    reportedSystemNames: Set<string>;
+    reportedVendors: Set<string>;
+  };
+
+  const summaries = new Map<string, MutableSummary>();
+  for (const record of index.records) {
+    if (record.state !== normalizedState) continue;
+    for (const match of record.matches) {
+      const summary = summaries.get(match.slug) ?? {
+        slug: match.slug,
+        state: normalizedState,
+        totalRecords: 0,
+        deviceFamilyRecords: 0,
+        manufacturerContextRecords: 0,
+        sourceIds: new Set<string>(),
+        reportedSystemNames: new Set<string>(),
+        reportedVendors: new Set<string>(),
+      };
+      summary.totalRecords += 1;
+      if (match.evidenceKind === "device_family") summary.deviceFamilyRecords += 1;
+      else summary.manufacturerContextRecords += 1;
+      summary.sourceIds.add(record.sourceId);
+      if (record.systemName.trim()) summary.reportedSystemNames.add(record.systemName.trim());
+      if (record.vendor.trim()) summary.reportedVendors.add(record.vendor.trim());
+      summaries.set(match.slug, summary);
+    }
+  }
+
+  return [...summaries.values()]
+    .map((summary) => ({
+      ...summary,
+      sourceIds: [...summary.sourceIds].sort(),
+      reportedSystemNames: [...summary.reportedSystemNames].sort(),
+      reportedVendors: [...summary.reportedVendors].sort(),
+    }))
+    .sort((left, right) => {
+      const evidenceDifference = Number(right.deviceFamilyRecords > 0) - Number(left.deviceFamilyRecords > 0);
+      return evidenceDifference || left.slug.localeCompare(right.slug);
+    });
 }
 
 export function getEquipmentUsageSource(sourceId: string) {

--- a/tests/api/equipment-social-preview.test.mjs
+++ b/tests/api/equipment-social-preview.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const [
+  catalog,
+  usage,
+  socialLibrary,
+  indexPage,
+  detailPage,
+  statePage,
+  socialRoute,
+  sitemap,
+] = await Promise.all([
+  readFile("data/equipment-catalog.json", "utf8").then(JSON.parse),
+  readFile("data/equipment-usage-index.json", "utf8").then(JSON.parse),
+  readFile("src/lib/equipment-social-preview.ts", "utf8"),
+  readFile("src/app/equipment/page.tsx", "utf8"),
+  readFile("src/app/equipment/[slug]/page.tsx", "utf8"),
+  readFile("src/app/equipment/state/[state]/page.tsx", "utf8"),
+  readFile("src/app/api/equipment-social-card/route.tsx", "utf8"),
+  readFile("src/app/sitemap.ts", "utf8"),
+]);
+
+assert.equal(catalog.systems.length, 6);
+for (const system of catalog.systems) {
+  assert.match(
+    socialLibrary,
+    new RegExp(`"${system.slug}"\\s*:\\s*\\{`),
+    `${system.slug} must have an editorially reviewed networking quick fact`,
+  );
+}
+
+assert.match(socialLibrary, /"ess-evs-6400-ds200"[\s\S]*?status: "optional"/);
+assert.match(socialLibrary, /Optional cellular modem hardware documented historically/);
+assert.match(socialLibrary, /do not establish inclusion in EVS 6\.4\.0\.0 certification, modem firmware, activation, or use/i);
+assert.match(socialLibrary, /"dominion-democracy-suite-517-imagecast-x"[\s\S]*?Built-in Ethernet capability documented/);
+assert.match(socialLibrary, /A physical interface is not evidence that an external peer was connected, enabled, or used/i);
+assert.match(socialLibrary, /"clear-ballot-clearvote-25-clearaccess"[\s\S]*?status: "reviewed_without_attachment"/);
+
+const colorado = new Map();
+for (const record of usage.records.filter((entry) => entry.state === "CO")) {
+  for (const match of record.matches) {
+    const summary = colorado.get(match.slug) ?? { deviceFamily: 0, manufacturerContext: 0 };
+    if (match.evidenceKind === "device_family") summary.deviceFamily += 1;
+    else summary.manufacturerContext += 1;
+    colorado.set(match.slug, summary);
+  }
+}
+assert.equal(colorado.size, 4);
+assert.equal([...colorado.values()].filter((entry) => entry.deviceFamily > 0).length, 2);
+assert.equal([...colorado.values()].filter((entry) => entry.deviceFamily === 0 && entry.manufacturerContext > 0).length, 2);
+
+assert.match(indexPage, /State equipment share pages/);
+assert.match(indexPage, /action="\/equipment\/state"/);
+assert.match(indexPage, /getEquipmentNetworkQuickFact/);
+assert.match(indexPage, /openGraph:/);
+assert.match(indexPage, /twitter:/);
+assert.match(detailPage, /buildEquipmentMachineSocialPreview/);
+assert.match(detailPage, /summary_large_image/);
+assert.match(statePage, /Named product-family records/);
+assert.match(statePage, /Manufacturer context only/);
+assert.match(statePage, /preview\.caveat/);
+assert.match(socialLibrary, /Dossier network capability does not establish/i);
+assert.match(statePage, /equipmentSocialCardPath/);
+assert.match(socialRoute, /new ImageResponse/);
+assert.match(socialRoute, /width: 1200, height: 630/);
+assert.match(socialRoute, /Equipment dossier not found/);
+assert.match(socialRoute, /Tracked state equipment not found/);
+assert.match(sitemap, /listTrackedEquipmentStates/);
+assert.match(sitemap, /equipment\/state\/\$\{stateCode\}/);
+
+console.log("equipment social preview tests passed");

--- a/tests/e2e/equipment-catalog.spec.ts
+++ b/tests/e2e/equipment-catalog.spec.ts
@@ -30,7 +30,7 @@ test("lists six source-linked equipment dossiers", async ({ page }) => {
   await expect(page.getByAltText("Front view of an open ES&S DS200 scanner and ballot container on casters")).toBeVisible();
 });
 
-test("exposes U.S. Equipment in the shared top navigation and route-specific tours", async ({ page }) => {
+test("exposes U.S. Equipment in the shared top navigation and equipment index tour", async ({ page }) => {
   await page.goto("/");
   const homeEquipmentLink = page.getByRole("link", { name: "U.S. Equipment" });
   await expect(homeEquipmentLink).toBeVisible();
@@ -44,17 +44,21 @@ test("exposes U.S. Equipment in the shared top navigation and route-specific tou
   await expect(equipmentTour.getByLabel("Jump to tour step")).toHaveValue("equipment-index-scope");
   await page.keyboard.press("Escape");
   await expect(equipmentTour).toHaveCount(0);
+});
 
+test("jumps to jurisdiction evidence in the equipment detail tour", async ({ page }) => {
   await page.goto(ds200Path);
   await page.getByRole("button", { name: "Start a guided tour of this page" }).click();
   const detailTour = page.getByRole("dialog");
   await expect(detailTour).toBeVisible();
   await expect(detailTour).toHaveAccessibleName("Identify the reviewed configuration");
   await detailTour.getByLabel("Jump to tour step").selectOption("equipment-detail-usage");
-  await expect(page.locator("[data-tour='equipment-usage']")).toBeInViewport();
   await expect(detailTour).toHaveAccessibleName("Open jurisdiction and map records");
+  await expect(page.locator("[data-tour='equipment-usage']")).toBeInViewport({ timeout: 15_000 });
   await detailTour.getByRole("button", { name: "Close tutorial" }).click();
+});
 
+test("exposes U.S. Equipment and the route tour on the security page", async ({ page }) => {
   await page.goto("/security");
   await expect(page.getByRole("link", { name: "U.S. Equipment" })).toBeVisible();
   await page.getByRole("button", { name: "Start a guided tour of this page" }).click();

--- a/tests/e2e/equipment-social-previews.spec.ts
+++ b/tests/e2e/equipment-social-previews.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+
+const ds200Path = "/equipment/ess-evs-6400-ds200";
+const equipmentSlugs = [
+  "clear-ballot-clearvote-25-clearaccess",
+  "clear-ballot-clearvote-25-clearcount",
+  "dominion-democracy-suite-517-imagecast-central",
+  "dominion-democracy-suite-517-imagecast-x",
+  "ess-evs-6400-ds200",
+  "ess-evs-6400-ds950",
+];
+
+function expectPngDimensions(body: Buffer, width: number, height: number) {
+  expect(body.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
+  expect(body.readUInt32BE(16)).toBe(width);
+  expect(body.readUInt32BE(20)).toBe(height);
+}
+
+test.describe.configure({ mode: "serial", timeout: 90_000 });
+
+test("builds a stable state share page with exact-family and manufacturer-context boundaries", async ({ page, request }) => {
+  await page.goto("/equipment");
+  const picker = page.getByLabel("State", { exact: true });
+  await expect(picker).toContainText("Colorado (CO)");
+  await picker.selectOption("CO");
+  await Promise.all([
+    page.waitForURL(/\/equipment\/state\/CO$/, { waitUntil: "domcontentloaded" }),
+    page.getByRole("button", { name: "View state equipment" }).click(),
+  ]);
+
+  await expect(page.getByRole("heading", { name: "Colorado election equipment records" })).toBeVisible();
+  await expect(page.locator("article[data-evidence='device-family']")).toHaveCount(2);
+  await expect(page.locator("article[data-evidence='manufacturer-context']")).toHaveCount(2);
+  await expect(page.getByRole("heading", { name: "Named product-family records" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Manufacturer context only" })).toBeVisible();
+  await expect(page.getByText(/Dossier network capability does not establish a state or local connection/)).toBeVisible();
+
+  const clearCountContext = page.locator("article[data-evidence='manufacturer-context']")
+    .filter({ hasText: "Clear Ballot ClearVote 2.5 / ClearCount" });
+  await expect(clearCountContext.getByText("Clear Ballot ClearAccess", { exact: true })).toBeVisible();
+  await expect(clearCountContext.getByText(/do not identify this dossier's exact model/i)).toBeVisible();
+  await expect(clearCountContext.getByText("Closed wired Ethernet system documented", { exact: true })).toBeVisible();
+
+  await expect(page.locator("meta[property='og:title']")).toHaveAttribute("content", /Colorado tracked election equipment/);
+  await expect(page.locator("meta[property='og:image']")).toHaveAttribute("content", /\/api\/equipment-social-card\?v=equipment-v1&state=CO$/);
+  await expect(page.locator("meta[name='twitter:card']")).toHaveAttribute("content", "summary_large_image");
+  await expect(page.getByRole("link", { name: "Open preview image" })).toHaveAttribute("href", /state=CO$/);
+
+  const stateCard = await request.get("/api/equipment-social-card?v=equipment-v1&state=CO");
+  expect(stateCard.status()).toBe(200);
+  expect(stateCard.headers()["content-type"]).toMatch(/^image\/png/);
+  expect(stateCard.headers()["cache-control"]).toContain("s-maxage=900");
+  expectPngDimensions(await stateCard.body(), 1200, 630);
+
+  const denseStateCard = await request.get("/api/equipment-social-card?v=equipment-v1&state=KS");
+  expect(denseStateCard.status()).toBe(200);
+  expect(denseStateCard.headers()["content-type"]).toMatch(/^image\/png/);
+  expectPngDimensions(await denseStateCard.body(), 1200, 630);
+});
+
+test("publishes machine quick facts and optional-networking metadata", async ({ page, request }) => {
+  await page.goto(ds200Path);
+  await expect(page.locator("meta[property='og:title']")).toHaveAttribute("content", /ES&S EVS 6\.4\.0\.0 \/ DS200 equipment dossier/i);
+  await expect(page.locator("meta[property='og:description']")).toHaveAttribute("content", /Optional cellular modem hardware documented historically/);
+  await expect(page.locator("meta[property='og:image']")).toHaveAttribute("content", /slug=ess-evs-6400-ds200$/);
+  await expect(page.locator("meta[name='twitter:card']")).toHaveAttribute("content", "summary_large_image");
+
+  for (const slug of equipmentSlugs) {
+    const machineCard = await request.get(`/api/equipment-social-card?v=equipment-v1&slug=${slug}`);
+    expect(machineCard.status()).toBe(200);
+    expect(machineCard.headers()["content-type"]).toMatch(/^image\/png/);
+    expectPngDimensions(await machineCard.body(), 1200, 630);
+  }
+
+  const unknownMachine = await request.get("/api/equipment-social-card?slug=not-a-machine");
+  expect(unknownMachine.status()).toBe(404);
+  const unknownState = await request.get("/api/equipment-social-card?state=ZZ");
+  expect(unknownState.status()).toBe(404);
+});


### PR DESCRIPTION
## Summary

- Add machine-specific Open Graph and Twitter metadata with 1200 x 630 social cards for all six equipment dossiers.
- Add a state selector and shareable `/equipment/state/[state]` pages summarizing known or tracked equipment.
- Distinguish named product-family records from manufacturer-context matches.
- Show confirmed or optional networking capability with the corresponding source caveats.
- Add a social-card API route, sitemap coverage, and automated tests.

## Why

This makes individual machine dossiers and state equipment summaries shareable with accurate link previews. A state preview can show all tracked machines for that state and whether each has built-in or optional networking equipment, without overstating incomplete source records.

## Validation

- `npm run typecheck`
- `npm run test:equipment-catalog`
- `npm run build`
- Focused Playwright verification for all six machine images and the Colorado and Kansas state cards
- Independent browser verification with no overlay or page errors
