### PR TITLE
Fix dense equipment social cards

### DIFF
--- a/src/app/api/equipment-social-card/route.tsx
+++ b/src/app/api/equipment-social-card/route.tsx
@@ -76,9 +76,11 @@ function statusColors(status: EquipmentNetworkPreviewStatus) {
 }
 
 function NetworkPill({
+  compact = false,
   label,
   status,
 }: {
+  compact?: boolean;
   label: string;
   status: EquipmentNetworkPreviewStatus;
 }) {
@@ -88,17 +90,17 @@ function NetworkPill({
       style={{
         display: "flex",
         alignItems: "center",
-        gap: 8,
-        padding: "8px 11px",
+        gap: compact ? 7 : 8,
+        padding: compact ? "6px 10px" : "8px 11px",
         border: `1px solid ${palette.border}`,
         borderRadius: 999,
         background: palette.background,
         color: palette.text,
-        fontSize: 14,
+        fontSize: compact ? 13 : 14,
         fontWeight: 800,
       }}
     >
-      <div style={{ display: "flex", width: 8, height: 8, borderRadius: 999, background: palette.text }} />
+      <div style={{ display: "flex", width: compact ? 7 : 8, height: compact ? 7 : 8, borderRadius: 999, background: palette.text }} />
       {label}
     </div>
   );
@@ -247,6 +249,7 @@ function machineCard(preview: EquipmentMachineSocialPreview, origin: string) {
 }
 
 function stateCard(preview: EquipmentStateSocialPreview) {
+  const dense = preview.systems.length >= 5;
   const response = new ImageResponse(
     (
       <div
@@ -275,18 +278,19 @@ function stateCard(preview: EquipmentStateSocialPreview) {
           <div style={{ display: "flex", fontSize: 38, fontWeight: 900, letterSpacing: "-0.035em" }}>{preview.stateName} equipment records</div>
         </div>
 
-        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 7 }}>
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: dense ? 5 : 7 }}>
           {preview.systems.map((system) => {
             const exactFamily = system.usage.deviceFamilyRecords > 0;
             return (
               <div
                 key={system.slug}
                 style={{
-                  minHeight: 62,
+                  minHeight: dense ? 52 : 62,
+                  flexShrink: 0,
                   display: "flex",
                   alignItems: "center",
                   gap: 14,
-                  padding: "9px 13px",
+                  padding: dense ? "5px 13px" : "9px 13px",
                   border: `1px solid ${colors.border}`,
                   borderLeft: `4px solid ${exactFamily ? colors.accent : colors.context}`,
                   borderRadius: 10,
@@ -304,7 +308,7 @@ function stateCard(preview: EquipmentStateSocialPreview) {
                   <div style={{ display: "flex", color: colors.muted, fontSize: 11 }}>{system.evidenceLabel}</div>
                 </div>
                 <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
-                  <NetworkPill label={system.network.shortLabel} status={system.network.status} />
+                  <NetworkPill compact={dense} label={system.network.shortLabel} status={system.network.status} />
                 </div>
               </div>
             );

--- a/src/lib/equipment-social-preview.ts
+++ b/src/lib/equipment-social-preview.ts
@@ -10,7 +10,7 @@ import {
 } from "./equipment-usage";
 import { stateNameForCode } from "./us-states";
 
-export const equipmentSocialCardVersion = "equipment-v1";
+export const equipmentSocialCardVersion = "equipment-v2";
 
 export type EquipmentNetworkPreviewStatus = "documented" | "optional" | "reviewed_without_attachment";
 

--- a/tests/api/equipment-social-preview.test.mjs
+++ b/tests/api/equipment-social-preview.test.mjs
@@ -30,6 +30,7 @@ for (const system of catalog.systems) {
   );
 }
 
+assert.match(socialLibrary, /equipmentSocialCardVersion = "equipment-v2"/);
 assert.match(socialLibrary, /"ess-evs-6400-ds200"[\s\S]*?status: "optional"/);
 assert.match(socialLibrary, /Optional cellular modem hardware documented historically/);
 assert.match(socialLibrary, /do not establish inclusion in EVS 6\.4\.0\.0 certification, modem firmware, activation, or use/i);
@@ -50,6 +51,15 @@ assert.equal(colorado.size, 4);
 assert.equal([...colorado.values()].filter((entry) => entry.deviceFamily > 0).length, 2);
 assert.equal([...colorado.values()].filter((entry) => entry.deviceFamily === 0 && entry.manufacturerContext > 0).length, 2);
 
+const stateSystems = new Map();
+for (const record of usage.records) {
+  const systems = stateSystems.get(record.state) ?? new Set();
+  for (const match of record.matches) systems.add(match.slug);
+  stateSystems.set(record.state, systems);
+}
+const maximumStateSystemCount = Math.max(...[...stateSystems.values()].map((systems) => systems.size));
+assert.equal(maximumStateSystemCount, 6, "the social-card regression fixture must cover the maximum state density");
+
 assert.match(indexPage, /State equipment share pages/);
 assert.match(indexPage, /action="\/equipment\/state"/);
 assert.match(indexPage, /getEquipmentNetworkQuickFact/);
@@ -64,6 +74,11 @@ assert.match(socialLibrary, /Dossier network capability does not establish/i);
 assert.match(statePage, /equipmentSocialCardPath/);
 assert.match(socialRoute, /new ImageResponse/);
 assert.match(socialRoute, /width: 1200, height: 630/);
+assert.match(socialRoute, /const dense = preview\.systems\.length >= 5/);
+assert.match(socialRoute, /minHeight: dense \? 52 : 62/);
+assert.match(socialRoute, /gap: dense \? 5 : 7/);
+assert.match(socialRoute, /compact=\{dense\}/);
+assert.match(socialRoute, /flexShrink: 0/);
 assert.match(socialRoute, /Equipment dossier not found/);
 assert.match(socialRoute, /Tracked state equipment not found/);
 assert.match(sitemap, /listTrackedEquipmentStates/);

--- a/tests/e2e/equipment-social-previews.spec.ts
+++ b/tests/e2e/equipment-social-previews.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import sharp from "sharp";
 
 const ds200Path = "/equipment/ess-evs-6400-ds200";
 const equipmentSlugs = [
@@ -14,6 +15,29 @@ function expectPngDimensions(body: Buffer, width: number, height: number) {
   expect(body.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
   expect(body.readUInt32BE(16)).toBe(width);
   expect(body.readUInt32BE(20)).toBe(height);
+}
+
+async function expectDenseStateCardLayout(body: Buffer) {
+  const { data, info } = await sharp(body).raw().toBuffer({ resolveWithObject: true });
+  const rowBackground = [0x0d, 0x24, 0x27];
+  const scanX = 900;
+  const runs: Array<{ start: number; end: number }> = [];
+  let start = -1;
+
+  for (let y = 0; y < info.height; y += 1) {
+    const offset = (y * info.width + scanX) * info.channels;
+    const matches = rowBackground.every((value, channel) => data[offset + channel] === value);
+    if (matches && start < 0) start = y;
+    if (!matches && start >= 0) {
+      runs.push({ start, end: y - 1 });
+      start = -1;
+    }
+  }
+  if (start >= 0) runs.push({ start, end: info.height - 1 });
+
+  expect(runs).toHaveLength(6);
+  expect(runs.every((run) => run.end - run.start >= 45)).toBe(true);
+  expect(runs[runs.length - 1]?.end).toBeLessThan(540);
 }
 
 test.describe.configure({ mode: "serial", timeout: 90_000 });
@@ -42,20 +66,22 @@ test("builds a stable state share page with exact-family and manufacturer-contex
   await expect(clearCountContext.getByText("Closed wired Ethernet system documented", { exact: true })).toBeVisible();
 
   await expect(page.locator("meta[property='og:title']")).toHaveAttribute("content", /Colorado tracked election equipment/);
-  await expect(page.locator("meta[property='og:image']")).toHaveAttribute("content", /\/api\/equipment-social-card\?v=equipment-v1&state=CO$/);
+  await expect(page.locator("meta[property='og:image']")).toHaveAttribute("content", /\/api\/equipment-social-card\?v=equipment-v2&state=CO$/);
   await expect(page.locator("meta[name='twitter:card']")).toHaveAttribute("content", "summary_large_image");
   await expect(page.getByRole("link", { name: "Open preview image" })).toHaveAttribute("href", /state=CO$/);
 
-  const stateCard = await request.get("/api/equipment-social-card?v=equipment-v1&state=CO");
+  const stateCard = await request.get("/api/equipment-social-card?v=equipment-v2&state=CO");
   expect(stateCard.status()).toBe(200);
   expect(stateCard.headers()["content-type"]).toMatch(/^image\/png/);
   expect(stateCard.headers()["cache-control"]).toContain("s-maxage=900");
   expectPngDimensions(await stateCard.body(), 1200, 630);
 
-  const denseStateCard = await request.get("/api/equipment-social-card?v=equipment-v1&state=KS");
+  const denseStateCard = await request.get("/api/equipment-social-card?v=equipment-v2&state=WI");
   expect(denseStateCard.status()).toBe(200);
   expect(denseStateCard.headers()["content-type"]).toMatch(/^image\/png/);
-  expectPngDimensions(await denseStateCard.body(), 1200, 630);
+  const denseStateCardBody = await denseStateCard.body();
+  expectPngDimensions(denseStateCardBody, 1200, 630);
+  await expectDenseStateCardLayout(denseStateCardBody);
 });
 
 test("publishes machine quick facts and optional-networking metadata", async ({ page, request }) => {
@@ -66,7 +92,7 @@ test("publishes machine quick facts and optional-networking metadata", async ({ 
   await expect(page.locator("meta[name='twitter:card']")).toHaveAttribute("content", "summary_large_image");
 
   for (const slug of equipmentSlugs) {
-    const machineCard = await request.get(`/api/equipment-social-card?v=equipment-v1&slug=${slug}`);
+    const machineCard = await request.get(`/api/equipment-social-card?v=equipment-v2&slug=${slug}`);
     expect(machineCard.status()).toBe(200);
     expect(machineCard.headers()["content-type"]).toMatch(/^image\/png/);
     expectPngDimensions(await machineCard.body(), 1200, 630);


### PR DESCRIPTION
## What changed

- Add a compact Satori/Yoga layout tier for state equipment cards with five or more dossiers.
- Keep each dense row at a stable height and use compact network-capability pills.
- Advance equipment social-image URLs from `equipment-v1` to `equipment-v2` so social crawlers request the corrected image instead of a cached broken PNG.
- Add a Wisconsin PNG boundary regression that verifies all six rows render intact and end above the footer.

## Root cause

Wisconsin has six tracked equipment dossiers. Six 62-pixel rows plus their gaps exceeded the vertical space remaining after the card header, title, and footer. Yoga allowed the list content to collide with the caveat/footer area, so Bluesky displayed overlapping text at the bottom of the image.

The issue also affected the other current six-dossier states: Kansas, New York, Ohio, Pennsylvania, and Washington.

## User impact

State rollup links with six dossiers now generate a clean 1200×630 Open Graph image. One-, two-, and four-dossier states retain the existing roomier layout. The new `equipment-v2` image URL provides a fresh CDN/social-cache key.

## Validation

- `npm run typecheck`
- `npm run test:equipment-catalog`
- `npm run build`
- `npx playwright test tests/e2e/equipment-social-previews.spec.ts --workers=1`
- Local render comparison for Wisconsin and Colorado
- Browser verification of `/equipment/state/WI`: page content present, no Next.js error overlay
- Independent read-only diff review: no actionable findings after the Wisconsin pixel-boundary regression was added
