### PR TITLE
Clarify advisory indicator scopes

### DIFF
--- a/src/app/county/[fips]/county-profile.module.css
+++ b/src/app/county/[fips]/county-profile.module.css
@@ -530,6 +530,31 @@
   text-transform: uppercase;
 }
 
+.advisoryGrid article > .scopeKind {
+  background: rgba(126, 162, 255, 0.1);
+  border: 1px solid rgba(126, 162, 255, 0.32);
+  border-radius: 999px;
+  color: #c8d5ff;
+  display: inline-flex;
+  font-family: inherit;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0;
+  margin-top: 8px;
+  padding: 3px 7px;
+  text-transform: none;
+  width: fit-content;
+}
+
+.scopeName {
+  color: var(--text);
+  display: block;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1.4;
+  margin-top: 7px;
+}
+
 .advisoryGrid h3,
 .provenanceGrid h3 {
   font-size: 14px;

--- a/src/app/county/[fips]/page.tsx
+++ b/src/app/county/[fips]/page.tsx
@@ -15,6 +15,11 @@ import { BrandMark } from "@/app/brand-mark";
 import { GlobalCountySearch } from "@/app/global-county-search";
 import { findCanonicalCountyByFips } from "@/lib/county-search";
 import { loadCountyProfile, type CountyProfile } from "@/lib/county-profile";
+import {
+  formatIndicatorScopeSummary,
+  presentIndicatorScope,
+  summarizeIndicatorScopes,
+} from "@/lib/indicator-presentation";
 import type { DataConfidence } from "@/lib/data-confidence";
 import styles from "./county-profile.module.css";
 
@@ -76,6 +81,7 @@ export default async function CountyPage({ params }: CountyPageProps) {
   if (!profile) notFound();
 
   const availableYears = profile.history.filter((row) => row.available).length;
+  const advisorySummary = summarizeIndicatorScopes(profile.advisoryIndicators);
   const compareHref = `/compare?from=2020&to=2024&fips=${profile.fips}`;
   const stateHref = `/?state=${profile.state}&tab=map&fips=${profile.fips}`;
 
@@ -289,7 +295,7 @@ export default async function CountyPage({ params }: CountyPageProps) {
               <p className={styles.eyebrow}>Review context</p>
               <h2 id="advisory-context">Advisory indicators</h2>
             </div>
-            <span>{profile.advisoryIndicators.length} matched {profile.advisoryIndicators.length === 1 ? "indicator" : "indicators"}</span>
+            <span>{formatIndicatorScopeSummary(advisorySummary)}</span>
           </div>
           <p className={styles.advisoryCaveat}>
             These calculated indicators are prompts for checking source data, reporting grain, denominators, and local context.
@@ -299,6 +305,8 @@ export default async function CountyPage({ params }: CountyPageProps) {
             <div className={styles.advisoryGrid}>
               {profile.advisoryIndicators.map((indicator) => (
                 <article key={indicator.id}>
+                  <span className={styles.scopeKind}>{presentIndicatorScope(indicator).kind}</span>
+                  <strong className={styles.scopeName}>Scope: {presentIndicatorScope(indicator).name}</strong>
                   <span>{indicator.type.replaceAll("_", " ")} · severity {indicator.severity.toFixed(2)}</span>
                   <h3>{indicator.label}</h3>
                   <p>{indicator.summary}</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2603,6 +2603,23 @@ input {
   margin: 0;
 }
 
+.indicator-count-summary {
+  align-items: baseline;
+  display: flex;
+  gap: 6px;
+}
+
+.indicator-count-summary strong {
+  font-size: 18px;
+}
+
+.indicator-count-summary small {
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 700;
+}
+
 .drawer-source span,
 .drawer-indicators small {
   color: var(--muted);
@@ -2635,6 +2652,31 @@ input {
 
 .drawer-indicators article strong {
   font-size: 13px;
+}
+
+.indicator-card-heading {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.indicator-scope-kind {
+  background: rgba(126, 162, 255, 0.1);
+  border: 1px solid rgba(126, 162, 255, 0.32);
+  border-radius: 999px;
+  color: #c8d5ff;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1.2;
+  padding: 4px 7px;
+}
+
+.drawer-indicators .indicator-scope-name {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1.35;
 }
 
 .legend-item {
@@ -3902,6 +3944,21 @@ td {
   gap: 4px;
   line-height: 1.2;
   padding: 4px 7px;
+}
+
+.indicator-table-entry {
+  align-items: flex-start;
+  display: grid;
+  gap: 4px;
+  justify-items: start;
+}
+
+.indicator-scope-inline {
+  color: var(--quiet);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1.25;
+  max-width: 240px;
 }
 
 .benefit-cell {

--- a/src/app/results-explorer.tsx
+++ b/src/app/results-explorer.tsx
@@ -17,6 +17,11 @@ import {
 import type { PointerEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Eli5 } from "./eli5";
+import {
+  formatIndicatorScopeSummary,
+  presentIndicatorScope,
+  summarizeIndicatorScopes,
+} from "@/lib/indicator-presentation";
 import { hasBaseResultGeometry } from "@/lib/map-geometry";
 import { activeMapSelection } from "@/lib/map-selection";
 import {
@@ -1097,6 +1102,7 @@ export function ResultsExplorer({
       ?? indicatorsByName.get(normalizeName(activeMapName))
       ?? []
     : [];
+  const selectedMapIndicatorSummary = summarizeIndicatorScopes(selectedMapIndicators);
   const selectedMapVoteMethod = activeMapName
     ? voteMethodByCounty.get(normalizeName(resultNameForFeature(selectedState, activeMapName)))
     : undefined;
@@ -1183,6 +1189,7 @@ export function ResultsExplorer({
       ?? indicatorsByName.get(normalizeName(pinnedMapName))
       ?? []
     : [];
+  const pinnedMapIndicatorSummary = summarizeIndicatorScopes(pinnedMapIndicators);
   const pinnedSource = pinnedMapResult ? sourceById.get(pinnedMapResult.sourceId) : undefined;
 
   const mapJoinStats = useMemo(() => {
@@ -1663,6 +1670,16 @@ export function ResultsExplorer({
                 const countyIndicators = (row?.jurisdictionTag ? mapIndicatorsByTag.get(row.jurisdictionTag) : undefined)
                   ?? mapIndicatorsByName.get(normalizeName(resultName))
                   ?? [];
+                const countyIndicatorSummary = summarizeIndicatorScopes(countyIndicators);
+                const countyIndicatorText = mapMode !== "security" && countyIndicators.length
+                  ? formatIndicatorScopeSummary(countyIndicatorSummary)
+                  : "";
+                const featureResultText = mapMode === "security"
+                  ? securitySummary(countySecurityIncidents)
+                  : row
+                    ? `${row.winner} by ${row.marginPct.toFixed(2)} percent`
+                    : "";
+                const featureAriaLabel = [name, featureResultText, countyIndicatorText].filter(Boolean).join(", ");
                 const rings = polygonRings(feature);
                 const point = centroid(selectedState, feature, bounds);
                 const isSelected = selectedMapName && normalizeName(selectedMapName) === normalizeName(resultName);
@@ -1671,7 +1688,7 @@ export function ResultsExplorer({
                   <g key={`${selectedState}-${mapMode}-${name}-${featureIndex}`}>
                     <path
                       aria-pressed={Boolean(isPinned)}
-                      aria-label={`${name}${mapMode === "security" ? `, ${securitySummary(countySecurityIncidents)}` : row ? `, ${row.winner} by ${row.marginPct.toFixed(2)} percent` : ""}`}
+                      aria-label={featureAriaLabel}
                       className={isPinned ? "map-shape pinned" : isSelected ? "map-shape selected" : "map-shape"}
                       d={makePath(selectedState, rings, bounds)}
                       fill={countyFill(
@@ -1728,7 +1745,7 @@ export function ResultsExplorer({
                                 ? `${row.winner} by ${row.marginPct.toFixed(2)}%`
                                 : "No result row"}
                         {mapMode !== "security" && countyIndicators.length
-                          ? `; ${countyIndicators.length} advisory review flag(s)`
+                          ? `; ${countyIndicatorText}`
                           : ""}
                       </title>
                     </path>
@@ -1792,7 +1809,7 @@ export function ResultsExplorer({
           )}
           {mapMode !== "security" && <span className="legend-item legend-volume">Vote volume</span>}
           {mapMode !== "security" && <span className="legend-item legend-missing">No joined result</span>}
-          {mapMode !== "security" && <span className="legend-item legend-flag">Advisory count</span>}
+          {mapMode !== "security" && <span className="legend-item legend-flag">Indicator count</span>}
           {mapMode === "volume" && <span className="legend-note">Gold intensity shows total vote volume.</span>}
           {mapMode === "method" && (
             <span className="legend-note">Method layer is participation method, not candidate vote by method.</span>
@@ -1815,13 +1832,13 @@ export function ResultsExplorer({
           {mapMode !== "security" && (
             <span className="legend-note">
               {indicatorsEvaluated
-                ? "Badge numbers count advisory indicators, not confirmed findings."
+                ? "Badge numbers count individual advisory indicators. One boundary can contain more than one calculation scope."
                 : "Advisory indicators are not evaluated for this state-year because same-grain comparison rows are not loaded."}
             </span>
           )}
           {mapMode !== "security" && selectedMapIndicators.length > 0 && (
             <span className="legend-note">
-              {selectedMapIndicators.length} advisory flag{selectedMapIndicators.length === 1 ? "" : "s"} selected
+              {formatIndicatorScopeSummary(selectedMapIndicatorSummary)} selected
             </span>
           )}
         </div>
@@ -1873,8 +1890,22 @@ export function ResultsExplorer({
                   <dd>{selectedMapResult.totalVotes.toLocaleString()}</dd>
                 </div>
                 <div>
-                  <dt>Flags</dt>
-                  <dd>{indicatorsEvaluated ? selectedMapIndicators.length : "N/E"}</dd>
+                  <dt>Indicators</dt>
+                  <dd
+                    aria-label={formatIndicatorScopeSummary(selectedMapIndicatorSummary)}
+                    className="indicator-count-summary"
+                    title={formatIndicatorScopeSummary(selectedMapIndicatorSummary)}
+                  >
+                    {indicatorsEvaluated ? (
+                      <>
+                        <strong>{selectedMapIndicatorSummary.indicatorCount}</strong>
+                        <small>
+                          &middot; {selectedMapIndicatorSummary.scopeCount}{" "}
+                          {selectedMapIndicatorSummary.scopeCount === 1 ? "scope" : "scopes"}
+                        </small>
+                      </>
+                    ) : "N/E"}
+                  </dd>
                 </div>
                 <div>
                   <dt>{selectedVoteMethodLabel}</dt>
@@ -1976,13 +2007,20 @@ export function ResultsExplorer({
               )}
               <div className="drawer-indicators">
                 {selectedMapIndicators.length ? (
-                  selectedMapIndicators.map((indicator) => (
-                    <article key={indicator.id}>
-                      <span className="indicator-pill">! {indicator.label}</span>
-                      <strong>{indicator.summary}</strong>
-                      <small>{indicator.detail}</small>
-                    </article>
-                  ))
+                  selectedMapIndicators.map((indicator) => {
+                    const scope = presentIndicatorScope(indicator);
+                    return (
+                      <article key={indicator.id}>
+                        <div className="indicator-card-heading">
+                          <span className="indicator-pill">! {indicator.label}</span>
+                          <span className="indicator-scope-kind">{scope.kind}</span>
+                        </div>
+                        <strong className="indicator-scope-name">Scope: {scope.name}</strong>
+                        <strong>{indicator.summary}</strong>
+                        <small>{indicator.detail}</small>
+                      </article>
+                    );
+                  })
                 ) : (
                                     <span className="no-indicator">
                     {indicatorsEvaluated
@@ -2146,7 +2184,7 @@ export function ResultsExplorer({
                   </span>
                 </div>
                 <div className="selected-result-actions">
-                  <span>{pinnedMapIndicators.length} advisory flags</span>
+                  <span>{formatIndicatorScopeSummary(pinnedMapIndicatorSummary)}</span>
                   {pinnedSource?.sourceUrl && (
                     <a href={pinnedSource.sourceUrl} rel="noreferrer" target="_blank">
                       <ExternalLink aria-hidden size={14} />
@@ -2164,7 +2202,7 @@ export function ResultsExplorer({
                 <thead>
                   <tr>
                     <th>Jurisdiction</th>
-                    <th>Flags</th>
+                    <th>Indicators / scope</th>
                     <th>Directional screen</th>
                     <th>Winner</th>
                     <th>{yearCandidates.dem}</th>
@@ -2232,11 +2270,19 @@ export function ResultsExplorer({
                       <td>
                         {rowIndicators.length > 0 ? (
                           <div className="indicator-stack">
-                            {rowIndicators.map((indicator) => (
-                              <span className="indicator-pill" key={indicator.id} title={indicator.detail}>
-                                ! {indicator.label}
-                              </span>
-                            ))}
+                            {rowIndicators.map((indicator) => {
+                              const scope = presentIndicatorScope(indicator);
+                              return (
+                                <span
+                                  className="indicator-table-entry"
+                                  key={indicator.id}
+                                  title={`${scope.label}. ${indicator.detail}`}
+                                >
+                                  <span className="indicator-pill">! {indicator.label}</span>
+                                  <small className="indicator-scope-inline">{scope.label}</small>
+                                </span>
+                              );
+                            })}
                           </div>
                         ) : (
                                                     <span

--- a/src/lib/indicator-presentation.ts
+++ b/src/lib/indicator-presentation.ts
@@ -1,0 +1,57 @@
+import type { AnalysisIndicator } from "./types";
+
+const scopeKindByLevel: Record<AnalysisIndicator["level"], string> = {
+  city: "City",
+  city_town: "City / town",
+  county: "Countywide",
+  district: "District",
+  precinct: "Precinct",
+  rest_of_county: "Rest of county",
+  state: "Statewide",
+  town: "Town",
+};
+
+export type IndicatorScopePresentation = {
+  key: string;
+  kind: string;
+  label: string;
+  name: string;
+};
+
+export type IndicatorScopeSummary = {
+  indicatorCount: number;
+  scopeCount: number;
+};
+
+function humanizeLevel(level: string) {
+  return level
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export function presentIndicatorScope(indicator: AnalysisIndicator): IndicatorScopePresentation {
+  const kind = scopeKindByLevel[indicator.level] ?? humanizeLevel(indicator.level);
+  const name = indicator.jurisdictionName.trim() || "Unspecified jurisdiction";
+
+  return {
+    key: `${indicator.level}:${indicator.jurisdictionCode || name}`,
+    kind,
+    label: `${kind} \u00b7 ${name}`,
+    name,
+  };
+}
+
+export function summarizeIndicatorScopes(
+  indicators: readonly AnalysisIndicator[],
+): IndicatorScopeSummary {
+  return {
+    indicatorCount: indicators.length,
+    scopeCount: new Set(indicators.map((indicator) => presentIndicatorScope(indicator).key)).size,
+  };
+}
+
+export function formatIndicatorScopeSummary(summary: IndicatorScopeSummary) {
+  const indicatorNoun = summary.indicatorCount === 1 ? "advisory indicator" : "advisory indicators";
+  const scopeNoun = summary.scopeCount === 1 ? "scope" : "scopes";
+  return `${summary.indicatorCount} ${indicatorNoun} across ${summary.scopeCount} ${scopeNoun}`;
+}

--- a/tests/api/analysis-indicators.test.mjs
+++ b/tests/api/analysis-indicators.test.mjs
@@ -8,6 +8,11 @@ import {
   isComparableDownBallotRow,
   summarizeIndicatorEvaluation,
 } from "../../src/lib/analysis-indicators.ts";
+import {
+  formatIndicatorScopeSummary,
+  presentIndicatorScope,
+  summarizeIndicatorScopes,
+} from "../../src/lib/indicator-presentation.ts";
 import { buildStagingIndicatorReport } from "../../scripts/report-staging-indicator-counts.mjs";
 
 function precinctRows({ year = 2020, count = 10, coverageMode = "presidentVsSenate" } = {}) {
@@ -174,5 +179,84 @@ test("year-aware staging report distinguishes evaluated historical rows from mis
     assert.equal(currentReport.states[0].evaluationCaveat, "Current comparison caveat.");
   } finally {
     rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function presentationIndicator(overrides = {}) {
+  return {
+    detail: "Advisory detail.",
+    electionYear: 2024,
+    id: "example-indicator",
+    jurisdictionCode: "WI-OUTAGAMIE",
+    jurisdictionName: "Outagamie",
+    level: "county",
+    label: "Vote-share pattern",
+    metrics: {},
+    severity: 1,
+    state: "WI",
+    summary: "Advisory summary.",
+    type: "vote_share_pattern",
+    ...overrides,
+  };
+}
+
+test("indicator presentation separates repeated flag types by calculation scope", () => {
+  const outsideAppleton = presentationIndicator({
+    id: "outside-appleton-vote-share",
+    jurisdictionCode: "WI-OUTAGAMIE-APPLETON-REST",
+    jurisdictionName: "Outagamie County outside Appleton",
+    level: "rest_of_county",
+    metrics: { city: "Appleton", county: "Outagamie" },
+  });
+  const indicators = [
+    outsideAppleton,
+    {
+      ...outsideAppleton,
+      id: "outside-appleton-dropoff",
+      label: "Average down-ballot difference",
+      type: "average_down_ballot_difference",
+    },
+    presentationIndicator({
+      id: "appleton-vote-share",
+      jurisdictionCode: "WI-OUTAGAMIE-APPLETON-CITY",
+      jurisdictionName: "Appleton, Outagamie County",
+      level: "city",
+      metrics: { city: "Appleton", county: "Outagamie" },
+    }),
+  ];
+
+  assert.deepEqual(summarizeIndicatorScopes(indicators), { indicatorCount: 3, scopeCount: 2 });
+  assert.equal(
+    formatIndicatorScopeSummary(summarizeIndicatorScopes(indicators)),
+    "3 advisory indicators across 2 scopes",
+  );
+  assert.deepEqual(presentIndicatorScope(outsideAppleton), {
+    key: "rest_of_county:WI-OUTAGAMIE-APPLETON-REST",
+    kind: "Rest of county",
+    label: "Rest of county \u00b7 Outagamie County outside Appleton",
+    name: "Outagamie County outside Appleton",
+  });
+});
+
+test("indicator presentation labels every supported reporting level", () => {
+  const expectedKinds = {
+    city: "City",
+    city_town: "City / town",
+    county: "Countywide",
+    district: "District",
+    precinct: "Precinct",
+    rest_of_county: "Rest of county",
+    state: "Statewide",
+    town: "Town",
+  };
+
+  for (const [level, expectedKind] of Object.entries(expectedKinds)) {
+    const scope = presentIndicatorScope(presentationIndicator({
+      jurisdictionCode: `scope-${level}`,
+      jurisdictionName: `Example ${level}`,
+      level,
+    }));
+    assert.equal(scope.kind, expectedKind);
+    assert.equal(scope.name, `Example ${level}`);
   }
 });


### PR DESCRIPTION
## Summary

- Distinguish individual advisory indicators from their calculation scopes.
- Show the scope type and exact jurisdiction name in the map drawer, results table, hover details, and permanent county profile.
- Report summaries such as `3 advisory indicators across 2 scopes` instead of presenting same-type indicators as apparent duplicates.
- Cover every supported indicator geography level through a reusable presentation helper and tests.

## Why

Outagamie County currently has three advisory indicators, including two vote-share-pattern indicators calculated for different scopes: Appleton and the remainder of Outagamie County outside Appleton. The previous UI grouped both under the county boundary without displaying that distinction, so they looked duplicated at a glance.

## User impact

Users can now see both the number of individual indicators and the number and names of distinct calculation scopes. The implementation is data-driven and applies across states and counties rather than special-casing Wisconsin.

## Validation

- `node --experimental-strip-types tests/api/analysis-indicators.test.mjs`
- `npm run typecheck`
- `npm run test:api`
- `npm run build`
- `git diff --check`
- Browser verification of the Outagamie map drawer and `/county/55087` profile
