### PR TITLE
Harden Equipment Explorer release paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ VERCEL_PROJECT_ID=
 VERCEL_ORG_ID=
 VERCEL_TOKEN=
 
+# Equipment Explorer (local/preview review; production accepts only public)
+EQUIPMENT_CATALOG_CHANNEL=staging
+EQUIPMENT_EXPLORER_ENABLED=0
+NEXT_PUBLIC_EQUIPMENT_EXPLORER=0
+
 # Private workspace layout editor
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Security incident tests
         run: npm run test:security-incidents
 
+      - name: Equipment catalog validation
+        run: npm run test:equipment-catalog
+
       - name: ETL tests
         run: npm run test:etl
 
@@ -63,14 +66,22 @@ jobs:
       - name: Production provenance validation
         run: npm run validate:provenance
 
-      - name: Build
+      - name: Feature-enabled public equipment build
         run: npm run build
+        env:
+          EQUIPMENT_CATALOG_CHANNEL: public
+          EQUIPMENT_EXPLORER_ENABLED: "1"
+          NEXT_PUBLIC_EQUIPMENT_EXPLORER: "1"
+          VERCEL_ENV: production
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
+      - name: Equipment browser tests
+        run: npm run test:e2e:equipment
+
       - name: Workspace layout browser tests
-        run: npm run test:e2e
+        run: npm run test:e2e:workspace
 
   vercel-preview:
     if: github.event_name == 'pull_request'
@@ -113,6 +124,9 @@ jobs:
         if: steps.vercel-secrets.outputs.available == 'true'
         run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
         env:
+          EQUIPMENT_CATALOG_CHANNEL: staging
+          EQUIPMENT_EXPLORER_ENABLED: "1"
+          NEXT_PUBLIC_EQUIPMENT_EXPLORER: "1"
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
@@ -130,3 +144,7 @@ jobs:
       - name: Smoke-test security incident preview
         if: steps.vercel-secrets.outputs.available == 'true'
         run: node scripts/verify-security-incidents-deployment.mjs --base-url=${{ steps.deploy-preview.outputs.url }}
+
+      - name: Smoke-test staging equipment preview
+        if: steps.vercel-secrets.outputs.available == 'true'
+        run: node scripts/verify-equipment-deployment.mjs --base-url=${{ steps.deploy-preview.outputs.url }} --expect-channel=staging

--- a/.github/workflows/security-production-smoke.yml
+++ b/.github/workflows/security-production-smoke.yml
@@ -1,4 +1,4 @@
-name: Security incident production smoke
+name: Production deployment smoke
 
 on:
   deployment_status:
@@ -23,3 +23,6 @@ jobs:
 
       - name: Verify national, Georgia, and Minnesota security reports
         run: node scripts/verify-security-incidents-deployment.mjs --base-url=https://civicresultmaps.org
+
+      - name: Verify the public Equipment Explorer catalog
+        run: node scripts/verify-equipment-deployment.mjs --base-url=https://civicresultmaps.org --expect-channel=public

--- a/.vercelignore
+++ b/.vercelignore
@@ -25,7 +25,8 @@ tsconfig.tsbuildinfo
 # Large raw election artifacts stay in GitHub/source storage and are not
 # needed in Vercel deployment bundles.
 data/**
-!data/equipment-catalog.json
+!data/equipment-catalog.staging.json
+!data/equipment-catalog.public.json
 !data/equipment-usage-index.json
 !data/admin-source-packages.json
 !data/election-security-incident-source-inventory-2024.json

--- a/data/equipment-catalog.public.json
+++ b/data/equipment-catalog.public.json
@@ -1,9 +1,13 @@
 {
   "schemaVersion": 2,
+  "catalogChannel": "public",
   "generatedOn": "2026-07-21",
-  "status": "reviewed_pilot",
-  "editorialState": "staging_review",
+  "status": "published_catalog",
+  "editorialState": "public_release",
   "productionRequirement": "published",
+  "releaseIds": [
+    "equipment-explorer-2026-07-22-r1"
+  ],
   "methodology": {
     "title": "Election equipment catalog evidence policy",
     "description": "The pilot records what an official source actually establishes and keeps certified configurations, state approvals, jurisdiction deployment observations, historical configuration changes, and unknown field details in separate scopes.",
@@ -1179,45 +1183,6 @@
           "supersedesRevisionId": null,
           "contentStatus": "baseline",
           "pageOrSection": "ECO metadata and attachment",
-          "archiveStatus": "verified"
-        }
-      ],
-      "revisionComparisons": []
-    },
-    {
-      "id": "eac-eco-index",
-      "publisher": "U.S. Election Assistance Commission",
-      "authorityLevel": "federal_official",
-      "title": "Engineering Change Orders",
-      "url": "https://www.eac.gov/voting-equipment/engineering-change-orders",
-      "localArtifact": "data/equipment-sources/eac-engineering-change-orders.html",
-      "sha256": "4fe152aa1eecdefa43c7cdc7240182ed54f4ed6dd26b1d70fc409e1ead8bb4b5",
-      "documentType": "official_registry_html",
-      "publishedOn": null,
-      "retrievedOn": "2026-07-19",
-      "pageOrSection": "Public ECO registry",
-      "caveat": "The archived first registry page is discovery context; individual ECO records and attachments support the catalog claims.",
-      "canonicalUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders",
-      "currentReviewedRevisionId": "eac-eco-index@2026-07-19",
-      "latestRetrievedRevisionId": "eac-eco-index@2026-07-19",
-      "revisions": [
-        {
-          "id": "eac-eco-index@2026-07-19",
-          "localArtifact": "data/equipment-sources/eac-engineering-change-orders.html",
-          "sha256": "4fe152aa1eecdefa43c7cdc7240182ed54f4ed6dd26b1d70fc409e1ead8bb4b5",
-          "byteLength": 117800,
-          "publishedOn": null,
-          "retrievedOn": "2026-07-19",
-          "retrievedAt": null,
-          "retrievalPrecision": "date",
-          "resolvedUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders",
-          "http": {
-            "etag": null,
-            "lastModified": null
-          },
-          "supersedesRevisionId": null,
-          "contentStatus": "baseline",
-          "pageOrSection": "Public ECO registry",
           "archiveStatus": "verified"
         }
       ],

--- a/data/equipment-catalog.staging.json
+++ b/data/equipment-catalog.staging.json
@@ -1,0 +1,9293 @@
+{
+  "schemaVersion": 2,
+  "catalogChannel": "staging",
+  "generatedOn": "2026-07-21",
+  "status": "reviewed_pilot",
+  "editorialState": "staging_review",
+  "productionRequirement": "published",
+  "releaseIds": [
+    "equipment-explorer-2026-07-22-r1"
+  ],
+  "methodology": {
+    "title": "Election equipment catalog evidence policy",
+    "description": "The pilot records what an official source actually establishes and keeps certified configurations, state approvals, jurisdiction deployment observations, historical configuration changes, and unknown field details in separate scopes.",
+    "changeControlSourceIds": [
+      "eac-changes-certified-systems",
+      "eac-program-manual-v3"
+    ],
+    "caveat": "An EAC engineering change order documents an approved change to one or more certified configurations. It does not establish that a particular jurisdiction installed the change, and a VSTL record is not a unit-level service or repair history."
+  },
+  "sources": [
+    {
+      "id": "cisa-kev-catalog",
+      "publisher": "Cybersecurity and Infrastructure Security Agency",
+      "authorityLevel": "federal_known_exploited_vulnerability_catalog",
+      "title": "Known Exploited Vulnerabilities Catalog",
+      "url": "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+      "localArtifact": "data/equipment-sources/cisa-known-exploited-vulnerabilities-2026-07-16.json",
+      "sha256": "41d27023a5912a49ca2b06370550fa6da50e35794c269766a6332618d82f243e",
+      "documentType": "federal_vulnerability_catalog_json",
+      "publishedOn": "2026-07-16",
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "Catalog version 2026.07.16; 1,647 records",
+      "caveat": "No reviewed catalog record matched MultiTech, Telit, SocketModem, MTSMC, or LE910 terms. KEV contains vulnerabilities known to be exploited in the wild; absence from KEV does not mean a product has no vulnerabilities or that exploitation has never occurred.",
+      "canonicalUrl": "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+      "currentReviewedRevisionId": "cisa-kev-catalog@2026-07-20",
+      "latestRetrievedRevisionId": "cisa-kev-catalog@2026-07-20",
+      "revisions": [
+        {
+          "id": "cisa-kev-catalog@2026-07-20",
+          "localArtifact": "data/equipment-sources/cisa-known-exploited-vulnerabilities-2026-07-16.json",
+          "sha256": "41d27023a5912a49ca2b06370550fa6da50e35794c269766a6332618d82f243e",
+          "byteLength": 1552342,
+          "publishedOn": "2026-07-16",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Catalog version 2026.07.16; 1,647 records",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "clearballot-clearaccess-product-page",
+      "publisher": "Clear Ballot Group",
+      "authorityLevel": "manufacturer_primary",
+      "title": "ClearAccess product page",
+      "url": "https://www.clearballot.com/products/clear-access",
+      "localArtifact": "data/equipment-sources/clearballot-clearaccess-product.html",
+      "documentType": "manufacturer_product_page_html",
+      "publishedOn": null,
+      "pageOrSection": "Accessible interface and versatile configurations",
+      "caveat": "The current manufacturer product page supports the external product concept and available case or tabletop configurations. It is not a certified bill of materials, dimensional drawing, firmware record, or field-deployment record.",
+      "sha256": "7082393fed9ac136b7ae33a8a7022920bbd9bd545442c094348a283c9d7a4d82",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.clearballot.com/products/clear-access",
+      "currentReviewedRevisionId": "clearballot-clearaccess-product-page@2026-07-20",
+      "latestRetrievedRevisionId": "clearballot-clearaccess-product-page@2026-07-20",
+      "revisions": [
+        {
+          "id": "clearballot-clearaccess-product-page@2026-07-20",
+          "localArtifact": "data/equipment-sources/clearballot-clearaccess-product.html",
+          "sha256": "7082393fed9ac136b7ae33a8a7022920bbd9bd545442c094348a283c9d7a4d82",
+          "byteLength": 42125,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.clearballot.com/products/clear-access",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Accessible interface and versatile configurations",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "clearballot-clearaccess-reference-photo",
+      "publisher": "Clear Ballot Group",
+      "authorityLevel": "manufacturer_primary",
+      "title": "ClearAccess official product reference image",
+      "url": "https://www.clearballot.com/hs-fs/hubfs/ClearAccessStormKeypad.png?height=1500&name=ClearAccessStormKeypad.png&width=2000",
+      "localArtifact": "data/equipment-sources/clearballot-clearaccess-reference.png",
+      "documentType": "manufacturer_product_image_png",
+      "publishedOn": null,
+      "pageOrSection": "ClearAccessStormKeypad product image",
+      "caveat": "The official image supports a portrait Elo touchscreen, headphones, and accessible keypad as an external appearance reference only. It does not show the full certified component set, internal placement, ports, printer, UPS, or dimensional scale.",
+      "sha256": "baed0a3acf052caf79bafb84b87787bb974115b1203640e7ec27b0c9bbef6a0e",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.clearballot.com/hs-fs/hubfs/ClearAccessStormKeypad.png?height=1500&name=ClearAccessStormKeypad.png&width=2000",
+      "currentReviewedRevisionId": "clearballot-clearaccess-reference-photo@2026-07-20",
+      "latestRetrievedRevisionId": "clearballot-clearaccess-reference-photo@2026-07-20",
+      "revisions": [
+        {
+          "id": "clearballot-clearaccess-reference-photo@2026-07-20",
+          "localArtifact": "data/equipment-sources/clearballot-clearaccess-reference.png",
+          "sha256": "baed0a3acf052caf79bafb84b87787bb974115b1203640e7ec27b0c9bbef6a0e",
+          "byteLength": 334649,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.clearballot.com/hs-fs/hubfs/ClearAccessStormKeypad.png?height=1500&name=ClearAccessStormKeypad.png&width=2000",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "ClearAccessStormKeypad product image",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "clearballot-clearcount-product-page",
+      "publisher": "Clear Ballot Group",
+      "authorityLevel": "manufacturer_primary",
+      "title": "ClearCount product page",
+      "url": "https://www.clearballot.com/products/clear-count",
+      "localArtifact": "data/equipment-sources/clearballot-clearcount-product-page.html",
+      "sha256": "847bf04e801a77dbac0c4dc6b1da286af0d4377b18b8684899a9fbb1081e2b1a",
+      "documentType": "manufacturer_product_page_html",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "Product overview, tabulation and reporting sections",
+      "caveat": "The current manufacturer page describes the ClearCount product family and user-facing functions. It does not establish the exact ClearVote 2.5 certified COTS alternatives, software installed on a fielded system, or a particular jurisdiction deployment.",
+      "canonicalUrl": "https://www.clearballot.com/products/clear-count",
+      "currentReviewedRevisionId": "clearballot-clearcount-product-page@2026-07-20",
+      "latestRetrievedRevisionId": "clearballot-clearcount-product-page@2026-07-20",
+      "revisions": [
+        {
+          "id": "clearballot-clearcount-product-page@2026-07-20",
+          "localArtifact": "data/equipment-sources/clearballot-clearcount-product-page.html",
+          "sha256": "847bf04e801a77dbac0c4dc6b1da286af0d4377b18b8684899a9fbb1081e2b1a",
+          "byteLength": 37843,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.clearballot.com/products/clear-count",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Product overview, tabulation and reporting sections",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "clearballot-clearcount-reference-photo",
+      "publisher": "Clear Ballot Group",
+      "authorityLevel": "manufacturer_primary",
+      "title": "ClearCount central scanner and laptop product photograph",
+      "url": "https://www.clearballot.com/hubfs/ClearCount%20Hero%20Photo_0-2.jpg",
+      "localArtifact": "data/equipment-sources/clearballot-clearcount-reference-photo.jpg",
+      "sha256": "3a200921253c25ecd5cd93d89545f71de3aa416e3954f49599ebfbe8faa9c570",
+      "documentType": "manufacturer_product_image_jpeg",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "ClearCount hero product photograph, original 2000 x 1333 image",
+      "caveat": "The photograph supports the external appearance of a ClearCount scanner-and-laptop arrangement only. It does not identify the pictured scanner or laptop model, establish that it is a ClearVote 2.5 certified alternative, or depict the CountServer, CountStation, switch, UPS, and all cabling.",
+      "canonicalUrl": "https://www.clearballot.com/hubfs/ClearCount%20Hero%20Photo_0-2.jpg",
+      "currentReviewedRevisionId": "clearballot-clearcount-reference-photo@2026-07-20",
+      "latestRetrievedRevisionId": "clearballot-clearcount-reference-photo@2026-07-20",
+      "revisions": [
+        {
+          "id": "clearballot-clearcount-reference-photo@2026-07-20",
+          "localArtifact": "data/equipment-sources/clearballot-clearcount-reference-photo.jpg",
+          "sha256": "3a200921253c25ecd5cd93d89545f71de3aa416e3954f49599ebfbe8faa9c570",
+          "byteLength": 250286,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.clearballot.com/hubfs/ClearCount%20Hero%20Photo_0-2.jpg",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "ClearCount hero product photograph, original 2000 x 1333 image",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "clearballot-security",
+      "publisher": "Clear Ballot Group",
+      "authorityLevel": "manufacturer_primary",
+      "title": "Protecting Elections: Security",
+      "url": "https://www.clearballot.com/security",
+      "localArtifact": "data/equipment-sources/clearballot-security.html",
+      "sha256": "52c1f6999bcf4b3ffc1022ee0c5e66fdeb637f0c10736745013bda34b79aa025",
+      "documentType": "manufacturer_security_page_html",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-21",
+      "pageOrSection": "Closed Network section",
+      "caveat": "The current manufacturer page states a product-wide security policy for certified Clear Ballot products. It does not identify the wiring, switch configuration, enabled interfaces, or deployment state of a particular ClearAccess or ClearCount unit and is not substituted for the exact ClearVote 2.5 certification record.",
+      "canonicalUrl": "https://www.clearballot.com/security",
+      "currentReviewedRevisionId": "clearballot-security@2026-07-21",
+      "latestRetrievedRevisionId": "clearballot-security@2026-07-21",
+      "revisions": [
+        {
+          "id": "clearballot-security@2026-07-21",
+          "localArtifact": "data/equipment-sources/clearballot-security.html",
+          "sha256": "52c1f6999bcf4b3ffc1022ee0c5e66fdeb637f0c10736745013bda34b79aa025",
+          "byteLength": 47604,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-21",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.clearballot.com/security",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Closed Network section",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "co-dvs-517-avalue-sid21-manual",
+      "publisher": "Colorado Secretary of State; Avalue Technology, Inc.",
+      "authorityLevel": "state_election_office_hosted_manufacturer_primary",
+      "title": "Avalue SID-21V-Z37-A1R User Manual",
+      "url": "https://www.coloradosos.gov/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/AvalueSID21VZ37UserManual.pdf",
+      "localArtifact": "data/equipment-sources/co-avalue-sid21-user-manual.pdf",
+      "documentType": "manufacturer_hardware_user_manual_pdf",
+      "publishedOn": "2016-04-20",
+      "pageOrSection": "Pages 8-10, 12-14, and 22-23",
+      "caveat": "The manual documents the Avalue SID-21V-Z37-A1R COTS hardware family used as an ImageCast X option. Its Android 4.4 example environment is not the certified Democracy Suite 5.17 software environment, and optional hardware in the manual is not assumed installed in every certified or fielded unit.",
+      "sha256": "2fc9d9fd422c196708bac17ef3b0d235767e67f375cba7dd2dfa1ba3d56142f2",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.coloradosos.gov/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/AvalueSID21VZ37UserManual.pdf",
+      "currentReviewedRevisionId": "co-dvs-517-avalue-sid21-manual@2026-07-20",
+      "latestRetrievedRevisionId": "co-dvs-517-avalue-sid21-manual@2026-07-20",
+      "revisions": [
+        {
+          "id": "co-dvs-517-avalue-sid21-manual@2026-07-20",
+          "localArtifact": "data/equipment-sources/co-avalue-sid21-user-manual.pdf",
+          "sha256": "2fc9d9fd422c196708bac17ef3b0d235767e67f375cba7dd2dfa1ba3d56142f2",
+          "byteLength": 2092925,
+          "publishedOn": "2016-04-20",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.coloradosos.gov/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/AvalueSID21VZ37UserManual.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Pages 8-10, 12-14, and 22-23",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "co-dvs-517-icc-user-guide",
+      "publisher": "Colorado Secretary of State; Dominion Voting Systems",
+      "authorityLevel": "state_election_office_hosted_vendor_manual",
+      "title": "Democracy Suite ImageCast Central User Guide 5.17-CO::4",
+      "url": "https://www.sos.state.co.us/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/UGICCUserGuide5-17CO.pdf",
+      "localArtifact": "data/equipment-sources/co-dvs-517-icc-user-guide.pdf",
+      "sha256": "f164b0eda2039470c9817217029366e3096aea67ee2b5795c480023b0672c7fa",
+      "documentType": "state_election_office_hosted_vendor_user_guide_pdf",
+      "publishedOn": "2023-05-02",
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "PDF pages 6, 39, and 69-71; system parts, power/network requirements, and scanner photographs",
+      "caveat": "The guide documents Colorado's 5.17-CO ImageCast Central procedures and photographs scanner alternatives. It does not establish which alternative a jurisdiction selected, a unit-level inventory, or applicability outside the named configuration.",
+      "canonicalUrl": "https://www.sos.state.co.us/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/UGICCUserGuide5-17CO.pdf",
+      "currentReviewedRevisionId": "co-dvs-517-icc-user-guide@2026-07-20",
+      "latestRetrievedRevisionId": "co-dvs-517-icc-user-guide@2026-07-20",
+      "revisions": [
+        {
+          "id": "co-dvs-517-icc-user-guide@2026-07-20",
+          "localArtifact": "data/equipment-sources/co-dvs-517-icc-user-guide.pdf",
+          "sha256": "f164b0eda2039470c9817217029366e3096aea67ee2b5795c480023b0672c7fa",
+          "byteLength": 3755112,
+          "publishedOn": "2023-05-02",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.sos.state.co.us/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/UGICCUserGuide5-17CO.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "PDF pages 6, 39, and 69-71; system parts, power/network requirements, and scanner photographs",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "co-dvs-517-icx-maintenance-manual",
+      "publisher": "Colorado Secretary of State; Dominion Voting Systems",
+      "authorityLevel": "state_election_office_hosted_manufacturer_primary",
+      "title": "Democracy Suite ImageCast X System Maintenance Manual 5.17-CO::4",
+      "url": "https://www.coloradosos.gov/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/2-09-ICXSystemMaintenanceManual517CO.pdf",
+      "localArtifact": "data/equipment-sources/co-icx-517-maintenance-manual.pdf",
+      "documentType": "state_hosted_system_maintenance_manual_pdf",
+      "publishedOn": "2023-05-02",
+      "pageOrSection": "Pages 7-19 and 25-28",
+      "caveat": "The maintenance manual identifies supported ICX hardware variants, build checks, battery care, and service procedures for the Colorado-certified configuration. It does not establish which variant or optional battery a particular jurisdiction fielded.",
+      "sha256": "8dcf7aa62bce757a7ad1f1dc6b01d8607842de7e8dc120c9997c0a025b17eda0",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.coloradosos.gov/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/2-09-ICXSystemMaintenanceManual517CO.pdf",
+      "currentReviewedRevisionId": "co-dvs-517-icx-maintenance-manual@2026-07-20",
+      "latestRetrievedRevisionId": "co-dvs-517-icx-maintenance-manual@2026-07-20",
+      "revisions": [
+        {
+          "id": "co-dvs-517-icx-maintenance-manual@2026-07-20",
+          "localArtifact": "data/equipment-sources/co-icx-517-maintenance-manual.pdf",
+          "sha256": "8dcf7aa62bce757a7ad1f1dc6b01d8607842de7e8dc120c9997c0a025b17eda0",
+          "byteLength": 523433,
+          "publishedOn": "2023-05-02",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.coloradosos.gov/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/2-09-ICXSystemMaintenanceManual517CO.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Pages 7-19 and 25-28",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "co-dvs-517-system-overview",
+      "publisher": "Colorado Secretary of State; Dominion Voting Systems",
+      "authorityLevel": "state_election_office_hosted_vendor_manual",
+      "title": "Democracy Suite System Overview 5.17-CO::3",
+      "url": "https://www.coloradosos.gov/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/2-02-DSSystemOverview517CO.pdf",
+      "localArtifact": "data/equipment-sources/co-dvs-517-system-overview.pdf",
+      "sha256": "2e2490ce02b5e9e73a396672c61b2beb6795355944cf1692c7c96dbd4bcf4971",
+      "documentType": "state_election_office_hosted_vendor_system_overview_pdf",
+      "publishedOn": "2023-04-18",
+      "retrievedOn": "2026-07-21",
+      "pageOrSection": "PDF pages 9, 21, 47, 67-68, and 77",
+      "caveat": "This vendor-authored Colorado technical-data document describes Democracy Suite 5.17-CO. Its own disclaimer excludes modem and transmission functionality from that certification campaign, and its high-level diagram warns that not every depicted component applies to every jurisdiction. It does not establish a field installation or live network configuration.",
+      "canonicalUrl": "https://www.coloradosos.gov/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/2-02-DSSystemOverview517CO.pdf",
+      "currentReviewedRevisionId": "co-dvs-517-system-overview@2026-07-21",
+      "latestRetrievedRevisionId": "co-dvs-517-system-overview@2026-07-21",
+      "revisions": [
+        {
+          "id": "co-dvs-517-system-overview@2026-07-21",
+          "localArtifact": "data/equipment-sources/co-dvs-517-system-overview.pdf",
+          "sha256": "2e2490ce02b5e9e73a396672c61b2beb6795355944cf1692c7c96dbd4bcf4971",
+          "byteLength": 7385740,
+          "publishedOn": "2023-04-18",
+          "retrievedOn": "2026-07-21",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.coloradosos.gov/pubs/elections/VotingSystems/DVS-DemocracySuite517/documentation/2-02-DSSystemOverview517CO.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "PDF pages 9, 21, 47, 67-68, and 77",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "dell-optiplex-5250-specifications",
+      "publisher": "Dell Technologies",
+      "authorityLevel": "manufacturer_primary",
+      "title": "OptiPlex 5250 All-in-One Technical Specifications",
+      "url": "https://i.dell.com/sites/csdocuments/Shared-Content_data-Sheets_Documents/en/OptiPlex-5250-All-in-One-Technical-Specifications.pdf",
+      "localArtifact": "data/equipment-sources/dell-optiplex-5250-specifications.pdf",
+      "documentType": "manufacturer_technical_specification_pdf",
+      "publishedOn": "2017-02-13",
+      "pageOrSection": "Pages 1-3",
+      "caveat": "The manufacturer sheet describes the OptiPlex 5250 product family and its configurable options. Pro V&V separately identifies that model as a ClearAccess option; the sheet does not establish the exact processor, memory, storage, wireless option, or port occupation of a certified or fielded ClearAccess unit.",
+      "sha256": "8561b5309bea351dcedaf1d08b35b5f07fb1fbca2b64b6432667d20977cdd654",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://i.dell.com/sites/csdocuments/Shared-Content_data-Sheets_Documents/en/OptiPlex-5250-All-in-One-Technical-Specifications.pdf",
+      "currentReviewedRevisionId": "dell-optiplex-5250-specifications@2026-07-20",
+      "latestRetrievedRevisionId": "dell-optiplex-5250-specifications@2026-07-20",
+      "revisions": [
+        {
+          "id": "dell-optiplex-5250-specifications@2026-07-20",
+          "localArtifact": "data/equipment-sources/dell-optiplex-5250-specifications.pdf",
+          "sha256": "8561b5309bea351dcedaf1d08b35b5f07fb1fbca2b64b6432667d20977cdd654",
+          "byteLength": 552820,
+          "publishedOn": "2017-02-13",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://i.dell.com/sites/csdocuments/Shared-Content_data-Sheets_Documents/en/OptiPlex-5250-All-in-One-Technical-Specifications.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Pages 1-3",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "dvs-icx-prime-ssd-advisory",
+      "publisher": "Dominion Voting Systems",
+      "authorityLevel": "manufacturer_primary_eac_hosted",
+      "title": "ImageCast X Solid State Flash Drive Customer Advisory Notice",
+      "url": "https://www.eac.gov/sites/default/files/2024-09/2024-AUG-16_FINAL_CAN_ICX%20Prime%20SSD.pdf",
+      "localArtifact": "data/equipment-sources/eac-icx-prime-ssd-advisory.pdf",
+      "documentType": "manufacturer_advisory_pdf",
+      "publishedOn": "2024-08-16",
+      "pageOrSection": "Page 1",
+      "caveat": "The advisory describes a bounded project-file installation or removal condition and a remediation path. It is not evidence that the condition occurred in an election or affected voted paper records.",
+      "sha256": "43b4e87d82b79d978f5e7f62938c10c2269df1045874704addb6b1f899a75cdd",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2024-09/2024-AUG-16_FINAL_CAN_ICX%20Prime%20SSD.pdf",
+      "currentReviewedRevisionId": "dvs-icx-prime-ssd-advisory@2026-07-20",
+      "latestRetrievedRevisionId": "dvs-icx-prime-ssd-advisory@2026-07-20",
+      "revisions": [
+        {
+          "id": "dvs-icx-prime-ssd-advisory@2026-07-20",
+          "localArtifact": "data/equipment-sources/eac-icx-prime-ssd-advisory.pdf",
+          "sha256": "43b4e87d82b79d978f5e7f62938c10c2269df1045874704addb6b1f899a75cdd",
+          "byteLength": 126792,
+          "publishedOn": "2024-08-16",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2024-09/2024-AUG-16_FINAL_CAN_ICX%20Prime%20SSD.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "dvs-icx-straight-party-advisory",
+      "publisher": "Dominion Voting Systems",
+      "authorityLevel": "manufacturer_primary_eac_hosted",
+      "title": "Straight Party Voting on the ImageCast X Customer Advisory Notice",
+      "url": "https://www.eac.gov/sites/default/files/2024-11/2024-SEPT-26_DVS_5.17_CAN_Straight_Party_Voting_on_the_ImageCast_X_508.pdf",
+      "localArtifact": "data/equipment-sources/eac-icx-straight-party-advisory.pdf",
+      "documentType": "manufacturer_advisory_pdf",
+      "publishedOn": "2024-09-26",
+      "pageOrSection": "Page 1",
+      "caveat": "The advisory describes a specific interaction sequence and review recommendation. It does not quantify field occurrence, establish an election outcome effect, or document a software resolution.",
+      "sha256": "74310d93548a352f616cc8e05d929f512211538b74858784a7cdd1e8841f0b98",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2024-11/2024-SEPT-26_DVS_5.17_CAN_Straight_Party_Voting_on_the_ImageCast_X_508.pdf",
+      "currentReviewedRevisionId": "dvs-icx-straight-party-advisory@2026-07-20",
+      "latestRetrievedRevisionId": "dvs-icx-straight-party-advisory@2026-07-20",
+      "revisions": [
+        {
+          "id": "dvs-icx-straight-party-advisory@2026-07-20",
+          "localArtifact": "data/equipment-sources/eac-icx-straight-party-advisory.pdf",
+          "sha256": "74310d93548a352f616cc8e05d929f512211538b74858784a7cdd1e8841f0b98",
+          "byteLength": 69679,
+          "publishedOn": "2024-09-26",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2024-11/2024-SEPT-26_DVS_5.17_CAN_Straight_Party_Voting_on_the_ImageCast_X_508.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "dvs-icx-touchscreen-advisory",
+      "publisher": "Dominion Voting Systems",
+      "authorityLevel": "manufacturer_primary_eac_hosted",
+      "title": "ImageCast X Touch Screen Responsiveness Product Advisory Notice",
+      "url": "https://www.eac.gov/sites/default/files/2024-09/2024-MAY-20-FINAL-PAN-ICX-Touchscreen-Initialization%20%28003%29.pdf",
+      "localArtifact": "data/equipment-sources/eac-icx-touchscreen-advisory.pdf",
+      "documentType": "manufacturer_advisory_pdf",
+      "publishedOn": "2024-05-20",
+      "pageOrSection": "Page 1",
+      "caveat": "This manufacturer advisory is hosted on the EAC certification record and is scoped to named versions and jurisdictions; it is not a quantified incidence report or evidence about every ICX unit.",
+      "sha256": "0b434ff891c31e7a950cfc1d774db63628f7152f916ca52c8cad6c88f462a25d",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2024-09/2024-MAY-20-FINAL-PAN-ICX-Touchscreen-Initialization%20%28003%29.pdf",
+      "currentReviewedRevisionId": "dvs-icx-touchscreen-advisory@2026-07-20",
+      "latestRetrievedRevisionId": "dvs-icx-touchscreen-advisory@2026-07-20",
+      "revisions": [
+        {
+          "id": "dvs-icx-touchscreen-advisory@2026-07-20",
+          "localArtifact": "data/equipment-sources/eac-icx-touchscreen-advisory.pdf",
+          "sha256": "0b434ff891c31e7a950cfc1d774db63628f7152f916ca52c8cad6c88f462a25d",
+          "byteLength": 70723,
+          "publishedOn": "2024-05-20",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2024-09/2024-MAY-20-FINAL-PAN-ICX-Touchscreen-Initialization%20%28003%29.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-changes-certified-systems",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "Changes to Certified Systems",
+      "url": "https://www.eac.gov/testing-and-certification/changes-certified-systems",
+      "localArtifact": "data/equipment-sources/eac-changes-certified-systems.html",
+      "sha256": "2b6b3da672392f5dc55890497692cf05ab9cb348aa615d18008f1bd9ec0f4f58",
+      "documentType": "official_guidance_html",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Change orders and modifications",
+      "caveat": "Program guidance defines certification change control; it is not evidence of field installation.",
+      "canonicalUrl": "https://www.eac.gov/testing-and-certification/changes-certified-systems",
+      "currentReviewedRevisionId": "eac-changes-certified-systems@2026-07-19",
+      "latestRetrievedRevisionId": "eac-changes-certified-systems@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-changes-certified-systems@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-changes-certified-systems.html",
+          "sha256": "2b6b3da672392f5dc55890497692cf05ab9cb348aa615d18008f1bd9ec0f4f58",
+          "byteLength": 61375,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/testing-and-certification/changes-certified-systems",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Change orders and modifications",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-clearvote-25-record",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ClearVote 2.5 certification record",
+      "url": "https://www.eac.gov/voting-equipment/clearvote-25",
+      "localArtifact": "data/equipment-sources/eac-clearvote-25.html",
+      "sha256": "f0e494dfe35a71a91ecff1231c49bc458efb0bed67b8e690c4411826bb6a46e3",
+      "documentType": "official_certification_record_html",
+      "publishedOn": "2025-11-24",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Certification record and public attachments",
+      "caveat": "This record establishes certification of the evaluated ClearVote 2.5 configuration, not deployment or the configuration of a fielded unit.",
+      "canonicalUrl": "https://www.eac.gov/voting-equipment/clearvote-25",
+      "currentReviewedRevisionId": "eac-clearvote-25-record@2026-07-19",
+      "latestRetrievedRevisionId": "eac-clearvote-25-record@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-clearvote-25-record@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-clearvote-25.html",
+          "sha256": "f0e494dfe35a71a91ecff1231c49bc458efb0bed67b8e690c4411826bb6a46e3",
+          "byteLength": 69195,
+          "publishedOn": "2025-11-24",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/voting-equipment/clearvote-25",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Certification record and public attachments",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-clearvote-25-scope",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ClearVote 2.5 Certificate and Scope of Conformance",
+      "url": "https://www.eac.gov/sites/default/files/2025-11/Certificate_and_Scope_of_Conformance_CBG_CV_2.5.pdf",
+      "localArtifact": "data/equipment-sources/eac-clearvote-25-certificate-scope.pdf",
+      "sha256": "c651bd3f0812b0ee03dfb149ac67e838ed0c159a150547c258ee8cf41112b212",
+      "documentType": "official_scope_pdf",
+      "publishedOn": "2025-11-19",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Pages 17-25: proprietary versions, COTS software, and COTS hardware",
+      "caveat": "The scope lists permitted components and versions in the certified configuration; it does not identify which option a jurisdiction selected.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2025-11/Certificate_and_Scope_of_Conformance_CBG_CV_2.5.pdf",
+      "currentReviewedRevisionId": "eac-clearvote-25-scope@2026-07-19",
+      "latestRetrievedRevisionId": "eac-clearvote-25-scope@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-clearvote-25-scope@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-clearvote-25-certificate-scope.pdf",
+          "sha256": "c651bd3f0812b0ee03dfb149ac67e838ed0c159a150547c258ee8cf41112b212",
+          "byteLength": 1540498,
+          "publishedOn": "2025-11-19",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2025-11/Certificate_and_Scope_of_Conformance_CBG_CV_2.5.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Pages 17-25: proprietary versions, COTS software, and COTS hardware",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-dsuite-517-record",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "Democracy Suite 5.17",
+      "url": "https://www.eac.gov/voting-equipment/democracy-suite-517",
+      "localArtifact": "data/equipment-sources/eac-democracy-suite-517.html",
+      "documentType": "official_certification_record_html",
+      "publishedOn": "2024-11-04",
+      "pageOrSection": "Certification summary, testing documents, certification media, and advisory notices",
+      "caveat": "The EAC record establishes certification metadata and linked public documents; it does not establish a jurisdiction deployment, field configuration, or unit inspection.",
+      "sha256": "37837c0f9f6a5ad9340e7925b842e5bf941b1f66f666711674c1908a4d464de0",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.eac.gov/voting-equipment/democracy-suite-517",
+      "currentReviewedRevisionId": "eac-dsuite-517-record@2026-07-20",
+      "latestRetrievedRevisionId": "eac-dsuite-517-record@2026-07-20",
+      "revisions": [
+        {
+          "id": "eac-dsuite-517-record@2026-07-20",
+          "localArtifact": "data/equipment-sources/eac-democracy-suite-517.html",
+          "sha256": "37837c0f9f6a5ad9340e7925b842e5bf941b1f66f666711674c1908a4d464de0",
+          "byteLength": 69768,
+          "publishedOn": "2024-11-04",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/voting-equipment/democracy-suite-517",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Certification summary, testing documents, certification media, and advisory notices",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-dsuite-517-scope",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "Democracy Suite 5.17 Certificate and Scope of Certification",
+      "url": "https://www.eac.gov/sites/default/files/voting_system/files/D-Suite%205.17%20Certificate%20and%20Scope%20SIGNED.pdf",
+      "localArtifact": "data/equipment-sources/eac-dsuite-517-certificate-scope.pdf",
+      "documentType": "official_scope_pdf",
+      "publishedOn": "2023-03-16",
+      "pageOrSection": "Certificate page 1; scope pages 1-3, 7, and 10-13",
+      "caveat": "The certificate applies only to the evaluated configuration. The scope date shows March 15, while the certificate and EAC record use March 16, 2023; this dossier preserves that document-level discrepancy.",
+      "sha256": "f34bb9ad218dc68639e19bd4f9bed5de0d63c0af0f061eb59eb486db6c5eb36e",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/voting_system/files/D-Suite%205.17%20Certificate%20and%20Scope%20SIGNED.pdf",
+      "currentReviewedRevisionId": "eac-dsuite-517-scope@2026-07-20",
+      "latestRetrievedRevisionId": "eac-dsuite-517-scope@2026-07-20",
+      "revisions": [
+        {
+          "id": "eac-dsuite-517-scope@2026-07-20",
+          "localArtifact": "data/equipment-sources/eac-dsuite-517-certificate-scope.pdf",
+          "sha256": "f34bb9ad218dc68639e19bd4f9bed5de0d63c0af0f061eb59eb486db6c5eb36e",
+          "byteLength": 1021978,
+          "publishedOn": "2023-03-16",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/voting_system/files/D-Suite%205.17%20Certificate%20and%20Scope%20SIGNED.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Certificate page 1; scope pages 1-3, 7, and 10-13",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-1035-approval",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ES&S ECO 1035 approval",
+      "url": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201035%20Approval%2002-14-2020.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-1035-approval.pdf",
+      "sha256": "498e55e1c337f9b2d270d2a72d487708cb706b18a39e7bb0080ef83d8f76b5c0",
+      "documentType": "official_change_approval_pdf",
+      "publishedOn": "2020-02-14",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Approval letter",
+      "caveat": "Approval of a certified-system change is not a field installation record.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201035%20Approval%2002-14-2020.pdf",
+      "currentReviewedRevisionId": "eac-eco-ess-1035-approval@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-1035-approval@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-1035-approval@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-1035-approval.pdf",
+          "sha256": "498e55e1c337f9b2d270d2a72d487708cb706b18a39e7bb0080ef83d8f76b5c0",
+          "byteLength": 56809,
+          "publishedOn": "2020-02-14",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201035%20Approval%2002-14-2020.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Approval letter",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-1035-record",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ESS-1035 engineering change record",
+      "url": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1035",
+      "localArtifact": "data/equipment-sources/eac-eco-ess-1035.html",
+      "sha256": "bc83d6c6eea445319419067fb5983c4e97f69d0d729bd867d78bdf0c33aa734a",
+      "documentType": "official_change_record_html",
+      "publishedOn": "2020-02-14",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "ECO metadata, analysis, and approval attachments",
+      "caveat": "Historical DS200 component change; do not infer current firmware or board revision.",
+      "canonicalUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1035",
+      "currentReviewedRevisionId": "eac-eco-ess-1035-record@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-1035-record@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-1035-record@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-eco-ess-1035.html",
+          "sha256": "bc83d6c6eea445319419067fb5983c4e97f69d0d729bd867d78bdf0c33aa734a",
+          "byteLength": 62184,
+          "publishedOn": "2020-02-14",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1035",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "ECO metadata, analysis, and approval attachments",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-1042-approval",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ESS ECO 1042 approval",
+      "url": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201042%20Approval%209.13.19.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-1042-approval.pdf",
+      "sha256": "592e01e31f0b44c5594aa47695ac3ea4d5d1a132f4ba23dd9d02b5327a6da14e",
+      "documentType": "official_change_approval_pdf",
+      "publishedOn": "2019-09-13",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Approval letter",
+      "caveat": "Approval of a certified-system change is not a field installation record.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201042%20Approval%209.13.19.pdf",
+      "currentReviewedRevisionId": "eac-eco-ess-1042-approval@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-1042-approval@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-1042-approval@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-1042-approval.pdf",
+          "sha256": "592e01e31f0b44c5594aa47695ac3ea4d5d1a132f4ba23dd9d02b5327a6da14e",
+          "byteLength": 56718,
+          "publishedOn": "2019-09-13",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201042%20Approval%209.13.19.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Approval letter",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-1042-record",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ESS-1042 engineering change record",
+      "url": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1042",
+      "localArtifact": "data/equipment-sources/eac-eco-ess-1042.html",
+      "sha256": "bedebf2dc991441d438fe1b3301469cca8f90252ec8dcaf1c7cdcb0fc7fd6222",
+      "documentType": "official_change_record_html",
+      "publishedOn": "2019-09-13",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "ECO metadata, analysis, and approval attachments",
+      "caveat": "Historical DS200 hardware 1.3.11 change; field deployment and EVS 6.4 inclusion are not established by this record.",
+      "canonicalUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1042",
+      "currentReviewedRevisionId": "eac-eco-ess-1042-record@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-1042-record@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-1042-record@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-eco-ess-1042.html",
+          "sha256": "bedebf2dc991441d438fe1b3301469cca8f90252ec8dcaf1c7cdcb0fc7fd6222",
+          "byteLength": 62334,
+          "publishedOn": "2019-09-13",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1042",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "ECO metadata, analysis, and approval attachments",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-1044-approval",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ESS ECO 1044 approval",
+      "url": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201044%20Approval%209.13.19.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-1044-approval.pdf",
+      "sha256": "d5e4332acfa8d833cb8b3430d04ef9118a53433060ff357b057d85d2a403b352",
+      "documentType": "official_change_approval_pdf",
+      "publishedOn": "2019-09-13",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Approval letter",
+      "caveat": "Approval of a certified-system change is not a field installation record.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201044%20Approval%209.13.19.pdf",
+      "currentReviewedRevisionId": "eac-eco-ess-1044-approval@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-1044-approval@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-1044-approval@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-1044-approval.pdf",
+          "sha256": "d5e4332acfa8d833cb8b3430d04ef9118a53433060ff357b057d85d2a403b352",
+          "byteLength": 56719,
+          "publishedOn": "2019-09-13",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201044%20Approval%209.13.19.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Approval letter",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-1044-record",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ESS-1044 engineering change record",
+      "url": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1044",
+      "localArtifact": "data/equipment-sources/eac-eco-ess-1044.html",
+      "sha256": "a184649320b35fea20e7425533c4c97c0c44cdf46384d991ce294ff8dee43623",
+      "documentType": "official_change_record_html",
+      "publishedOn": "2019-09-13",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "ECO metadata, analysis, and approval attachments",
+      "caveat": "Historical ballot-box accessory change; field adoption is unknown.",
+      "canonicalUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1044",
+      "currentReviewedRevisionId": "eac-eco-ess-1044-record@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-1044-record@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-1044-record@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-eco-ess-1044.html",
+          "sha256": "a184649320b35fea20e7425533c4c97c0c44cdf46384d991ce294ff8dee43623",
+          "byteLength": 61772,
+          "publishedOn": "2019-09-13",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1044",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "ECO metadata, analysis, and approval attachments",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-1055-approval",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ES&S ECO 1055 approval",
+      "url": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201055%20Approval%2012-19-2019.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-1055-approval.pdf",
+      "sha256": "f01d25ccd320d3712910e1b666e5df390471c35df7f25d70f6f2011d85595fbc",
+      "documentType": "official_change_approval_pdf",
+      "publishedOn": "2019-12-19",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Approval letter",
+      "caveat": "Approval of a certified-system change is not a field installation record.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201055%20Approval%2012-19-2019.pdf",
+      "currentReviewedRevisionId": "eac-eco-ess-1055-approval@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-1055-approval@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-1055-approval@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-1055-approval.pdf",
+          "sha256": "f01d25ccd320d3712910e1b666e5df390471c35df7f25d70f6f2011d85595fbc",
+          "byteLength": 56727,
+          "publishedOn": "2019-12-19",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201055%20Approval%2012-19-2019.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Approval letter",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-1055-record",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ESS-1055 engineering change record",
+      "url": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1055",
+      "localArtifact": "data/equipment-sources/eac-eco-ess-1055.html",
+      "sha256": "2b84f8b40b6b38bbbb1cbd18672a52eedc3a2400552011414ca9efc5e5fde9a4",
+      "documentType": "official_change_record_html",
+      "publishedOn": "2019-12-19",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "ECO metadata, analysis, and approval attachments",
+      "caveat": "Historical ballot-box/trolley option; field adoption is unknown.",
+      "canonicalUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1055",
+      "currentReviewedRevisionId": "eac-eco-ess-1055-record@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-1055-record@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-1055-record@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-eco-ess-1055.html",
+          "sha256": "2b84f8b40b6b38bbbb1cbd18672a52eedc3a2400552011414ca9efc5e5fde9a4",
+          "byteLength": 62231,
+          "publishedOn": "2019-12-19",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1055",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "ECO metadata, analysis, and approval attachments",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-1165-approval",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ECO ESS 1165 approval letter",
+      "url": "https://www.eac.gov/sites/default/files/2024-05/ECO_ESS_1165_Approval_Letter.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-1165-approval.pdf",
+      "sha256": "70f52edf82918db862eb299ac102963d97c66019c84ebb614dce78b2cd1ec50e",
+      "documentType": "official_change_approval_pdf",
+      "publishedOn": "2024-05-15",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Approval letter",
+      "caveat": "Approval of a certified-system change is not a field installation record.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2024-05/ECO_ESS_1165_Approval_Letter.pdf",
+      "currentReviewedRevisionId": "eac-eco-ess-1165-approval@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-1165-approval@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-1165-approval@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-1165-approval.pdf",
+          "sha256": "70f52edf82918db862eb299ac102963d97c66019c84ebb614dce78b2cd1ec50e",
+          "byteLength": 219437,
+          "publishedOn": "2024-05-15",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2024-05/ECO_ESS_1165_Approval_Letter.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Approval letter",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-1165-record",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ESS-1165 engineering change record",
+      "url": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1165",
+      "localArtifact": "data/equipment-sources/eac-eco-ess-1165.html",
+      "sha256": "857f26b6988a1aab79114e811e91ab108857200d8fc80a697f08a195947e5c97",
+      "documentType": "official_change_record_html",
+      "publishedOn": "2024-05-15",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "ECO metadata, analysis, and approval attachments",
+      "caveat": "The approved change applies to listed certified systems including EVS 6.4.0.0; installation by a particular jurisdiction remains unknown.",
+      "canonicalUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1165",
+      "currentReviewedRevisionId": "eac-eco-ess-1165-record@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-1165-record@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-1165-record@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-eco-ess-1165.html",
+          "sha256": "857f26b6988a1aab79114e811e91ab108857200d8fc80a697f08a195947e5c97",
+          "byteLength": 62290,
+          "publishedOn": "2024-05-15",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-1165",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "ECO metadata, analysis, and approval attachments",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-eco-ess-983-record",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "ESS-983 engineering change record",
+      "url": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-983",
+      "localArtifact": "data/equipment-sources/eac-eco-ess-983.html",
+      "sha256": "25e91beda5cb0b21ac22329d4847abfb25ee1272dad434245fd21831d27ca61f",
+      "documentType": "official_change_record_html",
+      "publishedOn": "2018-12-14",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "ECO metadata and attachment",
+      "caveat": "Historical DS200 family change; field deployment and EVS 6.4 inclusion are not established by this record.",
+      "canonicalUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-983",
+      "currentReviewedRevisionId": "eac-eco-ess-983-record@2026-07-19",
+      "latestRetrievedRevisionId": "eac-eco-ess-983-record@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-eco-ess-983-record@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-eco-ess-983.html",
+          "sha256": "25e91beda5cb0b21ac22329d4847abfb25ee1272dad434245fd21831d27ca61f",
+          "byteLength": 61442,
+          "publishedOn": "2018-12-14",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/voting-equipment/engineering-change-orders/ess-983",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "ECO metadata and attachment",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-evs-6400-record",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "EVS 6.4.0.0 certification record",
+      "url": "https://www.eac.gov/voting-equipment/evs-6400",
+      "localArtifact": "data/equipment-sources/eac-evs-6400.html",
+      "sha256": "5ad71e34c04a2ccbfc1b57aa4cadbf44ab1a27247afa5d985793ec7eab820b7c",
+      "documentType": "official_certification_record_html",
+      "publishedOn": "2023-08-18",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Certification record and public attachments",
+      "caveat": "This is a certification record for the evaluated configuration, not a field inventory.",
+      "canonicalUrl": "https://www.eac.gov/voting-equipment/evs-6400",
+      "currentReviewedRevisionId": "eac-evs-6400-record@2026-07-19",
+      "latestRetrievedRevisionId": "eac-evs-6400-record@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-evs-6400-record@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-evs-6400.html",
+          "sha256": "5ad71e34c04a2ccbfc1b57aa4cadbf44ab1a27247afa5d985793ec7eab820b7c",
+          "byteLength": 65196,
+          "publishedOn": "2023-08-18",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/voting-equipment/evs-6400",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Certification record and public attachments",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-evs-6400-scope",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "EVS 6.4.0.0 Certificate and Scope of Conformance",
+      "url": "https://www.eac.gov/sites/default/files/2023-08/ES%26S%20EVS%206.4.0.0%20Certificate%20and%20Scope%20of%20Conformance%20Signed%20%282%29.pdf",
+      "localArtifact": "data/equipment-sources/eac-evs-6400-certificate-scope.pdf",
+      "sha256": "18ac832291345ff96e5bfe8bd63ede7d1af2ed9a4387b8bf47f0b9fb2564ebae",
+      "documentType": "official_scope_pdf",
+      "publishedOn": "2023-08-18",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Pages 1-10, especially proprietary components on pages 6-7",
+      "caveat": "The scope applies only to EVS 6.4.0.0 in its evaluated configuration and expressly does not establish election readiness or field operation.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2023-08/ES%26S%20EVS%206.4.0.0%20Certificate%20and%20Scope%20of%20Conformance%20Signed%20%282%29.pdf",
+      "currentReviewedRevisionId": "eac-evs-6400-scope@2026-07-19",
+      "latestRetrievedRevisionId": "eac-evs-6400-scope@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-evs-6400-scope@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-evs-6400-certificate-scope.pdf",
+          "sha256": "18ac832291345ff96e5bfe8bd63ede7d1af2ed9a4387b8bf47f0b9fb2564ebae",
+          "byteLength": 1659956,
+          "publishedOn": "2023-08-18",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2023-08/ES%26S%20EVS%206.4.0.0%20Certificate%20and%20Scope%20of%20Conformance%20Signed%20%282%29.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Pages 1-10, especially proprietary components on pages 6-7",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-program-manual-v3",
+      "publisher": "U.S. Election Assistance Commission",
+      "authorityLevel": "federal_official",
+      "title": "Voting System Testing and Certification Program Manual, Version 3.0",
+      "url": "https://www.eac.gov/sites/default/files/TestingCertification/Testing_and_Certification_Program_Manual_Version_3_020421.pdf",
+      "localArtifact": "data/equipment-sources/eac-testing-certification-program-manual-v3.pdf",
+      "sha256": "87c2e3aba912e2c6673ca10b6c302893836a713a2d3610b79aa0102f097812a7",
+      "documentType": "official_program_manual_pdf",
+      "publishedOn": "2021-02-04",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Sections 3.4.3 and 3.5",
+      "caveat": "The manual governs EAC certification changes; state and local deployment records remain separate.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/TestingCertification/Testing_and_Certification_Program_Manual_Version_3_020421.pdf",
+      "currentReviewedRevisionId": "eac-program-manual-v3@2026-07-19",
+      "latestRetrievedRevisionId": "eac-program-manual-v3@2026-07-19",
+      "revisions": [
+        {
+          "id": "eac-program-manual-v3@2026-07-19",
+          "localArtifact": "data/equipment-sources/eac-testing-certification-program-manual-v3.pdf",
+          "sha256": "87c2e3aba912e2c6673ca10b6c302893836a713a2d3610b79aa0102f097812a7",
+          "byteLength": 676480,
+          "publishedOn": "2021-02-04",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/TestingCertification/Testing_and_Certification_Program_Manual_Version_3_020421.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Sections 3.4.3 and 3.5",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-unity-3200-document-report",
+      "publisher": "U.S. Election Assistance Commission; SysTest Labs",
+      "authorityLevel": "federal_certification_record",
+      "title": "ES&S Unity 3.2.0.0 Document Report",
+      "url": "https://www.eac.gov/sites/default/files/document_library/files/775.PDF",
+      "localArtifact": "data/equipment-sources/eac-unity-3200-document-report.pdf",
+      "sha256": "a896d01387f1814df269337543c976595775dbce9a1bd355975221d0ea79e989",
+      "documentType": "vstl_document_inventory_pdf",
+      "publishedOn": "2007-06-21",
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "PDF page 13; DS200 SocketModem dial-up, GPRS, CDMA, and reference-guide records",
+      "caveat": "This document inventory establishes that Multi-Tech SocketModem documentation was reviewed for the older Unity 3.2.0.0 DS200 project. It does not identify a precise ordering part, radio firmware, later certified configuration, or field installation.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/document_library/files/775.PDF",
+      "currentReviewedRevisionId": "eac-unity-3200-document-report@2026-07-20",
+      "latestRetrievedRevisionId": "eac-unity-3200-document-report@2026-07-20",
+      "revisions": [
+        {
+          "id": "eac-unity-3200-document-report@2026-07-20",
+          "localArtifact": "data/equipment-sources/eac-unity-3200-document-report.pdf",
+          "sha256": "a896d01387f1814df269337543c976595775dbce9a1bd355975221d0ea79e989",
+          "byteLength": 184804,
+          "publishedOn": "2007-06-21",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/document_library/files/775.PDF",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "PDF page 13; DS200 SocketModem dial-up, GPRS, CDMA, and reference-guide records",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "eac-unity-3400-test-plan",
+      "publisher": "U.S. Election Assistance Commission; Wyle Laboratories, Inc.",
+      "authorityLevel": "federal_certification_record",
+      "title": "ES&S Unity 3.4.0.0 Certification Test Plan T58722.01",
+      "url": "https://www.eac.gov/sites/default/files/voting_system/files/ESS%20Unity%203.4.0.0%20Test%20Plan-8-31-2011.pdf",
+      "localArtifact": "data/equipment-sources/eac-unity-3400-test-plan.pdf",
+      "sha256": "76535438c308b7d1c761bf3d2fc48e2a994d9a1acec2aefc014bf91e14c8226f",
+      "documentType": "vstl_certification_test_plan_pdf",
+      "publishedOn": "2011-08-31",
+      "retrievedOn": "2026-07-21",
+      "pageOrSection": "PDF page 20, report page 17, Figure 1-2 Secure File Transfer Configuration Guide",
+      "caveat": "The Wyle test-plan figure documents a historical Unity 3.4.0.0 wireline modem, DMZ, SFTP, firewall, and ERM reference configuration. It is not a cellular topology, a current EVS 6.4.0.0 configuration, or evidence that a jurisdiction deployed the pictured design. Sample addresses visible in the source PDF are not transcribed into the public topology.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/voting_system/files/ESS%20Unity%203.4.0.0%20Test%20Plan-8-31-2011.pdf",
+      "currentReviewedRevisionId": "eac-unity-3400-test-plan@2026-07-21",
+      "latestRetrievedRevisionId": "eac-unity-3400-test-plan@2026-07-21",
+      "revisions": [
+        {
+          "id": "eac-unity-3400-test-plan@2026-07-21",
+          "localArtifact": "data/equipment-sources/eac-unity-3400-test-plan.pdf",
+          "sha256": "76535438c308b7d1c761bf3d2fc48e2a994d9a1acec2aefc014bf91e14c8226f",
+          "byteLength": 1631095,
+          "publishedOn": "2011-08-31",
+          "retrievedOn": "2026-07-21",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/voting_system/files/ESS%20Unity%203.4.0.0%20Test%20Plan-8-31-2011.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "PDF page 20, report page 17, Figure 1-2 Secure File Transfer Configuration Guide",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "ess-ds200-one-sheet",
+      "publisher": "Election Systems & Software",
+      "authorityLevel": "manufacturer_primary",
+      "title": "DS200 Poll Place Scanner and Tabulator One-Sheet",
+      "url": "https://www.essvote.com/storage/2024/07/DS200_One-Sheet.pdf",
+      "localArtifact": "data/equipment-sources/ess-ds200-one-sheet.pdf",
+      "documentType": "manufacturer_product_one_sheet_pdf",
+      "publishedOn": "2024-06-26",
+      "pageOrSection": "Pages 1-2",
+      "caveat": "The manufacturer one-sheet supports the DS200 external appearance and named features, including battery backup. It is not a dimensional drawing, component bill of materials, certified version record, or source for the battery manufacturer, capacity, runtime, or internal component placement.",
+      "sha256": "a26ae54b61b92dbbaa6e97300bd703fdc01c57f1f0766469339e1332b63ca4e5",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.essvote.com/storage/2024/07/DS200_One-Sheet.pdf",
+      "currentReviewedRevisionId": "ess-ds200-one-sheet@2026-07-20",
+      "latestRetrievedRevisionId": "ess-ds200-one-sheet@2026-07-20",
+      "revisions": [
+        {
+          "id": "ess-ds200-one-sheet@2026-07-20",
+          "localArtifact": "data/equipment-sources/ess-ds200-one-sheet.pdf",
+          "sha256": "a26ae54b61b92dbbaa6e97300bd703fdc01c57f1f0766469339e1332b63ca4e5",
+          "byteLength": 841983,
+          "publishedOn": "2024-06-26",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.essvote.com/storage/2024/07/DS200_One-Sheet.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Pages 1-2",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "ess-ds200-reference-photo",
+      "publisher": "Election Systems & Software",
+      "authorityLevel": "manufacturer_primary",
+      "title": "DS200 Full Front Screen official product photograph",
+      "url": "https://www.essvote.com/storage/2018/12/DS200-Full-Front-Screen.png",
+      "localArtifact": "data/equipment-sources/ess-ds200-reference-photo.png",
+      "sha256": "a68d0646ca2707ccdcf735f57d3b0b65e3021bec0a480bc8af8b0d517c412dda",
+      "documentType": "manufacturer_product_image_png",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "Original 1280 x 854 product photograph linked from the DS200 product page",
+      "caveat": "The manufacturer photograph supports the DS200's external appearance only. It is not a dimensional drawing, teardown, certified version record, internal component map, or field-unit inventory.",
+      "canonicalUrl": "https://www.essvote.com/storage/2018/12/DS200-Full-Front-Screen.png",
+      "currentReviewedRevisionId": "ess-ds200-reference-photo@2026-07-20",
+      "latestRetrievedRevisionId": "ess-ds200-reference-photo@2026-07-20",
+      "revisions": [
+        {
+          "id": "ess-ds200-reference-photo@2026-07-20",
+          "localArtifact": "data/equipment-sources/ess-ds200-reference-photo.png",
+          "sha256": "a68d0646ca2707ccdcf735f57d3b0b65e3021bec0a480bc8af8b0d517c412dda",
+          "byteLength": 430127,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.essvote.com/storage/2018/12/DS200-Full-Front-Screen.png",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Original 1280 x 854 product photograph linked from the DS200 product page",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "ess-ds950-product-page",
+      "publisher": "Election Systems & Software",
+      "authorityLevel": "manufacturer_primary",
+      "title": "DS950 high-speed scanner and tabulator product page",
+      "url": "https://www.essvote.com/products/ds950/",
+      "localArtifact": "data/equipment-sources/ess-ds950-product-page.html",
+      "sha256": "001a17e5b579bc94a0efd15871c1d0c8565aa58dd135df03344163687e62fba3",
+      "documentType": "manufacturer_product_page_html",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "High-speed scanner and tabulator overview and security sections",
+      "caveat": "The current manufacturer page describes the DS950 product family and may reflect a later marketed configuration. It is used for model-family functions and external appearance, not to override the EVS 6.4.0.0 certified firmware, hardware revision, or communications table.",
+      "canonicalUrl": "https://www.essvote.com/products/ds950/",
+      "currentReviewedRevisionId": "ess-ds950-product-page@2026-07-20",
+      "latestRetrievedRevisionId": "ess-ds950-product-page@2026-07-20",
+      "revisions": [
+        {
+          "id": "ess-ds950-product-page@2026-07-20",
+          "localArtifact": "data/equipment-sources/ess-ds950-product-page.html",
+          "sha256": "001a17e5b579bc94a0efd15871c1d0c8565aa58dd135df03344163687e62fba3",
+          "byteLength": 134130,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.essvote.com/products/ds950/",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "High-speed scanner and tabulator overview and security sections",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "ess-ds950-reference-photo",
+      "publisher": "Election Systems & Software",
+      "authorityLevel": "manufacturer_primary",
+      "title": "DS950 official catalog photograph",
+      "url": "https://www.essvote.com/storage/2022/01/DS950_catalog_image.jpg",
+      "localArtifact": "data/equipment-sources/ess-ds950-reference-photo.jpg",
+      "sha256": "0b6b919d9c91b8447f56c866174ce647c816a16c88dbc73d5c4c0497796e6c59",
+      "documentType": "manufacturer_product_image_jpeg",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "Original 1280 x 854 catalog photograph linked from the DS950 product page",
+      "caveat": "The manufacturer photograph supports DS950 external appearance only. It does not establish exact dimensions, internal placement, the EVS 6.4.0.0 certified revision, a selected UPS, or a particular fielded unit.",
+      "canonicalUrl": "https://www.essvote.com/storage/2022/01/DS950_catalog_image.jpg",
+      "currentReviewedRevisionId": "ess-ds950-reference-photo@2026-07-20",
+      "latestRetrievedRevisionId": "ess-ds950-reference-photo@2026-07-20",
+      "revisions": [
+        {
+          "id": "ess-ds950-reference-photo@2026-07-20",
+          "localArtifact": "data/equipment-sources/ess-ds950-reference-photo.jpg",
+          "sha256": "0b6b919d9c91b8447f56c866174ce647c816a16c88dbc73d5c4c0497796e6c59",
+          "byteLength": 90235,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.essvote.com/storage/2022/01/DS950_catalog_image.jpg",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Original 1280 x 854 catalog photograph linked from the DS950 product page",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "ess-election-security-faqs",
+      "publisher": "Election Systems & Software",
+      "authorityLevel": "manufacturer_primary",
+      "title": "Election Security Frequently Asked Questions",
+      "url": "https://www.essvote.com/faqs/",
+      "localArtifact": "data/equipment-sources/ess-faqs.html",
+      "sha256": "055a7cec69e43312a024b377abf6cad3ad70186b39e5c1043e235458158c161a",
+      "documentType": "manufacturer_faq_html",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "Are modems installed in poll place tabulators nationwide?; How do we know modems aren't in machines where they are not permitted?",
+      "caveat": "The current manufacturer FAQ describes optional modem-board use by jurisdiction and is not a certification record, bill of materials for a particular unit, or proof that a modem was enabled or used in any unlisted jurisdiction.",
+      "canonicalUrl": "https://www.essvote.com/faqs/",
+      "currentReviewedRevisionId": "ess-election-security-faqs@2026-07-20",
+      "latestRetrievedRevisionId": "ess-election-security-faqs@2026-07-20",
+      "revisions": [
+        {
+          "id": "ess-election-security-faqs@2026-07-20",
+          "localArtifact": "data/equipment-sources/ess-faqs.html",
+          "sha256": "055a7cec69e43312a024b377abf6cad3ad70186b39e5c1043e235458158c161a",
+          "byteLength": 125057,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.essvote.com/faqs/",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Are modems installed in poll place tabulators nationwide?; How do we know modems aren't in machines where they are not permitted?",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "fl-evs-4500-v4-modem-report",
+      "publisher": "Florida Department of State, Division of Elections",
+      "authorityLevel": "state_election_office",
+      "title": "ES&S EVS Release 4.5.0.0 Version 4 Test Report Addendum (Revision 1)",
+      "url": "https://files.floridados.gov/media/695182/ess-evs-release-4500-version-4-revision-1-test-report.pdf",
+      "localArtifact": "data/equipment-sources/fl-evs-4500-v4-modem-report.pdf",
+      "sha256": "c8fee19d7bfdda6aa80c75d36f3e9bae7482b7c6a81581ae8ba5cf5d3bd9d7ae",
+      "documentType": "state_voting_system_qualification_report_pdf",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "Cover and report pages 1-4; June 2015 addendum for ECO 920",
+      "caveat": "The report identifies a MultiTech MTSMC-C2-N3.R1 Verizon C2 modem only for Florida EVS 4.5.0.0 Version 4 with DS200 hardware 1.2 or 1.3. It does not establish EVS 6.4.0.0 certification, current deployment, or the modem firmware installed in a field unit.",
+      "canonicalUrl": "https://files.floridados.gov/media/695182/ess-evs-release-4500-version-4-revision-1-test-report.pdf",
+      "currentReviewedRevisionId": "fl-evs-4500-v4-modem-report@2026-07-20",
+      "latestRetrievedRevisionId": "fl-evs-4500-v4-modem-report@2026-07-20",
+      "revisions": [
+        {
+          "id": "fl-evs-4500-v4-modem-report@2026-07-20",
+          "localArtifact": "data/equipment-sources/fl-evs-4500-v4-modem-report.pdf",
+          "sha256": "c8fee19d7bfdda6aa80c75d36f3e9bae7482b7c6a81581ae8ba5cf5d3bd9d7ae",
+          "byteLength": 786340,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://files.floridados.gov/media/695182/ess-evs-release-4500-version-4-revision-1-test-report.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Cover and report pages 1-4; June 2015 addendum for ECO 920",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "mi-ess-voting-system-contract",
+      "publisher": "State of Michigan Department of Technology, Management & Budget; Election Systems & Software",
+      "authorityLevel": "state_official_hosted_vendor_contract",
+      "title": "Contract 071B7700120: Voting System Hardware, Firmware, Software and Service",
+      "url": "https://www.michigan.gov/-/media/Project/Websites/dtmb/Procurement/Contracts/MiDEAL-Media/008/7700120.pdf",
+      "localArtifact": "data/equipment-sources/mi-ess-voting-system-contract.pdf",
+      "sha256": "b3fcc36739a95325cd9e1b6988efa3364bf78be71cb3ed4ebc49a39f3bb768f5",
+      "documentType": "state_contract_vendor_response_pdf",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-21",
+      "pageOrSection": "PDF pages 95-105, especially contract page 62 Wireless Results Network; PDF pages 199-200 and 254 for EVS 5.3.2.0 transmission scope and SFTP workflow",
+      "caveat": "This official state-hosted contract compilation contains a historical vendor response and diagrams for Michigan's 2017 procurement. The relevant response expressly notes that EVS 5.3.2.0 was not EAC certified but met Michigan state election code. It does not establish a current EVS 6.4.0.0 configuration, a particular county deployment, installed modem model or firmware, carrier account, or election transmission event.",
+      "canonicalUrl": "https://www.michigan.gov/-/media/Project/Websites/dtmb/Procurement/Contracts/MiDEAL-Media/008/7700120.pdf",
+      "currentReviewedRevisionId": "mi-ess-voting-system-contract@2026-07-21",
+      "latestRetrievedRevisionId": "mi-ess-voting-system-contract@2026-07-21",
+      "revisions": [
+        {
+          "id": "mi-ess-voting-system-contract@2026-07-21",
+          "localArtifact": "data/equipment-sources/mi-ess-voting-system-contract.pdf",
+          "sha256": "b3fcc36739a95325cd9e1b6988efa3364bf78be71cb3ed4ebc49a39f3bb768f5",
+          "byteLength": 8061620,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-21",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.michigan.gov/-/media/Project/Websites/dtmb/Procurement/Contracts/MiDEAL-Media/008/7700120.pdf?rev=05177c3d7f5c4ca9b1cb3d981b9103e2",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "PDF pages 95-105, especially contract page 62 Wireless Results Network; PDF pages 199-200 and 254 for EVS 5.3.2.0 transmission scope and SFTP workflow",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "multitech-eol-products",
+      "publisher": "Multi-Tech Systems, Inc.",
+      "authorityLevel": "manufacturer_primary",
+      "title": "MultiTech End-of-Life Products",
+      "url": "https://multitech.com/eol-products/",
+      "localArtifact": "data/equipment-sources/multitech-eol-products.html",
+      "sha256": "c31d6a4b6609d1f777d6e407d721e1b57c7d5f2a77298aa6858fb40956639c61",
+      "documentType": "manufacturer_product_lifecycle_page_html",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "MTSMC-LVW3, R1, R2, and R4 rows",
+      "caveat": "The lifecycle table distinguishes several MTSMC-LVW3 ordering revisions. The Pro V&V hardware table names only MTSMC-LVW3, so no lifecycle row is treated as the exact revision installed in an evaluated or fielded DS200.",
+      "canonicalUrl": "https://multitech.com/eol-products/",
+      "currentReviewedRevisionId": "multitech-eol-products@2026-07-20",
+      "latestRetrievedRevisionId": "multitech-eol-products@2026-07-20",
+      "revisions": [
+        {
+          "id": "multitech-eol-products@2026-07-20",
+          "localArtifact": "data/equipment-sources/multitech-eol-products.html",
+          "sha256": "c31d6a4b6609d1f777d6e407d721e1b57c7d5f2a77298aa6858fb40956639c61",
+          "byteLength": 981097,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://multitech.com/eol-products/",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "MTSMC-LVW3, R1, R2, and R4 rows",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "multitech-lvw3-update-bulletin",
+      "publisher": "Multi-Tech Systems, Inc.",
+      "authorityLevel": "manufacturer_primary",
+      "title": "Verizon LTE Cat 1 Update Notice PB 031219-00",
+      "url": "https://multitech.com/wp-content/uploads/PB-031219-00_Verizon-Update-Notice.pdf",
+      "localArtifact": "data/equipment-sources/multitech-lvw3-verizon-update-2019.pdf",
+      "sha256": "b2f646c6e26210723bec0b31cf446dc1bb18679ce568945d6d8d43e53f2ef407",
+      "documentType": "manufacturer_product_bulletin_pdf",
+      "publishedOn": "2019-03-12",
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "Page 1; affected SocketModem Cell list and suggested action plan",
+      "caveat": "The bulletin says an urgent software patch may apply to named Verizon LTE Cat 1 products, including MTSMC-LVW3 variants, for service continuity. It does not identify a CVE, assign CVSS severity, publish a firmware version, or establish whether a historically evaluated DS200 modem was affected or patched.",
+      "canonicalUrl": "https://multitech.com/wp-content/uploads/PB-031219-00_Verizon-Update-Notice.pdf",
+      "currentReviewedRevisionId": "multitech-lvw3-update-bulletin@2026-07-20",
+      "latestRetrievedRevisionId": "multitech-lvw3-update-bulletin@2026-07-20",
+      "revisions": [
+        {
+          "id": "multitech-lvw3-update-bulletin@2026-07-20",
+          "localArtifact": "data/equipment-sources/multitech-lvw3-verizon-update-2019.pdf",
+          "sha256": "b2f646c6e26210723bec0b31cf446dc1bb18679ce568945d6d8d43e53f2ef407",
+          "byteLength": 370834,
+          "publishedOn": "2019-03-12",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://multitech.com/wp-content/uploads/PB-031219-00_Verizon-Update-Notice.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1; affected SocketModem Cell list and suggested action plan",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "multitech-security-advisories-index",
+      "publisher": "Multi-Tech Systems, Inc.",
+      "authorityLevel": "manufacturer_primary",
+      "title": "MultiTech Security Advisories",
+      "url": "https://multitech.com/security/",
+      "localArtifact": "data/equipment-sources/multitech-security-advisories-index.html",
+      "sha256": "b5857bf640bc558f8d33c323637f527a589d48ba6226c18dca150dd43a703492",
+      "documentType": "manufacturer_security_advisory_index_html",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "Security-advisory index and linked advisory list",
+      "caveat": "This is a point-in-time manufacturer index. Its absence of an exact model is not proof that the product has no vulnerability, and later advisories may change the result.",
+      "canonicalUrl": "https://multitech.com/security/",
+      "currentReviewedRevisionId": "multitech-security-advisories-index@2026-07-20",
+      "latestRetrievedRevisionId": "multitech-security-advisories-index@2026-07-20",
+      "revisions": [
+        {
+          "id": "multitech-security-advisories-index@2026-07-20",
+          "localArtifact": "data/equipment-sources/multitech-security-advisories-index.html",
+          "sha256": "b5857bf640bc558f8d33c323637f527a589d48ba6226c18dca150dd43a703492",
+          "byteLength": 474660,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://multitech.com/security/",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Security-advisory index and linked advisory list",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "multitech-security-advisory-bundle",
+      "publisher": "Multi-Tech Systems, Inc.",
+      "authorityLevel": "manufacturer_primary",
+      "title": "MultiTech security advisories linked from the reviewed index",
+      "url": "https://multitech.com/security/",
+      "localArtifact": "data/equipment-sources/multitech-security-advisories-2026-07-20.zip",
+      "sha256": "b2ea2e73d876b1c530ba67562270a7f3fbc96efb2c18b0568e4874dc0a7e145f",
+      "documentType": "manufacturer_security_advisory_pdf_bundle",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "Nine linked advisory PDFs covering ten CVEs; applicable-product tables and not-affected determinations",
+      "caveat": "The reviewed advisories either identify other MultiTech product families or state that MultiTech products are not affected. None expressly identifies MTSMC-C2, MTSMC-LVW3, CE910, or LE910. This exclusion is bounded to the archived advisory set and does not establish that those modem families are vulnerability-free.",
+      "canonicalUrl": "https://multitech.com/security/",
+      "currentReviewedRevisionId": "multitech-security-advisory-bundle@2026-07-20",
+      "latestRetrievedRevisionId": "multitech-security-advisory-bundle@2026-07-20",
+      "revisions": [
+        {
+          "id": "multitech-security-advisory-bundle@2026-07-20",
+          "localArtifact": "data/equipment-sources/multitech-security-advisories-2026-07-20.zip",
+          "sha256": "b2ea2e73d876b1c530ba67562270a7f3fbc96efb2c18b0568e4874dc0a7e145f",
+          "byteLength": 1447553,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://multitech.com/security/",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Nine linked advisory PDFs covering ten CVEs; applicable-product tables and not-affected determinations",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "multitech-universal-socket-guide",
+      "publisher": "Multi-Tech Systems, Inc.",
+      "authorityLevel": "manufacturer_primary",
+      "title": "Universal SocketModem Developer Guide S000342, Version W",
+      "url": "https://multitech.com/wp-content/uploads/s000342.pdf",
+      "localArtifact": "data/equipment-sources/multitech-universal-socket-guide.pdf",
+      "sha256": "59bdb4f77c516b793a191b77a5501e297b864c5108c4b1afbc1bb0017cd51283",
+      "documentType": "manufacturer_developer_guide_pdf",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "PDF pages 2, 12, 20, 22, 31, 53-60, and 63-64; supported SocketModem families, Universal Socket interface and developer-board references, antenna and SIM guidance, and firmware-update procedure",
+      "caveat": "The guide documents MultiTech's generic Universal Socket and SocketModem development platform, the MTSMC-C2 family, and a serial-port update process requiring MultiTech assistance. Its pinout, example developer board, ports, antenna, and SIM instructions are not a DS200 carrier-board schematic, installed-component inventory, or proof of enabled interfaces. It does not publish firmware installed in a DS200 or transfer a product-family option to another modem revision.",
+      "canonicalUrl": "https://multitech.com/wp-content/uploads/s000342.pdf",
+      "currentReviewedRevisionId": "multitech-universal-socket-guide@2026-07-20",
+      "latestRetrievedRevisionId": "multitech-universal-socket-guide@2026-07-20",
+      "revisions": [
+        {
+          "id": "multitech-universal-socket-guide@2026-07-20",
+          "localArtifact": "data/equipment-sources/multitech-universal-socket-guide.pdf",
+          "sha256": "59bdb4f77c516b793a191b77a5501e297b864c5108c4b1afbc1bb0017cd51283",
+          "byteLength": 1561985,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://multitech.com/wp-content/uploads/s000342.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "PDF pages 2, 12, 20, 22, 31, 53-60, and 63-64; supported SocketModem families, Universal Socket interface and developer-board references, antenna and SIM guidance, and firmware-update procedure",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "multitech-verizon-fota",
+      "publisher": "Multi-Tech Systems, Inc.",
+      "authorityLevel": "manufacturer_primary",
+      "title": "Verizon Firmware Over the Air Requirements",
+      "url": "https://multitech.com/verizon-firmware-over-the-air-fota/",
+      "localArtifact": "data/equipment-sources/multitech-verizon-fota.html",
+      "sha256": "d24c0dbeb1601a15b3725954054c8b59fd6728dc80ad8882aea07df39123636b",
+      "documentType": "manufacturer_support_page_html",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "SocketModem Cell table; MTSMC-LVW3 family row",
+      "caveat": "The current table maps the MTSMC-LVW3 family to a Telit LE910-NA1 radio for FOTA planning. The Pro V&V table does not identify the DS200 modem ordering revision, so this current family mapping is not proof of the radio module or firmware installed in the historically evaluated units.",
+      "canonicalUrl": "https://multitech.com/verizon-firmware-over-the-air-fota/",
+      "currentReviewedRevisionId": "multitech-verizon-fota@2026-07-20",
+      "latestRetrievedRevisionId": "multitech-verizon-fota@2026-07-20",
+      "revisions": [
+        {
+          "id": "multitech-verizon-fota@2026-07-20",
+          "localArtifact": "data/equipment-sources/multitech-verizon-fota.html",
+          "sha256": "d24c0dbeb1601a15b3725954054c8b59fd6728dc80ad8882aea07df39123636b",
+          "byteLength": 462238,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://multitech.com/verizon-firmware-over-the-air-fota/",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "SocketModem Cell table; MTSMC-LVW3 family row",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "nvd-modem-query-review",
+      "publisher": "National Institute of Standards and Technology, National Vulnerability Database",
+      "authorityLevel": "federal_vulnerability_catalog",
+      "title": "NVD CVE API exact-product modem query responses",
+      "url": "https://services.nvd.nist.gov/rest/json/cves/2.0",
+      "localArtifact": "data/equipment-sources/nvd-modem-query-responses-2026-07-20.zip",
+      "sha256": "830caaab82882993c9f8536177c46f2683e8b87e10fb05306c26ff22c7b8df40",
+      "documentType": "federal_api_response_bundle_zip",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "Eleven CVE API 2.0 keyword responses for exact model and radio-module aliases",
+      "caveat": "Every archived query returned zero keyword matches at review time. NVD keyword matching is not a complete product security assessment and cannot rule out unindexed, differently named, undisclosed, or firmware-dependent vulnerabilities.",
+      "canonicalUrl": "https://services.nvd.nist.gov/rest/json/cves/2.0",
+      "currentReviewedRevisionId": "nvd-modem-query-review@2026-07-20",
+      "latestRetrievedRevisionId": "nvd-modem-query-review@2026-07-20",
+      "revisions": [
+        {
+          "id": "nvd-modem-query-review@2026-07-20",
+          "localArtifact": "data/equipment-sources/nvd-modem-query-responses-2026-07-20.zip",
+          "sha256": "830caaab82882993c9f8536177c46f2683e8b87e10fb05306c26ff22c7b8df40",
+          "byteLength": 2618,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://services.nvd.nist.gov/rest/json/cves/2.0",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Eleven CVE API 2.0 keyword responses for exact model and radio-module aliases",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-clearvote-25-test-plan",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "ClearVote 2.5 Certification Test Plan, Version 01",
+      "url": "https://www.eac.gov/sites/default/files/2024-08/ClearVote%202.5%20Test%20Plan%20TP-01-01-CBG-07-01.01.pdf",
+      "localArtifact": "data/equipment-sources/provv-clearvote-25-test-plan.pdf",
+      "sha256": "dbdb0ca284db563934475d51c36f6f70b91afee7a12d92e7d0175cb1642b1b98",
+      "documentType": "vstl_test_plan_pdf",
+      "publishedOn": "2024-08-02",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Pages 4-12 and 27-30: submitted changes, system equipment, and known-field-issue scope",
+      "caveat": "The test plan records the submitted certification configuration and pre-certification changes; it is not a service history or deployment inventory.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2024-08/ClearVote%202.5%20Test%20Plan%20TP-01-01-CBG-07-01.01.pdf",
+      "currentReviewedRevisionId": "provv-clearvote-25-test-plan@2026-07-19",
+      "latestRetrievedRevisionId": "provv-clearvote-25-test-plan@2026-07-19",
+      "revisions": [
+        {
+          "id": "provv-clearvote-25-test-plan@2026-07-19",
+          "localArtifact": "data/equipment-sources/provv-clearvote-25-test-plan.pdf",
+          "sha256": "dbdb0ca284db563934475d51c36f6f70b91afee7a12d92e7d0175cb1642b1b98",
+          "byteLength": 1173498,
+          "publishedOn": "2024-08-02",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2024-08/ClearVote%202.5%20Test%20Plan%20TP-01-01-CBG-07-01.01.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Pages 4-12 and 27-30: submitted changes, system equipment, and known-field-issue scope",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-clearvote-25-test-report",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "ClearVote 2.5 Certification Test Report, Revision 03",
+      "url": "https://www.eac.gov/sites/default/files/2025-09/ClearVote%202.5%20Test%20Report%20TR-01-01-CBG-07-01.03.pdf",
+      "localArtifact": "data/equipment-sources/provv-clearvote-25-test-report.pdf",
+      "sha256": "7a3b939ee136136c20350f120d74fe0659ac4030736c68d4aa7a266fa8fc434a",
+      "documentType": "vstl_test_report_pdf",
+      "publishedOn": "2025-09-26",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Pages 35-37: anomalies, deficiencies, resolutions, and certification recommendation",
+      "caveat": "Reported findings are limited to the certification test campaign and do not establish field incidence or the absence of other defects.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2025-09/ClearVote%202.5%20Test%20Report%20TR-01-01-CBG-07-01.03.pdf",
+      "currentReviewedRevisionId": "provv-clearvote-25-test-report@2026-07-19",
+      "latestRetrievedRevisionId": "provv-clearvote-25-test-report@2026-07-19",
+      "revisions": [
+        {
+          "id": "provv-clearvote-25-test-report@2026-07-19",
+          "localArtifact": "data/equipment-sources/provv-clearvote-25-test-report.pdf",
+          "sha256": "7a3b939ee136136c20350f120d74fe0659ac4030736c68d4aa7a266fa8fc434a",
+          "byteLength": 1248710,
+          "publishedOn": "2025-09-26",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2025-09/ClearVote%202.5%20Test%20Report%20TR-01-01-CBG-07-01.03.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Pages 35-37: anomalies, deficiencies, resolutions, and certification recommendation",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-dsuite-517-test-plan",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "Democracy Suite 5.17 Test Plan, TP-01-01-DVS-50-01.01",
+      "url": "https://www.eac.gov/sites/default/files/voting_system/files/Dominion%20Voting%20Systems%20D-Suite%205.17%20Test%20Plan-Rev.%2001.pdf",
+      "localArtifact": "data/equipment-sources/provv-dsuite-517-test-plan.pdf",
+      "documentType": "vstl_test_plan_pdf",
+      "publishedOn": "2022-12-02",
+      "pageOrSection": "Revision 01; test-plan pages 13-17, 22-23, and 37-38",
+      "caveat": "The plan records submitted and planned test configurations. It is not the final certification scope and does not establish field installation or current device state.",
+      "sha256": "9f38b17fec258a03aaed33a4dcabc455889a01723cdb0ebaa1aa12d304294fe4",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/voting_system/files/Dominion%20Voting%20Systems%20D-Suite%205.17%20Test%20Plan-Rev.%2001.pdf",
+      "currentReviewedRevisionId": "provv-dsuite-517-test-plan@2026-07-20",
+      "latestRetrievedRevisionId": "provv-dsuite-517-test-plan@2026-07-20",
+      "revisions": [
+        {
+          "id": "provv-dsuite-517-test-plan@2026-07-20",
+          "localArtifact": "data/equipment-sources/provv-dsuite-517-test-plan.pdf",
+          "sha256": "9f38b17fec258a03aaed33a4dcabc455889a01723cdb0ebaa1aa12d304294fe4",
+          "byteLength": 908113,
+          "publishedOn": "2022-12-02",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/voting_system/files/Dominion%20Voting%20Systems%20D-Suite%205.17%20Test%20Plan-Rev.%2001.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Revision 01; test-plan pages 13-17, 22-23, and 37-38",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-dsuite-517-test-report",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "Democracy Suite 5.17 Test Report, TR-01-01-DVS-50-01.03",
+      "url": "https://www.eac.gov/sites/default/files/voting_system/files/Dominion%20Voting%20Systems%20D-Suite%205.17%20Test%20Report-Rev.%2003.pdf",
+      "localArtifact": "data/equipment-sources/provv-dsuite-517-test-report.pdf",
+      "documentType": "vstl_test_report_pdf",
+      "publishedOn": "2023-03-15",
+      "pageOrSection": "Revision 03; report pages 31-41 and final certified configuration",
+      "caveat": "The report describes the certification campaign and evaluated configuration. Its findings do not establish the condition of every fielded unit or all later operating circumstances.",
+      "sha256": "b99cbefa3381f7a4f1b9acde1f9bb80a95156a7b5e7cdb212af9ccfeb3cd1e6b",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/voting_system/files/Dominion%20Voting%20Systems%20D-Suite%205.17%20Test%20Report-Rev.%2003.pdf",
+      "currentReviewedRevisionId": "provv-dsuite-517-test-report@2026-07-20",
+      "latestRetrievedRevisionId": "provv-dsuite-517-test-report@2026-07-20",
+      "revisions": [
+        {
+          "id": "provv-dsuite-517-test-report@2026-07-20",
+          "localArtifact": "data/equipment-sources/provv-dsuite-517-test-report.pdf",
+          "sha256": "b99cbefa3381f7a4f1b9acde1f9bb80a95156a7b5e7cdb212af9ccfeb3cd1e6b",
+          "byteLength": 1062318,
+          "publishedOn": "2023-03-15",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/voting_system/files/Dominion%20Voting%20Systems%20D-Suite%205.17%20Test%20Report-Rev.%2003.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Revision 03; report pages 31-41 and final certified configuration",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-dsuite-eco-100936-analysis",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "DVS ECO 100936 Analysis Rev. 00",
+      "url": "https://www.eac.gov/sites/default/files/2024-09/DVS%20ECO%20100936%20Analysis%2000.pdf",
+      "localArtifact": "data/equipment-sources/provv-dsuite-eco-100936-analysis.pdf",
+      "documentType": "vstl_change_analysis_pdf",
+      "publishedOn": "2024-09-24",
+      "pageOrSection": "Page 1",
+      "caveat": "The VSTL analysis records a documentation and SSD-firmware update path affecting D-Suite 5.17. It does not establish adoption by a jurisdiction or disclose the SSD firmware version in this artifact.",
+      "sha256": "ff494c1b8a85e6d66942d316ea8491a4c52c219862b520efd2c27811e9719a1b",
+      "retrievedOn": "2026-07-20",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2024-09/DVS%20ECO%20100936%20Analysis%2000.pdf",
+      "currentReviewedRevisionId": "provv-dsuite-eco-100936-analysis@2026-07-20",
+      "latestRetrievedRevisionId": "provv-dsuite-eco-100936-analysis@2026-07-20",
+      "revisions": [
+        {
+          "id": "provv-dsuite-eco-100936-analysis@2026-07-20",
+          "localArtifact": "data/equipment-sources/provv-dsuite-eco-100936-analysis.pdf",
+          "sha256": "ff494c1b8a85e6d66942d316ea8491a4c52c219862b520efd2c27811e9719a1b",
+          "byteLength": 314357,
+          "publishedOn": "2024-09-24",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2024-09/DVS%20ECO%20100936%20Analysis%2000.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-eco-ess-1035-analysis",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "ES&S ECO 1035 Analysis Form",
+      "url": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201035%20Analysis%20Form.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-1035-analysis.pdf",
+      "sha256": "4ce50831e8ee00a7230dd99e6660917938b67e207aa3c097c8ecdbc57b0b1237",
+      "documentType": "vstl_change_analysis_pdf",
+      "publishedOn": "2020-02-14",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Page 1 overview and affected systems",
+      "caveat": "The analysis describes an FPGA-code change for identified certified configurations, not an installed-field inventory.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201035%20Analysis%20Form.pdf",
+      "currentReviewedRevisionId": "provv-eco-ess-1035-analysis@2026-07-19",
+      "latestRetrievedRevisionId": "provv-eco-ess-1035-analysis@2026-07-19",
+      "revisions": [
+        {
+          "id": "provv-eco-ess-1035-analysis@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-1035-analysis.pdf",
+          "sha256": "4ce50831e8ee00a7230dd99e6660917938b67e207aa3c097c8ecdbc57b0b1237",
+          "byteLength": 339922,
+          "publishedOn": "2020-02-14",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201035%20Analysis%20Form.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1 overview and affected systems",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-eco-ess-1042-analysis",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "ESS ECO 1042 Analysis",
+      "url": "https://www.eac.gov/sites/default/files/eoc-documents/ESS%20ECO%201042%20Analysis.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-1042-analysis.pdf",
+      "sha256": "11f20564ec1065f2aa8ec3bff17b9a24d0d55d36a83e651ddc01ae25d92fdef4",
+      "documentType": "vstl_change_analysis_pdf",
+      "publishedOn": "2019-09-13",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Page 1 overview and affected systems",
+      "caveat": "The analysis identifies components changed in DS200 hardware configuration 1.3.11; it does not identify a jurisdiction's installed revision.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ESS%20ECO%201042%20Analysis.pdf",
+      "currentReviewedRevisionId": "provv-eco-ess-1042-analysis@2026-07-19",
+      "latestRetrievedRevisionId": "provv-eco-ess-1042-analysis@2026-07-19",
+      "revisions": [
+        {
+          "id": "provv-eco-ess-1042-analysis@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-1042-analysis.pdf",
+          "sha256": "11f20564ec1065f2aa8ec3bff17b9a24d0d55d36a83e651ddc01ae25d92fdef4",
+          "byteLength": 628112,
+          "publishedOn": "2019-09-13",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ESS%20ECO%201042%20Analysis.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1 overview and affected systems",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-eco-ess-1044-analysis",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "ESS ECO 1044 Analysis",
+      "url": "https://www.eac.gov/sites/default/files/eoc-documents/ESS%20ECO%201044%20Analysis.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-1044-analysis.pdf",
+      "sha256": "c1699ca92f55477de8446f4b5505aa6497afaa19b5743db68c18f5df1a89a799",
+      "documentType": "vstl_change_analysis_pdf",
+      "publishedOn": "2019-09-13",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Page 1 analysis",
+      "caveat": "The analysis is configuration-change evidence, not proof that the accessory was deployed.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ESS%20ECO%201044%20Analysis.pdf",
+      "currentReviewedRevisionId": "provv-eco-ess-1044-analysis@2026-07-19",
+      "latestRetrievedRevisionId": "provv-eco-ess-1044-analysis@2026-07-19",
+      "revisions": [
+        {
+          "id": "provv-eco-ess-1044-analysis@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-1044-analysis.pdf",
+          "sha256": "c1699ca92f55477de8446f4b5505aa6497afaa19b5743db68c18f5df1a89a799",
+          "byteLength": 497474,
+          "publishedOn": "2019-09-13",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ESS%20ECO%201044%20Analysis.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1 analysis",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-eco-ess-1055-analysis",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "ES&S ECO 1055 Analysis",
+      "url": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201055%20Analysis.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-1055-analysis.pdf",
+      "sha256": "32b4c4b21362589254aa53efc2b8ddb113712883c8a03939b8468c40437839ae",
+      "documentType": "vstl_change_analysis_pdf",
+      "publishedOn": "2019-12-19",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Page 1 analysis",
+      "caveat": "The analysis is configuration-change evidence, not proof that the option was deployed.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201055%20Analysis.pdf",
+      "currentReviewedRevisionId": "provv-eco-ess-1055-analysis@2026-07-19",
+      "latestRetrievedRevisionId": "provv-eco-ess-1055-analysis@2026-07-19",
+      "revisions": [
+        {
+          "id": "provv-eco-ess-1055-analysis@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-1055-analysis.pdf",
+          "sha256": "32b4c4b21362589254aa53efc2b8ddb113712883c8a03939b8468c40437839ae",
+          "byteLength": 511095,
+          "publishedOn": "2019-12-19",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%201055%20Analysis.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1 analysis",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-eco-ess-1165-analysis",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "ES&S ECO 1165 Analysis Rev. 01",
+      "url": "https://www.eac.gov/sites/default/files/2024-05/ES%26S_ECO_1165_Analysis_Rev_01.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-1165-analysis.pdf",
+      "sha256": "54ded58752af1888f3aacd0c08434df5a2301bb91b9d185f8f9c16e933c4ebf8",
+      "documentType": "vstl_change_analysis_pdf",
+      "publishedOn": "2024-05-15",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Page 1 analysis and affected systems",
+      "caveat": "Pro V&V reviewed and functionally tested the tote-bin security gasketing change; this does not prove local installation.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2024-05/ES%26S_ECO_1165_Analysis_Rev_01.pdf",
+      "currentReviewedRevisionId": "provv-eco-ess-1165-analysis@2026-07-19",
+      "latestRetrievedRevisionId": "provv-eco-ess-1165-analysis@2026-07-19",
+      "revisions": [
+        {
+          "id": "provv-eco-ess-1165-analysis@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-1165-analysis.pdf",
+          "sha256": "54ded58752af1888f3aacd0c08434df5a2301bb91b9d185f8f9c16e933c4ebf8",
+          "byteLength": 262230,
+          "publishedOn": "2024-05-15",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2024-05/ES%26S_ECO_1165_Analysis_Rev_01.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1 analysis and affected systems",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-eco-ess-983-analysis",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "ES&S ECO 983 analysis",
+      "url": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%20983.pdf",
+      "localArtifact": "data/equipment-sources/eco-ess-983-analysis.pdf",
+      "sha256": "32020f43cd6abb908ce3f60dd5b6dc294d2322eadb94b50edf43fc46017232f7",
+      "documentType": "vstl_change_analysis_pdf",
+      "publishedOn": "2018-12-14",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "DS200 hardware 1.3.10.0 seal-area change",
+      "caveat": "Historical certified-configuration evidence, not proof of installation on a current unit.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%20983.pdf",
+      "currentReviewedRevisionId": "provv-eco-ess-983-analysis@2026-07-19",
+      "latestRetrievedRevisionId": "provv-eco-ess-983-analysis@2026-07-19",
+      "revisions": [
+        {
+          "id": "provv-eco-ess-983-analysis@2026-07-19",
+          "localArtifact": "data/equipment-sources/eco-ess-983-analysis.pdf",
+          "sha256": "32020f43cd6abb908ce3f60dd5b6dc294d2322eadb94b50edf43fc46017232f7",
+          "byteLength": 2503040,
+          "publishedOn": "2018-12-14",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/eoc-documents/ES%26S%20ECO%20983.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "DS200 hardware 1.3.10.0 seal-area change",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-evs-5341-modem-hardware-table",
+      "publisher": "Pro V&V, Inc.; Minnesota Judicial Branch record mirrored by Democracy Docket",
+      "authorityLevel": "court_record_mirror_supplemental",
+      "title": "EVS 5.3.4.1 Test Report hardware-components table, court-filed Exhibit A",
+      "url": "https://www.democracydocket.com/wp-content/uploads/2022/11/24-sos-affadvit.pdf",
+      "localArtifact": "data/equipment-sources/mn-court-evs-5341-provv-exhibit.pdf",
+      "sha256": "d34fe0f7927dd2c64307922be9f365424958279f67c25dac20e9449cd0723ff6",
+      "documentType": "court_filed_vstl_report_exhibit_pdf",
+      "publishedOn": "2022-10-13",
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "PDF page 16, attached Pro V&V report page 12, Table 2-2",
+      "caveat": "The court-filed exhibit contains a Pro V&V report naming MTSMC-LVW3 test units for DS200 hardware 1.2 and 1.3. It is hosted by a supplemental mirror, identifies no ordering revision or firmware, and does not establish EVS 6.4.0.0 certification or field deployment.",
+      "canonicalUrl": "https://www.democracydocket.com/wp-content/uploads/2022/11/24-sos-affadvit.pdf",
+      "currentReviewedRevisionId": "provv-evs-5341-modem-hardware-table@2026-07-20",
+      "latestRetrievedRevisionId": "provv-evs-5341-modem-hardware-table@2026-07-20",
+      "revisions": [
+        {
+          "id": "provv-evs-5341-modem-hardware-table@2026-07-20",
+          "localArtifact": "data/equipment-sources/mn-court-evs-5341-provv-exhibit.pdf",
+          "sha256": "d34fe0f7927dd2c64307922be9f365424958279f67c25dac20e9449cd0723ff6",
+          "byteLength": 4830709,
+          "publishedOn": "2022-10-13",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.democracydocket.com/wp-content/uploads/2022/11/24-sos-affadvit.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "PDF page 16, attached Pro V&V report page 12, Table 2-2",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "provv-evs-6400-test-report",
+      "publisher": "Pro V&V, Inc.",
+      "authorityLevel": "eac_accredited_vstl",
+      "title": "ES&S EVS 6.4.0.0 Certification Test Report TR-01-01-ESS-2023-01.03",
+      "url": "https://www.eac.gov/sites/default/files/2023-08/ESS%20EVS6400%20Test%20Report%2001%20Rev%2003.pdf",
+      "localArtifact": "data/equipment-sources/provv-evs-6400-test-report.pdf",
+      "sha256": "cfc04d88fd4be79cb793eb18ab940b01be1295426c14d43062081acd69a6ba84",
+      "documentType": "vstl_test_report_pdf",
+      "publishedOn": "2023-08-15",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Sections 3.2, 3.3, and Tables 4-1 through 4-3",
+      "caveat": "Test results describe the submitted test campaign. They are not a statement about every fielded unit or later operating conditions.",
+      "canonicalUrl": "https://www.eac.gov/sites/default/files/2023-08/ESS%20EVS6400%20Test%20Report%2001%20Rev%2003.pdf",
+      "currentReviewedRevisionId": "provv-evs-6400-test-report@2026-07-19",
+      "latestRetrievedRevisionId": "provv-evs-6400-test-report@2026-07-19",
+      "revisions": [
+        {
+          "id": "provv-evs-6400-test-report@2026-07-19",
+          "localArtifact": "data/equipment-sources/provv-evs-6400-test-report.pdf",
+          "sha256": "cfc04d88fd4be79cb793eb18ab940b01be1295426c14d43062081acd69a6ba84",
+          "byteLength": 1308247,
+          "publishedOn": "2023-08-15",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.eac.gov/sites/default/files/2023-08/ESS%20EVS6400%20Test%20Report%2001%20Rev%2003.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Sections 3.2, 3.3, and Tables 4-1 through 4-3",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "ri-ds200-pollworker-manual-2021",
+      "publisher": "Rhode Island Board of Elections",
+      "authorityLevel": "state_election_office",
+      "title": "Poll Worker Manual 2021",
+      "url": "https://elections.ri.gov/sites/g/files/xkgbur756/files/publications/Election_Publications/Pollworker_Training/Poll-worker-Manual-2021.pdf",
+      "localArtifact": "data/equipment-sources/ri-ds200-pollworker-manual-2021.pdf",
+      "sha256": "a5738b52d5a49525dcb9a0acb80abaf359cfd4f8b016b23cef2cad75ddea4d0e",
+      "documentType": "state_poll_worker_manual_pdf",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "PDF pages 82-83, Step 5 through Step 7",
+      "caveat": "The manual directly documents Rhode Island's 2021 DS200 post-poll transmission procedure. It does not establish that every DS200, every jurisdiction, or the EVS 6.4.0.0 certified configuration contains or permits a cellular modem.",
+      "canonicalUrl": "https://elections.ri.gov/sites/g/files/xkgbur756/files/publications/Election_Publications/Pollworker_Training/Poll-worker-Manual-2021.pdf",
+      "currentReviewedRevisionId": "ri-ds200-pollworker-manual-2021@2026-07-20",
+      "latestRetrievedRevisionId": "ri-ds200-pollworker-manual-2021@2026-07-20",
+      "revisions": [
+        {
+          "id": "ri-ds200-pollworker-manual-2021@2026-07-20",
+          "localArtifact": "data/equipment-sources/ri-ds200-pollworker-manual-2021.pdf",
+          "sha256": "a5738b52d5a49525dcb9a0acb80abaf359cfd4f8b016b23cef2cad75ddea4d0e",
+          "byteLength": 5946616,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://elections.ri.gov/sites/g/files/xkgbur756/files/publications/Election_Publications/Pollworker_Training/Poll-worker-Manual-2021.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "PDF pages 82-83, Step 5 through Step 7",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "sf-icx-usability-test-report-510",
+      "publisher": "San Francisco Department of Elections; SLI Compliance",
+      "authorityLevel": "local_election_office_hosted_vstl_report",
+      "title": "Usability Test Report of ImageCast X 5.0 with 36 Participants for VVSG 1.0",
+      "url": "https://sfelections.sfgov.org/sites/default/files/Documents/GetInvolved/AgendasMinutes/20210528_VAAC_SD_ICX_UsabilityTestReport_5.10_CA.pdf",
+      "localArtifact": "data/equipment-sources/sf-icx-usability-test-report-510.pdf",
+      "sha256": "838754693ea1dcd90c4f8d8944e63347af7fccf4de4692af538f60b70223ee6e",
+      "documentType": "local_election_office_hosted_usability_test_report_pdf",
+      "publishedOn": "2021-06-11",
+      "retrievedOn": "2026-07-20",
+      "pageOrSection": "PDF page 7, report page 4, Figure 2-1",
+      "caveat": "Figure 2-1 is an actual-device reference photograph for the ICX 21, ICX 15, and ICX 12.2 in an older 5.0 usability-test context. It does not establish the exact hardware alternative, accessories, software, or field installation for Democracy Suite 5.17.",
+      "canonicalUrl": "https://sfelections.sfgov.org/sites/default/files/Documents/GetInvolved/AgendasMinutes/20210528_VAAC_SD_ICX_UsabilityTestReport_5.10_CA.pdf",
+      "currentReviewedRevisionId": "sf-icx-usability-test-report-510@2026-07-20",
+      "latestRetrievedRevisionId": "sf-icx-usability-test-report-510@2026-07-20",
+      "revisions": [
+        {
+          "id": "sf-icx-usability-test-report-510@2026-07-20",
+          "localArtifact": "data/equipment-sources/sf-icx-usability-test-report-510.pdf",
+          "sha256": "838754693ea1dcd90c4f8d8944e63347af7fccf4de4692af538f60b70223ee6e",
+          "byteLength": 2409680,
+          "publishedOn": "2021-06-11",
+          "retrievedOn": "2026-07-20",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://sfelections.sfgov.org/sites/default/files/Documents/GetInvolved/AgendasMinutes/20210528_VAAC_SD_ICX_UsabilityTestReport_5.10_CA.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "PDF page 7, report page 4, Figure 2-1",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "wa-2025-county-system-table",
+      "publisher": "Washington Office of the Secretary of State",
+      "authorityLevel": "state_official",
+      "title": "Voting systems used by county",
+      "url": "https://www.sos.wa.gov/elections/data-research/election-technology/voting-systems-county",
+      "localArtifact": "data/equipment-sources/wa-voting-systems-by-county.html",
+      "sha256": "42c21aae5aee6a8e1f3469b8c025fe49697764dfaec78c7f19afb1a384ce0291",
+      "documentType": "state_deployment_table_html",
+      "publishedOn": null,
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "County table and November 2025 version note",
+      "caveat": "The table identifies county-level EVS system versions used in the November 2025 general election. It does not identify DS200 unit counts, component revisions, firmware installed on each device, or backup power.",
+      "canonicalUrl": "https://www.sos.wa.gov/elections/data-research/election-technology/voting-systems-county",
+      "currentReviewedRevisionId": "wa-2025-county-system-table@2026-07-19",
+      "latestRetrievedRevisionId": "wa-2025-county-system-table@2026-07-19",
+      "revisions": [
+        {
+          "id": "wa-2025-county-system-table@2026-07-19",
+          "localArtifact": "data/equipment-sources/wa-voting-systems-by-county.html",
+          "sha256": "42c21aae5aee6a8e1f3469b8c025fe49697764dfaec78c7f19afb1a384ce0291",
+          "byteLength": 202475,
+          "publishedOn": null,
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.sos.wa.gov/elections/data-research/election-technology/voting-systems-county",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "County table and November 2025 version note",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "wa-evs-6400-application",
+      "publisher": "Washington Office of the Secretary of State",
+      "authorityLevel": "state_official",
+      "title": "Amended Vendor Application for EVS 6.4.0.0 Certification",
+      "url": "https://www.sos.wa.gov/sites/default/files/2023-12/Amended%20Certification%20Application%20EVS%206400.pdf",
+      "localArtifact": "data/equipment-sources/wa-evs-6400-certification-application.pdf",
+      "sha256": "10f6716ce5cf0cc564625cf9e7023ae23056339f9aa5cbeb3f7752a93ad6cc16",
+      "documentType": "state_certification_application_pdf",
+      "publishedOn": "2023-11-28",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Page 1 hardware list",
+      "caveat": "The application identifies the configuration submitted for Washington certification, not a county unit inventory.",
+      "canonicalUrl": "https://www.sos.wa.gov/sites/default/files/2023-12/Amended%20Certification%20Application%20EVS%206400.pdf",
+      "currentReviewedRevisionId": "wa-evs-6400-application@2026-07-19",
+      "latestRetrievedRevisionId": "wa-evs-6400-application@2026-07-19",
+      "revisions": [
+        {
+          "id": "wa-evs-6400-application@2026-07-19",
+          "localArtifact": "data/equipment-sources/wa-evs-6400-certification-application.pdf",
+          "sha256": "10f6716ce5cf0cc564625cf9e7023ae23056339f9aa5cbeb3f7752a93ad6cc16",
+          "byteLength": 213436,
+          "publishedOn": "2023-11-28",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.sos.wa.gov/sites/default/files/2023-12/Amended%20Certification%20Application%20EVS%206400.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Page 1 hardware list",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    },
+    {
+      "id": "wa-evs-6400-staff-report",
+      "publisher": "Washington Office of the Secretary of State",
+      "authorityLevel": "state_official",
+      "title": "Report on the Examination of ES&S EVS 6.4.0.0",
+      "url": "https://www.sos.wa.gov/sites/default/files/2023-12/ES%26S%20EVS%206.4.0.0%20staff%20report.pdf",
+      "localArtifact": "data/equipment-sources/wa-evs-6400-staff-report.pdf",
+      "sha256": "d5be815af919e039722c8965cd3523499218068c99ccbab4160b784a8e38dc56",
+      "documentType": "state_staff_report_pdf",
+      "publishedOn": "2023-11-30",
+      "retrievedOn": "2026-07-19",
+      "pageOrSection": "Pages 3-6",
+      "caveat": "The report describes Washington certification examination and states that detailed technical specifications were supplied in the EAC Technical Data Package; it is not a public internal bill of materials.",
+      "canonicalUrl": "https://www.sos.wa.gov/sites/default/files/2023-12/ES%26S%20EVS%206.4.0.0%20staff%20report.pdf",
+      "currentReviewedRevisionId": "wa-evs-6400-staff-report@2026-07-19",
+      "latestRetrievedRevisionId": "wa-evs-6400-staff-report@2026-07-19",
+      "revisions": [
+        {
+          "id": "wa-evs-6400-staff-report@2026-07-19",
+          "localArtifact": "data/equipment-sources/wa-evs-6400-staff-report.pdf",
+          "sha256": "d5be815af919e039722c8965cd3523499218068c99ccbab4160b784a8e38dc56",
+          "byteLength": 220421,
+          "publishedOn": "2023-11-30",
+          "retrievedOn": "2026-07-19",
+          "retrievedAt": null,
+          "retrievalPrecision": "date",
+          "resolvedUrl": "https://www.sos.wa.gov/sites/default/files/2023-12/ES%26S%20EVS%206.4.0.0%20staff%20report.pdf",
+          "http": {
+            "etag": null,
+            "lastModified": null
+          },
+          "supersedesRevisionId": null,
+          "contentStatus": "baseline",
+          "pageOrSection": "Pages 3-6",
+          "archiveStatus": "verified"
+        }
+      ],
+      "revisionComparisons": []
+    }
+  ],
+  "systems": [
+    {
+      "id": "clear-ballot-clearvote-25-clearaccess",
+      "slug": "clear-ballot-clearvote-25-clearaccess",
+      "status": "pilot",
+      "manufacturer": "Clear Ballot Group, Inc.",
+      "systemName": "ClearVote",
+      "systemVersion": "2.5",
+      "deviceName": "ClearAccess",
+      "displayName": "Clear Ballot ClearVote 2.5 / ClearAccess",
+      "deviceRole": "Accessible touchscreen ballot-marking configuration",
+      "summary": "A source-linked dossier for the ClearAccess ballot-marking configuration within EAC-certified ClearVote 2.5, including named COTS components, explicit external UPS options, certified software observations, and Pro V&V test findings.",
+      "certification": {
+        "certificationId": "CBG-CV-25",
+        "standard": "VVSG 1.0",
+        "certifiedOn": "2025-11-19",
+        "vstl": "Pro V&V, Inc.",
+        "scopeKind": "certified_configuration",
+        "sourceIds": [
+          "eac-clearvote-25-record",
+          "eac-clearvote-25-scope",
+          "provv-clearvote-25-test-report"
+        ],
+        "caveat": "EAC certification applies only to the evaluated ClearVote 2.5 certified configuration. It does not establish which permitted ClearAccess options a jurisdiction selected or what is installed in a particular fielded unit.",
+        "sourceRevisionIds": [
+          "eac-clearvote-25-record@2026-07-19",
+          "eac-clearvote-25-scope@2026-07-19",
+          "provv-clearvote-25-test-report@2026-07-19"
+        ]
+      },
+      "components": [
+        {
+          "id": "clearaccess-software",
+          "name": "ClearAccess software",
+          "category": "software",
+          "description": "The certified scope lists proprietary ClearAccess software version 2.5.6 and its configured COTS software environment.",
+          "evidenceStatus": "certified_component",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [
+            "clearaccess-software-256",
+            "clearaccess-windows-10-iot-2021"
+          ],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-report"
+          ],
+          "sceneNodeName": "ClearAccess_Software",
+          "caveat": "These are versions in the certified configuration, not a live reading from a deployed workstation and not a claim that 2.5.6 is the newest product-family release.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-report@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "clearaccess-touchscreen-computer",
+          "name": "All-in-one touchscreen computer",
+          "category": "interface_compute",
+          "description": "The certified scope permits ELO 15-inch EloPOS and E-Series or X-Series all-in-one touchscreens, plus a Dell OptiPlex 5250 option. The reference scene follows Clear Ballot's official portrait Elo product image.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "EPS15E2",
+            "ESY15E2",
+            "ESY20X2",
+            "Dell OptiPlex 5250"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan",
+            "dell-optiplex-5250-specifications",
+            "clearballot-clearaccess-product-page",
+            "clearballot-clearaccess-reference-photo"
+          ],
+          "sceneNodeName": "Touchscreen_AIO",
+          "caveat": "The computers are alternatives. Dell specifications are restricted to the OptiPlex 5250 family, and the official portrait Elo product image is not treated as proof of which certified Elo model or internal configuration it depicts.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19",
+            "dell-optiplex-5250-specifications@2026-07-20",
+            "clearballot-clearaccess-product-page@2026-07-20",
+            "clearballot-clearaccess-reference-photo@2026-07-20"
+          ],
+          "technicalSpecifications": [
+            {
+              "id": "clearaccess-supported-aio-models",
+              "category": "model_profile",
+              "label": "Certified touchscreen alternatives",
+              "value": "Elo EPS15E2, ESY15E2, ESY20X2; Dell OptiPlex 5250",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "ClearAccess 2.5",
+              "sourceIds": [
+                "eac-clearvote-25-scope",
+                "provv-clearvote-25-test-plan"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19",
+                "provv-clearvote-25-test-plan@2026-07-19"
+              ],
+              "caveat": "These are alternatives, not a single combined hardware configuration and not evidence of a jurisdiction's selected model."
+            },
+            {
+              "id": "clearaccess-dell-processor-options",
+              "category": "processor",
+              "label": "CPU options",
+              "value": "Intel 6th/7th Generation Pentium, Core i3 dual-core, or Core i5/i7 quad-core product-family options",
+              "knowledgeStatus": "documented_partial",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Dell OptiPlex 5250 alternative",
+              "sourceIds": [
+                "provv-clearvote-25-test-plan",
+                "dell-optiplex-5250-specifications"
+              ],
+              "sourceRevisionIds": [
+                "provv-clearvote-25-test-plan@2026-07-19",
+                "dell-optiplex-5250-specifications@2026-07-20"
+              ],
+              "caveat": "Pro V&V identifies the OptiPlex 5250 as an option; Dell lists configurable processor choices. The exact processor in a certified or fielded ClearAccess unit is not established."
+            },
+            {
+              "id": "clearaccess-dell-memory",
+              "category": "memory",
+              "label": "RAM",
+              "value": "Two DDR4 SODIMM slots; up to 32 GB product-family maximum",
+              "knowledgeStatus": "documented_partial",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Dell OptiPlex 5250 alternative",
+              "sourceIds": [
+                "provv-clearvote-25-test-plan",
+                "dell-optiplex-5250-specifications"
+              ],
+              "sourceRevisionIds": [
+                "provv-clearvote-25-test-plan@2026-07-19",
+                "dell-optiplex-5250-specifications@2026-07-20"
+              ],
+              "caveat": "This is capacity supported by the Dell product family, not the installed RAM in a certified or fielded ClearAccess computer."
+            },
+            {
+              "id": "clearaccess-dell-storage",
+              "category": "storage",
+              "label": "Storage",
+              "value": "2.5-inch bay plus M.2 SSD connector; HDD, hybrid-drive, SATA/PCIe SSD, and dual-storage product-family options",
+              "knowledgeStatus": "documented_partial",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Dell OptiPlex 5250 alternative",
+              "sourceIds": [
+                "provv-clearvote-25-test-plan",
+                "dell-optiplex-5250-specifications"
+              ],
+              "sourceRevisionIds": [
+                "provv-clearvote-25-test-plan@2026-07-19",
+                "dell-optiplex-5250-specifications@2026-07-20"
+              ],
+              "caveat": "The exact installed drive type and capacity for the certified ClearAccess option are not established by the reviewed sources."
+            },
+            {
+              "id": "clearaccess-dell-usb",
+              "category": "usb",
+              "label": "USB ports",
+              "value": "6 external: 4 × USB 3.1 Gen 1 and 2 × USB 2.0",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Dell OptiPlex 5250 alternative",
+              "sourceIds": [
+                "provv-clearvote-25-test-plan",
+                "dell-optiplex-5250-specifications"
+              ],
+              "sourceRevisionIds": [
+                "provv-clearvote-25-test-plan@2026-07-19",
+                "dell-optiplex-5250-specifications@2026-07-20"
+              ],
+              "caveat": "This is the physical connector count for the Dell alternative, not for the Elo alternatives and not proof of port occupation or enabled devices."
+            },
+            {
+              "id": "clearaccess-dell-ethernet",
+              "category": "ethernet",
+              "label": "Ethernet",
+              "value": "Integrated Intel I219-V 10/100/1000 Ethernet; 1 rear RJ-45",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Dell OptiPlex 5250 alternative",
+              "sourceIds": [
+                "provv-clearvote-25-test-plan",
+                "dell-optiplex-5250-specifications"
+              ],
+              "sourceRevisionIds": [
+                "provv-clearvote-25-test-plan@2026-07-19",
+                "dell-optiplex-5250-specifications@2026-07-20"
+              ],
+              "caveat": "Physical Ethernet capability does not establish a connected, enabled, or field-used election network."
+            },
+            {
+              "id": "clearaccess-cellular-gap",
+              "category": "cellular",
+              "label": "Cellular modem",
+              "value": null,
+              "knowledgeStatus": "not_publicly_established",
+              "assertionScope": "evidence_gap",
+              "modelContext": "ClearAccess 2.5 touchscreen alternatives",
+              "sourceIds": [
+                "eac-clearvote-25-scope",
+                "provv-clearvote-25-test-plan",
+                "dell-optiplex-5250-specifications"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19",
+                "provv-clearvote-25-test-plan@2026-07-19",
+                "dell-optiplex-5250-specifications@2026-07-20"
+              ],
+              "caveat": "No cellular modem is identified for the reviewed alternatives. Dell lists optional Wi-Fi/Bluetooth for its general product family, but that is not proof of an installed certified ClearAccess radio or of field use."
+            },
+            {
+              "id": "clearaccess-elo-internals-gap",
+              "category": "compute",
+              "label": "Elo CPU, RAM, and storage",
+              "value": null,
+              "knowledgeStatus": "not_publicly_established",
+              "assertionScope": "evidence_gap",
+              "modelContext": "EPS15E2, ESY15E2, and ESY20X2 alternatives",
+              "sourceIds": [
+                "eac-clearvote-25-scope",
+                "provv-clearvote-25-test-plan",
+                "clearballot-clearaccess-reference-photo"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19",
+                "provv-clearvote-25-test-plan@2026-07-19",
+                "clearballot-clearaccess-reference-photo@2026-07-20"
+              ],
+              "caveat": "The reviewed immutable artifacts establish the Elo model alternatives and an external reference image but do not provide a safely attributable exact CPU, installed RAM, or storage configuration for those certified variants."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "clearaccess-ballot-printer",
+          "name": "Ballot printer",
+          "category": "printer",
+          "description": "The certified scope lists Oki Data B432dn and Lexmark MS521dn or MS531dw laser-printer options for ClearAccess.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Oki Data B432dn",
+            "Lexmark MS521dn",
+            "Lexmark MS531dw"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan"
+          ],
+          "sceneNodeName": "Ballot_Printer",
+          "caveat": "These are certified alternatives, not evidence that all three printers are present in one configuration or that a particular jurisdiction uses one of them.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "clearaccess-ups",
+          "name": "External uninterruptible power supply",
+          "category": "power",
+          "description": "The certified scope lists CyberPower PR1500RT2U and APC SMT2200C or SRT1500RMXLA UPS models for ClearAccess.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "CyberPower PR1500RT2U",
+            "APC SMT2200C",
+            "APC SRT1500RMXLA"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan"
+          ],
+          "sceneNodeName": "External_UPS",
+          "caveat": "The source confirms permitted UPS models but does not state battery capacity, runtime under a ClearAccess load, field topology, maintenance condition, or the option selected by a jurisdiction.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "clearaccess-accessible-keypad",
+          "name": "Accessible keypad",
+          "category": "assistive_input",
+          "description": "The reviewed scope and test plan list Storm EZ Access keypad models as accessible input devices for ClearAccess.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "EZ08-22000",
+            "EZ08-22200",
+            "EZ08-22201"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan"
+          ],
+          "sceneNodeName": "Accessible_Keypad",
+          "caveat": "The records list approved or evaluated keypad alternatives; they do not identify the model connected to a particular unit.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "clearaccess-barcode-scanner",
+          "name": "Barcode scanner",
+          "category": "scanner_peripheral",
+          "description": "The certified scope lists Zebra DS457-SR and ELO UM600149 barcode-scanner options for ClearAccess.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Zebra DS457-SR",
+            "ELO UM600149"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan"
+          ],
+          "sceneNodeName": "Barcode_Scanner",
+          "caveat": "The sources establish certified alternatives, not the scanner attached to a fielded ClearAccess configuration.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "clearaccess-assistive-accessories",
+          "name": "Sip-and-puff and audio accessories",
+          "category": "assistive_accessory",
+          "description": "The Pro V&V physical configuration audit lists Origin Instruments BZ2 and BZ2U sip-and-puff devices and Samson SASR350 headphones with the ClearAccess test components.",
+          "evidenceStatus": "vstl_tested_component_options",
+          "scopeKind": "certification_test_configuration",
+          "modelNumbers": [
+            "Origin Instruments BZ2",
+            "Origin Instruments BZ2U",
+            "Samson SASR350"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "provv-clearvote-25-test-plan"
+          ],
+          "sceneNodeName": "Assistive_Accessories",
+          "caveat": "The test-plan PCA documents components submitted for evaluation. It does not establish that these accessories are packaged with or connected to every deployed setup.",
+          "sourceRevisionIds": [
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "clearaccess-esd-emi-controls",
+          "name": "ESD and EMI control materials",
+          "category": "electromagnetic_controls",
+          "description": "The certified scope lists copper tape, acrylic and polyimide films, and named ferrite parts under ClearAccess COTS hardware.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "TM-36-COPP-1M-3",
+            "CV-1180-1.4-1",
+            "CV-1210-2.0",
+            "CV-1211-2.0",
+            "CV-1212-2.0",
+            "Wurth 742-416-33S",
+            "Laird 28A2029-0A2",
+            "Takachi TFT152613N"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-report"
+          ],
+          "sceneNodeName": "ESD_EMI_Controls",
+          "caveat": "The schematic marker is only a selection aid. The public scope does not establish the exact quantity, placement, routing, or physical appearance of these materials in a particular setup.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-report@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "clearaccess-transport-case",
+          "name": "Transportation and setup case",
+          "category": "case",
+          "description": "The test plan lists case models 62311-1-1 and 62312-1-1 for the ClearAccess touchscreen, printer, headphones, keypad, and associated cables.",
+          "evidenceStatus": "vstl_tested_component_options",
+          "scopeKind": "certification_test_configuration",
+          "modelNumbers": [
+            "62311-1-1",
+            "62312-1-1"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "provv-clearvote-25-test-plan"
+          ],
+          "sceneNodeName": "Setup_Case",
+          "caveat": "A tested transportation option does not establish a jurisdiction's storage, transport, setup, or chain-of-custody procedure.",
+          "sourceRevisionIds": [
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        }
+      ],
+      "versionObservations": [
+        {
+          "id": "clearaccess-software-256",
+          "componentId": "clearaccess-software",
+          "versionType": "software",
+          "value": "2.5.6",
+          "label": "EAC-certified ClearAccess software",
+          "scopeKind": "certified_configuration",
+          "observedOn": "2025-11-19",
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-report"
+          ],
+          "caveat": "This is the software version in the certified ClearVote 2.5 configuration, not a live device reading or a claim about the newest ClearVote release.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-report@2026-07-19"
+          ],
+          "assertionScope": "certified",
+          "approvalScope": null,
+          "fieldStatus": "not_established",
+          "assertedFor": {
+            "systemCertificationId": "CBG-CV-25",
+            "jurisdiction": null,
+            "observedOn": "2025-11-19"
+          }
+        },
+        {
+          "id": "clearaccess-windows-10-iot-2021",
+          "componentId": "clearaccess-software",
+          "versionType": "operating_system",
+          "value": "Windows 10 IoT Enterprise LTSC 2021",
+          "label": "Certified COTS operating-system environment",
+          "scopeKind": "certified_configuration",
+          "observedOn": "2025-11-19",
+          "sourceIds": [
+            "eac-clearvote-25-scope"
+          ],
+          "caveat": "The scope lists the certified software environment; it does not establish patch state or configuration on a fielded computer.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19"
+          ],
+          "assertionScope": "certified",
+          "approvalScope": null,
+          "fieldStatus": "not_established",
+          "assertedFor": {
+            "systemCertificationId": "CBG-CV-25",
+            "jurisdiction": null,
+            "observedOn": "2025-11-19"
+          }
+        }
+      ],
+      "configurationChanges": [
+        {
+          "id": "clearvote-25-sw-10275",
+          "changeId": "SW-10275",
+          "componentIds": [
+            "clearaccess-software"
+          ],
+          "submittedOn": "2024-08-02",
+          "eacApprovedOn": "2025-11-19",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "included_in_certified_25_configuration",
+          "description": "ClearAccess automatically rolls the system log when more than 1,000 log entries are present to reduce performance risk.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "provv-clearvote-25-test-plan",
+            "eac-clearvote-25-scope"
+          ],
+          "caveat": "The change appears in the submitted ClearVote 2.5 certification modification set. It does not establish installation on a particular fielded unit.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ]
+        },
+        {
+          "id": "clearvote-25-sw-10691",
+          "changeId": "SW-10691",
+          "componentIds": [
+            "clearaccess-software"
+          ],
+          "submittedOn": "2024-08-02",
+          "eacApprovedOn": "2025-11-19",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "included_in_certified_25_configuration",
+          "description": "ClearAccess and ClearCast received minor libssl and OpenSSL version updates in the submitted modification set.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "provv-clearvote-25-test-plan",
+            "eac-clearvote-25-scope"
+          ],
+          "caveat": "This is certification configuration history, not evidence of a field update, patch installation date, or current exposure on any unit.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ]
+        },
+        {
+          "id": "clearvote-25-deficiency-556",
+          "changeId": "TR-DEF-556",
+          "componentIds": [
+            "clearaccess-software",
+            "clearaccess-touchscreen-computer"
+          ],
+          "submittedOn": "2025-09-22",
+          "eacApprovedOn": "2025-11-19",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "resolved_during_certification_campaign",
+          "description": "The ClearAccess 2.5.5 write-in controls did not meet specified touch-area dimensions; the report records the corrected 2.5.6 interface.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "provv-clearvote-25-test-report",
+            "eac-clearvote-25-scope"
+          ],
+          "caveat": "This is a test-campaign deficiency and resolution, not evidence that version 2.5.5 was used in a public election.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-report@2026-07-19"
+          ]
+        }
+      ],
+      "findings": [
+        {
+          "id": "clearaccess-ui-size-deficiency",
+          "findingType": "resolved_test_deficiency",
+          "title": "ClearAccess 2.5.5 write-in controls were undersized",
+          "affectedSystemVersions": [
+            "ClearAccess 2.5.5"
+          ],
+          "componentIds": [
+            "clearaccess-software",
+            "clearaccess-touchscreen-computer"
+          ],
+          "publicStatus": "resolved_in_clearaccess_2_5_6",
+          "description": "Pro V&V reported that the write-in menu button dimensions and spacing in ClearAccess 2.5.5 did not meet the cited VVSG requirement and documented corrected dimensions and keyboard options in 2.5.6.",
+          "sourceIds": [
+            "provv-clearvote-25-test-report"
+          ],
+          "caveat": "This is a certification-test finding with a reported resolution. It is not evidence that the deficient build was deployed in an election.",
+          "sourceRevisionIds": [
+            "provv-clearvote-25-test-report@2026-07-19"
+          ]
+        },
+        {
+          "id": "clearaccess-cve-2022-0778-update",
+          "findingType": "certification_change_note",
+          "title": "OpenSSL libraries updated in the submitted modification set",
+          "affectedSystemVersions": [
+            "ClearAccess before certified 2.5.6",
+            "ClearCast before certified 2.5.3"
+          ],
+          "componentIds": [
+            "clearaccess-software"
+          ],
+          "publicStatus": "update_recorded_for_cve_2022_0778",
+          "description": "The Pro V&V test plan identifies the ClearAccess and ClearCast libssl/OpenSSL update as a bug change addressing CVE-2022-0778.",
+          "sourceIds": [
+            "provv-clearvote-25-test-plan",
+            "eac-clearvote-25-scope"
+          ],
+          "caveat": "The record describes the submitted certified configuration. It is not a field vulnerability scan, a current security assessment, or evidence of exploitation.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ]
+        },
+        {
+          "id": "clearvote-25-test-campaign-findings",
+          "findingType": "test_campaign_result",
+          "title": "One anomaly and multiple deficiencies were documented during testing",
+          "affectedSystemVersions": [
+            "ClearVote 2.5 test campaign"
+          ],
+          "componentIds": [],
+          "publicStatus": "certified_after_documented_resolutions",
+          "description": "The final Pro V&V report describes one ClearMark anomaly with no determined root cause and lists test deficiencies with reported corrective actions before recommending certification of the submitted system.",
+          "sourceIds": [
+            "provv-clearvote-25-test-report",
+            "eac-clearvote-25-record"
+          ],
+          "caveat": "This system-level summary is not a claim that ClearAccess caused the ClearMark anomaly, that findings occurred in the field, or that no other defects exist.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-record@2026-07-19",
+            "provv-clearvote-25-test-report@2026-07-19"
+          ]
+        },
+        {
+          "id": "clearvote-25-precertification-field-status",
+          "findingType": "historical_scope_note",
+          "title": "The modification had not been fielded when the 2024 test plan was written",
+          "affectedSystemVersions": [
+            "ClearVote 2.5 submitted modification"
+          ],
+          "componentIds": [],
+          "publicStatus": "not_fielded_as_of_2024_08_02_test_plan",
+          "description": "The Pro V&V test plan stated that the ClearVote 2.5 modification had not been fielded for use as of the plan date.",
+          "sourceIds": [
+            "provv-clearvote-25-test-plan"
+          ],
+          "caveat": "This is a historical pre-certification statement. Do not infer that ClearVote 2.5 remained undeployed after certification or is not deployed today.",
+          "sourceRevisionIds": [
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ]
+        }
+      ],
+      "power": [
+        {
+          "id": "clearaccess-certified-ups-options",
+          "componentId": "clearaccess-ups",
+          "knowledgeStatus": "confirmed",
+          "supplyType": "external uninterruptible power supply",
+          "manufacturer": "CyberPower; APC",
+          "model": "PR1500RT2U; SMT2200C; SRT1500RMXLA",
+          "capacity": null,
+          "runtime": null,
+          "description": "The certified ClearVote 2.5 scope names three external UPS options for ClearAccess. The reviewed sources do not provide a ClearAccess load-specific capacity or runtime claim.",
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan"
+          ],
+          "caveat": "Confirmed means the models appear in the certified configuration, not that every jurisdiction uses one, that all are used together, or that battery health and runtime are known for a fielded setup.",
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ]
+        }
+      ],
+      "networkEvidence": {
+        "reviewedOn": "2026-07-21",
+        "summary": "The reviewed ClearVote 2.5 record identifies the ClearAccess station and its local peripherals, while Clear Ballot's current security policy says certified products are never attached to modems, the Internet, Wi-Fi, or Bluetooth. The exact port occupation and field wiring of a particular station are not established.",
+        "publicationBoundary": "This public view records device roles, connection media, evidence scope, and isolation controls. It intentionally excludes IP addresses, credentials, keys, access codes, APNs, SIM identifiers, serial numbers, and site-specific routing details.",
+        "configurations": [
+          {
+            "id": "clearaccess-certified-boundary",
+            "title": "Certified station boundary and local peripherals",
+            "evidenceLayer": "expected",
+            "assertionScope": "certified_configuration",
+            "knowledgeStatus": "documented_partial",
+            "topologyKind": "standalone_local_peripherals",
+            "description": "ClearAccess is represented as a touchscreen ballot-marking station with a ballot printer and accessibility inputs. The reviewed sources support local peripheral relationships and a product-level communications boundary, not a field-observed network.",
+            "observedOn": null,
+            "assertedFor": null,
+            "nodes": [
+              {
+                "id": "clearaccess-station",
+                "label": "ClearAccess station",
+                "role": "Ballot-marking workstation",
+                "componentId": "clearaccess-touchscreen-computer",
+                "optional": false,
+                "details": "Certified alternatives include named all-in-one touchscreen computers running ClearAccess software."
+              },
+              {
+                "id": "clearaccess-printer",
+                "label": "Ballot printer",
+                "role": "Local paper-ballot output",
+                "componentId": "clearaccess-ballot-printer",
+                "optional": false,
+                "details": "The printer is a local ClearAccess peripheral; the selected certified model and occupied connector are jurisdiction-specific."
+              },
+              {
+                "id": "clearaccess-accessibility",
+                "label": "Accessibility inputs",
+                "role": "Local voter input and audio accessories",
+                "componentId": "clearaccess-accessible-keypad",
+                "optional": false,
+                "details": "The dossier separately identifies the accessible keypad and other assistive accessories."
+              }
+            ],
+            "links": [
+              {
+                "id": "clearaccess-print-link",
+                "from": "clearaccess-station",
+                "to": "clearaccess-printer",
+                "medium": "Local wired peripheral connection",
+                "direction": "one_way",
+                "purpose": "Print the voter-reviewed paper ballot",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "clearaccess-input-link",
+                "from": "clearaccess-accessibility",
+                "to": "clearaccess-station",
+                "medium": "Local assistive-device connection",
+                "direction": "one_way",
+                "purpose": "Provide accessible navigation and selection input",
+                "knowledgeStatus": "documented_partial"
+              }
+            ],
+            "controls": [
+              {
+                "id": "clearaccess-communications-boundary",
+                "label": "Manufacturer communications boundary",
+                "status": "documented",
+                "description": "Clear Ballot states that certified products are never attached to modems, the Internet, Wi-Fi, or Bluetooth."
+              },
+              {
+                "id": "clearaccess-field-port-state",
+                "label": "Field port state",
+                "status": "not_publicly_established",
+                "description": "The exact enabled interfaces, occupied connectors, and jurisdiction cabling were not established by the reviewed public record."
+              }
+            ],
+            "sensitiveDetailsWithheld": "No addresses, credentials, cryptographic material, access codes, or site-specific configuration values are collected or displayed.",
+            "sourceIds": [
+              "eac-clearvote-25-scope",
+              "clearballot-security"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19",
+              "clearballot-security@2026-07-21"
+            ],
+            "caveat": "A product-level communications policy and a certified component list do not prove the state of a particular port, cable, station, polling place, or election deployment."
+          }
+        ],
+        "sourceImages": [
+          {
+            "id": "clearaccess-clearvote-25-system-diagrams",
+            "assetUrl": "/equipment/network-evidence/clearvote-25-system-diagrams.png",
+            "assetSha256": "8e4edb8e355984e09c36431fc82177554cd94371554c023030dcdbf22e893c07",
+            "width": 1148,
+            "height": 1485,
+            "kind": "source_topology_diagram",
+            "alt": "ClearVote 2.5 certification page showing system components and relationships, including ClearAccess, ClearCount, ClearCast, and ClearDesign.",
+            "caption": "ClearVote 2.5 system components and component-relationship diagrams",
+            "pageOrSection": "EAC scope PDF page 8, document page 6",
+            "derivativeNote": "Rendered from the archived official PDF at 135 DPI; the source page content was not edited.",
+            "caveat": "The suite-level diagram shows product and data relationships. It is not a cable map and does not establish that ClearAccess is attached to a network in a field deployment.",
+            "sourceIds": [
+              "eac-clearvote-25-scope"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19"
+            ]
+          }
+        ],
+        "gaps": [
+          {
+            "id": "clearaccess-port-map-gap",
+            "label": "Exact port and cable map",
+            "description": "The reviewed ClearVote 2.5 public certification attachments do not provide an installation-specific ClearAccess port-occupation or cable-routing record.",
+            "sourceIds": [
+              "eac-clearvote-25-scope"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19"
+            ],
+            "caveat": "This is a public-evidence gap, not evidence that an undocumented connection exists."
+          },
+          {
+            "id": "clearaccess-field-network-gap",
+            "label": "Field-observed configuration",
+            "description": "No dated, unit-level or polling-place network inspection was collected for this dossier.",
+            "sourceIds": [
+              "eac-clearvote-25-scope",
+              "clearballot-security"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19",
+              "clearballot-security@2026-07-21"
+            ],
+            "caveat": "Certified and manufacturer evidence must not be presented as a live observation."
+          }
+        ]
+      },
+      "deployments": [],
+      "scene": {
+        "assetUrl": "/equipment/clear-ballot-clearvote-25-clearaccess/orthographic-pilot.glb",
+        "assetLicense": "Apache-2.0",
+        "assetAttribution": "Original CivicResultMaps schematic generated from scripts/build-clearaccess-model.mjs",
+        "geometryFidelity": "illustrative_not_to_scale",
+        "description": "An original, photo-informed navigational schematic using Clear Ballot's portrait Elo ClearAccess product image as the external reference, with separately source-supported printer, UPS, keypad, scanner, and accessibility components.",
+        "referenceConfiguration": "Portrait Elo ClearAccess product-photo configuration with accessible keypad and headphones; printer and external UPS shown as certified alternative categories",
+        "referenceSourceIds": [
+          "clearballot-clearaccess-product-page",
+          "clearballot-clearaccess-reference-photo",
+          "eac-clearvote-25-scope",
+          "provv-clearvote-25-test-plan"
+        ],
+        "referenceSourceRevisionIds": [
+          "clearballot-clearaccess-product-page@2026-07-20",
+          "clearballot-clearaccess-reference-photo@2026-07-20",
+          "eac-clearvote-25-scope@2026-07-19",
+          "provv-clearvote-25-test-plan@2026-07-19"
+        ],
+        "referenceNote": "The touchscreen, keypad, and headphone silhouette follows the official product image. The image does not establish which Elo model is pictured, and the printer, UPS, port locations, cabling, and explosion paths remain illustrative.",
+        "referenceImages": [
+          {
+            "id": "clearaccess-official-product-photo",
+            "assetUrl": "/equipment/clear-ballot-clearvote-25-clearaccess/reference-clearaccess.png",
+            "assetSha256": "baed0a3acf052caf79bafb84b87787bb974115b1203640e7ec27b0c9bbef6a0e",
+            "width": 2000,
+            "height": 1500,
+            "alt": "ClearAccess portrait touchscreen shown with headphones and an accessible tactile keypad",
+            "caption": "Manufacturer product image: ClearAccess touchscreen, headphones, and accessible keypad.",
+            "kind": "manufacturer_product_photo",
+            "sourceIds": [
+              "clearballot-clearaccess-reference-photo"
+            ],
+            "sourceRevisionIds": [
+              "clearballot-clearaccess-reference-photo@2026-07-20"
+            ],
+            "pageOrSection": "ClearAccessStormKeypad product image",
+            "derivativeNote": "Exact local copy of the archived manufacturer image; no crop or content alteration.",
+            "caveat": "External appearance reference only; the image does not establish the pictured Elo model, certified component alternatives, printer, UPS, port occupation, or a particular fielded setup."
+          }
+        ],
+        "camera": {
+          "position": [
+            7,
+            5,
+            8
+          ],
+          "zoom": 72,
+          "near": 0.1,
+          "far": 100
+        },
+        "nodes": [
+          {
+            "componentId": "clearaccess-software",
+            "nodeName": "ClearAccess_Software",
+            "color": "#33c6b5",
+            "explodedOffset": [
+              0,
+              0.3,
+              0.65
+            ]
+          },
+          {
+            "componentId": "clearaccess-touchscreen-computer",
+            "nodeName": "Touchscreen_AIO",
+            "color": "#78a6ff",
+            "explodedOffset": [
+              0,
+              0.75,
+              0
+            ]
+          },
+          {
+            "componentId": "clearaccess-ballot-printer",
+            "nodeName": "Ballot_Printer",
+            "color": "#f0b95a",
+            "explodedOffset": [
+              1.2,
+              0.25,
+              0.25
+            ]
+          },
+          {
+            "componentId": "clearaccess-ups",
+            "nodeName": "External_UPS",
+            "color": "#e87fb3",
+            "explodedOffset": [
+              -1.15,
+              -0.15,
+              0.2
+            ]
+          },
+          {
+            "componentId": "clearaccess-accessible-keypad",
+            "nodeName": "Accessible_Keypad",
+            "color": "#d1e8e5",
+            "explodedOffset": [
+              0.7,
+              -0.25,
+              0.75
+            ]
+          },
+          {
+            "componentId": "clearaccess-barcode-scanner",
+            "nodeName": "Barcode_Scanner",
+            "color": "#ff8c69",
+            "explodedOffset": [
+              -0.7,
+              0.3,
+              0.75
+            ]
+          },
+          {
+            "componentId": "clearaccess-assistive-accessories",
+            "nodeName": "Assistive_Accessories",
+            "color": "#a68cf2",
+            "explodedOffset": [
+              -1.1,
+              0.8,
+              0.5
+            ]
+          },
+          {
+            "componentId": "clearaccess-esd-emi-controls",
+            "nodeName": "ESD_EMI_Controls",
+            "color": "#ef6f6c",
+            "explodedOffset": [
+              0,
+              1.15,
+              -0.25
+            ]
+          },
+          {
+            "componentId": "clearaccess-transport-case",
+            "nodeName": "Setup_Case",
+            "color": "#53676d",
+            "explodedOffset": [
+              0,
+              -0.85,
+              -0.6
+            ]
+          }
+        ]
+      },
+      "caveats": [
+        "Certified component alternatives are not evidence that all listed options are installed together or that a jurisdiction selected a particular model.",
+        "The 3D reference follows an official ClearAccess product photo but remains a selection aid, not vendor CAD, a teardown, a wiring diagram, or proof of exact dimensions and internal placement.",
+        "The UPS models are confirmed configuration options, but capacity, load-specific runtime, maintenance condition, and field topology remain unknown.",
+        "Test findings are time- and version-scoped. They do not prove a field incident, exploitation, altered votes, fraud, misconduct, or an incorrect election outcome."
+      ],
+      "claimRevision": 5,
+      "editorialState": "published",
+      "sourceIds": [
+        "clearballot-clearaccess-product-page",
+        "clearballot-clearaccess-reference-photo",
+        "clearballot-security",
+        "dell-optiplex-5250-specifications",
+        "eac-clearvote-25-record",
+        "eac-clearvote-25-scope",
+        "provv-clearvote-25-test-plan",
+        "provv-clearvote-25-test-report"
+      ],
+      "sourceRevisionIds": [
+        "clearballot-clearaccess-product-page@2026-07-20",
+        "clearballot-clearaccess-reference-photo@2026-07-20",
+        "clearballot-security@2026-07-21",
+        "dell-optiplex-5250-specifications@2026-07-20",
+        "eac-clearvote-25-record@2026-07-19",
+        "eac-clearvote-25-scope@2026-07-19",
+        "provv-clearvote-25-test-plan@2026-07-19",
+        "provv-clearvote-25-test-report@2026-07-19"
+      ],
+      "coverage": {
+        "componentCount": 9,
+        "sourcedComponentCount": 9,
+        "technicalSpecificationCount": 8,
+        "establishedTechnicalSpecificationCount": 6,
+        "unknownTechnicalSpecificationCount": 2,
+        "configurationChangeCount": 3,
+        "deploymentObservationCount": 0,
+        "findingCount": 4,
+        "powerRecordCount": 1,
+        "confirmedPowerRecordCount": 1,
+        "sourceCount": 8,
+        "sourceRevisionCount": 8,
+        "componentSecurityReviewCount": 0,
+        "exactApplicableVulnerabilityCount": 0,
+        "nonCveAdvisoryCount": 0,
+        "networkConfigurationCount": 1,
+        "networkSourceImageCount": 1,
+        "fieldObservedNetworkConfigurationCount": 0
+      }
+    },
+    {
+      "id": "clear-ballot-clearvote-25-clearcount",
+      "slug": "clear-ballot-clearvote-25-clearcount",
+      "status": "pilot",
+      "manufacturer": "Clear Ballot Group",
+      "systemName": "ClearVote",
+      "systemVersion": "2.5",
+      "deviceName": "ClearCount",
+      "displayName": "Clear Ballot ClearVote 2.5 / ClearCount",
+      "deviceRole": "Central-count scanning, tabulation, adjudication, and reporting system",
+      "summary": "A separate source-linked dossier for the ClearCount 2.5 central-count system, which uses a CountServer, ScanStations paired with certified COTS scanners, CountStations, a closed wired network, and an external UPS.",
+      "certification": {
+        "certificationId": "CBG-CV-25",
+        "standard": "VVSG 1.0",
+        "certifiedOn": "2025-11-19",
+        "vstl": "Pro V&V, Inc.",
+        "scopeKind": "certified_configuration",
+        "sourceIds": [
+          "eac-clearvote-25-record",
+          "eac-clearvote-25-scope",
+          "provv-clearvote-25-test-report"
+        ],
+        "sourceRevisionIds": [
+          "eac-clearvote-25-record@2026-07-19",
+          "eac-clearvote-25-scope@2026-07-19",
+          "provv-clearvote-25-test-report@2026-07-19"
+        ],
+        "caveat": "EAC certification applies only to the evaluated ClearVote 2.5 certified configuration. It does not establish which COTS alternatives a jurisdiction selected, their present condition, or the configuration of a particular installation."
+      },
+      "components": [
+        {
+          "id": "clearcount-application",
+          "name": "ClearCount tabulation application",
+          "category": "tabulation_software",
+          "description": "ClearCount provides central-count ballot tabulation, image processing, adjudication, election reporting, and consolidation of supported precinct-tabulator results.",
+          "evidenceStatus": "certified_component",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [
+            "clearcount-certified-version-258"
+          ],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan",
+            "clearballot-clearcount-product-page"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19",
+            "clearballot-clearcount-product-page@2026-07-20"
+          ],
+          "sceneNodeName": "ClearCount_Application",
+          "caveat": "The certified version is not a field reading. The schematic screen is symbolic and does not reproduce a proprietary user interface.",
+          "technicalSpecifications": [
+            {
+              "id": "clearcount-certified-software-258",
+              "category": "software",
+              "label": "Certified ClearCount version",
+              "value": "2.5.8",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "ClearVote 2.5 certified configuration",
+              "sourceIds": [
+                "eac-clearvote-25-scope"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19"
+              ],
+              "caveat": "This is the certified software version in the federal scope, not a field-observed installation."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "clearcount-central-scanner",
+          "name": "Central-count COTS scanner",
+          "category": "central_scanner",
+          "description": "One supported commercial scanner is paired with each ScanStation to capture ballot images for ClearCount tabulation.",
+          "evidenceStatus": "certified_alternatives",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Fujitsu fi-6400",
+            "Fujitsu fi-6800",
+            "Fujitsu fi-7180",
+            "Fujitsu/Ricoh fi-7800",
+            "Fujitsu/Ricoh fi-7600",
+            "Fujitsu/Ricoh fi-7900",
+            "Ricoh fi-8950"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan",
+            "clearballot-clearcount-reference-photo"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19",
+            "clearballot-clearcount-reference-photo@2026-07-20"
+          ],
+          "sceneNodeName": "ClearCount_Central_Scanner",
+          "caveat": "The certified list contains alternatives, not a requirement to use all models. The manufacturer photo does not identify its pictured scanner, so the schematic depicts only a generic photo-informed central-scanner form.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "clearcount-scanstation",
+          "name": "ScanStation computer",
+          "category": "workstation",
+          "description": "A Windows laptop or desktop ScanStation runs an instance of the Tabulator application and controls its paired scanner.",
+          "evidenceStatus": "certified_alternatives",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Dell OptiPlex XE4 SFF",
+            "Dell Latitude 5580",
+            "Dell Latitude 5590",
+            "Dell Latitude 5500",
+            "Dell Latitude 5511",
+            "Dell Latitude 5521",
+            "Dell Latitude 5540",
+            "Dell Latitude 5550",
+            "Lenovo ThinkPad E14 G-series"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "sceneNodeName": "ClearCount_ScanStation",
+          "caveat": "These are certified COTS alternatives. The source does not establish which model, processor, memory, storage, or connector occupation exists at a particular installation.",
+          "technicalSpecifications": [
+            {
+              "id": "clearcount-scanstation-os",
+              "category": "operating_system",
+              "label": "ScanStation operating system",
+              "value": "Windows 10 IoT Enterprise LTSC 2021",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "ClearCount 2.5 ScanStation",
+              "sourceIds": [
+                "eac-clearvote-25-scope"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19"
+              ],
+              "caveat": "The scope identifies the certified operating-system platform, not the patch state or field configuration of a particular workstation."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "clearcount-countserver",
+          "name": "CountServer",
+          "category": "server",
+          "description": "The CountServer hosts the ClearCount election database, web server, shared application files, and reports for connected client stations.",
+          "evidenceStatus": "certified_alternatives",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Dell PowerEdge T140",
+            "Dell PowerEdge T150",
+            "Dell PowerEdge R440",
+            "Dell PowerEdge R450",
+            "Dell PowerEdge T440"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "sceneNodeName": "ClearCount_CountServer",
+          "caveat": "The certified alternatives do not establish the selected model, installed processor, memory, storage, or current patch state in a jurisdiction.",
+          "technicalSpecifications": [
+            {
+              "id": "clearcount-server-os",
+              "category": "operating_system",
+              "label": "CountServer platform",
+              "value": "Ubuntu 20.04.5 LTS",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "ClearCount 2.5 CountServer",
+              "sourceIds": [
+                "eac-clearvote-25-scope"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19"
+              ],
+              "caveat": "This is the certified platform listed for ClearCount 2.5, not a field patch-level observation."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "clearcount-countstation",
+          "name": "CountStation",
+          "category": "workstation",
+          "description": "A CountStation is a client computer used to administer ClearCount and review reports and ballot images.",
+          "evidenceStatus": "certified_alternatives",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Dell OptiPlex XE3 SFF",
+            "Dell OptiPlex XE4 SFF",
+            "Dell Latitude 5580",
+            "Dell Latitude 5590",
+            "Dell Latitude 5500",
+            "Dell Latitude 5511",
+            "Dell Latitude 5521",
+            "Dell Latitude 5540",
+            "Dell Latitude 5550",
+            "Lenovo ThinkPad E14 G-series"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "sceneNodeName": "ClearCount_CountStation",
+          "caveat": "The schematic uses a generic monitor-and-stand form. It does not identify which certified desktop or laptop alternative is installed.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "clearcount-network-switch",
+          "name": "Closed-network Ethernet switch",
+          "category": "network",
+          "description": "Certified switch alternatives connect ScanStations and CountStations to the CountServer on a wired, closed, isolated Ethernet network.",
+          "evidenceStatus": "certified_alternatives",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Cisco SG250-08-K9-NA",
+            "Cisco SG250-26-K9-NA",
+            "Cisco 1300-8T-E-2G",
+            "Cisco CBS350-8T-E-2G-NA",
+            "Cisco CBS350-24T-4G-NA",
+            "NetGear FVS318G",
+            "TRENDnet TEG-S80G",
+            "TP-Link TL-SG108E",
+            "TP-Link TL-R600VPN"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19"
+          ],
+          "sceneNodeName": "ClearCount_Network_Switch",
+          "caveat": "The certified scope describes a closed isolated network. Connector occupation, switch configuration, field cabling, and jurisdiction selection are not established.",
+          "technicalSpecifications": [
+            {
+              "id": "clearcount-closed-ethernet-network",
+              "category": "ethernet",
+              "label": "Certified network architecture",
+              "value": "Wired, closed Ethernet network isolated from other systems and the Internet",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "ClearCount 2.5 client/server architecture",
+              "sourceIds": [
+                "eac-clearvote-25-scope"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19"
+              ],
+              "caveat": "This describes the evaluated architecture, not proof of a particular field installation or a claim about every physical port."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "clearcount-ups",
+          "name": "External uninterruptible power supply",
+          "category": "power",
+          "description": "The certified ClearCount hardware table names an APC Smart-UPS alternative.",
+          "evidenceStatus": "certified_component",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "APC SMT-1500C"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-clearvote-25-scope"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19"
+          ],
+          "sceneNodeName": "ClearCount_UPS",
+          "caveat": "The scope names the UPS model but does not publish a ClearCount workload runtime, battery condition, or jurisdiction selection.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        }
+      ],
+      "versionObservations": [
+        {
+          "id": "clearcount-certified-version-258",
+          "componentId": "clearcount-application",
+          "label": "Certified software",
+          "value": "ClearCount 2.5.8",
+          "assertionScope": "certified",
+          "fieldStatus": "not_established",
+          "observedOn": "2025-11-19",
+          "sourceIds": [
+            "eac-clearvote-25-scope"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19"
+          ],
+          "caveat": "This is the version in the certified configuration, not the software observed on a jurisdiction workstation."
+        }
+      ],
+      "configurationChanges": [
+        {
+          "id": "clearcount-backside-card-change",
+          "changeId": "SW-11911 / SW-11928",
+          "componentIds": [
+            "clearcount-application"
+          ],
+          "submittedOn": "2024-08-02",
+          "eacApprovedOn": "2025-11-19",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "included_in_certified_25_configuration",
+          "description": "The ClearVote 2.5 modification list records corrections so the ballot tabulator properly handles a card with contests only on its back side.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "caveat": "This is certification configuration history. It does not establish a field occurrence, election impact, or update date for any jurisdiction."
+        }
+      ],
+      "findings": [
+        {
+          "id": "clearcount-backside-card-tabulation-fix",
+          "findingType": "certification_change_note",
+          "title": "Back-side-only contest card tabulation correction",
+          "affectedSystemVersions": [
+            "ClearCount before certified 2.5.8"
+          ],
+          "componentIds": [
+            "clearcount-application"
+          ],
+          "publicStatus": "correction_included_in_certified_2_5",
+          "description": "The submitted modification list identifies a correction for cards with contests only on the back side.",
+          "sourceIds": [
+            "eac-clearvote-25-scope",
+            "provv-clearvote-25-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19",
+            "provv-clearvote-25-test-plan@2026-07-19"
+          ],
+          "caveat": "The record does not quantify occurrence, identify a fielded version, or establish an effect on a certified election result."
+        }
+      ],
+      "power": [
+        {
+          "id": "clearcount-certified-ups",
+          "componentId": "clearcount-ups",
+          "knowledgeStatus": "documented_partial",
+          "supplyType": "external uninterruptible power supply",
+          "manufacturer": "APC",
+          "model": "SMT-1500C",
+          "capacity": null,
+          "runtime": null,
+          "description": "The certified hardware table names the APC SMT-1500C for ClearCount but does not state a ClearCount load-specific runtime.",
+          "sourceIds": [
+            "eac-clearvote-25-scope"
+          ],
+          "sourceRevisionIds": [
+            "eac-clearvote-25-scope@2026-07-19"
+          ],
+          "caveat": "A certified option is not evidence that every installation uses it or that a field battery retains its original capacity."
+        }
+      ],
+      "networkEvidence": {
+        "reviewedOn": "2026-07-21",
+        "summary": "The ClearVote 2.5 EAC scope documents ClearCount as a wired, closed, isolated Ethernet system linking the CountServer, ScanStations, and CountStations through a certified switch alternative. COTS scanners attach to ScanStations; field cabling and switch settings remain installation-specific.",
+        "publicationBoundary": "The module publishes only source-supported roles, media, direction, and isolation controls. It excludes IP addressing, credentials, keys, switch-management values, VLAN details, hostnames, serial numbers, and site diagrams.",
+        "configurations": [
+          {
+            "id": "clearcount-certified-closed-lan",
+            "title": "Certified closed wired ClearCount LAN",
+            "evidenceLayer": "expected",
+            "assertionScope": "certified_configuration",
+            "knowledgeStatus": "confirmed",
+            "topologyKind": "closed_wired_lan",
+            "description": "One CountServer is shared by one or more ScanStations and CountStations over a network switch. Each COTS scanner is paired locally with a ScanStation, while tabulation results and card images are stored in the central election database on the CountServer.",
+            "observedOn": null,
+            "assertedFor": null,
+            "nodes": [
+              {
+                "id": "clearcount-scanner",
+                "label": "Central scanner",
+                "role": "Ballot image capture",
+                "componentId": "clearcount-central-scanner",
+                "optional": false,
+                "details": "A certified COTS scanner alternative is paired with each ScanStation."
+              },
+              {
+                "id": "clearcount-scanstation",
+                "label": "ScanStation",
+                "role": "Ballot scanning and tabulation client",
+                "componentId": "clearcount-scanstation",
+                "optional": false,
+                "details": "One or more Windows ScanStations execute the Tabulator application from the CountServer."
+              },
+              {
+                "id": "clearcount-switch",
+                "label": "Network switch",
+                "role": "Closed Ethernet interconnect",
+                "componentId": "clearcount-network-switch",
+                "optional": false,
+                "details": "The certified scope lists several permitted switch alternatives; jurisdiction selection is not established."
+              },
+              {
+                "id": "clearcount-server",
+                "label": "CountServer",
+                "role": "Election database and application host",
+                "componentId": "clearcount-countserver",
+                "optional": false,
+                "details": "The Ubuntu CountServer hosts ClearCount software, its database, and election reports."
+              },
+              {
+                "id": "clearcount-countstation",
+                "label": "CountStation",
+                "role": "Administration, adjudication, and reporting client",
+                "componentId": "clearcount-countstation",
+                "optional": false,
+                "details": "One or more browser-based CountStations connect to the CountServer through the switch."
+              }
+            ],
+            "links": [
+              {
+                "id": "clearcount-scanner-usb",
+                "from": "clearcount-scanner",
+                "to": "clearcount-scanstation",
+                "medium": "Local scanner interface / USB cabling",
+                "direction": "one_way",
+                "purpose": "Deliver captured ballot images to the paired ScanStation",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "clearcount-scanstation-ethernet",
+                "from": "clearcount-scanstation",
+                "to": "clearcount-switch",
+                "medium": "Wired Ethernet",
+                "direction": "bidirectional",
+                "purpose": "Run the server-hosted tabulation workflow and send results and card images",
+                "knowledgeStatus": "confirmed"
+              },
+              {
+                "id": "clearcount-server-ethernet",
+                "from": "clearcount-switch",
+                "to": "clearcount-server",
+                "medium": "Wired Ethernet",
+                "direction": "bidirectional",
+                "purpose": "Provide application, database, and report services to ClearCount clients",
+                "knowledgeStatus": "confirmed"
+              },
+              {
+                "id": "clearcount-countstation-ethernet",
+                "from": "clearcount-countstation",
+                "to": "clearcount-switch",
+                "medium": "Wired Ethernet",
+                "direction": "bidirectional",
+                "purpose": "Provide administration, adjudication, consolidation, and reporting access",
+                "knowledgeStatus": "confirmed"
+              }
+            ],
+            "controls": [
+              {
+                "id": "clearcount-isolation",
+                "label": "Closed and isolated",
+                "status": "documented",
+                "description": "The exact 2.5 scope says the ClearCount network is not connected to other systems or the Internet."
+              },
+              {
+                "id": "clearcount-no-wireless-modem",
+                "label": "No modem or wireless attachment",
+                "status": "documented",
+                "description": "Clear Ballot's current security policy says certified products are never attached to modems, Wi-Fi, or Bluetooth."
+              },
+              {
+                "id": "clearcount-encrypted-traffic",
+                "label": "Encrypted traffic policy",
+                "status": "documented",
+                "description": "The manufacturer states that traffic on its certified-product closed network is encrypted using NIST-recommended algorithms."
+              }
+            ],
+            "sensitiveDetailsWithheld": "No addresses, credentials, cryptographic material, hostnames, switch settings, VLANs, or site-specific cable routes are collected or shown.",
+            "sourceIds": [
+              "eac-clearvote-25-scope",
+              "provv-clearvote-25-test-plan",
+              "clearballot-security"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19",
+              "provv-clearvote-25-test-plan@2026-07-19",
+              "clearballot-security@2026-07-21"
+            ],
+            "caveat": "This is the certified architecture, not proof that a jurisdiction selected every alternative, used the maximum number of stations, or installed a particular switch or cabling layout."
+          }
+        ],
+        "sourceImages": [
+          {
+            "id": "clearcount-clearvote-25-system-diagrams",
+            "assetUrl": "/equipment/network-evidence/clearvote-25-system-diagrams.png",
+            "assetSha256": "8e4edb8e355984e09c36431fc82177554cd94371554c023030dcdbf22e893c07",
+            "width": 1148,
+            "height": 1485,
+            "kind": "source_topology_diagram",
+            "alt": "ClearVote 2.5 certification diagram showing the CountServer, network switch, ScanStations and scanners, and CountStation within the ClearCount product area.",
+            "caption": "ClearVote 2.5 system diagram with the ClearCount server, switch, and station topology",
+            "pageOrSection": "EAC scope PDF page 8, document page 6",
+            "derivativeNote": "Rendered from the archived official PDF at 135 DPI; the source page content was not edited.",
+            "caveat": "The diagram establishes certified system relationships, not the number, placement, make, port assignment, or operational state of equipment at a particular site.",
+            "sourceIds": [
+              "eac-clearvote-25-scope"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19"
+            ]
+          },
+          {
+            "id": "clearcount-clearvote-25-network-scope-page",
+            "assetUrl": "/equipment/network-evidence/clearvote-25-clearcount-scope.png",
+            "assetSha256": "54f2a8bd74f88c865245fdea2183943e9f074225e73a690aef1b6622de2465d0",
+            "width": 1148,
+            "height": 1485,
+            "kind": "source_document_page",
+            "alt": "ClearVote 2.5 certification scope page describing ClearCount as a wired, closed, isolated network with CountServer, ScanStations, network switch, and CountStations.",
+            "caption": "Exact ClearVote 2.5 scope text for the ClearCount closed Ethernet architecture",
+            "pageOrSection": "EAC scope PDF page 5, document page 3",
+            "derivativeNote": "Rendered from the archived official PDF at 135 DPI; the source page content was not edited.",
+            "caveat": "The page is a certification description and does not document a jurisdiction's live switch configuration or cable installation.",
+            "sourceIds": [
+              "eac-clearvote-25-scope"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19"
+            ]
+          }
+        ],
+        "gaps": [
+          {
+            "id": "clearcount-switch-config-gap",
+            "label": "Switch and addressing configuration",
+            "description": "The reviewed public package does not establish selected switch model, port occupation, addressing, management settings, cable routes, or the number of active stations for a jurisdiction.",
+            "sourceIds": [
+              "eac-clearvote-25-scope",
+              "provv-clearvote-25-test-plan"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19",
+              "provv-clearvote-25-test-plan@2026-07-19"
+            ],
+            "caveat": "Those details require a dated jurisdiction record or authorized inspection and should not be inferred from the certified alternatives."
+          },
+          {
+            "id": "clearcount-field-observation-gap",
+            "label": "Field-observed topology",
+            "description": "No dated jurisdiction installation diagram, network inventory, or unit-level observation was collected for this dossier.",
+            "sourceIds": [
+              "eac-clearvote-25-scope"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19"
+            ],
+            "caveat": "Absence of field evidence is reported as a gap, not as a claim about actual operation."
+          }
+        ]
+      },
+      "deployments": [],
+      "scene": {
+        "assetUrl": "/equipment/clear-ballot-clearvote-25-clearcount/orthographic-pilot.glb",
+        "assetLicense": "Apache-2.0",
+        "assetAttribution": "Original CivicResultMaps schematic generated from scripts/build-tabulator-models.mjs",
+        "geometryFidelity": "illustrative_not_to_scale",
+        "description": "An original photo-informed schematic of a ClearCount central scanner with separate ScanStation, CountServer, CountStation, closed-network switch, and UPS categories.",
+        "referenceConfiguration": "ClearCount COTS scanner and laptop form, with certified server, workstation, switch, and UPS categories shown separately",
+        "referenceSourceIds": [
+          "clearballot-clearcount-product-page",
+          "clearballot-clearcount-reference-photo",
+          "eac-clearvote-25-scope",
+          "provv-clearvote-25-test-plan"
+        ],
+        "referenceSourceRevisionIds": [
+          "clearballot-clearcount-product-page@2026-07-20",
+          "clearballot-clearcount-reference-photo@2026-07-20",
+          "eac-clearvote-25-scope@2026-07-19",
+          "provv-clearvote-25-test-plan@2026-07-19"
+        ],
+        "referenceNote": "The scanner outline follows the manufacturer photo. Other components follow certified categories; exact alternatives, dimensions, cabling, connector occupation, and placement are illustrative.",
+        "referenceImages": [
+          {
+            "id": "clearcount-manufacturer-scanner-setup",
+            "assetUrl": "/equipment/clear-ballot-clearvote-25-clearcount/reference-clearcount-setup.png",
+            "assetSha256": "2e1bef8928cf11a8cfdc945ca6fbdec9f644f7c30b936fc72c81b45fddce4975",
+            "width": 1280,
+            "height": 853,
+            "alt": "ClearCount central scanner with an open paper path, output ballots, and a laptop mounted above it",
+            "caption": "Manufacturer photograph of a ClearCount scanner-and-laptop arrangement.",
+            "kind": "manufacturer_product_photo",
+            "sourceIds": [
+              "clearballot-clearcount-reference-photo"
+            ],
+            "sourceRevisionIds": [
+              "clearballot-clearcount-reference-photo@2026-07-20"
+            ],
+            "pageOrSection": "ClearCount hero product photograph",
+            "derivativeNote": "Local PNG conversion resized from the archived 2000 x 1333 manufacturer JPEG to 1280 x 853; no crop or content alteration.",
+            "caveat": "The photo does not identify the pictured COTS models or establish that they are the alternatives selected for a ClearVote 2.5 certified or fielded installation."
+          }
+        ],
+        "camera": {
+          "position": [
+            7,
+            5.5,
+            8
+          ],
+          "zoom": 64,
+          "near": 0.1,
+          "far": 100
+        },
+        "nodes": [
+          {
+            "componentId": "clearcount-central-scanner",
+            "nodeName": "ClearCount_Central_Scanner",
+            "color": "#d4d9d8",
+            "explodedOffset": [
+              0,
+              0.55,
+              0
+            ]
+          },
+          {
+            "componentId": "clearcount-scanstation",
+            "nodeName": "ClearCount_ScanStation",
+            "color": "#657478",
+            "explodedOffset": [
+              0,
+              1.25,
+              -0.6
+            ]
+          },
+          {
+            "componentId": "clearcount-application",
+            "nodeName": "ClearCount_Application",
+            "color": "#78a6ff",
+            "explodedOffset": [
+              0,
+              1.55,
+              0.2
+            ]
+          },
+          {
+            "componentId": "clearcount-countserver",
+            "nodeName": "ClearCount_CountServer",
+            "color": "#344247",
+            "explodedOffset": [
+              -1.35,
+              0.2,
+              0
+            ]
+          },
+          {
+            "componentId": "clearcount-countstation",
+            "nodeName": "ClearCount_CountStation",
+            "color": "#33c6b5",
+            "explodedOffset": [
+              1.45,
+              0.4,
+              0
+            ]
+          },
+          {
+            "componentId": "clearcount-network-switch",
+            "nodeName": "ClearCount_Network_Switch",
+            "color": "#33c6b5",
+            "explodedOffset": [
+              -1.2,
+              -0.7,
+              0.6
+            ]
+          },
+          {
+            "componentId": "clearcount-ups",
+            "nodeName": "ClearCount_UPS",
+            "color": "#e87fb3",
+            "explodedOffset": [
+              1.2,
+              -0.65,
+              -0.2
+            ]
+          }
+        ]
+      },
+      "caveats": [
+        "ClearCount is a system of COTS scanners, computers, server software, network equipment, and power equipment; it is not one proprietary enclosure.",
+        "Certified alternatives are listed separately and must not be read as an instruction to combine every option.",
+        "The 3D scene is a navigation aid, not a wiring diagram, teardown, exact installation, or claim about a jurisdiction's selected hardware.",
+        "A certification change or test finding is not evidence of field occurrence, misconduct, exploitation, or an election outcome effect."
+      ],
+      "claimRevision": 3,
+      "editorialState": "published",
+      "sourceIds": [
+        "clearballot-clearcount-product-page",
+        "clearballot-clearcount-reference-photo",
+        "clearballot-security",
+        "eac-clearvote-25-record",
+        "eac-clearvote-25-scope",
+        "provv-clearvote-25-test-plan",
+        "provv-clearvote-25-test-report"
+      ],
+      "sourceRevisionIds": [
+        "clearballot-clearcount-product-page@2026-07-20",
+        "clearballot-clearcount-reference-photo@2026-07-20",
+        "clearballot-security@2026-07-21",
+        "eac-clearvote-25-record@2026-07-19",
+        "eac-clearvote-25-scope@2026-07-19",
+        "provv-clearvote-25-test-plan@2026-07-19",
+        "provv-clearvote-25-test-report@2026-07-19"
+      ],
+      "coverage": {
+        "componentCount": 7,
+        "sourcedComponentCount": 7,
+        "technicalSpecificationCount": 4,
+        "establishedTechnicalSpecificationCount": 4,
+        "unknownTechnicalSpecificationCount": 0,
+        "configurationChangeCount": 1,
+        "deploymentObservationCount": 0,
+        "findingCount": 1,
+        "powerRecordCount": 1,
+        "confirmedPowerRecordCount": 1,
+        "sourceCount": 7,
+        "sourceRevisionCount": 7,
+        "componentSecurityReviewCount": 0,
+        "exactApplicableVulnerabilityCount": 0,
+        "nonCveAdvisoryCount": 0,
+        "networkConfigurationCount": 1,
+        "networkSourceImageCount": 2,
+        "fieldObservedNetworkConfigurationCount": 0
+      }
+    },
+    {
+      "id": "dominion-democracy-suite-517-imagecast-central",
+      "slug": "dominion-democracy-suite-517-imagecast-central",
+      "status": "pilot",
+      "manufacturer": "Dominion Voting Systems Corp.",
+      "systemName": "Democracy Suite",
+      "systemVersion": "5.17",
+      "deviceName": "ImageCast Central",
+      "displayName": "Dominion Democracy Suite 5.17 / ImageCast Central",
+      "deviceRole": "Central-count ballot scanning and tabulation system",
+      "summary": "A separate source-linked dossier for the ImageCast Central configuration: a certified COTS high-speed scanner, workstation, ICC application, removable-media accessories, optional isolated network infrastructure, and documented backup power.",
+      "certification": {
+        "certificationId": "DVS-DemSuite5.17",
+        "standard": "VVSG 1.0",
+        "certifiedOn": "2023-03-16",
+        "vstl": "Pro V&V, Inc.",
+        "scopeKind": "certified_configuration",
+        "sourceIds": [
+          "eac-dsuite-517-record",
+          "eac-dsuite-517-scope",
+          "provv-dsuite-517-test-report"
+        ],
+        "sourceRevisionIds": [
+          "eac-dsuite-517-record@2026-07-20",
+          "eac-dsuite-517-scope@2026-07-20",
+          "provv-dsuite-517-test-report@2026-07-20"
+        ],
+        "caveat": "EAC certification applies only to the evaluated Democracy Suite 5.17 certified configuration. It does not establish which scanner or workstation alternative a jurisdiction selected, the condition of a field unit, or an installation's network configuration."
+      },
+      "components": [
+        {
+          "id": "icc-central-scanner",
+          "name": "Central-count COTS scanner",
+          "category": "central_scanner",
+          "description": "ImageCast Central pairs one supported commercial high-speed scanner with the ICC workstation and ballot-processing application.",
+          "evidenceStatus": "certified_alternatives",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Canon DR-G2140",
+            "Canon DR-G1130",
+            "Canon DR-M160 II",
+            "Canon DR-M260",
+            "InoTec HiPro 821"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [
+            "icc-hipro-firmware-101074"
+          ],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-report",
+            "co-dvs-517-icc-user-guide"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20",
+            "co-dvs-517-icc-user-guide@2026-07-20"
+          ],
+          "sceneNodeName": "ICC_Central_Scanner",
+          "caveat": "These are certified alternatives, not components used together. The scene and gallery show representative scanner forms and do not identify the selected model at a jurisdiction.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "icc-workstation",
+          "name": "ICC client workstation",
+          "category": "workstation",
+          "description": "The ICC application runs on a certified desktop or all-in-one workstation paired with the selected scanner.",
+          "evidenceStatus": "certified_alternatives",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Dell Precision 3460 XE",
+            "Dell Precision 3450 XE",
+            "Dell Precision 3440 XE",
+            "Dell OptiPlex 5270 AIO",
+            "Dell OptiPlex 3050 AIO",
+            "Dell OptiPlex 7440 AIO",
+            "Dell OptiPlex 9030 AIO",
+            "Dell OptiPlex 9020 AIO",
+            "Dell OptiPlex 9010 AIO",
+            "Dell OptiPlex XE4",
+            "Dell OptiPlex XE3",
+            "Dell OptiPlex 7070",
+            "Dell OptiPlex 7060",
+            "Dell OptiPlex 7050"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "sceneNodeName": "ICC_Workstation",
+          "caveat": "Workstation alternatives vary by scanner configuration. The certification documents do not establish which processor, memory, storage, display, or connector occupation exists in a particular installation.",
+          "technicalSpecifications": [
+            {
+              "id": "icc-workstation-operating-system",
+              "category": "operating_system",
+              "label": "Certified workstation operating system",
+              "value": "Windows 10 Professional, 64-bit",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "Democracy Suite 5.17 ImageCast Central workstation",
+              "sourceIds": [
+                "eac-dsuite-517-scope",
+                "provv-dsuite-517-test-report"
+              ],
+              "sourceRevisionIds": [
+                "eac-dsuite-517-scope@2026-07-20",
+                "provv-dsuite-517-test-report@2026-07-20"
+              ],
+              "caveat": "This is the evaluated operating-system platform, not a live patch-level reading or evidence for a particular field workstation."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "icc-application",
+          "name": "ImageCast Central application",
+          "category": "software",
+          "description": "The proprietary ICC application controls ballot image capture, interpretation, batch acceptance, and central-count tabulation.",
+          "evidenceStatus": "certified_component",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [
+            "icc-certified-application-517151"
+          ],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "sceneNodeName": "ICC_Application",
+          "caveat": "The certified version is not a live field reading. The schematic screen is symbolic and does not reproduce a proprietary user interface.",
+          "technicalSpecifications": [
+            {
+              "id": "icc-certified-application-version",
+              "category": "software",
+              "label": "Certified ICC application",
+              "value": "5.17.15.1",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "Democracy Suite 5.17 ImageCast Central",
+              "sourceIds": [
+                "eac-dsuite-517-scope",
+                "provv-dsuite-517-test-report"
+              ],
+              "sourceRevisionIds": [
+                "eac-dsuite-517-scope@2026-07-20",
+                "provv-dsuite-517-test-report@2026-07-20"
+              ],
+              "caveat": "This is the application version in the final certified configuration, not a field-observed installation or a claim that it is the newest later release."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "icc-ibutton-reader",
+          "name": "iButton reader and adapter",
+          "category": "authentication_accessory",
+          "description": "Certified auxiliary hardware includes the Dallas Maxim iButton reader/writer and its 1-Wire USB adapter.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Dallas Maxim DS9490R#",
+            "Dallas Maxim DS1402-RP8+"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "sceneNodeName": "ICC_iButton_Reader",
+          "caveat": "The models are named auxiliary equipment. The source does not establish that the schematic location or cable arrangement matches a particular installation.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "icc-media-reader",
+          "name": "CompactFlash media reader",
+          "category": "removable_media",
+          "description": "Certified auxiliary hardware includes USB CompactFlash reader alternatives used with election media.",
+          "evidenceStatus": "certified_alternatives",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Lexar Professional USB 3.0 Dual-Slot Card Reader",
+            "Kingston USB 3.0 High-Speed Media Reader",
+            "Hoodman Steel USB3"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "sceneNodeName": "ICC_Media_Reader",
+          "caveat": "The listed readers are alternatives. Their presence, attached port, and media contents at a particular jurisdiction are not established.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "icc-optional-isolated-lan",
+          "name": "Optional isolated network infrastructure",
+          "category": "network",
+          "optionality": "optional",
+          "description": "Colorado's 5.17-CO guide calls for high-speed network infrastructure only when an additional central ballot scan repository or data center is used, and requires election computers to remain isolated from the Internet and other networks.",
+          "evidenceStatus": "documented_optional_model_component",
+          "scopeKind": "manufacturer_hardware_documentation",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "co-dvs-517-icc-user-guide"
+          ],
+          "sourceRevisionIds": [
+            "co-dvs-517-icc-user-guide@2026-07-20"
+          ],
+          "sceneNodeName": "ICC_Optional_Isolated_LAN",
+          "caveat": "This is a conditional 5.17-CO infrastructure requirement, not evidence that every ICC installation is networked or that any ICC is connected to the Internet.",
+          "technicalSpecifications": [
+            {
+              "id": "icc-optional-isolated-ethernet",
+              "category": "ethernet",
+              "label": "Conditional central-repository network",
+              "value": "100 Mbps infrastructure when an additional central repository/data center is used; isolated from the Internet and all other networks",
+              "knowledgeStatus": "documented_partial",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Colorado Democracy Suite 5.17-CO ImageCast Central",
+              "sourceIds": [
+                "co-dvs-517-icc-user-guide"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-icc-user-guide@2026-07-20"
+              ],
+              "caveat": "The guide states a conditional capability and isolation rule. It does not establish cabling, port occupation, enabled services, or field use elsewhere."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "icc-ups",
+          "name": "External uninterruptible power supply",
+          "category": "power",
+          "description": "Colorado's 5.17-CO guide identifies an approved APC UPS and a minimum backup duration for the central scanner and workstation.",
+          "evidenceStatus": "documented_model_family",
+          "scopeKind": "manufacturer_hardware_documentation",
+          "modelNumbers": [
+            "APC SMC1500 Smart-UPS"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "co-dvs-517-icc-user-guide"
+          ],
+          "sourceRevisionIds": [
+            "co-dvs-517-icc-user-guide@2026-07-20"
+          ],
+          "sceneNodeName": "ICC_UPS",
+          "caveat": "The guide establishes a Colorado-approved model and minimum operating requirement, not the battery age, health, or actual runtime at a particular site.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        }
+      ],
+      "versionObservations": [
+        {
+          "id": "icc-certified-application-517151",
+          "componentId": "icc-application",
+          "label": "Certified ICC application",
+          "value": "5.17.15.1",
+          "assertionScope": "certified",
+          "fieldStatus": "not_established",
+          "observedOn": "2023-03-16",
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "caveat": "This is the final certified application version, not a field reading or evidence of a jurisdiction's current installed version."
+        },
+        {
+          "id": "icc-hipro-firmware-101074",
+          "componentId": "icc-central-scanner",
+          "label": "Certified HiPro firmware support",
+          "value": "1.0.1074",
+          "assertionScope": "certified",
+          "fieldStatus": "not_established",
+          "observedOn": "2023-03-16",
+          "sourceIds": [
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "caveat": "This version applies only to the InoTec HiPro scanner alternative and is not a firmware claim for the Canon alternatives or a field-observed scanner."
+        }
+      ],
+      "configurationChanges": [
+        {
+          "id": "icc-hipro-firmware-support-change",
+          "changeId": "D-Suite 5.17 ICC HiPro support",
+          "componentIds": [
+            "icc-central-scanner",
+            "icc-application"
+          ],
+          "submittedOn": "2022-12-02",
+          "eacApprovedOn": "2023-03-16",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "included_in_certified_517_configuration",
+          "description": "The Pro V&V report records an ICC application update to support InoTec HiPro firmware version 1.0.1074.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "provv-dsuite-517-test-plan",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "provv-dsuite-517-test-plan@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "caveat": "This is certification configuration history. It does not establish that a jurisdiction selected the HiPro alternative or installed the firmware on a field scanner."
+        }
+      ],
+      "findings": [
+        {
+          "id": "icc-dsuite-517-test-campaign",
+          "findingType": "vstl_test_campaign_result",
+          "title": "No anomalies or deficiencies reported in the 5.17 certification campaign",
+          "affectedSystemVersions": [
+            "Democracy Suite 5.17 certified configuration"
+          ],
+          "componentIds": [
+            "icc-central-scanner",
+            "icc-workstation",
+            "icc-application"
+          ],
+          "publicStatus": "none_reported_in_test_campaign",
+          "description": "Pro V&V reported no anomalies and no deficiencies during the Democracy Suite 5.17 certification campaign; ICC accuracy and integration testing met the stated requirements.",
+          "sourceIds": [
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "caveat": "A bounded certification-test result is not evidence that every fielded unit is defect-free, and it is not a claim about later versions, operations, misconduct, or election outcomes."
+        }
+      ],
+      "power": [
+        {
+          "id": "icc-colorado-approved-ups",
+          "componentId": "icc-ups",
+          "knowledgeStatus": "confirmed",
+          "supplyType": "external uninterruptible power supply",
+          "manufacturer": "APC",
+          "model": "SMC1500 Smart-UPS",
+          "capacity": "900 W / 1500 VA",
+          "runtime": "Minimum 15 minutes required by the 5.17-CO guide",
+          "description": "The Colorado guide names the APC SMC1500 and requires enough backup power to complete and save a ballot batch before graceful shutdown.",
+          "sourceIds": [
+            "co-dvs-517-icc-user-guide"
+          ],
+          "sourceRevisionIds": [
+            "co-dvs-517-icc-user-guide@2026-07-20"
+          ],
+          "caveat": "The minimum is a documented Colorado configuration requirement, not a measured runtime or battery-health observation at a field installation."
+        }
+      ],
+      "networkEvidence": {
+        "reviewedOn": "2026-07-21",
+        "summary": "Colorado's exact 5.17-CO technical data connects the ImageCast Central scanner locally to an ICC workstation by USB and describes ICC workstations using a Gigabit Ethernet port on a closed LAN to the EMS data-center network. The ICC user guide makes additional central-repository infrastructure conditional and requires election computers to remain isolated from the Internet and other networks.",
+        "publicationBoundary": "This view publishes only the documented system roles, connection media, conditionality, and isolation controls. It omits addressing, credentials, database identifiers, cryptographic keys, switch settings, hostnames, and jurisdiction cable routes.",
+        "configurations": [
+          {
+            "id": "icc-517co-conditional-closed-lan",
+            "title": "ICC workstation with conditional closed data-center LAN",
+            "evidenceLayer": "expected",
+            "assertionScope": "state_certification_documentation",
+            "knowledgeStatus": "documented_partial",
+            "topologyKind": "conditional_closed_wired_lan",
+            "description": "A COTS scanner attaches directly to its ICC workstation. Where the additional central ballot-scan repository or data center is used, ICC workstations connect through isolated network infrastructure to EMS storage and services.",
+            "observedOn": null,
+            "assertedFor": null,
+            "nodes": [
+              {
+                "id": "icc-scanner",
+                "label": "ICC central scanner",
+                "role": "Ballot image capture",
+                "componentId": "icc-central-scanner",
+                "optional": false,
+                "details": "The certified configuration permits multiple named COTS scanner alternatives."
+              },
+              {
+                "id": "icc-workstation",
+                "label": "ICC workstation",
+                "role": "Image processing and central-count client",
+                "componentId": "icc-workstation",
+                "optional": false,
+                "details": "The workstation hosts the ICC application and provides the scanner's local computer interface."
+              },
+              {
+                "id": "icc-closed-lan",
+                "label": "Isolated LAN infrastructure",
+                "role": "Conditional closed Ethernet transport",
+                "componentId": "icc-optional-isolated-lan",
+                "optional": true,
+                "details": "The ICC user guide calls for high-speed network infrastructure only when an additional central repository or data center is used."
+              },
+              {
+                "id": "icc-ems-data-center",
+                "label": "EMS data center",
+                "role": "Central result and ballot-image services",
+                "componentId": null,
+                "optional": true,
+                "details": "The system overview describes the closed LAN as connecting ICC workstations to the EMS data-center network."
+              }
+            ],
+            "links": [
+              {
+                "id": "icc-scanner-usb",
+                "from": "icc-scanner",
+                "to": "icc-workstation",
+                "medium": "USB interface",
+                "direction": "one_way",
+                "purpose": "Deliver scanner-captured ballot images to the ICC workstation",
+                "knowledgeStatus": "confirmed"
+              },
+              {
+                "id": "icc-workstation-lan",
+                "from": "icc-workstation",
+                "to": "icc-closed-lan",
+                "medium": "Gigabit Ethernet",
+                "direction": "bidirectional",
+                "purpose": "Connect an ICC workstation to the closed EMS data-center network when the additional repository configuration is used",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "icc-lan-data-center",
+                "from": "icc-closed-lan",
+                "to": "icc-ems-data-center",
+                "medium": "Closed local area network",
+                "direction": "bidirectional",
+                "purpose": "Store and exchange results and ballot-image data within the election system boundary",
+                "knowledgeStatus": "documented_partial"
+              }
+            ],
+            "controls": [
+              {
+                "id": "icc-internet-isolation",
+                "label": "Internet isolation",
+                "status": "documented",
+                "description": "The 5.17-CO ICC guide requires election computers to be isolated from any Internet connection."
+              },
+              {
+                "id": "icc-other-network-isolation",
+                "label": "Other-network isolation",
+                "status": "documented",
+                "description": "The election computing network must be isolated from jurisdiction computers and networks not used for election operations."
+              },
+              {
+                "id": "icc-field-switch-state",
+                "label": "Field switch state",
+                "status": "not_publicly_established",
+                "description": "The selected switch, ports, addressing, and enabled services for any jurisdiction installation are not established here."
+              }
+            ],
+            "sensitiveDetailsWithheld": "No addresses, credentials, keys, database names, hostnames, switch settings, or site-specific network diagrams are collected or displayed.",
+            "sourceIds": [
+              "co-dvs-517-system-overview",
+              "co-dvs-517-icc-user-guide",
+              "provv-dsuite-517-test-plan"
+            ],
+            "sourceRevisionIds": [
+              "co-dvs-517-system-overview@2026-07-21",
+              "co-dvs-517-icc-user-guide@2026-07-20",
+              "provv-dsuite-517-test-plan@2026-07-20"
+            ],
+            "caveat": "The documents describe permitted 5.17-CO architectures. They do not establish that a particular jurisdiction uses the optional repository, which COTS alternatives it selected, or the live state of a network."
+          }
+        ],
+        "sourceImages": [
+          {
+            "id": "icc-dvs-517-high-level-block-diagram",
+            "assetUrl": "/equipment/network-evidence/dvs-517-system-block-diagram.png",
+            "assetSha256": "e556f3f0d2cb52c77be4bb6b54561ed76c08a13cb01af5035b6e52eddd480cd2",
+            "width": 1148,
+            "height": 1485,
+            "kind": "source_topology_diagram",
+            "alt": "Democracy Suite 5.17-CO high-level block diagram showing EMS services, ImageCast devices, secure electronic transfers, and physical result transfers.",
+            "caption": "Democracy Suite 5.17-CO high-level system block diagram",
+            "pageOrSection": "Colorado system-overview PDF page 21, Figure 2-3",
+            "derivativeNote": "Rendered from the archived official PDF at 135 DPI; the source page content was not edited.",
+            "caveat": "The source itself warns that not all depicted components apply to every jurisdiction, and its disclaimer excludes modem and transmission functionality from the 5.17-CO campaign.",
+            "sourceIds": [
+              "co-dvs-517-system-overview"
+            ],
+            "sourceRevisionIds": [
+              "co-dvs-517-system-overview@2026-07-21"
+            ]
+          },
+          {
+            "id": "icc-dvs-517-workstation-network-page",
+            "assetUrl": "/equipment/network-evidence/dvs-517-icc-network.png",
+            "assetSha256": "c7675e73b62ccb2e21d86a06f6561b3c0cda7b162264e9826a09e3e4f51aa052",
+            "width": 1148,
+            "height": 1485,
+            "kind": "source_document_page",
+            "alt": "Democracy Suite 5.17-CO system overview page describing the ICC scanner USB connection, workstation specifications, and closed Gigabit Ethernet LAN connection to the EMS data center.",
+            "caption": "Exact 5.17-CO ICC workstation and closed-LAN description",
+            "pageOrSection": "Colorado system-overview PDF page 68, document page 60",
+            "derivativeNote": "Rendered from the archived official PDF at 135 DPI; the source page content was not edited.",
+            "caveat": "This technical-data statement is not a jurisdiction inventory and does not resolve the conditional repository language in the ICC user guide for a particular deployment.",
+            "sourceIds": [
+              "co-dvs-517-system-overview"
+            ],
+            "sourceRevisionIds": [
+              "co-dvs-517-system-overview@2026-07-21"
+            ]
+          }
+        ],
+        "gaps": [
+          {
+            "id": "icc-repository-selection-gap",
+            "label": "Additional repository selection",
+            "description": "The reviewed dossier does not establish whether a jurisdiction uses the optional additional central ballot-scan repository or data-center configuration.",
+            "sourceIds": [
+              "co-dvs-517-icc-user-guide",
+              "co-dvs-517-system-overview"
+            ],
+            "sourceRevisionIds": [
+              "co-dvs-517-icc-user-guide@2026-07-20",
+              "co-dvs-517-system-overview@2026-07-21"
+            ],
+            "caveat": "The module preserves the conditional language instead of forcing one topology onto every ICC installation."
+          },
+          {
+            "id": "icc-field-topology-gap",
+            "label": "Field-observed network topology",
+            "description": "No dated jurisdiction diagram, switch inventory, interface state, or authorized inspection was collected.",
+            "sourceIds": [
+              "co-dvs-517-icc-user-guide"
+            ],
+            "sourceRevisionIds": [
+              "co-dvs-517-icc-user-guide@2026-07-20"
+            ],
+            "caveat": "A documented system architecture is not a live network observation."
+          }
+        ]
+      },
+      "deployments": [],
+      "scene": {
+        "assetUrl": "/equipment/dominion-democracy-suite-517-imagecast-central/orthographic-pilot.glb",
+        "assetLicense": "Apache-2.0",
+        "assetAttribution": "Original CivicResultMaps schematic generated from scripts/build-tabulator-models.mjs",
+        "geometryFidelity": "illustrative_not_to_scale",
+        "description": "An original schematic separating the ICC scanner, workstation, application, authentication and media accessories, conditional isolated network, and UPS.",
+        "referenceConfiguration": "ImageCast Central scanner-and-workstation arrangement informed by the official 5.17-CO scanner reference page",
+        "referenceSourceIds": [
+          "co-dvs-517-icc-user-guide",
+          "eac-dsuite-517-scope",
+          "provv-dsuite-517-test-report"
+        ],
+        "referenceSourceRevisionIds": [
+          "co-dvs-517-icc-user-guide@2026-07-20",
+          "eac-dsuite-517-scope@2026-07-20",
+          "provv-dsuite-517-test-report@2026-07-20"
+        ],
+        "referenceNote": "The scanner outline is informed by the official guide's scanner photographs. Component shapes, scale, placement, cabling, ports, and the simultaneous arrangement of alternatives are illustrative.",
+        "referenceImages": [
+          {
+            "id": "icc-certified-scanner-reference-page",
+            "assetUrl": "/equipment/dominion-democracy-suite-517-imagecast-central/reference-icc-certified-scanners.png",
+            "assetSha256": "60691f00aa5a138b3f385a5edd7a49edde541f7cace7c0d02b8151b4291bbe3a",
+            "width": 1224,
+            "height": 1584,
+            "alt": "Official ImageCast Central guide page showing the Canon DR-G1130 and Canon DR-G2140 scanner alternatives",
+            "caption": "Colorado-hosted 5.17-CO guide page with photographs of two certified Canon scanner alternatives.",
+            "kind": "state_hosted_vendor_manual_page",
+            "sourceIds": [
+              "co-dvs-517-icc-user-guide"
+            ],
+            "sourceRevisionIds": [
+              "co-dvs-517-icc-user-guide@2026-07-20"
+            ],
+            "pageOrSection": "PDF page 69",
+            "derivativeNote": "Full-page 144 DPI PNG render of PDF page 69 using the local Poppler renderer; no crop or content alteration.",
+            "caveat": "The page shows certified alternatives and does not establish which scanner model a jurisdiction selected or the condition of a field unit."
+          }
+        ],
+        "camera": {
+          "position": [
+            7,
+            5.5,
+            8
+          ],
+          "zoom": 65,
+          "near": 0.1,
+          "far": 100
+        },
+        "nodes": [
+          {
+            "componentId": "icc-central-scanner",
+            "nodeName": "ICC_Central_Scanner",
+            "color": "#d4d9d8",
+            "explodedOffset": [
+              0,
+              0.7,
+              0
+            ]
+          },
+          {
+            "componentId": "icc-workstation",
+            "nodeName": "ICC_Workstation",
+            "color": "#657478",
+            "explodedOffset": [
+              0,
+              1.25,
+              -0.5
+            ]
+          },
+          {
+            "componentId": "icc-application",
+            "nodeName": "ICC_Application",
+            "color": "#78a6ff",
+            "explodedOffset": [
+              0,
+              1.55,
+              0.25
+            ]
+          },
+          {
+            "componentId": "icc-ibutton-reader",
+            "nodeName": "ICC_iButton_Reader",
+            "color": "#f0b95a",
+            "explodedOffset": [
+              -1.2,
+              0.25,
+              0.7
+            ]
+          },
+          {
+            "componentId": "icc-media-reader",
+            "nodeName": "ICC_Media_Reader",
+            "color": "#e87fb3",
+            "explodedOffset": [
+              1.2,
+              0.25,
+              0.7
+            ]
+          },
+          {
+            "componentId": "icc-optional-isolated-lan",
+            "nodeName": "ICC_Optional_Isolated_LAN",
+            "color": "#33c6b5",
+            "explodedOffset": [
+              -1.25,
+              -0.65,
+              0.2
+            ]
+          },
+          {
+            "componentId": "icc-ups",
+            "nodeName": "ICC_UPS",
+            "color": "#e87fb3",
+            "explodedOffset": [
+              1.25,
+              -0.65,
+              -0.2
+            ]
+          }
+        ]
+      },
+      "caveats": [
+        "ImageCast Central is a COTS scanner-and-workstation system, not one proprietary enclosure.",
+        "Certified scanner and workstation alternatives are listed separately and must not be read as an instruction to combine every option.",
+        "The optional network component is conditional and isolated; it is not evidence of Internet connectivity or field use.",
+        "The 3D scene is a navigation aid, not a teardown, wiring diagram, exact installation, or unit inventory.",
+        "A certification change or test result is not evidence of field occurrence, misconduct, exploitation, or an election outcome effect."
+      ],
+      "claimRevision": 3,
+      "editorialState": "published",
+      "sourceIds": [
+        "co-dvs-517-icc-user-guide",
+        "co-dvs-517-system-overview",
+        "eac-dsuite-517-record",
+        "eac-dsuite-517-scope",
+        "provv-dsuite-517-test-plan",
+        "provv-dsuite-517-test-report"
+      ],
+      "sourceRevisionIds": [
+        "co-dvs-517-icc-user-guide@2026-07-20",
+        "co-dvs-517-system-overview@2026-07-21",
+        "eac-dsuite-517-record@2026-07-20",
+        "eac-dsuite-517-scope@2026-07-20",
+        "provv-dsuite-517-test-plan@2026-07-20",
+        "provv-dsuite-517-test-report@2026-07-20"
+      ],
+      "coverage": {
+        "componentCount": 7,
+        "sourcedComponentCount": 7,
+        "technicalSpecificationCount": 3,
+        "establishedTechnicalSpecificationCount": 3,
+        "unknownTechnicalSpecificationCount": 0,
+        "configurationChangeCount": 1,
+        "deploymentObservationCount": 0,
+        "findingCount": 1,
+        "powerRecordCount": 1,
+        "confirmedPowerRecordCount": 1,
+        "sourceCount": 6,
+        "sourceRevisionCount": 6,
+        "componentSecurityReviewCount": 0,
+        "exactApplicableVulnerabilityCount": 0,
+        "nonCveAdvisoryCount": 0,
+        "networkConfigurationCount": 1,
+        "networkSourceImageCount": 2,
+        "fieldObservedNetworkConfigurationCount": 0
+      }
+    },
+    {
+      "id": "dominion-democracy-suite-517-imagecast-x",
+      "slug": "dominion-democracy-suite-517-imagecast-x",
+      "status": "pilot",
+      "manufacturer": "Dominion Voting Systems Corp.",
+      "systemName": "Democracy Suite",
+      "systemVersion": "5.17",
+      "deviceName": "ImageCast X",
+      "displayName": "Dominion Democracy Suite 5.17 / ImageCast X",
+      "deviceRole": "Accessible touchscreen ballot-marking configuration",
+      "summary": "A source-linked dossier for the ImageCast X ballot-marking device within EAC-certified Democracy Suite 5.17, including certified device alternatives, external UPS options, version observations, Pro V&V results, and EAC-hosted post-certification advisories.",
+      "certification": {
+        "certificationId": "DVS-DemSuite5.17",
+        "standard": "VVSG 1.0",
+        "certifiedOn": "2023-03-16",
+        "vstl": "Pro V&V, Inc.",
+        "scopeKind": "certified_configuration",
+        "sourceIds": [
+          "eac-dsuite-517-record",
+          "eac-dsuite-517-scope",
+          "provv-dsuite-517-test-report"
+        ],
+        "sourceRevisionIds": [
+          "eac-dsuite-517-record@2026-07-20",
+          "eac-dsuite-517-scope@2026-07-20",
+          "provv-dsuite-517-test-report@2026-07-20"
+        ],
+        "caveat": "EAC certification applies only to the evaluated Democracy Suite 5.17 certified configuration. It does not establish election readiness, a jurisdiction deployment, the option selected for a fielded unit, or the condition of any unit. The certification-era documents name Dominion Voting Systems; the current EAC record separately notes a later Liberty Vote USA acquisition."
+      },
+      "components": [
+        {
+          "id": "icx-application",
+          "name": "ImageCast X application and configuration",
+          "category": "software",
+          "description": "The final EAC scope lists the ICX application and Android environment, while the Pro V&V plan and report preserve submitted-test and final configuration identifiers.",
+          "evidenceStatus": "certified_component",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [
+            "icx-certified-application-517171",
+            "icx-certified-android-810224",
+            "icx-submitted-test-version-517131",
+            "icx-final-mcf-517151"
+          ],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_Application",
+          "caveat": "These are source-scoped certification and test observations, not a live device reading and not a claim about the newest Democracy Suite or ImageCast X release.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "icx-touchscreen-bmd",
+          "name": "ImageCast X touchscreen BMD computer",
+          "category": "interface_compute",
+          "description": "The certified configuration lists Avalue Classic 15-inch and 21-inch tablet options and an Avalue Prime 21-inch option. The reference scene uses the documented SID-21V-Z37-A1R Classic 21.5-inch profile.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Avalue SID-15V-Z37",
+            "Avalue SID-21V-Z37",
+            "Avalue HID-21V-BTX"
+          ],
+          "hardwareRevisions": [
+            "Classic 15.6-inch",
+            "Classic 21.5-inch",
+            "Prime 21.5-inch - steel or aluminum chassis"
+          ],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan",
+            "provv-dsuite-517-test-report",
+            "co-dvs-517-avalue-sid21-manual",
+            "co-dvs-517-icx-maintenance-manual"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20",
+            "co-dvs-517-avalue-sid21-manual@2026-07-20",
+            "co-dvs-517-icx-maintenance-manual@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_Touchscreen",
+          "caveat": "The models and chassis are permitted alternatives. The reference scene depicts the SID-21V-Z37-A1R hardware family and must not be read as the Prime variant or as evidence of a jurisdiction's selected hardware.",
+          "technicalSpecifications": [
+            {
+              "id": "icx-sid21-display",
+              "category": "display",
+              "label": "Display and touch panel",
+              "value": "21.5-inch, 1920 × 1080, projected-capacitive touch",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Avalue SID-21V-Z37-A1R (ICX Classic reference)",
+              "sourceIds": [
+                "co-dvs-517-avalue-sid21-manual",
+                "co-dvs-517-icx-maintenance-manual"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-avalue-sid21-manual@2026-07-20",
+                "co-dvs-517-icx-maintenance-manual@2026-07-20"
+              ],
+              "caveat": "The manufacturer specification is tied to the named SID-21V model family. It is not transferred to the 15-inch Classic or 21-inch Prime alternatives."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "icx-sid21-compute-board",
+          "name": "SID-21V compute board profile",
+          "category": "compute",
+          "description": "The Avalue SID-21V-Z37-A1R manual identifies the processor, memory, and eMMC storage used by the Classic 21.5-inch hardware profile.",
+          "evidenceStatus": "documented_model_family",
+          "scopeKind": "manufacturer_hardware_documentation",
+          "modelNumbers": [
+            "SID-21V-Z37-A1R"
+          ],
+          "hardwareRevisions": [
+            "Manual revision 1.0"
+          ],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "co-dvs-517-avalue-sid21-manual",
+            "co-dvs-517-icx-maintenance-manual"
+          ],
+          "sourceRevisionIds": [
+            "co-dvs-517-avalue-sid21-manual@2026-07-20",
+            "co-dvs-517-icx-maintenance-manual@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_Compute_Board",
+          "caveat": "The scene makes this documented hardware profile selectable, but its board outline and placement are illustrative. The profile must not be transferred to ICX Prime or a particular fielded unit.",
+          "technicalSpecifications": [
+            {
+              "id": "icx-sid21-cpu",
+              "category": "processor",
+              "label": "CPU",
+              "value": "Intel Atom Z3735F",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Avalue SID-21V-Z37-A1R",
+              "sourceIds": [
+                "co-dvs-517-avalue-sid21-manual"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-avalue-sid21-manual@2026-07-20"
+              ],
+              "caveat": "This is the COTS manufacturer specification for the named SID-21V model family, not a live inventory of a jurisdiction unit."
+            },
+            {
+              "id": "icx-sid21-memory",
+              "category": "memory",
+              "label": "RAM",
+              "value": "2 GB DDR3L",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Avalue SID-21V-Z37-A1R",
+              "sourceIds": [
+                "co-dvs-517-avalue-sid21-manual"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-avalue-sid21-manual@2026-07-20"
+              ],
+              "caveat": "This is the COTS manufacturer specification for the named SID-21V model family."
+            },
+            {
+              "id": "icx-sid21-storage",
+              "category": "storage",
+              "label": "Internal storage",
+              "value": "32 GB eMMC",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Avalue SID-21V-Z37-A1R",
+              "sourceIds": [
+                "co-dvs-517-avalue-sid21-manual"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-avalue-sid21-manual@2026-07-20"
+              ],
+              "caveat": "This eMMC specification belongs to the SID-21V Classic profile and is not the source-supported ICX Prime SSD advisory component."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "icx-sid21-io-panel",
+          "name": "SID-21V connector panel",
+          "category": "ports_and_interfaces",
+          "description": "The SID-21V manufacturer manual identifies the model-family connector set. The certified scope separately describes allowed system communications use.",
+          "evidenceStatus": "documented_model_family",
+          "scopeKind": "manufacturer_hardware_documentation",
+          "modelNumbers": [
+            "SID-21V-Z37-A1R"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "co-dvs-517-avalue-sid21-manual",
+            "eac-dsuite-517-scope"
+          ],
+          "sourceRevisionIds": [
+            "co-dvs-517-avalue-sid21-manual@2026-07-20",
+            "eac-dsuite-517-scope@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_IO_Panel",
+          "caveat": "Connector presence is a model-family specification. It does not establish port occupation, enabled services, cabling, or jurisdiction use; the scene location is illustrative.",
+          "technicalSpecifications": [
+            {
+              "id": "icx-sid21-usb",
+              "category": "usb",
+              "label": "USB ports",
+              "value": "4 × USB 2.0",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Avalue SID-21V-Z37-A1R",
+              "sourceIds": [
+                "co-dvs-517-avalue-sid21-manual"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-avalue-sid21-manual@2026-07-20"
+              ],
+              "caveat": "The manual states the physical connector count; it does not establish which ports are occupied or enabled in a fielded election configuration."
+            },
+            {
+              "id": "icx-sid21-ethernet",
+              "category": "ethernet",
+              "label": "Ethernet",
+              "value": "1 × 10/100 RJ-45 Ethernet",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Avalue SID-21V-Z37-A1R",
+              "sourceIds": [
+                "co-dvs-517-avalue-sid21-manual"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-avalue-sid21-manual@2026-07-20"
+              ],
+              "caveat": "Physical connector presence does not establish an enabled election network connection or field use."
+            },
+            {
+              "id": "icx-sid21-other-io",
+              "category": "other_io",
+              "label": "Other documented I/O",
+              "value": "1 × HDMI, 1 × headphone jack, 1 × smart-card reader, 1 × microSD slot",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Avalue SID-21V-Z37-A1R",
+              "sourceIds": [
+                "co-dvs-517-avalue-sid21-manual"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-avalue-sid21-manual@2026-07-20"
+              ],
+              "caveat": "These are hardware-family connectors and peripherals, not proof of a connected accessory or inserted media."
+            },
+            {
+              "id": "icx-cellular-certified-scope",
+              "category": "cellular",
+              "label": "Cellular modem",
+              "value": "No WAN modem or WAN wireless use listed in the Democracy Suite 5.17 certified-system table",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "Democracy Suite 5.17 certified configuration",
+              "sourceIds": [
+                "eac-dsuite-517-scope"
+              ],
+              "sourceRevisionIds": [
+                "eac-dsuite-517-scope@2026-07-20"
+              ],
+              "caveat": "This is a system-scope communications statement, not a teardown-based assertion that every ICX chassis lacks every radio component."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "icx-sid21-internal-battery",
+          "name": "SID-21V optional internal battery",
+          "category": "power",
+          "description": "The Avalue manual documents an optional rechargeable battery and its hinged top-cover installation path for the SID-21V-Z37-A1R profile.",
+          "evidenceStatus": "documented_optional_model_component",
+          "scopeKind": "manufacturer_hardware_documentation",
+          "modelNumbers": [
+            "ACC-BAT-3S1P-01R"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "co-dvs-517-avalue-sid21-manual",
+            "co-dvs-517-icx-maintenance-manual"
+          ],
+          "sourceRevisionIds": [
+            "co-dvs-517-avalue-sid21-manual@2026-07-20",
+            "co-dvs-517-icx-maintenance-manual@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_Internal_Battery",
+          "caveat": "The component is optional. Its source-supported cover area guides the scene, but the simplified cell-pack geometry is illustrative and no field installation or battery condition is established.",
+          "technicalSpecifications": [
+            {
+              "id": "icx-sid21-battery-pack",
+              "category": "power",
+              "label": "Battery pack",
+              "value": "ACC-BAT-3S1P-01R; rechargeable Li-ion; 10.8 V nominal",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "Optional SID-21V-Z37-A1R battery",
+              "sourceIds": [
+                "co-dvs-517-avalue-sid21-manual"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-avalue-sid21-manual@2026-07-20"
+              ],
+              "caveat": "A documented optional accessory is not presumed installed in every certified or fielded ICX."
+            },
+            {
+              "id": "icx-sid21-battery-capacity",
+              "category": "power",
+              "label": "Battery capacity",
+              "value": "2,400 mAh typical; 2,215 mAh minimum at the documented test conditions",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "ACC-BAT-3S1P-01R",
+              "sourceIds": [
+                "co-dvs-517-avalue-sid21-manual"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-avalue-sid21-manual@2026-07-20"
+              ],
+              "caveat": "Capacity is a manufacturer specification, not runtime under an election workload or a measure of any unit's current battery health."
+            },
+            {
+              "id": "icx-sid21-battery-runtime-gap",
+              "category": "power",
+              "label": "Election-workload runtime",
+              "value": null,
+              "knowledgeStatus": "not_publicly_established",
+              "assertionScope": "evidence_gap",
+              "modelContext": "ACC-BAT-3S1P-01R",
+              "sourceIds": [
+                "co-dvs-517-avalue-sid21-manual",
+                "co-dvs-517-icx-maintenance-manual"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-avalue-sid21-manual@2026-07-20",
+                "co-dvs-517-icx-maintenance-manual@2026-07-20"
+              ],
+              "caveat": "The reviewed manuals provide electrical capacity and storage guidance but not a source-supported election-workload runtime."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "icx-ballot-printer",
+          "name": "ImageCast X ballot printer",
+          "category": "printer",
+          "description": "The reviewed scope and test records list six laser-printer alternatives for an ICX ballot-marking configuration.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "HP M402dn",
+            "HP M402dne",
+            "HP M501dn",
+            "HP M404dn",
+            "HP 4001dn",
+            "Avision AP3061"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_Ballot_Printer",
+          "caveat": "These are certified alternatives, not evidence that all printers appear together or that a particular jurisdiction uses a named model.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "icx-external-ups",
+          "name": "External uninterruptible power supply",
+          "category": "power",
+          "description": "The Pro V&V ICX configuration lists APC and CyberPower external UPS alternatives, and the EAC scope includes the same model families in the certified COTS hardware list.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "APC SMT-1500",
+            "APC SMT-1500C",
+            "CyberPower PR1500LCD",
+            "CyberPower PR1500LCD-VTVM"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_External_UPS",
+          "caveat": "The sources confirm permitted UPS alternatives but do not provide ICX load-specific capacity or runtime, field topology, battery condition, maintenance status, or a jurisdiction selection.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "icx-accessible-tactile-interface",
+          "name": "Accessible-tactile interface",
+          "category": "assistive_input",
+          "description": "The certified hardware list includes ATI-USB and ATI serial handset interfaces used with accessible voting configurations.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "ATI-USB",
+            "ATI serial handset"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_ATI",
+          "caveat": "The records identify certified or tested interface options; they do not establish which interface is connected to a fielded device.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "icx-assistive-accessories",
+          "name": "Audio, sip-and-puff, and switch accessories",
+          "category": "assistive_accessory",
+          "description": "The certification records list named headphones, sip-and-puff devices, rocker or paddle switches, and a switch cable for accessible operation.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "Cyber Acoustics ACM-70",
+            "Cyber Acoustics ACM-70B",
+            "Enabling Devices #972",
+            "Enabling Devices #971",
+            "AbleNet 10033400",
+            "Hosa YMM-261"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_Assistive_Accessories",
+          "caveat": "Listed alternatives do not establish that every accessory is supplied, connected, or used with every deployed ImageCast X setup.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "icx-election-media",
+          "name": "Election media and activation cards",
+          "category": "removable_media",
+          "description": "The reviewed test configuration lists ACOS-6-64 smart cards and named USB media used in the Democracy Suite configuration.",
+          "evidenceStatus": "vstl_tested_component_options",
+          "scopeKind": "certification_test_configuration",
+          "modelNumbers": [
+            "ACOS-6-64",
+            "Centon S4-CM-U3P2-16.1",
+            "Apacer EH353-M APHA016GAG0CG-3TM",
+            "Centon S4-CM-U3P2-8.1"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_Election_Media",
+          "caveat": "This groups source-listed removable media for navigation. It does not describe a jurisdiction's activation, programming, storage, or chain-of-custody procedure.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "icx-physical-accessories",
+          "name": "Optional transport and privacy accessories",
+          "category": "case_and_privacy",
+          "description": "The test plan lists ICX Classic and Prime transport bags, a privacy screen, a voting booth, and a Prime dual-bay battery charger as optional physical accessories.",
+          "evidenceStatus": "vstl_tested_component_options",
+          "scopeKind": "certification_test_configuration",
+          "modelNumbers": [
+            "ICX Classic BMD Transport Bag",
+            "ICX Prime BMD Transport Bag",
+            "ICX Privacy Screen",
+            "ICX Voting Booth",
+            "ICX Prime Battery Charger - Dual Bay"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "provv-dsuite-517-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "provv-dsuite-517-test-plan@2026-07-20"
+          ],
+          "sceneNodeName": "ICX_Physical_Accessories",
+          "caveat": "Optional accessories are not evidence of a jurisdiction's storage or setup procedure. The dual-bay charger is not represented as proof of an internal or external backup-power topology.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "icx-prime-ssd",
+          "name": "ICX Prime solid-state drive",
+          "category": "internal_storage",
+          "description": "An EAC-hosted advisory and Pro V&V ECO analysis identify an ICX Prime solid-state drive and an SSD-firmware update path for a bounded project-file installation or removal condition.",
+          "evidenceStatus": "official_advisory_component",
+          "scopeKind": "post_certification_advisory",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "dvs-icx-prime-ssd-advisory",
+            "provv-dsuite-eco-100936-analysis"
+          ],
+          "sourceRevisionIds": [
+            "dvs-icx-prime-ssd-advisory@2026-07-20",
+            "provv-dsuite-eco-100936-analysis@2026-07-20"
+          ],
+          "sceneNodeName": null,
+          "caveat": "The records establish the component category but do not disclose a source-supported SSD model, firmware number, physical placement, cabling, or board-level arrangement, so it is not placed in the 3D scene.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        }
+      ],
+      "versionObservations": [
+        {
+          "id": "icx-certified-application-517171",
+          "componentId": "icx-application",
+          "versionType": "software",
+          "value": "5.17.17.1",
+          "label": "Final EAC-certified ICX application",
+          "scopeKind": "certified_configuration",
+          "assertionScope": "certified",
+          "approvalScope": null,
+          "fieldStatus": "not_established",
+          "assertedFor": {
+            "systemCertificationId": "DVS-DemSuite5.17",
+            "jurisdiction": null,
+            "observedOn": "2023-03-16"
+          },
+          "observedOn": "2023-03-16",
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "caveat": "This is the application version in the final certified configuration, not a live field reading and not a claim that it is the newest ICX release."
+        },
+        {
+          "id": "icx-certified-android-810224",
+          "componentId": "icx-application",
+          "versionType": "operating_system",
+          "value": "Android 8.1.0-2.2.4",
+          "label": "Certified ICX COTS operating environment",
+          "scopeKind": "certified_configuration",
+          "assertionScope": "certified",
+          "approvalScope": null,
+          "fieldStatus": "not_established",
+          "assertedFor": {
+            "systemCertificationId": "DVS-DemSuite5.17",
+            "jurisdiction": null,
+            "observedOn": "2023-03-16"
+          },
+          "observedOn": "2023-03-16",
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "caveat": "The scope establishes the evaluated environment, not a device's installed patch state or present field configuration."
+        },
+        {
+          "id": "icx-submitted-test-version-517131",
+          "componentId": "icx-application",
+          "versionType": "submitted_test_software",
+          "value": "5.17.13.1",
+          "label": "Version submitted in the Pro V&V test plan",
+          "scopeKind": "certification_test_configuration",
+          "assertionScope": "documented",
+          "approvalScope": null,
+          "fieldStatus": "not_established",
+          "assertedFor": {
+            "systemCertificationId": "DVS-DemSuite5.17",
+            "jurisdiction": null,
+            "observedOn": "2022-12-02"
+          },
+          "observedOn": "2022-12-02",
+          "sourceIds": [
+            "provv-dsuite-517-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "provv-dsuite-517-test-plan@2026-07-20"
+          ],
+          "caveat": "This is a submitted test-plan version, not the final certified application version and not evidence of field use."
+        },
+        {
+          "id": "icx-final-mcf-517151",
+          "componentId": "icx-application",
+          "versionType": "machine_configuration_file",
+          "value": "MCF_5.17.15.1_20220920",
+          "label": "Final report ICX machine-configuration-file identifier",
+          "scopeKind": "certified_configuration",
+          "assertionScope": "certified",
+          "approvalScope": null,
+          "fieldStatus": "not_established",
+          "assertedFor": {
+            "systemCertificationId": "DVS-DemSuite5.17",
+            "jurisdiction": null,
+            "observedOn": "2023-03-15"
+          },
+          "observedOn": "2023-03-15",
+          "sourceIds": [
+            "provv-dsuite-517-test-report"
+          ],
+          "sourceRevisionIds": [
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "caveat": "This is a named MCF identifier in the final test report, not an ICX application version, live readout, or field-installation record."
+        }
+      ],
+      "configurationChanges": [
+        {
+          "id": "dsuite-517-icx-smart-card-security",
+          "changeId": "DVS-5.17-ICX-AUTH",
+          "componentIds": [
+            "icx-application",
+            "icx-election-media"
+          ],
+          "submittedOn": "2022-10-04",
+          "eacApprovedOn": "2023-03-16",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "included_in_certified_517_configuration",
+          "description": "The 5.17 modification set added ICX smart-card mutual authentication and secure messaging.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20"
+          ],
+          "caveat": "This is certified configuration history relative to the 5.5-D baseline; it is not evidence that a jurisdiction installed or enabled the change."
+        },
+        {
+          "id": "dsuite-517-icx-database-encryption",
+          "changeId": "DVS-5.17-ICX-DB-ENC",
+          "componentIds": [
+            "icx-application"
+          ],
+          "submittedOn": "2022-10-04",
+          "eacApprovedOn": "2023-03-16",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "included_in_certified_517_configuration",
+          "description": "The 5.17 modification set added encryption of election databases on ICX and named companion devices.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20"
+          ],
+          "caveat": "The source describes a bounded certification change, not a general security guarantee, field audit, or claim about every form of stored data."
+        },
+        {
+          "id": "dsuite-517-icx-functional-changes",
+          "changeId": "DVS-5.17-ICX-FUNCTIONS",
+          "componentIds": [
+            "icx-application",
+            "icx-ballot-printer"
+          ],
+          "submittedOn": "2022-10-04",
+          "eacApprovedOn": "2023-03-16",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "included_in_certified_517_configuration",
+          "description": "The 5.17 modification set added ICX support for provisional and Uniform Ballots, additional ballot-barcode information, and configurable on-screen contest columns.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20"
+          ],
+          "caveat": "The record establishes the evaluated 5.17 modification set, not the election features configured or used by a jurisdiction."
+        },
+        {
+          "id": "dsuite-eco-100936",
+          "changeId": "DVS-ECO-100936",
+          "componentIds": [
+            "icx-prime-ssd",
+            "icx-application",
+            "icx-touchscreen-bmd"
+          ],
+          "submittedOn": "2024-08-16",
+          "eacApprovedOn": "2024-09-24",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "post_certification_change_for_517",
+          "description": "Pro V&V reviewed updated ICX Prime user-manual procedures for an SSD-firmware update path and classified the documentation change as de minimis with no additional 5.17 testing required.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "dvs-icx-prime-ssd-advisory",
+            "provv-dsuite-eco-100936-analysis"
+          ],
+          "sourceRevisionIds": [
+            "dvs-icx-prime-ssd-advisory@2026-07-20",
+            "provv-dsuite-eco-100936-analysis@2026-07-20"
+          ],
+          "caveat": "The records document a post-certification change path affecting federal 5.17, but do not name the SSD firmware version or establish adoption by any jurisdiction."
+        }
+      ],
+      "findings": [
+        {
+          "id": "dsuite-517-test-campaign-outcome",
+          "findingType": "test_campaign_result",
+          "title": "No anomalies or deficiencies were reported in the 5.17 certification campaign",
+          "affectedSystemVersions": [
+            "Democracy Suite 5.17 certification campaign"
+          ],
+          "componentIds": [],
+          "publicStatus": "none_reported_in_test_campaign",
+          "description": "The final Pro V&V report states that no anomalies and no deficiencies were encountered during the D-Suite 5.17 test campaign and recommends certification of the evaluated system.",
+          "sourceIds": [
+            "provv-dsuite-517-test-report",
+            "eac-dsuite-517-record"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-record@2026-07-20",
+            "provv-dsuite-517-test-report@2026-07-20"
+          ],
+          "caveat": "This statement is limited to that test campaign and evaluated configuration. It is not evidence that every field unit or later operating condition is defect-free."
+        },
+        {
+          "id": "icx-touchscreen-responsiveness-advisory",
+          "findingType": "product_advisory_notice",
+          "title": "Touchscreen responsiveness advisory for named ICX Classic versions",
+          "affectedSystemVersions": [
+            "ICX 5.17.17.1 / Android 8.1.0-2.2.4"
+          ],
+          "componentIds": [
+            "icx-touchscreen-bmd",
+            "icx-application"
+          ],
+          "jurisdictionsNamed": [
+            "Michigan",
+            "Colorado",
+            "Arizona"
+          ],
+          "publicStatus": "restart_procedure_documented",
+          "description": "A May 2024 EAC-hosted manufacturer notice describes rare startup occasions when a named ICX Classic screen may not respond to touch and provides a power-cycle procedure.",
+          "sourceIds": [
+            "dvs-icx-touchscreen-advisory"
+          ],
+          "sourceRevisionIds": [
+            "dvs-icx-touchscreen-advisory@2026-07-20"
+          ],
+          "caveat": "The notice names versions and jurisdictions but does not quantify occurrence or establish that every named jurisdiction or unit experienced the condition."
+        },
+        {
+          "id": "icx-prime-ssd-advisory",
+          "findingType": "customer_advisory_notice",
+          "title": "ICX Prime SSD advisory and firmware-update documentation path",
+          "affectedSystemVersions": [
+            "ICX 5.17.17.1 / Android 8.1.0-2.2.4",
+            "ICX 5.6.105.1 / Android 8.1.0-1.1.16"
+          ],
+          "componentIds": [
+            "icx-prime-ssd",
+            "icx-application",
+            "icx-touchscreen-bmd"
+          ],
+          "jurisdictionsNamed": [
+            "Alaska",
+            "Illinois",
+            "Nevada",
+            "Ohio",
+            "Utah"
+          ],
+          "publicStatus": "documentation_and_ssd_firmware_update_path_recorded",
+          "description": "An August 2024 advisory describes a bounded SSD error during election-project installation or removal, before logic-and-accuracy testing. The linked ECO records updated user-manual procedures for an SSD-firmware update path.",
+          "sourceIds": [
+            "dvs-icx-prime-ssd-advisory",
+            "provv-dsuite-eco-100936-analysis"
+          ],
+          "sourceRevisionIds": [
+            "dvs-icx-prime-ssd-advisory@2026-07-20",
+            "provv-dsuite-eco-100936-analysis@2026-07-20"
+          ],
+          "caveat": "The sources do not establish occurrence during an election, adoption of the update by a jurisdiction, or an SSD model or firmware number. Do not infer a field incident or effect on voted paper records."
+        },
+        {
+          "id": "icx-straight-party-selection-advisory",
+          "findingType": "customer_advisory_notice",
+          "title": "Straight-party and split-ticket selection review advisory",
+          "affectedSystemVersions": [
+            "ImageCast X accessible BMD - advisory dated 2024-09-26"
+          ],
+          "componentIds": [
+            "icx-application",
+            "icx-touchscreen-bmd",
+            "icx-ballot-printer"
+          ],
+          "publicStatus": "advisory_issued_review_guidance",
+          "description": "An EAC-hosted customer notice describes a sequence in which previously removed selections can be reapplied after a straight-party selection is manually changed to split-ticket, and recommends review of the summary screen and printed ballot.",
+          "sourceIds": [
+            "dvs-icx-straight-party-advisory"
+          ],
+          "sourceRevisionIds": [
+            "dvs-icx-straight-party-advisory@2026-07-20"
+          ],
+          "caveat": "The notice does not quantify field occurrence, identify an election outcome effect, or document a software resolution. It is not evidence of fraud, misconduct, or altered votes."
+        }
+      ],
+      "power": [
+        {
+          "id": "icx-sid21-optional-battery",
+          "componentId": "icx-sid21-internal-battery",
+          "knowledgeStatus": "documented_partial",
+          "supplyType": "optional internal rechargeable Li-ion battery",
+          "manufacturer": null,
+          "model": "ACC-BAT-3S1P-01R",
+          "capacity": "2,400 mAh typical; 2,215 mAh minimum",
+          "runtime": null,
+          "description": "The SID-21V manual documents the optional battery model, chemistry, voltage, capacity, connector locations, and installation path. It does not publish an election-workload runtime.",
+          "sourceIds": [
+            "co-dvs-517-avalue-sid21-manual",
+            "co-dvs-517-icx-maintenance-manual"
+          ],
+          "sourceRevisionIds": [
+            "co-dvs-517-avalue-sid21-manual@2026-07-20",
+            "co-dvs-517-icx-maintenance-manual@2026-07-20"
+          ],
+          "caveat": "This is an optional model-family component, not evidence that a particular certified or fielded ICX contains the battery or that its present capacity matches the specification."
+        },
+        {
+          "id": "icx-certified-ups-options",
+          "componentId": "icx-external-ups",
+          "knowledgeStatus": "confirmed",
+          "supplyType": "external uninterruptible power supply",
+          "manufacturer": "APC; CyberPower",
+          "model": "SMT-1500; SMT-1500C; PR1500LCD; PR1500LCD-VTVM",
+          "capacity": null,
+          "runtime": null,
+          "description": "The Pro V&V ICX configuration lists four external UPS alternatives. The reviewed sources do not state an ICX load-specific capacity or runtime.",
+          "sourceIds": [
+            "eac-dsuite-517-scope",
+            "provv-dsuite-517-test-plan"
+          ],
+          "sourceRevisionIds": [
+            "eac-dsuite-517-scope@2026-07-20",
+            "provv-dsuite-517-test-plan@2026-07-20"
+          ],
+          "caveat": "Confirmed means the UPS models appear in the reviewed certified or test configuration, not that all are used together, that a jurisdiction selected one, or that battery health and runtime are known."
+        }
+      ],
+      "networkEvidence": {
+        "reviewedOn": "2026-07-21",
+        "summary": "The certified ICX hardware profile includes a physical 10/100 RJ-45 interface on the SID-21V platform, but the Democracy Suite 5.17 test plan says the evaluated system does not use public networks, does not support transmission over public networks, and uses no wireless technology. No external network peer or field connection is established for this ICX dossier.",
+        "publicationBoundary": "The module distinguishes physical interface capability from an enabled or used connection. It excludes addresses, credentials, keys, activation-card contents, port settings, hostnames, and site-specific topology.",
+        "configurations": [
+          {
+            "id": "icx-517-physical-interface-boundary",
+            "title": "ICX physical Ethernet capability with certified communications boundary",
+            "evidenceLayer": "expected",
+            "assertionScope": "vstl_test_configuration",
+            "knowledgeStatus": "documented_partial",
+            "topologyKind": "physical_network_capability_only",
+            "description": "The SID-21V hardware exposes an RJ-45 interface, while the exact 5.17 test-plan boundary excludes public-network transmission and wireless use. The reviewed record does not identify a certified external peer for the ICX port or show that it is connected in a jurisdiction.",
+            "observedOn": null,
+            "assertedFor": null,
+            "nodes": [
+              {
+                "id": "icx-station",
+                "label": "ImageCast X station",
+                "role": "Accessible ballot-marking platform",
+                "componentId": "icx-touchscreen-bmd",
+                "optional": false,
+                "details": "The station includes the certified ICX application and one of the permitted hardware configurations."
+              },
+              {
+                "id": "icx-rj45-interface",
+                "label": "SID-21V RJ-45 interface",
+                "role": "Physical 10/100 Ethernet capability",
+                "componentId": "icx-sid21-io-panel",
+                "optional": false,
+                "details": "Connector presence is documented; enabled state, peer, service, and field use are not established."
+              },
+              {
+                "id": "icx-election-media",
+                "label": "Election and activation media",
+                "role": "Physical configuration and session transfer",
+                "componentId": "icx-election-media",
+                "optional": false,
+                "details": "The certified system uses physical media and activation cards for election configuration and voter-session workflows."
+              }
+            ],
+            "links": [
+              {
+                "id": "icx-rj45-capability-link",
+                "from": "icx-rj45-interface",
+                "to": "icx-station",
+                "medium": "Internal connection to a 10/100 RJ-45 physical interface",
+                "direction": "bidirectional",
+                "purpose": "Expose hardware network capability without establishing an attached external network",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "icx-physical-media-link",
+                "from": "icx-election-media",
+                "to": "icx-station",
+                "medium": "Physical election media and activation cards",
+                "direction": "one_way",
+                "purpose": "Load election configuration and activate voting sessions without treating physical transfer as a network connection",
+                "knowledgeStatus": "documented_partial"
+              }
+            ],
+            "controls": [
+              {
+                "id": "icx-no-public-network",
+                "label": "No public-network use in evaluated system",
+                "status": "documented",
+                "description": "Pro V&V states that Democracy Suite 5.17 does not utilize public networks."
+              },
+              {
+                "id": "icx-no-public-transmission",
+                "label": "No public-network transmission",
+                "status": "documented",
+                "description": "The test plan states that the evaluated 5.17 system does not support transmission over public networks."
+              },
+              {
+                "id": "icx-no-wireless",
+                "label": "No wireless technology",
+                "status": "documented",
+                "description": "The 5.17 test plan states that no wireless technology is utilized in the system."
+              },
+              {
+                "id": "icx-external-peer",
+                "label": "External Ethernet peer",
+                "status": "not_publicly_established",
+                "description": "No external device, service, or network attached to the ICX RJ-45 port is established in the reviewed record."
+              }
+            ],
+            "sensitiveDetailsWithheld": "No addressing, credentials, keys, activation-card contents, port configuration, hostnames, or jurisdiction topology is collected or shown.",
+            "sourceIds": [
+              "eac-dsuite-517-scope",
+              "provv-dsuite-517-test-plan",
+              "co-dvs-517-system-overview",
+              "co-dvs-517-avalue-sid21-manual"
+            ],
+            "sourceRevisionIds": [
+              "eac-dsuite-517-scope@2026-07-20",
+              "provv-dsuite-517-test-plan@2026-07-20",
+              "co-dvs-517-system-overview@2026-07-21",
+              "co-dvs-517-avalue-sid21-manual@2026-07-20"
+            ],
+            "caveat": "An RJ-45 connector is capability evidence only. It does not prove that Ethernet is enabled, cabled, assigned an address, attached to a network, or used during an election."
+          }
+        ],
+        "sourceImages": [
+          {
+            "id": "icx-dvs-517-high-level-block-diagram",
+            "assetUrl": "/equipment/network-evidence/dvs-517-system-block-diagram.png",
+            "assetSha256": "e556f3f0d2cb52c77be4bb6b54561ed76c08a13cb01af5035b6e52eddd480cd2",
+            "width": 1148,
+            "height": 1485,
+            "kind": "source_topology_diagram",
+            "alt": "Democracy Suite 5.17-CO high-level block diagram showing ImageCast X among EMS services, ImageCast devices, and physical or secure-electronic transfers.",
+            "caption": "Democracy Suite 5.17-CO high-level system block diagram",
+            "pageOrSection": "Colorado system-overview PDF page 21, Figure 2-3",
+            "derivativeNote": "Rendered from the archived official PDF at 135 DPI; the source page content was not edited.",
+            "caveat": "The page says not every depicted component applies to every jurisdiction, and the document disclaimer excludes modem and transmission functionality from the 5.17-CO campaign.",
+            "sourceIds": [
+              "co-dvs-517-system-overview"
+            ],
+            "sourceRevisionIds": [
+              "co-dvs-517-system-overview@2026-07-21"
+            ]
+          },
+          {
+            "id": "icx-dvs-517-network-boundary-page",
+            "assetUrl": "/equipment/network-evidence/dvs-517-network-boundary.png",
+            "assetSha256": "c54b8ff1cf8c91117ce8885c03cd5fd1a6de54748ab31c04bbf495b825f3726c",
+            "width": 1148,
+            "height": 1485,
+            "kind": "source_document_page",
+            "alt": "Pro V and V Democracy Suite 5.17 test-plan page stating that public networks and public-network transmission are not used and that no wireless technology is utilized.",
+            "caption": "Pro V&V 5.17 public-network and wireless boundary statements",
+            "pageOrSection": "Pro V&V test-plan PDF page 43, report page 38",
+            "derivativeNote": "Rendered from the archived official PDF at 135 DPI; the source page content was not edited.",
+            "caveat": "The statements define the evaluated system boundary. They do not constitute an inspection of a particular ICX unit or jurisdiction installation.",
+            "sourceIds": [
+              "provv-dsuite-517-test-plan"
+            ],
+            "sourceRevisionIds": [
+              "provv-dsuite-517-test-plan@2026-07-20"
+            ]
+          }
+        ],
+        "gaps": [
+          {
+            "id": "icx-rj45-use-gap",
+            "label": "RJ-45 enabled state and peer",
+            "description": "The reviewed public record does not identify an enabled service, external peer, cable, or field use for the physical ICX Ethernet interface.",
+            "sourceIds": [
+              "eac-dsuite-517-scope",
+              "co-dvs-517-avalue-sid21-manual",
+              "provv-dsuite-517-test-plan"
+            ],
+            "sourceRevisionIds": [
+              "eac-dsuite-517-scope@2026-07-20",
+              "co-dvs-517-avalue-sid21-manual@2026-07-20",
+              "provv-dsuite-517-test-plan@2026-07-20"
+            ],
+            "caveat": "The gap must not be converted into an assumption that the port is either active or disabled."
+          },
+          {
+            "id": "icx-field-network-gap",
+            "label": "Field-observed configuration",
+            "description": "No dated unit-level interface inspection or polling-place network diagram was collected.",
+            "sourceIds": [
+              "provv-dsuite-517-test-plan"
+            ],
+            "sourceRevisionIds": [
+              "provv-dsuite-517-test-plan@2026-07-20"
+            ],
+            "caveat": "Certified boundary evidence is not a live observation."
+          }
+        ]
+      },
+      "deployments": [],
+      "scene": {
+        "assetUrl": "/equipment/dominion-democracy-suite-517-imagecast-x/orthographic-pilot.glb",
+        "assetLicense": "Apache-2.0",
+        "assetAttribution": "Original CivicResultMaps schematic generated from scripts/build-imagecast-x-model.mjs",
+        "geometryFidelity": "illustrative_not_to_scale",
+        "description": "An original, drawing-informed navigational schematic of the Avalue SID-21V-Z37-A1R ICX Classic reference configuration and its supported peripherals. The Prime SSD remains omitted because public records do not establish its model or placement.",
+        "referenceConfiguration": "ICX Classic with Avalue SID-21V-Z37-A1R 21.5-inch terminal, rear arm, tabletop base, ballot printer, and external UPS",
+        "referenceSourceIds": [
+          "co-dvs-517-avalue-sid21-manual",
+          "co-dvs-517-icx-maintenance-manual",
+          "eac-dsuite-517-scope",
+          "provv-dsuite-517-test-plan",
+          "sf-icx-usability-test-report-510"
+        ],
+        "referenceSourceRevisionIds": [
+          "co-dvs-517-avalue-sid21-manual@2026-07-20",
+          "co-dvs-517-icx-maintenance-manual@2026-07-20",
+          "eac-dsuite-517-scope@2026-07-20",
+          "provv-dsuite-517-test-plan@2026-07-20",
+          "sf-icx-usability-test-report-510@2026-07-20"
+        ],
+        "referenceNote": "The terminal silhouette follows the Avalue mechanical drawing. The compute-board and connector-panel shapes and their separation paths are illustrative; the optional battery cover area follows the manual, but no unit-level installation is asserted.",
+        "referenceImages": [
+          {
+            "id": "icx-variants-usability-test-photo",
+            "assetUrl": "/equipment/dominion-democracy-suite-517-imagecast-x/reference-icx-variants.png",
+            "assetSha256": "a9b0898c52729f8a33e6ca9f8a91acc58c7c42a5fcf902ea647d6037d04de497",
+            "width": 392,
+            "height": 263,
+            "alt": "Three ImageCast X terminals in voting booths, including portrait displays and an external printer",
+            "caption": "Actual-device photograph from an official usability report: ICX 21, ICX 15, and ICX 12.2.",
+            "kind": "official_test_report_photo",
+            "sourceIds": [
+              "sf-icx-usability-test-report-510"
+            ],
+            "sourceRevisionIds": [
+              "sf-icx-usability-test-report-510@2026-07-20"
+            ],
+            "pageOrSection": "PDF page 7, report page 4, Figure 2-1",
+            "derivativeNote": "Exact embedded image extracted from Figure 2-1; no crop or content alteration.",
+            "caveat": "This photograph is from an older 5.0 usability-test context and shows multiple ICX sizes. It does not establish the exact 5.17 hardware alternative, accessories, software, or field installation represented by the schematic."
+          }
+        ],
+        "camera": {
+          "position": [
+            7,
+            5,
+            8
+          ],
+          "zoom": 72,
+          "near": 0.1,
+          "far": 100
+        },
+        "nodes": [
+          {
+            "componentId": "icx-application",
+            "nodeName": "ICX_Application",
+            "color": "#33c6b5",
+            "explodedOffset": [
+              0,
+              0.3,
+              0.65
+            ]
+          },
+          {
+            "componentId": "icx-touchscreen-bmd",
+            "nodeName": "ICX_Touchscreen",
+            "color": "#78a6ff",
+            "explodedOffset": [
+              0,
+              0.8,
+              0
+            ]
+          },
+          {
+            "componentId": "icx-sid21-compute-board",
+            "nodeName": "ICX_Compute_Board",
+            "color": "#f0b95a",
+            "explodedOffset": [
+              0,
+              0.1,
+              -1.15
+            ]
+          },
+          {
+            "componentId": "icx-sid21-io-panel",
+            "nodeName": "ICX_IO_Panel",
+            "color": "#ff8c69",
+            "explodedOffset": [
+              1.35,
+              0.1,
+              -0.35
+            ]
+          },
+          {
+            "componentId": "icx-sid21-internal-battery",
+            "nodeName": "ICX_Internal_Battery",
+            "color": "#e87fb3",
+            "explodedOffset": [
+              -1.2,
+              0.2,
+              -0.7
+            ]
+          },
+          {
+            "componentId": "icx-ballot-printer",
+            "nodeName": "ICX_Ballot_Printer",
+            "color": "#f0b95a",
+            "explodedOffset": [
+              1.15,
+              0.2,
+              0.25
+            ]
+          },
+          {
+            "componentId": "icx-external-ups",
+            "nodeName": "ICX_External_UPS",
+            "color": "#e87fb3",
+            "explodedOffset": [
+              -1.2,
+              -0.2,
+              0.2
+            ]
+          },
+          {
+            "componentId": "icx-accessible-tactile-interface",
+            "nodeName": "ICX_ATI",
+            "color": "#d1e8e5",
+            "explodedOffset": [
+              0.8,
+              -0.3,
+              0.7
+            ]
+          },
+          {
+            "componentId": "icx-assistive-accessories",
+            "nodeName": "ICX_Assistive_Accessories",
+            "color": "#a68cf2",
+            "explodedOffset": [
+              -1,
+              0.75,
+              0.5
+            ]
+          },
+          {
+            "componentId": "icx-election-media",
+            "nodeName": "ICX_Election_Media",
+            "color": "#ff8c69",
+            "explodedOffset": [
+              0.45,
+              0.25,
+              0.85
+            ]
+          },
+          {
+            "componentId": "icx-physical-accessories",
+            "nodeName": "ICX_Physical_Accessories",
+            "color": "#53676d",
+            "explodedOffset": [
+              0,
+              -0.85,
+              -0.6
+            ]
+          }
+        ]
+      },
+      "caveats": [
+        "Certified and tested component alternatives are not evidence that all listed options are installed together or that a jurisdiction selected a particular option.",
+        "The 3D reference follows the SID-21V mechanical outline but remains a selection aid, not vendor CAD, a teardown, a wiring diagram, or proof of exact internal placement.",
+        "The SSD component category is source-supported, but its model, firmware number, physical location, and internal geometry remain unknown and are not visualized.",
+        "The UPS alternatives are confirmed configuration options, but capacity, load-specific runtime, maintenance condition, and field topology remain unknown.",
+        "Advisory notices are time-, version-, scenario-, and sometimes jurisdiction-scoped. They do not prove an election incident, altered votes, fraud, misconduct, or an incorrect outcome."
+      ],
+      "claimRevision": 5,
+      "editorialState": "published",
+      "sourceIds": [
+        "co-dvs-517-avalue-sid21-manual",
+        "co-dvs-517-icx-maintenance-manual",
+        "co-dvs-517-system-overview",
+        "dvs-icx-prime-ssd-advisory",
+        "dvs-icx-straight-party-advisory",
+        "dvs-icx-touchscreen-advisory",
+        "eac-dsuite-517-record",
+        "eac-dsuite-517-scope",
+        "provv-dsuite-517-test-plan",
+        "provv-dsuite-517-test-report",
+        "provv-dsuite-eco-100936-analysis",
+        "sf-icx-usability-test-report-510"
+      ],
+      "sourceRevisionIds": [
+        "co-dvs-517-avalue-sid21-manual@2026-07-20",
+        "co-dvs-517-icx-maintenance-manual@2026-07-20",
+        "co-dvs-517-system-overview@2026-07-21",
+        "dvs-icx-prime-ssd-advisory@2026-07-20",
+        "dvs-icx-straight-party-advisory@2026-07-20",
+        "dvs-icx-touchscreen-advisory@2026-07-20",
+        "eac-dsuite-517-record@2026-07-20",
+        "eac-dsuite-517-scope@2026-07-20",
+        "provv-dsuite-517-test-plan@2026-07-20",
+        "provv-dsuite-517-test-report@2026-07-20",
+        "provv-dsuite-eco-100936-analysis@2026-07-20",
+        "sf-icx-usability-test-report-510@2026-07-20"
+      ],
+      "coverage": {
+        "componentCount": 12,
+        "sourcedComponentCount": 12,
+        "technicalSpecificationCount": 11,
+        "establishedTechnicalSpecificationCount": 10,
+        "unknownTechnicalSpecificationCount": 1,
+        "configurationChangeCount": 4,
+        "deploymentObservationCount": 0,
+        "findingCount": 4,
+        "powerRecordCount": 2,
+        "confirmedPowerRecordCount": 2,
+        "sourceCount": 12,
+        "sourceRevisionCount": 12,
+        "componentSecurityReviewCount": 0,
+        "exactApplicableVulnerabilityCount": 0,
+        "nonCveAdvisoryCount": 0,
+        "networkConfigurationCount": 1,
+        "networkSourceImageCount": 2,
+        "fieldObservedNetworkConfigurationCount": 0
+      }
+    },
+    {
+      "id": "ess-evs-6400-ds200",
+      "slug": "ess-evs-6400-ds200",
+      "status": "pilot",
+      "manufacturer": "Election Systems & Software",
+      "systemName": "EVS",
+      "systemVersion": "6.4.0.0",
+      "deviceName": "DS200",
+      "displayName": "ES&S EVS 6.4.0.0 / DS200",
+      "deviceRole": "Polling-place digital scanner and tabulator",
+      "summary": "A source-linked pilot dossier for the DS200 within the EAC-certified EVS 6.4.0.0 configuration, with historical change records, separately scoped optional modem models and vulnerability reviews, and a labeled Washington deployment observation.",
+      "certification": {
+        "certificationId": "ESSEVS6400",
+        "standard": "VVSG 1.0",
+        "certifiedOn": "2023-08-18",
+        "vstl": "Pro V&V, Inc.",
+        "scopeKind": "certified_configuration",
+        "sourceIds": [
+          "eac-evs-6400-record",
+          "eac-evs-6400-scope",
+          "provv-evs-6400-test-report"
+        ],
+        "caveat": "EAC certification applies only to the evaluated EVS 6.4.0.0 certified configuration. It is not an endorsement, warranty, field inventory, or determination that a particular unit was operated in that configuration.",
+        "sourceRevisionIds": [
+          "eac-evs-6400-record@2026-07-19",
+          "eac-evs-6400-scope@2026-07-19",
+          "provv-evs-6400-test-report@2026-07-19"
+        ]
+      },
+      "components": [
+        {
+          "id": "ds200-scanner-tabulator",
+          "name": "DS200 scanner and tabulator assembly",
+          "category": "device",
+          "description": "The certified scope describes the DS200 as a poll-place scanner and tabulator that scans voter selections from both sides of a ballot simultaneously.",
+          "evidenceStatus": "certified_component",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "DS200"
+          ],
+          "hardwareRevisions": [
+            "1.2",
+            "1.3"
+          ],
+          "versionObservationIds": [
+            "ds200-eac-firmware-3100",
+            "ds200-wa-firmware-3100",
+            "ds200-wa-hardware-1313"
+          ],
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report",
+            "ess-ds200-one-sheet"
+          ],
+          "sceneNodeName": "DS200_Shell",
+          "caveat": "Washington's state-approved configuration also lists hardware 1.3.13. No source in this pilot identifies the hardware revision of a particular county unit.",
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19",
+            "ess-ds200-one-sheet@2026-07-20"
+          ],
+          "technicalSpecifications": [
+            {
+              "id": "ds200-cellular-certified-scope",
+              "category": "cellular",
+              "label": "Cellular modem",
+              "value": "No WAN modem or WAN wireless use listed in the EVS 6.4.0.0 certified-system table",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "EVS 6.4.0.0 certified configuration",
+              "sourceIds": [
+                "eac-evs-6400-scope"
+              ],
+              "sourceRevisionIds": [
+                "eac-evs-6400-scope@2026-07-19"
+              ],
+              "caveat": "This is a certified-system communications-use statement. It does not prove the physical absence of every connector or service component inside every DS200 unit."
+            },
+            {
+              "id": "ds200-ethernet-certified-scope",
+              "category": "ethernet",
+              "label": "Ethernet / LAN",
+              "value": "No LAN TCP/IP or LAN wireless use listed in the EVS 6.4.0.0 certified-system table",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "EVS 6.4.0.0 certified configuration",
+              "sourceIds": [
+                "eac-evs-6400-scope"
+              ],
+              "sourceRevisionIds": [
+                "eac-evs-6400-scope@2026-07-19"
+              ],
+              "caveat": "This establishes permitted certified-system communications use, not a teardown-based count of physical RJ-45 connectors."
+            },
+            {
+              "id": "ds200-usb-port-count-gap",
+              "category": "usb",
+              "label": "Physical USB port count",
+              "value": null,
+              "knowledgeStatus": "not_publicly_established",
+              "assertionScope": "evidence_gap",
+              "modelContext": "DS200",
+              "sourceIds": [
+                "eac-evs-6400-scope",
+                "provv-evs-6400-test-report"
+              ],
+              "sourceRevisionIds": [
+                "eac-evs-6400-scope@2026-07-19",
+                "provv-evs-6400-test-report@2026-07-19"
+              ],
+              "caveat": "Reviewed certification artifacts identify removable media and system components but do not publish a DS200 physical USB-connector count."
+            },
+            {
+              "id": "ds200-memory-capacity-gap",
+              "category": "memory",
+              "label": "Installed RAM",
+              "value": null,
+              "knowledgeStatus": "not_publicly_established",
+              "assertionScope": "evidence_gap",
+              "modelContext": "DS200",
+              "sourceIds": [
+                "eac-evs-6400-scope",
+                "provv-evs-6400-test-report"
+              ],
+              "sourceRevisionIds": [
+                "eac-evs-6400-scope@2026-07-19",
+                "provv-evs-6400-test-report@2026-07-19"
+              ],
+              "caveat": "No reviewed artifact publishes the installed RAM technology or capacity for the certified DS200 configurations."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "ds200-optional-cellular-modem",
+          "name": "Optional modem carrier board",
+          "category": "cellular",
+          "optionality": "optional",
+          "description": "ES&S states that modem components are not resident by default and that a separate board is installed only where cellular transmission is permitted; Rhode Island's 2021 procedure documents post-poll cellular transmission. Exact historical modem modules are listed as separate evidence records below.",
+          "evidenceStatus": "documented_optional_model_component",
+          "scopeKind": "manufacturer_hardware_documentation",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "ess-election-security-faqs",
+            "ri-ds200-pollworker-manual-2021"
+          ],
+          "sourceRevisionIds": [
+            "ess-election-security-faqs@2026-07-20",
+            "ri-ds200-pollworker-manual-2021@2026-07-20"
+          ],
+          "sceneNodeName": "Optional_Cellular_Modem",
+          "caveat": "The sources establish an optional separate board and one jurisdiction's documented procedure, but not this carrier board's manufacturer, part number, radio module, firmware, antenna, exact placement, or presence in every DS200. The scene shape is symbolic.",
+          "technicalSpecifications": [
+            {
+              "id": "ds200-optional-cellular-capability",
+              "category": "cellular",
+              "label": "Optional cellular transmission",
+              "value": "Separate modem board installed only where permitted; Rhode Island documents transmission after polls close",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "jurisdiction_deployment_observation",
+              "modelContext": "DS200 model family; Rhode Island 2021 deployment procedure",
+              "sourceIds": [
+                "ess-election-security-faqs",
+                "ri-ds200-pollworker-manual-2021"
+              ],
+              "sourceRevisionIds": [
+                "ess-election-security-faqs@2026-07-20",
+                "ri-ds200-pollworker-manual-2021@2026-07-20"
+              ],
+              "caveat": "This does not mean every DS200 contains a modem, that EVS 6.4.0.0 permits WAN use, or that cellular transmission was enabled or used in an unlisted jurisdiction."
+            }
+          ],
+          "securityReview": {
+            "reviewedOn": "2026-07-20",
+            "productIdentityStatus": "component_identity_unresolved",
+            "firmwareStatus": "not_publicly_established",
+            "firmwareVersion": null,
+            "overallStatus": "exact_product_review_not_possible",
+            "coverageDefinition": "All publicly indexed, exact-product-applicable records found in the reviewed NVD, CISA KEV, and manufacturer security-advisory sources as of the review date.",
+            "rankingMethod": "Known exploitation in CISA KEV ranks first, then numeric CVSS score, then a source-assigned severity. No score or severity is invented when a source does not publish one.",
+            "sourcesReviewed": [],
+            "vulnerabilities": [],
+            "nonCveAdvisories": [],
+            "caveat": "An exact-product vulnerability review cannot be performed until the carrier board and installed modem module are identified. An empty list here is an evidence gap, not a claim of no vulnerabilities."
+          }
+        },
+        {
+          "id": "ds200-multitech-c2-modem",
+          "name": "MultiTech Verizon C2 cellular modem",
+          "category": "cellular",
+          "optionality": "optional",
+          "description": "Florida's June 2015 qualification addendum identifies a MultiTech Verizon C2 modem evaluated as an optional DS200 result-transmission component.",
+          "evidenceStatus": "historical_state_approved_model_component",
+          "scopeKind": "historical_state_approval",
+          "modelNumbers": [
+            "MTSMC-C2-N3-R.1"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "fl-evs-4500-v4-modem-report",
+            "eac-unity-3200-document-report",
+            "multitech-universal-socket-guide"
+          ],
+          "sourceRevisionIds": [
+            "fl-evs-4500-v4-modem-report@2026-07-20",
+            "eac-unity-3200-document-report@2026-07-20",
+            "multitech-universal-socket-guide@2026-07-20"
+          ],
+          "sceneNodeName": null,
+          "caveat": "This model is established only for Florida EVS 4.5.0.0 Version 4 and DS200 hardware 1.2 or 1.3. The public record does not establish EVS 6.4.0.0 certification, Rhode Island fielding, a current installed unit, radio firmware, antenna installation, or exact internal placement.",
+          "technicalSpecifications": [
+            {
+              "id": "ds200-c2-network-profile",
+              "category": "cellular",
+              "label": "Carrier and radio family",
+              "value": "Verizon CDMA2000 1xRTT / C2 wireless modem",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "approved_change",
+              "modelContext": "Florida EVS 4.5.0.0 Version 4; DS200 hardware 1.2 and 1.3",
+              "sourceIds": [
+                "fl-evs-4500-v4-modem-report",
+                "multitech-universal-socket-guide"
+              ],
+              "sourceRevisionIds": [
+                "fl-evs-4500-v4-modem-report@2026-07-20",
+                "multitech-universal-socket-guide@2026-07-20"
+              ],
+              "caveat": "This is a historical state-approved configuration, not proof that a modem was installed or enabled in another DS200 configuration or jurisdiction."
+            },
+            {
+              "id": "ds200-c2-firmware-update-path",
+              "category": "firmware",
+              "label": "Documented firmware update path",
+              "value": "Non-UIP C2 SocketModem firmware can be updated through the serial port with MultiTech assistance",
+              "knowledgeStatus": "documented_partial",
+              "assertionScope": "manufacturer_product",
+              "modelContext": "MultiTech MTSMC-C2 product family",
+              "sourceIds": [
+                "multitech-universal-socket-guide"
+              ],
+              "sourceRevisionIds": [
+                "multitech-universal-socket-guide@2026-07-20"
+              ],
+              "caveat": "The guide describes an update method, not the firmware version installed in the Florida test modem or any fielded DS200."
+            }
+          ],
+          "securityReview": {
+            "reviewedOn": "2026-07-20",
+            "productIdentityStatus": "exact_model_historical_scope",
+            "firmwareStatus": "not_publicly_established",
+            "firmwareVersion": null,
+            "overallStatus": "no_exact_product_matches_found",
+            "coverageDefinition": "All publicly indexed, exact-product-applicable records found in the reviewed NVD, CISA KEV, and manufacturer security-advisory sources as of the review date.",
+            "rankingMethod": "Known exploitation in CISA KEV ranks first, then numeric CVSS score, then a source-assigned severity. No score or severity is invented when a source does not publish one.",
+            "sourcesReviewed": [
+              {
+                "id": "ds200-c2-nvd-review",
+                "catalog": "NIST National Vulnerability Database",
+                "queryTerms": [
+                  "MTSMC-C2",
+                  "MTSMC-C2-N3.R1",
+                  "MultiTech SocketModem",
+                  "CE910",
+                  "Telit CE910"
+                ],
+                "resultStatus": "no_exact_product_matches",
+                "exactMatchCount": 0,
+                "sourceIds": [
+                  "nvd-modem-query-review"
+                ],
+                "sourceRevisionIds": [
+                  "nvd-modem-query-review@2026-07-20"
+                ],
+                "caveat": "Zero keyword matches does not rule out differently named, unindexed, undisclosed, or firmware-dependent vulnerabilities."
+              },
+              {
+                "id": "ds200-c2-cisa-kev-review",
+                "catalog": "CISA Known Exploited Vulnerabilities",
+                "queryTerms": [
+                  "MultiTech",
+                  "Telit",
+                  "SocketModem",
+                  "MTSMC",
+                  "CE910"
+                ],
+                "resultStatus": "no_catalog_matches",
+                "exactMatchCount": 0,
+                "sourceIds": [
+                  "cisa-kev-catalog"
+                ],
+                "sourceRevisionIds": [
+                  "cisa-kev-catalog@2026-07-20"
+                ],
+                "caveat": "KEV is a list of vulnerabilities known to be exploited in the wild, not an inventory of every vulnerability."
+              },
+              {
+                "id": "ds200-c2-multitech-advisory-review",
+                "catalog": "MultiTech security advisories",
+                "queryTerms": [
+                  "MTSMC-C2",
+                  "MTSMC-C2-N3.R1",
+                  "SocketModem"
+                ],
+                "resultStatus": "no_applicable_product_matches",
+                "exactMatchCount": 0,
+                "sourceIds": [
+                  "multitech-security-advisories-index",
+                  "multitech-security-advisory-bundle"
+                ],
+                "sourceRevisionIds": [
+                  "multitech-security-advisories-index@2026-07-20",
+                  "multitech-security-advisory-bundle@2026-07-20"
+                ],
+                "caveat": "The archived advisories name other product families or state that MultiTech products are not affected; the result is bounded to the reviewed advisory set."
+              }
+            ],
+            "vulnerabilities": [],
+            "nonCveAdvisories": [],
+            "caveat": "No exact-product-applicable public vulnerability record was found in the reviewed sources. This does not mean the modem has no vulnerability; the installed firmware is unknown and public catalogs may be incomplete."
+          }
+        },
+        {
+          "id": "ds200-multitech-lvw3-modem",
+          "name": "MultiTech Verizon 4G LTE modem",
+          "category": "cellular",
+          "optionality": "optional",
+          "description": "A court-filed copy of a Pro V&V EVS 5.3.4.1 test report identifies MTSMC-LVW3 Verizon 4G modem test units with DS200 hardware 1.2 and 1.3.",
+          "evidenceStatus": "historical_vstl_tested_model_component",
+          "scopeKind": "historical_test_configuration",
+          "modelNumbers": [
+            "MTSMC-LVW3"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "provv-evs-5341-modem-hardware-table",
+            "multitech-verizon-fota",
+            "multitech-eol-products",
+            "multitech-lvw3-update-bulletin"
+          ],
+          "sourceRevisionIds": [
+            "provv-evs-5341-modem-hardware-table@2026-07-20",
+            "multitech-verizon-fota@2026-07-20",
+            "multitech-eol-products@2026-07-20",
+            "multitech-lvw3-update-bulletin@2026-07-20"
+          ],
+          "sceneNodeName": null,
+          "caveat": "The Pro V&V table establishes the base model string in an EVS 5.3.4.1 test configuration, not EVS 6.4.0.0 certification or field use. It does not identify the ordering revision, installed Telit radio variant, radio firmware, patch state, antenna, or exact placement.",
+          "technicalSpecifications": [
+            {
+              "id": "ds200-lvw3-network-profile",
+              "category": "cellular",
+              "label": "Carrier and radio family",
+              "value": "Verizon 4G LTE Category 1 SocketModem",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "documented_model_family",
+              "modelContext": "MTSMC-LVW3; EVS 5.3.4.1 Pro V&V test hardware",
+              "sourceIds": [
+                "provv-evs-5341-modem-hardware-table",
+                "multitech-lvw3-update-bulletin"
+              ],
+              "sourceRevisionIds": [
+                "provv-evs-5341-modem-hardware-table@2026-07-20",
+                "multitech-lvw3-update-bulletin@2026-07-20"
+              ],
+              "caveat": "The sources establish the test-hardware model and manufacturer product family, not a live connection, installed firmware, or a fielded DS200 modem."
+            },
+            {
+              "id": "ds200-lvw3-current-radio-mapping",
+              "category": "cellular",
+              "label": "Current product-family radio mapping",
+              "value": "Telit LE910-NA1 in MultiTech's current MTSMC-LVW3 family table",
+              "knowledgeStatus": "documented_partial",
+              "assertionScope": "manufacturer_product",
+              "modelContext": "Current MultiTech MTSMC-LVW3 product-family FOTA table",
+              "sourceIds": [
+                "multitech-verizon-fota"
+              ],
+              "sourceRevisionIds": [
+                "multitech-verizon-fota@2026-07-20"
+              ],
+              "caveat": "The historical Pro V&V table omits the ordering revision. This current family mapping is not proof that either evaluated DS200 test modem contained an LE910-NA1 radio."
+            },
+            {
+              "id": "ds200-lvw3-ordering-revisions",
+              "category": "lifecycle",
+              "label": "Documented ordering variants",
+              "value": "MTSMC-LVW3 base, R1, R2, and R4 variants appear in the manufacturer lifecycle table",
+              "knowledgeStatus": "documented_partial",
+              "assertionScope": "manufacturer_product",
+              "modelContext": "MTSMC-LVW3 product family",
+              "sourceIds": [
+                "multitech-eol-products"
+              ],
+              "sourceRevisionIds": [
+                "multitech-eol-products@2026-07-20"
+              ],
+              "caveat": "The exact ordering revision used in the Pro V&V test units is not stated, so no listed lifecycle date is assigned to those units."
+            }
+          ],
+          "securityReview": {
+            "reviewedOn": "2026-07-20",
+            "productIdentityStatus": "exact_model_family_historical_scope",
+            "firmwareStatus": "not_publicly_established",
+            "firmwareVersion": null,
+            "overallStatus": "no_exact_product_matches_found",
+            "coverageDefinition": "All publicly indexed, exact-product-applicable records found in the reviewed NVD, CISA KEV, and manufacturer security-advisory sources as of the review date.",
+            "rankingMethod": "Known exploitation in CISA KEV ranks first, then numeric CVSS score, then a source-assigned severity. No score or severity is invented when a source does not publish one.",
+            "sourcesReviewed": [
+              {
+                "id": "ds200-lvw3-nvd-review",
+                "catalog": "NIST National Vulnerability Database",
+                "queryTerms": [
+                  "MTSMC-LVW3",
+                  "Telit LE910",
+                  "Telit LE910-SV1",
+                  "Telit LE910-NA1",
+                  "LE910-SV1",
+                  "LE910-NA1"
+                ],
+                "resultStatus": "no_exact_product_matches",
+                "exactMatchCount": 0,
+                "sourceIds": [
+                  "nvd-modem-query-review"
+                ],
+                "sourceRevisionIds": [
+                  "nvd-modem-query-review@2026-07-20"
+                ],
+                "caveat": "Zero keyword matches does not rule out differently named, unindexed, undisclosed, or firmware-dependent vulnerabilities."
+              },
+              {
+                "id": "ds200-lvw3-cisa-kev-review",
+                "catalog": "CISA Known Exploited Vulnerabilities",
+                "queryTerms": [
+                  "MultiTech",
+                  "Telit",
+                  "SocketModem",
+                  "MTSMC",
+                  "LE910"
+                ],
+                "resultStatus": "no_catalog_matches",
+                "exactMatchCount": 0,
+                "sourceIds": [
+                  "cisa-kev-catalog"
+                ],
+                "sourceRevisionIds": [
+                  "cisa-kev-catalog@2026-07-20"
+                ],
+                "caveat": "KEV is a list of vulnerabilities known to be exploited in the wild, not an inventory of every vulnerability."
+              },
+              {
+                "id": "ds200-lvw3-multitech-advisory-review",
+                "catalog": "MultiTech security advisories",
+                "queryTerms": [
+                  "MTSMC-LVW3",
+                  "LE910",
+                  "SocketModem"
+                ],
+                "resultStatus": "no_applicable_product_matches",
+                "exactMatchCount": 0,
+                "sourceIds": [
+                  "multitech-security-advisories-index",
+                  "multitech-security-advisory-bundle"
+                ],
+                "sourceRevisionIds": [
+                  "multitech-security-advisories-index@2026-07-20",
+                  "multitech-security-advisory-bundle@2026-07-20"
+                ],
+                "caveat": "The archived advisories name other product families or state that MultiTech products are not affected; the result is bounded to the reviewed advisory set."
+              }
+            ],
+            "vulnerabilities": [],
+            "nonCveAdvisories": [
+              {
+                "id": "mtsmc-lvw3-verizon-2019-update",
+                "kind": "vendor_operational_service_continuity_bulletin",
+                "title": "Verizon LTE Cat 1 software patch bulletin",
+                "publishedOn": "2019-03-12",
+                "cvssScore": null,
+                "cisaKev": false,
+                "securitySeverity": null,
+                "operationalImpact": "urgent_update_recommended",
+                "affectedFirmware": null,
+                "fixedFirmware": null,
+                "description": "MultiTech reported an urgent software-patch need for listed Verizon LTE Cat 1 products, possibly including MTSMC-LVW3 variants, to support future network updates and uninterrupted operation.",
+                "sourceIds": [
+                  "multitech-lvw3-update-bulletin"
+                ],
+                "sourceRevisionIds": [
+                  "multitech-lvw3-update-bulletin@2026-07-20"
+                ],
+                "caveat": "The bulletin is not a CVE or security advisory, assigns no CVSS score, and does not establish the firmware or patch state of the Pro V&V DS200 test modems or any fielded unit."
+              }
+            ],
+            "caveat": "No exact-product-applicable public vulnerability record was found in the reviewed sources. This does not mean the modem has no vulnerability; the exact ordering revision and installed firmware are unknown and public catalogs may be incomplete."
+          }
+        },
+        {
+          "id": "ds200-scanner-path",
+          "name": "Ballot scanning path",
+          "category": "scanner",
+          "description": "The public certification scope establishes simultaneous front-and-back ballot scanning. The schematic path is illustrative and does not reproduce proprietary internal drawings.",
+          "evidenceStatus": "function_documented_geometry_illustrative",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report"
+          ],
+          "sceneNodeName": "Scanner_Path",
+          "caveat": "Public sources document the function, not the exact internal shape or placement shown in the schematic.",
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds200-display-assembly",
+          "name": "Display and touchscreen assembly",
+          "category": "interface",
+          "description": "ECO 1042 identifies a touchscreen controller, LCD, mounting bracket, LVDS cables, and a field-service display subassembly in DS200 hardware configuration 1.3.11.",
+          "evidenceStatus": "historical_change_record",
+          "scopeKind": "historical_change",
+          "modelNumbers": [],
+          "hardwareRevisions": [
+            "1.3.11"
+          ],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "provv-eco-ess-1042-analysis",
+            "eac-eco-ess-1042-approval"
+          ],
+          "sceneNodeName": "Display_Assembly",
+          "caveat": "This historical ECO identifies a DS200-family configuration change. It does not prove that the illustrated assembly is present in an EVS 6.4.0.0 fielded unit.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-1042-approval@2026-07-19",
+            "provv-eco-ess-1042-analysis@2026-07-19"
+          ],
+          "technicalSpecifications": [
+            {
+              "id": "ds200-processor-core-count",
+              "category": "processor",
+              "label": "Processor architecture",
+              "value": "Quad-core processor",
+              "knowledgeStatus": "documented_partial",
+              "assertionScope": "approved_change",
+              "modelContext": "DS200 hardware configuration 1.3.11",
+              "sourceIds": [
+                "provv-eco-ess-1042-analysis",
+                "eac-eco-ess-1042-approval"
+              ],
+              "sourceRevisionIds": [
+                "provv-eco-ess-1042-analysis@2026-07-19",
+                "eac-eco-ess-1042-approval@2026-07-19"
+              ],
+              "caveat": "The approved change identifies the core count but not the processor manufacturer, model, clock speed, or the configuration of a particular fielded unit."
+            },
+            {
+              "id": "ds200-processor-model-gap",
+              "category": "processor",
+              "label": "Exact CPU model",
+              "value": null,
+              "knowledgeStatus": "not_publicly_established",
+              "assertionScope": "evidence_gap",
+              "modelContext": "DS200 hardware configuration 1.3.11",
+              "sourceIds": [
+                "provv-eco-ess-1042-analysis"
+              ],
+              "sourceRevisionIds": [
+                "provv-eco-ess-1042-analysis@2026-07-19"
+              ],
+              "caveat": "The reviewed ECO analysis does not name an exact processor part number."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "ds200-processor-module",
+          "name": "Processor module",
+          "category": "compute",
+          "description": "ECO 1042 records a move to a quad-core processor on the motherboard for DS200 hardware configuration 1.3.11.",
+          "evidenceStatus": "historical_change_record",
+          "scopeKind": "historical_change",
+          "modelNumbers": [],
+          "hardwareRevisions": [
+            "1.3.11"
+          ],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "provv-eco-ess-1042-analysis",
+            "eac-eco-ess-1042-approval"
+          ],
+          "sceneNodeName": "Processor_Module",
+          "caveat": "Processor make, model, location, and presence in a particular EVS 6.4.0.0 fielded unit are not publicly confirmed by this pilot.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-1042-approval@2026-07-19",
+            "provv-eco-ess-1042-analysis@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds200-scanner-board",
+          "name": "Scanner board and FPGA logic",
+          "category": "scanner_electronics",
+          "description": "ECO 1035 documents a DS200 scanner-board FPGA-code update intended to improve thermal stability and calibration resolution; ECO 1042 also references a board change for a new motor driver.",
+          "evidenceStatus": "historical_change_record",
+          "scopeKind": "historical_change",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "provv-eco-ess-1035-analysis",
+            "eac-eco-ess-1035-approval",
+            "provv-eco-ess-1042-analysis"
+          ],
+          "sceneNodeName": "Scanner_Board",
+          "caveat": "The public records do not identify a board part number or establish the board/FPGA revision installed in a particular EVS 6.4.0.0 unit.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-1035-approval@2026-07-19",
+            "provv-eco-ess-1035-analysis@2026-07-19",
+            "provv-eco-ess-1042-analysis@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds200-ballot-container",
+          "name": "Ballot container options",
+          "category": "ballot_storage",
+          "description": "The EVS 6.4.0.0 scope lists multiple DS200/DS300-compatible ballot boxes, tote bins, a trolley, tote bag, and carrying cases as proprietary configuration components.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "98-00009",
+            "98-00110",
+            "57521",
+            "00074",
+            "212516",
+            "76245",
+            "60"
+          ],
+          "hardwareRevisions": [
+            "1.0",
+            "1.1",
+            "1.2",
+            "1.3",
+            "1.4",
+            "1.5"
+          ],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report"
+          ],
+          "sceneNodeName": "Ballot_Container",
+          "caveat": "These are permitted configuration options, not a claim that every DS200 uses every listed container or accessory.",
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds200-tote-bin-security",
+          "name": "Tote-bin security gasketing",
+          "category": "physical_security",
+          "description": "ECO 1165 adds a security gasketing kit intended to prevent cards or ballots from entering through gaps along the tote-bin hinge area.",
+          "evidenceStatus": "approved_change_for_evs_6400",
+          "scopeKind": "certified_configuration_change",
+          "modelNumbers": [
+            "00074"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "provv-eco-ess-1165-analysis",
+            "eac-eco-ess-1165-approval"
+          ],
+          "sceneNodeName": "Tote_Bin_Gasket",
+          "caveat": "The change was approved for EVS 6.4.0.0, but the pilot has no evidence that a particular jurisdiction installed the kit.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-1165-approval@2026-07-19",
+            "provv-eco-ess-1165-analysis@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds200-seal-area",
+          "name": "Exterior seal area",
+          "category": "physical_security",
+          "description": "ECO 983 documents a historical DS200 hardware 1.3.10.0 exterior seal-area change.",
+          "evidenceStatus": "historical_change_record",
+          "scopeKind": "historical_change",
+          "modelNumbers": [],
+          "hardwareRevisions": [
+            "1.3.10.0"
+          ],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "provv-eco-ess-983-analysis",
+            "eac-eco-ess-983-record"
+          ],
+          "sceneNodeName": "Seal_Area",
+          "caveat": "This record does not establish inclusion in EVS 6.4.0.0 or installation on any fielded unit.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-983-record@2026-07-19",
+            "provv-eco-ess-983-analysis@2026-07-19"
+          ],
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds200-power-backup",
+          "name": "Battery backup and internal power",
+          "category": "power",
+          "description": "The ES&S one-sheet states that the DS200 has battery backup. The reviewed sources do not identify its battery chemistry, manufacturer, model, capacity, runtime, or internal placement.",
+          "evidenceStatus": "manufacturer_documented_partial",
+          "scopeKind": "manufacturer_product_documentation",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report",
+            "wa-evs-6400-staff-report",
+            "ess-ds200-one-sheet"
+          ],
+          "sceneNodeName": null,
+          "caveat": "Battery-backup presence is manufacturer-documented, but no reviewed source supports a battery model, capacity, runtime, chemistry, or scene placement. Central-count UPS models must not be transferred to the DS200.",
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19",
+            "wa-evs-6400-staff-report@2026-07-19",
+            "ess-ds200-one-sheet@2026-07-20"
+          ],
+          "technicalSpecifications": [
+            {
+              "id": "ds200-battery-backup-presence",
+              "category": "power",
+              "label": "Backup supply",
+              "value": "Battery backup documented; model, chemistry, capacity, and runtime not stated",
+              "knowledgeStatus": "documented_partial",
+              "assertionScope": "manufacturer_product",
+              "modelContext": "DS200",
+              "sourceIds": [
+                "ess-ds200-one-sheet"
+              ],
+              "sourceRevisionIds": [
+                "ess-ds200-one-sheet@2026-07-20"
+              ],
+              "caveat": "The one-sheet confirms battery-backup presence only. It does not disclose a battery part number or unit-level condition."
+            }
+          ],
+          "securityReview": null
+        }
+      ],
+      "versionObservations": [
+        {
+          "id": "ds200-eac-firmware-3100",
+          "componentId": "ds200-scanner-tabulator",
+          "versionType": "firmware",
+          "value": "3.1.0.0",
+          "label": "EAC-certified firmware",
+          "scopeKind": "certified_configuration",
+          "observedOn": "2023-08-18",
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report"
+          ],
+          "caveat": "This is the firmware in the certified EVS 6.4.0.0 configuration, not a live reading from a deployed unit and not a claim about the newest EVS family firmware.",
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19"
+          ],
+          "assertionScope": "certified",
+          "approvalScope": null,
+          "fieldStatus": "not_established",
+          "assertedFor": {
+            "systemCertificationId": "ESSEVS6400",
+            "jurisdiction": null,
+            "observedOn": "2023-08-18"
+          }
+        },
+        {
+          "id": "ds200-wa-firmware-3100",
+          "componentId": "ds200-scanner-tabulator",
+          "versionType": "firmware",
+          "value": "3.1.0.0",
+          "label": "Washington-approved firmware",
+          "scopeKind": "state_approved_configuration",
+          "observedOn": "2023-11-30",
+          "sourceIds": [
+            "wa-evs-6400-application",
+            "wa-evs-6400-staff-report"
+          ],
+          "caveat": "Washington's approved configuration is not a county device inspection.",
+          "sourceRevisionIds": [
+            "wa-evs-6400-application@2026-07-19",
+            "wa-evs-6400-staff-report@2026-07-19"
+          ],
+          "assertionScope": "documented",
+          "approvalScope": "state_approved_configuration",
+          "fieldStatus": "not_established",
+          "assertedFor": {
+            "systemCertificationId": "ESSEVS6400",
+            "jurisdiction": null,
+            "observedOn": "2023-11-30"
+          }
+        },
+        {
+          "id": "ds200-wa-hardware-1313",
+          "componentId": "ds200-scanner-tabulator",
+          "versionType": "hardware",
+          "value": "1.2, 1.3, 1.3.13",
+          "label": "Washington-approved hardware revisions",
+          "scopeKind": "state_approved_configuration",
+          "observedOn": "2023-11-30",
+          "sourceIds": [
+            "wa-evs-6400-application",
+            "wa-evs-6400-staff-report"
+          ],
+          "caveat": "The state record lists approved revisions; it does not identify which revision a county deployed.",
+          "sourceRevisionIds": [
+            "wa-evs-6400-application@2026-07-19",
+            "wa-evs-6400-staff-report@2026-07-19"
+          ],
+          "assertionScope": "documented",
+          "approvalScope": "state_approved_configuration",
+          "fieldStatus": "not_established",
+          "assertedFor": {
+            "systemCertificationId": "ESSEVS6400",
+            "jurisdiction": null,
+            "observedOn": "2023-11-30"
+          }
+        }
+      ],
+      "configurationChanges": [
+        {
+          "id": "ess-983",
+          "changeId": "ESS-983",
+          "componentIds": [
+            "ds200-seal-area"
+          ],
+          "submittedOn": "2018-10-10",
+          "eacApprovedOn": "2018-12-14",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "historical_ds200_family_change",
+          "description": "Exterior seal-area change for DS200 hardware 1.3.10.0.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-eco-ess-983-record",
+            "provv-eco-ess-983-analysis"
+          ],
+          "caveat": "The record does not establish inclusion in the EVS 6.4.0.0 baseline or local installation.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-983-record@2026-07-19",
+            "provv-eco-ess-983-analysis@2026-07-19"
+          ]
+        },
+        {
+          "id": "ess-1042",
+          "changeId": "ESS-1042",
+          "componentIds": [
+            "ds200-display-assembly",
+            "ds200-processor-module",
+            "ds200-scanner-board"
+          ],
+          "submittedOn": "2019-08-30",
+          "eacApprovedOn": "2019-09-13",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "historical_ds200_family_change",
+          "description": "End-of-life replacements and related DS200 hardware 1.3.11 changes: touchscreen controller, LCD/bracket/LVDS cables, display service subassembly, quad-core processor, scanner-board motor-driver accommodation, and USB-hub power-cable wire gauge.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-eco-ess-1042-record",
+            "provv-eco-ess-1042-analysis",
+            "eac-eco-ess-1042-approval"
+          ],
+          "caveat": "The ECO documents an approved historical configuration change, not the internals of every DS200 or an EVS 6.4.0.0 deployment.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-1042-approval@2026-07-19",
+            "eac-eco-ess-1042-record@2026-07-19",
+            "provv-eco-ess-1042-analysis@2026-07-19"
+          ]
+        },
+        {
+          "id": "ess-1035",
+          "changeId": "ESS-1035",
+          "componentIds": [
+            "ds200-scanner-board"
+          ],
+          "submittedOn": "2020-02-11",
+          "eacApprovedOn": "2020-02-14",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "historical_ds200_family_change",
+          "description": "Scanner-board FPGA-code update described as improving thermal stability and calibration resolution.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-eco-ess-1035-record",
+            "provv-eco-ess-1035-analysis",
+            "eac-eco-ess-1035-approval"
+          ],
+          "caveat": "The source does not identify the board or FPGA revision installed in a particular EVS 6.4.0.0 unit.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-1035-approval@2026-07-19",
+            "eac-eco-ess-1035-record@2026-07-19",
+            "provv-eco-ess-1035-analysis@2026-07-19"
+          ]
+        },
+        {
+          "id": "ess-1044",
+          "changeId": "ESS-1044",
+          "componentIds": [
+            "ds200-ballot-container"
+          ],
+          "submittedOn": "2019-08-30",
+          "eacApprovedOn": "2019-09-13",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "historical_ds200_family_change",
+          "description": "Ballot-box change adding a ballot-bag option.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-eco-ess-1044-record",
+            "provv-eco-ess-1044-analysis",
+            "eac-eco-ess-1044-approval"
+          ],
+          "caveat": "An approved accessory option does not establish use by a particular jurisdiction.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-1044-approval@2026-07-19",
+            "eac-eco-ess-1044-record@2026-07-19",
+            "provv-eco-ess-1044-analysis@2026-07-19"
+          ]
+        },
+        {
+          "id": "ess-1055",
+          "changeId": "ESS-1055",
+          "componentIds": [
+            "ds200-ballot-container"
+          ],
+          "submittedOn": "2019-11-22",
+          "eacApprovedOn": "2019-12-19",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "historical_ds200_family_change",
+          "description": "Collapsible ballot-box change adding a ballot-trolley/binning option.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-eco-ess-1055-record",
+            "provv-eco-ess-1055-analysis",
+            "eac-eco-ess-1055-approval"
+          ],
+          "caveat": "An approved accessory option does not establish use by a particular jurisdiction.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-1055-approval@2026-07-19",
+            "eac-eco-ess-1055-record@2026-07-19",
+            "provv-eco-ess-1055-analysis@2026-07-19"
+          ]
+        },
+        {
+          "id": "ess-1165",
+          "changeId": "ESS-1165",
+          "componentIds": [
+            "ds200-tote-bin-security",
+            "ds200-ballot-container"
+          ],
+          "submittedOn": "2024-05-13",
+          "eacApprovedOn": "2024-05-15",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "approved_for_evs_6400",
+          "description": "Tote-bin security gasketing intended to prevent cards or ballots from entering through hinge-area gaps; Pro V&V states the change was reviewed and functionally tested and requires no firmware/software change.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-eco-ess-1165-record",
+            "provv-eco-ess-1165-analysis",
+            "eac-eco-ess-1165-approval"
+          ],
+          "caveat": "EVS 6.4.0.0 is listed as affected, but local installation is not established.",
+          "sourceRevisionIds": [
+            "eac-eco-ess-1165-approval@2026-07-19",
+            "eac-eco-ess-1165-record@2026-07-19",
+            "provv-eco-ess-1165-analysis@2026-07-19"
+          ]
+        }
+      ],
+      "findings": [
+        {
+          "id": "evs-6400-test-anomaly-status",
+          "findingType": "test_campaign_result",
+          "title": "Pro V&V anomaly status",
+          "affectedSystemVersions": [
+            "6.4.0.0"
+          ],
+          "componentIds": [],
+          "publicStatus": "none_reported_in_test_campaign",
+          "description": "The certification test report states that no anomalies occurred during the EVS 6.4.0.0 test campaign.",
+          "sourceIds": [
+            "provv-evs-6400-test-report"
+          ],
+          "caveat": "This is scoped to the submitted test campaign. It is not a claim that the system has no bugs or that no field incident can occur.",
+          "sourceRevisionIds": [
+            "provv-evs-6400-test-report@2026-07-19"
+          ]
+        },
+        {
+          "id": "evs-6400-test-deficiency-disclosure",
+          "findingType": "public_documentation_gap",
+          "title": "Deficiencies described but not itemized",
+          "affectedSystemVersions": [
+            "6.4.0.0"
+          ],
+          "componentIds": [],
+          "publicStatus": "resolved_details_not_enumerated",
+          "description": "The public report says encountered deficiencies were tracked and resolutions verified as needed, but section 3.3 does not itemize those deficiencies.",
+          "sourceIds": [
+            "provv-evs-6400-test-report"
+          ],
+          "caveat": "Do not infer the number, severity, affected component, or field impact of non-enumerated test deficiencies.",
+          "sourceRevisionIds": [
+            "provv-evs-6400-test-report@2026-07-19"
+          ]
+        },
+        {
+          "id": "evs-6400-duplicate-scan-limitation",
+          "findingType": "documented_operational_limitation",
+          "title": "Previously scanned ballot is not automatically distinguished",
+          "affectedSystemVersions": [
+            "6.4.0.0"
+          ],
+          "componentIds": [
+            "ds200-scanner-tabulator"
+          ],
+          "publicStatus": "procedural_controls_recommended",
+          "description": "Washington's staff report states that EVS 6.4.0.0 cannot distinguish whether a ballot was previously scanned and describes ballot-handling and staffing controls recommended by ES&S.",
+          "sourceIds": [
+            "wa-evs-6400-staff-report"
+          ],
+          "caveat": "This is an operational limitation and mitigation note, not evidence that duplicate scanning occurred in an election.",
+          "sourceRevisionIds": [
+            "wa-evs-6400-staff-report@2026-07-19"
+          ]
+        },
+        {
+          "id": "evs-6400-public-advisory-status",
+          "findingType": "public_listing_status",
+          "title": "No advisory attachment listed on selected EAC record",
+          "affectedSystemVersions": [
+            "6.4.0.0"
+          ],
+          "componentIds": [],
+          "publicStatus": "none_listed_on_selected_record",
+          "description": "The archived EAC EVS 6.4.0.0 record did not list an advisory attachment when retrieved on 2026-07-19.",
+          "sourceIds": [
+            "eac-evs-6400-record"
+          ],
+          "caveat": "This is a page-listing observation, not a claim that no advisories, bugs, vulnerabilities, service bulletins, or field incidents exist.",
+          "sourceRevisionIds": [
+            "eac-evs-6400-record@2026-07-19"
+          ]
+        }
+      ],
+      "power": [
+        {
+          "id": "ds200-power-documentation",
+          "componentId": "ds200-power-backup",
+          "knowledgeStatus": "documented_partial",
+          "supplyType": "battery backup",
+          "manufacturer": null,
+          "model": null,
+          "capacity": null,
+          "runtime": null,
+          "description": "The ES&S one-sheet confirms DS200 battery backup. The certification and state records reviewed here do not publish the battery manufacturer, model, chemistry, capacity, runtime, condition, or jurisdiction power topology.",
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report",
+            "wa-evs-6400-staff-report",
+            "ess-ds200-one-sheet"
+          ],
+          "caveat": "Confirmed battery-backup presence must not be expanded into an inferred model, runtime, internal location, service condition, or claim about external site power.",
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19",
+            "wa-evs-6400-staff-report@2026-07-19",
+            "ess-ds200-one-sheet@2026-07-20"
+          ]
+        }
+      ],
+      "networkEvidence": {
+        "reviewedOn": "2026-07-21",
+        "summary": "For EVS 6.4.0.0, the EAC scope defines Regional Results as a separate application at a regional sending site, and Pro V&V tested transmission of DS200 result files through Regional Results over a VPN. The reviewed exact-version text does not establish that the DS200 itself was the VPN endpoint. Older federal and state records separately document a Unity 3.4.0.0 wireline SFTP reference design, a Michigan EVS 5.3.2.0 wireless-carrier and SFTP path, and optional DS200 cellular hardware families without proving EVS 6.4 certification, firmware, activation, or field use.",
+        "publicationBoundary": "The module publishes roles, high-level paths, connection media when established, and evidence boundaries. It excludes IP addresses, credentials, VPN parameters, keys, APNs, SIM identifiers, carrier accounts, device identifiers, and jurisdiction routing details.",
+        "configurations": [
+          {
+            "id": "ds200-6400-regional-results-test-path",
+            "title": "EVS 6.4.0.0 Regional Results test path",
+            "evidenceLayer": "expected",
+            "assertionScope": "vstl_test_configuration",
+            "knowledgeStatus": "documented_partial",
+            "topologyKind": "results_transmission_service",
+            "description": "Pro V&V tested DS200 results transmitted by the separate Regional Results application through a VPN to the EMS. The source establishes the end-to-end result workflow but not a direct DS200 network session or the local handoff medium from the tabulator to the Regional Results client.",
+            "observedOn": null,
+            "assertedFor": null,
+            "nodes": [
+              {
+                "id": "ds200-tabulator",
+                "label": "DS200",
+                "role": "Polling-place scanner and tabulator",
+                "componentId": "ds200-scanner-tabulator",
+                "optional": false,
+                "details": "The DS200 produces result data used in the tested Regional Results workflow."
+              },
+              {
+                "id": "ds200-regional-client",
+                "label": "Regional Results client",
+                "role": "Regional sending-site application",
+                "componentId": null,
+                "optional": true,
+                "details": "The EAC scope describes Regional Results as a standalone application deployed at regional sending sites."
+              },
+              {
+                "id": "ds200-customer-network",
+                "label": "Customer-dedicated VPN path",
+                "role": "Encrypted unofficial-results transport",
+                "componentId": null,
+                "optional": true,
+                "details": "Pro V&V reports a VPN test; the EAC scope describes a customer-dedicated network."
+              },
+              {
+                "id": "ds200-ems",
+                "label": "Electionware EMS",
+                "role": "Central results destination",
+                "componentId": null,
+                "optional": false,
+                "details": "The test transmitted correct result files to the EMS for compilation."
+              }
+            ],
+            "links": [
+              {
+                "id": "ds200-results-handoff",
+                "from": "ds200-tabulator",
+                "to": "ds200-regional-client",
+                "medium": "Result-data handoff; local medium not established in the reviewed passage",
+                "direction": "one_way",
+                "purpose": "Make DS200 result data available to Regional Results",
+                "knowledgeStatus": "not_publicly_established"
+              },
+              {
+                "id": "ds200-vpn-send",
+                "from": "ds200-regional-client",
+                "to": "ds200-customer-network",
+                "medium": "Virtual private network over a customer-dedicated network",
+                "direction": "one_way",
+                "purpose": "Transmit encrypted unofficial results collection files",
+                "knowledgeStatus": "confirmed"
+              },
+              {
+                "id": "ds200-vpn-receive",
+                "from": "ds200-customer-network",
+                "to": "ds200-ems",
+                "medium": "Virtual private network",
+                "direction": "one_way",
+                "purpose": "Deliver transmitted result files to the central EMS",
+                "knowledgeStatus": "confirmed"
+              }
+            ],
+            "controls": [
+              {
+                "id": "ds200-encrypted-results",
+                "label": "Encrypted unofficial result files",
+                "status": "documented",
+                "description": "The EAC scope states that Regional Results securely transmits encrypted unofficial results collection files."
+              },
+              {
+                "id": "ds200-dedicated-network",
+                "label": "Customer-dedicated network",
+                "status": "documented",
+                "description": "The certified Regional Results description specifies a customer-dedicated network."
+              },
+              {
+                "id": "ds200-direct-network-session",
+                "label": "Direct DS200 network session",
+                "status": "not_publicly_established",
+                "description": "The reviewed exact-version passages do not make the DS200 itself the VPN endpoint or identify a direct scanner-to-network connection."
+              }
+            ],
+            "sensitiveDetailsWithheld": "No addresses, credentials, VPN settings, keys, APNs, SIM data, carrier accounts, or site-specific routing information are collected or shown.",
+            "sourceIds": [
+              "eac-evs-6400-scope",
+              "provv-evs-6400-test-report"
+            ],
+            "sourceRevisionIds": [
+              "eac-evs-6400-scope@2026-07-19",
+              "provv-evs-6400-test-report@2026-07-19"
+            ],
+            "caveat": "A successful VSTL system test is not evidence that a jurisdiction enabled Regional Results, used the same network design, or transmitted results in a particular election."
+          },
+          {
+            "id": "ds200-historical-optional-cellular-context",
+            "title": "Historical optional cellular hardware context",
+            "evidenceLayer": "documented",
+            "assertionScope": "documented_model_family",
+            "knowledgeStatus": "documented_partial",
+            "topologyKind": "optional_cellular_hardware_context",
+            "description": "Separate historical certification and VSTL records identify optional DS200 modem carrier-board configurations using MultiTech C2 and MTSMC-LVW3 products. These alternatives are shown as historical component context, not as EVS 6.4.0.0 certification or proof of a fielded modem.",
+            "observedOn": null,
+            "assertedFor": null,
+            "nodes": [
+              {
+                "id": "ds200-historical-unit",
+                "label": "DS200 hardware family",
+                "role": "Historical scanner/tabulator context",
+                "componentId": "ds200-scanner-tabulator",
+                "optional": false,
+                "details": "The records apply to earlier EVS campaigns and named DS200 hardware revisions, not the field status of this 6.4 dossier."
+              },
+              {
+                "id": "ds200-modem-board",
+                "label": "Optional modem carrier board",
+                "role": "Internal optional modem interface",
+                "componentId": "ds200-optional-cellular-modem",
+                "optional": true,
+                "details": "The carrier-board component is separately identified and must not be treated as present in every DS200."
+              },
+              {
+                "id": "ds200-c2",
+                "label": "MultiTech C2 modem",
+                "role": "Historical optional cellular alternative",
+                "componentId": "ds200-multitech-c2-modem",
+                "optional": true,
+                "details": "A Florida EVS 4.5.0.0 addendum names the C2 profile; firmware and field status remain unresolved."
+              },
+              {
+                "id": "ds200-lvw3",
+                "label": "MultiTech MTSMC-LVW3",
+                "role": "Historical optional LTE alternative",
+                "componentId": "ds200-multitech-lvw3-modem",
+                "optional": true,
+                "details": "A Pro V&V EVS 5.3.4.1 hardware table names MTSMC-LVW3; ordering revision and firmware are not identified."
+              },
+              {
+                "id": "ds200-carrier-service",
+                "label": "Cellular carrier service",
+                "role": "Optional external transport context",
+                "componentId": null,
+                "optional": true,
+                "details": "Carrier, account, APN, activation state, and election use are not established by the reviewed records."
+              }
+            ],
+            "links": [
+              {
+                "id": "ds200-c2-board-link",
+                "from": "ds200-modem-board",
+                "to": "ds200-c2",
+                "medium": "Internal modem-board interface",
+                "direction": "bidirectional",
+                "purpose": "Host the historical C2 modem alternative",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "ds200-lvw3-board-link",
+                "from": "ds200-modem-board",
+                "to": "ds200-lvw3",
+                "medium": "Internal Universal Socket modem interface",
+                "direction": "bidirectional",
+                "purpose": "Host the historical MTSMC-LVW3 modem alternative",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "ds200-c2-cellular-link",
+                "from": "ds200-c2",
+                "to": "ds200-carrier-service",
+                "medium": "Cellular capability; activation profile not established",
+                "direction": "bidirectional",
+                "purpose": "Historical optional results-transmission capability",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "ds200-lvw3-cellular-link",
+                "from": "ds200-lvw3",
+                "to": "ds200-carrier-service",
+                "medium": "Verizon LTE capability; activation profile not established",
+                "direction": "bidirectional",
+                "purpose": "Historical optional results-transmission capability",
+                "knowledgeStatus": "documented_partial"
+              }
+            ],
+            "controls": [
+              {
+                "id": "ds200-alternate-not-simultaneous",
+                "label": "Alternative components",
+                "status": "documented",
+                "description": "The C2 and MTSMC-LVW3 records describe different historical alternatives and are not presented as simultaneously installed."
+              },
+              {
+                "id": "ds200-modem-firmware-gap",
+                "label": "Modem firmware",
+                "status": "not_publicly_established",
+                "description": "Neither historical DS200 record establishes installed modem firmware for a fielded unit."
+              },
+              {
+                "id": "ds200-modem-field-state",
+                "label": "Activation and field use",
+                "status": "not_publicly_established",
+                "description": "No carrier activation, SIM, APN, network session, or election use is established for a particular DS200."
+              }
+            ],
+            "sensitiveDetailsWithheld": "Carrier credentials, APNs, SIM and subscriber identifiers, device identifiers, keys, addresses, and account data are neither collected nor displayed.",
+            "sourceIds": [
+              "fl-evs-4500-v4-modem-report",
+              "provv-evs-5341-modem-hardware-table",
+              "multitech-universal-socket-guide"
+            ],
+            "sourceRevisionIds": [
+              "fl-evs-4500-v4-modem-report@2026-07-20",
+              "provv-evs-5341-modem-hardware-table@2026-07-20",
+              "multitech-universal-socket-guide@2026-07-20"
+            ],
+            "caveat": "Historical optional hardware is not evidence that EVS 6.4.0.0 certified, a jurisdiction purchased, or a fielded DS200 contains or uses either modem."
+          },
+          {
+            "id": "ds200-unity-3400-landline-sftp-reference",
+            "title": "Unity 3.4.0.0 wireline SFTP receiving topology",
+            "evidenceLayer": "documented",
+            "assertionScope": "vstl_test_configuration",
+            "knowledgeStatus": "documented_partial",
+            "topologyKind": "results_transmission_service",
+            "description": "A Wyle certification test plan for Unity 3.4.0.0 depicts a DS200 connected by wireline modem to a RAS/SFTP receiving server in a DMZ, separated by a firewall from an inside ERM environment. The public topology records roles and boundaries without reproducing the source's sample addresses.",
+            "observedOn": null,
+            "assertedFor": null,
+            "nodes": [
+              {
+                "id": "unity-3400-ds200",
+                "label": "DS200",
+                "role": "Historical precinct scanner and tabulator",
+                "componentId": "ds200-scanner-tabulator",
+                "optional": false,
+                "details": "The figure labels a DS200 as the wireline sending endpoint in the Unity 3.4.0.0 target-of-evaluation description."
+              },
+              {
+                "id": "unity-3400-ras-sftp",
+                "label": "RAS / SFTP receiver",
+                "role": "Result-file receiving service in the DMZ",
+                "componentId": null,
+                "optional": false,
+                "details": "The source combines remote-access and SFTP server roles on the illustrated DMZ-side receiving system."
+              },
+              {
+                "id": "unity-3400-firewall",
+                "label": "Firewall boundary",
+                "role": "Boundary between DMZ and inside network",
+                "componentId": null,
+                "optional": false,
+                "details": "The figure places a firewall between the DMZ receiving environment and the inside ERM network."
+              },
+              {
+                "id": "unity-3400-erm",
+                "label": "ERM",
+                "role": "Inside election-results management environment",
+                "componentId": null,
+                "optional": false,
+                "details": "Election Reporting Manager is shown on the inside side of the historical reference topology."
+              }
+            ],
+            "links": [
+              {
+                "id": "unity-3400-modem-line",
+                "from": "unity-3400-ds200",
+                "to": "unity-3400-ras-sftp",
+                "medium": "Wireline modem connection",
+                "direction": "bidirectional",
+                "purpose": "Establish the historical result-file transfer session",
+                "knowledgeStatus": "confirmed"
+              },
+              {
+                "id": "unity-3400-dmz-boundary",
+                "from": "unity-3400-ras-sftp",
+                "to": "unity-3400-firewall",
+                "medium": "DMZ network boundary",
+                "direction": "not_specified",
+                "purpose": "Separate the receiving service from the inside environment",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "unity-3400-inside-erm",
+                "from": "unity-3400-firewall",
+                "to": "unity-3400-erm",
+                "medium": "Inside network path",
+                "direction": "not_specified",
+                "purpose": "Make received result data available to ERM",
+                "knowledgeStatus": "documented_partial"
+              }
+            ],
+            "controls": [
+              {
+                "id": "unity-3400-sftp-service",
+                "label": "SFTP receiving service",
+                "status": "documented",
+                "description": "The test-plan figure labels the DMZ-side receiving service SFTP."
+              },
+              {
+                "id": "unity-3400-dmz-separation",
+                "label": "DMZ and inside separation",
+                "status": "documented",
+                "description": "The figure distinguishes a DMZ receiving segment from the inside ERM segment through a firewall."
+              },
+              {
+                "id": "unity-3400-field-implementation",
+                "label": "Field implementation",
+                "status": "not_publicly_established",
+                "description": "The test plan does not establish that a jurisdiction deployed this exact topology or retained it after the Unity 3.4.0.0 campaign."
+              }
+            ],
+            "sensitiveDetailsWithheld": "Sample addresses printed in the historical source are not transcribed; credentials, server settings, keys, phone numbers, and jurisdiction routing details are neither collected nor displayed.",
+            "sourceIds": [
+              "eac-unity-3400-test-plan"
+            ],
+            "sourceRevisionIds": [
+              "eac-unity-3400-test-plan@2026-07-21"
+            ],
+            "caveat": "This is a historical wireline test-plan reference, not a cellular design, current EVS 6.4.0.0 certification record, field inspection, or evidence of election-night use."
+          },
+          {
+            "id": "ds200-michigan-evs-5320-wireless-sftp-path",
+            "title": "Michigan EVS 5.3.2.0 wireless SFTP result path",
+            "evidenceLayer": "documented",
+            "assertionScope": "state_certification_documentation",
+            "knowledgeStatus": "documented_partial",
+            "topologyKind": "results_transmission_service",
+            "description": "Michigan's official state-hosted ES&S contract response depicts DS200 units reaching a communications server through a wireless carrier, customer interface, firewall, and DMZ. The accompanying vendor response says a poll worker could initiate an SFTP transfer after polls closed, after which an encrypted result file was deposited and the connection terminated before ERM processed received files.",
+            "observedOn": null,
+            "assertedFor": null,
+            "nodes": [
+              {
+                "id": "mi-5320-ds200",
+                "label": "DS200",
+                "role": "Historical precinct scanner and tabulator",
+                "componentId": "ds200-scanner-tabulator",
+                "optional": false,
+                "details": "The vendor response describes EVS 5.3.2.0 DS200 result transmission after polls close."
+              },
+              {
+                "id": "mi-5320-internal-modem",
+                "label": "Optional internal wireless modem",
+                "role": "Cellular interface for a configured DS200",
+                "componentId": "ds200-optional-cellular-modem",
+                "optional": true,
+                "details": "The response states that a DS200 could be configured with an internal wireless modem; it does not identify the module model or firmware."
+              },
+              {
+                "id": "mi-5320-wireless-carrier",
+                "label": "Wireless carrier network",
+                "role": "External cellular transport",
+                "componentId": null,
+                "optional": true,
+                "details": "The diagram labels a wireless-carrier path; carrier, account, APN, SIM, and activation state are not published here."
+              },
+              {
+                "id": "mi-5320-customer-interface",
+                "label": "Customer interface",
+                "role": "Boundary interface before the firewall",
+                "componentId": null,
+                "optional": false,
+                "details": "The vendor diagram places a customer interface between the external path and the firewall."
+              },
+              {
+                "id": "mi-5320-firewall",
+                "label": "Firewall / DMZ boundary",
+                "role": "Separates external, DMZ, and inside environments",
+                "componentId": null,
+                "optional": false,
+                "details": "The diagram labels outside, DMZ, and inside sides of the firewall."
+              },
+              {
+                "id": "mi-5320-communications-server",
+                "label": "Communications / SFTP server",
+                "role": "Receives transferred DS200 result files",
+                "componentId": null,
+                "optional": false,
+                "details": "The vendor response describes a secure county server receiving encrypted result files through SFTP."
+              },
+              {
+                "id": "mi-5320-local-ems",
+                "label": "Local network EMS / ERM",
+                "role": "Processes received result files",
+                "componentId": null,
+                "optional": false,
+                "details": "The response states that ERM monitors the receiving-server folder and processes files as they arrive."
+              }
+            ],
+            "links": [
+              {
+                "id": "mi-5320-modem-interface",
+                "from": "mi-5320-ds200",
+                "to": "mi-5320-internal-modem",
+                "medium": "Internal optional modem interface",
+                "direction": "bidirectional",
+                "purpose": "Provide the configured DS200 cellular interface",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "mi-5320-cellular-path",
+                "from": "mi-5320-internal-modem",
+                "to": "mi-5320-wireless-carrier",
+                "medium": "CDMA or GSM cellular service described for EVS 5.3.2.0",
+                "direction": "bidirectional",
+                "purpose": "Establish the historical post-poll SFTP session",
+                "knowledgeStatus": "confirmed"
+              },
+              {
+                "id": "mi-5320-carrier-customer",
+                "from": "mi-5320-wireless-carrier",
+                "to": "mi-5320-customer-interface",
+                "medium": "External carrier and network path",
+                "direction": "bidirectional",
+                "purpose": "Reach the county-side customer interface",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "mi-5320-customer-firewall",
+                "from": "mi-5320-customer-interface",
+                "to": "mi-5320-firewall",
+                "medium": "Outside network boundary",
+                "direction": "bidirectional",
+                "purpose": "Pass the result-transfer session to the protected receiving environment",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "mi-5320-firewall-server",
+                "from": "mi-5320-firewall",
+                "to": "mi-5320-communications-server",
+                "medium": "DMZ service path",
+                "direction": "bidirectional",
+                "purpose": "Terminate the historical SFTP transfer at the communications server",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "mi-5320-server-erm",
+                "from": "mi-5320-communications-server",
+                "to": "mi-5320-local-ems",
+                "medium": "Protected result-file handoff",
+                "direction": "one_way",
+                "purpose": "Make received files available for ERM processing",
+                "knowledgeStatus": "confirmed"
+              }
+            ],
+            "controls": [
+              {
+                "id": "mi-5320-post-poll-initiation",
+                "label": "Post-poll initiation",
+                "status": "documented",
+                "description": "The vendor response describes operator initiation after the DS200 has closed polls and printed its results tape."
+              },
+              {
+                "id": "mi-5320-encrypted-signed-results",
+                "label": "Encrypted and digitally signed result data",
+                "status": "documented",
+                "description": "The response states that transmitted result data was encrypted and digitally signed with FIPS-certified security functions."
+              },
+              {
+                "id": "mi-5320-session-termination",
+                "label": "Connection termination after deposit",
+                "status": "documented",
+                "description": "The response states that the connection was terminated after the encrypted result file was deposited on the receiving server."
+              },
+              {
+                "id": "mi-5320-dmz-boundary",
+                "label": "Firewall and DMZ boundary",
+                "status": "documented",
+                "description": "The vendor diagram separates outside, DMZ, and inside network roles."
+              }
+            ],
+            "sensitiveDetailsWithheld": "No addresses, credentials, firewall rules, SFTP configuration, keys, APNs, SIM or subscriber identifiers, carrier accounts, device identifiers, or jurisdiction routing details are collected or shown.",
+            "sourceIds": [
+              "mi-ess-voting-system-contract"
+            ],
+            "sourceRevisionIds": [
+              "mi-ess-voting-system-contract@2026-07-21"
+            ],
+            "caveat": "This is a historical Michigan procurement response for EVS 5.3.2.0, which the source says was not EAC certified. It is not evidence of EVS 6.4.0.0 certification, a current county design, an installed modem or firmware, a live connection, or a transmission during any election."
+          }
+        ],
+        "sourceImages": [
+          {
+            "id": "ds200-evs-6400-system-diagram",
+            "assetUrl": "/equipment/network-evidence/evs-6400-system-diagram.png",
+            "assetSha256": "d68f37906c6b91ec937c6f77952d44aded6c97bb17fb07e256e88aa82d51f412",
+            "width": 1055,
+            "height": 690,
+            "kind": "source_topology_diagram",
+            "alt": "EVS 6.4.0.0 certification system diagram showing election-data management, equipment configuration, voting and tabulation devices, and results consolidation infrastructure.",
+            "caption": "EVS 6.4.0.0 certified-system overview diagram",
+            "pageOrSection": "EAC scope PDF page 4, document page 3",
+            "derivativeNote": "Rendered at 135 DPI, rotated for readability, and cropped to the diagram boundary; diagram content was not edited.",
+            "caveat": "The system-level figure contains many EVS components and paths. It does not prove that every component or connection is present in a DS200 deployment.",
+            "sourceIds": [
+              "eac-evs-6400-scope"
+            ],
+            "sourceRevisionIds": [
+              "eac-evs-6400-scope@2026-07-19"
+            ]
+          },
+          {
+            "id": "ds200-evs-6400-transmission-test-page",
+            "assetUrl": "/equipment/network-evidence/evs-6400-transmission-test.png",
+            "assetSha256": "71296be17326a584587a366a530559e8d9f9eb3280b93a757486912b583a9736",
+            "width": 1148,
+            "height": 1485,
+            "kind": "source_document_page",
+            "alt": "Pro V and V EVS 6.4.0.0 test-report page describing DS200 results transmitted through Regional Results over a VPN and central-tabulator results transmitted over a closed LAN.",
+            "caption": "Pro V&V EVS 6.4.0.0 result-transmission accuracy-test statement",
+            "pageOrSection": "Pro V&V test-report PDF page 30, report page 25",
+            "derivativeNote": "Rendered from the archived official PDF at 135 DPI; the source page content was not edited.",
+            "caveat": "This is evidence of a laboratory test configuration and successful result transfer, not a field deployment or direct DS200 network-session record.",
+            "sourceIds": [
+              "provv-evs-6400-test-report"
+            ],
+            "sourceRevisionIds": [
+              "provv-evs-6400-test-report@2026-07-19"
+            ]
+          },
+          {
+            "id": "ds200-mi-wireless-results-network",
+            "assetUrl": "/equipment/network-evidence/mi-ess-wireless-results-network.png",
+            "assetSha256": "eb27edae388c1dc0f64ff37b0e9bbdf70a23da28f9fcb867f8909c71ff4af97b",
+            "width": 1600,
+            "height": 1236,
+            "kind": "source_topology_diagram",
+            "alt": "Historical Michigan vendor diagram showing DS200 units, a wireless carrier, customer interface, firewall and DMZ, communications server, and local election-management network.",
+            "caption": "Michigan contract exhibit: historical DS200 wireless results network",
+            "pageOrSection": "Michigan contract PDF page 101, contract page 62, Wireless Results Network",
+            "derivativeNote": "Rendered from the archived official state-hosted PDF with PDF.js at 1600 pixels wide; the source page content was not edited.",
+            "caveat": "The diagram belongs to a historical Michigan procurement response and does not establish EVS 6.4.0.0 certification, a current county topology, an installed modem, or election use.",
+            "sourceIds": [
+              "mi-ess-voting-system-contract"
+            ],
+            "sourceRevisionIds": [
+              "mi-ess-voting-system-contract@2026-07-21"
+            ]
+          },
+          {
+            "id": "ds200-multitech-universal-socket-pinout",
+            "assetUrl": "/equipment/network-evidence/multitech-universal-socket-pinout.png",
+            "assetSha256": "f8f297acd968659d77e7e191c01933c6bed8422f11c499c068c2c23edda1b0da",
+            "width": 1600,
+            "height": 2070,
+            "kind": "manufacturer_reference_pinout",
+            "alt": "MultiTech Universal Socket reference pinout showing the generic 74-pin interface and a note that individual modem models may omit pins.",
+            "caption": "MultiTech Universal Socket reference pinout",
+            "pageOrSection": "Universal SocketModem Developer Guide PDF page 12",
+            "derivativeNote": "Rendered from the archived manufacturer PDF with PDF.js at 1600 pixels wide; the source page content was not edited.",
+            "caveat": "This is a generic product-family interface reference. The guide says not all modems include every pin; it is not a DS200 carrier-board pin map or proof that any interface is wired or enabled in a DS200.",
+            "sourceIds": [
+              "multitech-universal-socket-guide"
+            ],
+            "sourceRevisionIds": [
+              "multitech-universal-socket-guide@2026-07-20"
+            ]
+          },
+          {
+            "id": "ds200-multitech-developer-board-layout",
+            "assetUrl": "/equipment/network-evidence/multitech-universal-socket-board-layout.png",
+            "assetSha256": "4705865fb62fa7a23656e6a20af1f2cae025469293dd17fce62e00729c6418aa",
+            "width": 1600,
+            "height": 2070,
+            "kind": "manufacturer_reference_board_drawing",
+            "alt": "MultiTech SocketModem developer-board drawing showing example connector, socket, antenna, switch, and board-component locations.",
+            "caption": "MultiTech generic SocketModem developer-board layout",
+            "pageOrSection": "Universal SocketModem Developer Guide PDF page 20",
+            "derivativeNote": "Rendered from the archived manufacturer PDF with PDF.js at 1600 pixels wide; the source page content was not edited.",
+            "caveat": "The source labels third-party components as examples and describes a developer board for SocketModems generally. It is not a DS200 carrier-board drawing, teardown, port inventory, or placement record.",
+            "sourceIds": [
+              "multitech-universal-socket-guide"
+            ],
+            "sourceRevisionIds": [
+              "multitech-universal-socket-guide@2026-07-20"
+            ]
+          },
+          {
+            "id": "ds200-multitech-developer-board-block-diagram",
+            "assetUrl": "/equipment/network-evidence/multitech-universal-socket-block-diagram.png",
+            "assetSha256": "709749ed8d2196386a33a5d9d4830c0a5c536f15ee2907dd84e58ef11c9b6291",
+            "width": 1600,
+            "height": 1236,
+            "kind": "manufacturer_reference_block_diagram",
+            "alt": "MultiTech generic SocketModem developer-board block diagram showing the 74-pin socket, serial driver, USB, RJ11, RJ45, handset, and antenna-holder reference connections.",
+            "caption": "MultiTech generic SocketModem developer-board block diagram",
+            "pageOrSection": "Universal SocketModem Developer Guide PDF page 22",
+            "derivativeNote": "Rendered from the archived manufacturer PDF with PDF.js at 1600 pixels wide; the source page content was not edited.",
+            "caveat": "This developer-board diagram shows possible reference connections across the broader SocketModem platform. It does not establish which ports exist, are connected, or are enabled on a DS200 modem carrier board.",
+            "sourceIds": [
+              "multitech-universal-socket-guide"
+            ],
+            "sourceRevisionIds": [
+              "multitech-universal-socket-guide@2026-07-20"
+            ]
+          },
+          {
+            "id": "ds200-multitech-sim-antenna-installation",
+            "assetUrl": "/equipment/network-evidence/multitech-universal-socket-sim-installation.png",
+            "assetSha256": "ebb7b9cd86df4e1cab7254c2381e2beea867a68ae1e3768f21a4db7af6a1b5ab",
+            "width": 1600,
+            "height": 2070,
+            "kind": "manufacturer_reference_installation_page",
+            "alt": "MultiTech manufacturer instructions for seating a Universal Socket communications device and using an optional antenna lead and a device SIM-card holder.",
+            "caption": "MultiTech generic modem, antenna-lead, and SIM installation guidance",
+            "pageOrSection": "Universal SocketModem Developer Guide PDF page 31",
+            "derivativeNote": "Rendered from the archived manufacturer PDF with PDF.js at 1600 pixels wide; the source page content was not edited.",
+            "caveat": "This generic procedure establishes product-family installation concepts only. It is not evidence that a DS200 contains a SIM holder, antenna lead, active SIM, or any particular SocketModem model.",
+            "sourceIds": [
+              "multitech-universal-socket-guide"
+            ],
+            "sourceRevisionIds": [
+              "multitech-universal-socket-guide@2026-07-20"
+            ]
+          }
+        ],
+        "gaps": [
+          {
+            "id": "ds200-local-handoff-gap",
+            "label": "DS200-to-Regional Results handoff",
+            "description": "The reviewed exact-version passages do not identify whether the local result handoff used removable media or another mechanism, and they do not establish the DS200 as the VPN endpoint.",
+            "sourceIds": [
+              "eac-evs-6400-scope",
+              "provv-evs-6400-test-report"
+            ],
+            "sourceRevisionIds": [
+              "eac-evs-6400-scope@2026-07-19",
+              "provv-evs-6400-test-report@2026-07-19"
+            ],
+            "caveat": "The module leaves the local medium unresolved instead of drawing a direct network link."
+          },
+          {
+            "id": "ds200-field-network-gap",
+            "label": "Field configuration and modem state",
+            "description": "No dated jurisdiction network diagram, interface inspection, modem inventory, firmware reading, carrier activation record, or transmission log was collected for a particular DS200.",
+            "sourceIds": [
+              "eac-evs-6400-scope",
+              "fl-evs-4500-v4-modem-report",
+              "provv-evs-5341-modem-hardware-table"
+            ],
+            "sourceRevisionIds": [
+              "eac-evs-6400-scope@2026-07-19",
+              "fl-evs-4500-v4-modem-report@2026-07-20",
+              "provv-evs-5341-modem-hardware-table@2026-07-20"
+            ],
+            "caveat": "Optional and historical records must not be presented as field evidence."
+          }
+        ]
+      },
+      "deployments": [
+        {
+          "id": "wa-jefferson-evs-6400-2025",
+          "jurisdiction": "Jefferson County, Washington",
+          "state": "WA",
+          "electionOrAsOf": "November 2025 general election",
+          "systemVersion": "6.4.0.0",
+          "scopeKind": "jurisdiction_deployment_observation",
+          "componentsConfirmed": [],
+          "sourceIds": [
+            "wa-2025-county-system-table"
+          ],
+          "caveat": "The state table confirms the EVS version at county grain, not DS200 use, unit count, firmware, hardware revision, ECO installation, or power configuration.",
+          "sourceRevisionIds": [
+            "wa-2025-county-system-table@2026-07-19"
+          ]
+        },
+        {
+          "id": "wa-thurston-evs-6400-2025",
+          "jurisdiction": "Thurston County, Washington",
+          "state": "WA",
+          "electionOrAsOf": "November 2025 general election",
+          "systemVersion": "6.4.0.0",
+          "scopeKind": "jurisdiction_deployment_observation",
+          "componentsConfirmed": [],
+          "sourceIds": [
+            "wa-2025-county-system-table"
+          ],
+          "caveat": "The state table confirms the EVS version at county grain, not DS200 use, unit count, firmware, hardware revision, ECO installation, or power configuration.",
+          "sourceRevisionIds": [
+            "wa-2025-county-system-table@2026-07-19"
+          ]
+        },
+        {
+          "id": "wa-walla-walla-evs-6400-2025",
+          "jurisdiction": "Walla Walla County, Washington",
+          "state": "WA",
+          "electionOrAsOf": "November 2025 general election",
+          "systemVersion": "6.4.0.0",
+          "scopeKind": "jurisdiction_deployment_observation",
+          "componentsConfirmed": [],
+          "sourceIds": [
+            "wa-2025-county-system-table"
+          ],
+          "caveat": "The state table confirms the EVS version at county grain, not DS200 use, unit count, firmware, hardware revision, ECO installation, or power configuration.",
+          "sourceRevisionIds": [
+            "wa-2025-county-system-table@2026-07-19"
+          ]
+        },
+        {
+          "id": "wa-whitman-evs-6400-2025",
+          "jurisdiction": "Whitman County, Washington",
+          "state": "WA",
+          "electionOrAsOf": "November 2025 general election",
+          "systemVersion": "6.4.0.0",
+          "scopeKind": "jurisdiction_deployment_observation",
+          "componentsConfirmed": [],
+          "sourceIds": [
+            "wa-2025-county-system-table"
+          ],
+          "caveat": "The state table confirms the EVS version at county grain, not DS200 use, unit count, firmware, hardware revision, ECO installation, or power configuration.",
+          "sourceRevisionIds": [
+            "wa-2025-county-system-table@2026-07-19"
+          ]
+        }
+      ],
+      "scene": {
+        "assetUrl": "/equipment/ess-evs-6400-ds200/orthographic-pilot.glb",
+        "assetLicense": "Apache-2.0",
+        "assetAttribution": "Original CivicResultMaps schematic generated from scripts/build-equipment-model.mjs",
+        "geometryFidelity": "illustrative_not_to_scale",
+        "description": "An original, photo-informed navigational schematic of the DS200 cabinet, scanner deck, raised protective lid, display, ballot compartments, and selected source-supported internal categories. It is not a teardown or dimensional reproduction.",
+        "referenceConfiguration": "DS200 open poll-place configuration with ballot cabinet, raised protective cover, scanner deck, and tilted display",
+        "referenceSourceIds": [
+          "ess-ds200-one-sheet",
+          "ess-ds200-reference-photo",
+          "ess-election-security-faqs"
+        ],
+        "referenceSourceRevisionIds": [
+          "ess-ds200-one-sheet@2026-07-20",
+          "ess-ds200-reference-photo@2026-07-20",
+          "ess-election-security-faqs@2026-07-20"
+        ],
+        "referenceNote": "External proportions and features follow the official ES&S one-sheet. The optional modem board is a symbolic board-shaped marker because the reviewed sources do not establish its model, dimensions, or placement. Other internal board positions and all explosion paths remain illustrative.",
+        "referenceImages": [
+          {
+            "id": "ds200-official-front-product-photo",
+            "assetUrl": "/equipment/ess-evs-6400-ds200/reference-ds200-front.png",
+            "assetSha256": "a68d0646ca2707ccdcf735f57d3b0b65e3021bec0a480bc8af8b0d517c412dda",
+            "width": 1280,
+            "height": 854,
+            "alt": "Front view of an open ES&S DS200 scanner and ballot container on casters",
+            "caption": "Manufacturer product photograph: DS200 open in its poll-place configuration.",
+            "kind": "manufacturer_product_photo",
+            "sourceIds": [
+              "ess-ds200-reference-photo"
+            ],
+            "sourceRevisionIds": [
+              "ess-ds200-reference-photo@2026-07-20"
+            ],
+            "pageOrSection": "Original 1280 x 854 product photograph",
+            "derivativeNote": "Exact local copy of the archived manufacturer image; no crop or content alteration.",
+            "caveat": "External appearance reference only; the photograph does not establish dimensions, internal components, certified software, modem installation, or a particular fielded unit."
+          }
+        ],
+        "camera": {
+          "position": [
+            6,
+            5,
+            7
+          ],
+          "zoom": 78,
+          "near": 0.1,
+          "far": 100
+        },
+        "nodes": [
+          {
+            "componentId": "ds200-scanner-tabulator",
+            "nodeName": "DS200_Shell",
+            "color": "#8ca3a8",
+            "explodedOffset": [
+              0,
+              0.55,
+              0
+            ]
+          },
+          {
+            "componentId": "ds200-optional-cellular-modem",
+            "nodeName": "Optional_Cellular_Modem",
+            "color": "#33c6b5",
+            "explodedOffset": [
+              1.45,
+              0.8,
+              -0.45
+            ]
+          },
+          {
+            "componentId": "ds200-scanner-path",
+            "nodeName": "Scanner_Path",
+            "color": "#33c6b5",
+            "explodedOffset": [
+              0,
+              0.4,
+              -0.5
+            ]
+          },
+          {
+            "componentId": "ds200-display-assembly",
+            "nodeName": "Display_Assembly",
+            "color": "#78a6ff",
+            "explodedOffset": [
+              0,
+              1.1,
+              0.7
+            ]
+          },
+          {
+            "componentId": "ds200-processor-module",
+            "nodeName": "Processor_Module",
+            "color": "#f0b95a",
+            "explodedOffset": [
+              1.2,
+              0.35,
+              0.25
+            ]
+          },
+          {
+            "componentId": "ds200-scanner-board",
+            "nodeName": "Scanner_Board",
+            "color": "#e87fb3",
+            "explodedOffset": [
+              -1.2,
+              0.35,
+              0.25
+            ]
+          },
+          {
+            "componentId": "ds200-ballot-container",
+            "nodeName": "Ballot_Container",
+            "color": "#53676d",
+            "explodedOffset": [
+              0,
+              -0.75,
+              0
+            ]
+          },
+          {
+            "componentId": "ds200-tote-bin-security",
+            "nodeName": "Tote_Bin_Gasket",
+            "color": "#d1e8e5",
+            "explodedOffset": [
+              0,
+              -0.2,
+              0.7
+            ]
+          },
+          {
+            "componentId": "ds200-seal-area",
+            "nodeName": "Seal_Area",
+            "color": "#ff8c69",
+            "explodedOffset": [
+              1.4,
+              0.2,
+              0.8
+            ]
+          }
+        ]
+      },
+      "caveats": [
+        "Certified configuration is not the same as field deployment. A county system-version record does not establish the components, firmware, hardware revision, or change orders installed on each unit.",
+        "The photo-informed 3D schematic is a selection aid, not vendor CAD, a teardown, an engineering drawing, or proof of exact dimensions or internal placement.",
+        "Public findings and modem vulnerability reviews are presented with exact product, firmware, date, and source scope. A zero-match catalog review is not evidence that no bug, vulnerability, incident, or service bulletin exists.",
+        "The manufacturer documents DS200 battery backup, but its model, chemistry, capacity, runtime, internal placement, condition, and county-level power topology remain unknown."
+      ],
+      "claimRevision": 8,
+      "editorialState": "published",
+      "sourceIds": [
+        "cisa-kev-catalog",
+        "eac-eco-ess-1035-approval",
+        "eac-eco-ess-1035-record",
+        "eac-eco-ess-1042-approval",
+        "eac-eco-ess-1042-record",
+        "eac-eco-ess-1044-approval",
+        "eac-eco-ess-1044-record",
+        "eac-eco-ess-1055-approval",
+        "eac-eco-ess-1055-record",
+        "eac-eco-ess-1165-approval",
+        "eac-eco-ess-1165-record",
+        "eac-eco-ess-983-record",
+        "eac-evs-6400-record",
+        "eac-evs-6400-scope",
+        "eac-unity-3200-document-report",
+        "eac-unity-3400-test-plan",
+        "ess-ds200-one-sheet",
+        "ess-ds200-reference-photo",
+        "ess-election-security-faqs",
+        "fl-evs-4500-v4-modem-report",
+        "mi-ess-voting-system-contract",
+        "multitech-eol-products",
+        "multitech-lvw3-update-bulletin",
+        "multitech-security-advisories-index",
+        "multitech-security-advisory-bundle",
+        "multitech-universal-socket-guide",
+        "multitech-verizon-fota",
+        "nvd-modem-query-review",
+        "provv-eco-ess-1035-analysis",
+        "provv-eco-ess-1042-analysis",
+        "provv-eco-ess-1044-analysis",
+        "provv-eco-ess-1055-analysis",
+        "provv-eco-ess-1165-analysis",
+        "provv-eco-ess-983-analysis",
+        "provv-evs-5341-modem-hardware-table",
+        "provv-evs-6400-test-report",
+        "ri-ds200-pollworker-manual-2021",
+        "wa-2025-county-system-table",
+        "wa-evs-6400-application",
+        "wa-evs-6400-staff-report"
+      ],
+      "sourceRevisionIds": [
+        "cisa-kev-catalog@2026-07-20",
+        "eac-eco-ess-1035-approval@2026-07-19",
+        "eac-eco-ess-1035-record@2026-07-19",
+        "eac-eco-ess-1042-approval@2026-07-19",
+        "eac-eco-ess-1042-record@2026-07-19",
+        "eac-eco-ess-1044-approval@2026-07-19",
+        "eac-eco-ess-1044-record@2026-07-19",
+        "eac-eco-ess-1055-approval@2026-07-19",
+        "eac-eco-ess-1055-record@2026-07-19",
+        "eac-eco-ess-1165-approval@2026-07-19",
+        "eac-eco-ess-1165-record@2026-07-19",
+        "eac-eco-ess-983-record@2026-07-19",
+        "eac-evs-6400-record@2026-07-19",
+        "eac-evs-6400-scope@2026-07-19",
+        "eac-unity-3200-document-report@2026-07-20",
+        "eac-unity-3400-test-plan@2026-07-21",
+        "ess-ds200-one-sheet@2026-07-20",
+        "ess-ds200-reference-photo@2026-07-20",
+        "ess-election-security-faqs@2026-07-20",
+        "fl-evs-4500-v4-modem-report@2026-07-20",
+        "mi-ess-voting-system-contract@2026-07-21",
+        "multitech-eol-products@2026-07-20",
+        "multitech-lvw3-update-bulletin@2026-07-20",
+        "multitech-security-advisories-index@2026-07-20",
+        "multitech-security-advisory-bundle@2026-07-20",
+        "multitech-universal-socket-guide@2026-07-20",
+        "multitech-verizon-fota@2026-07-20",
+        "nvd-modem-query-review@2026-07-20",
+        "provv-eco-ess-1035-analysis@2026-07-19",
+        "provv-eco-ess-1042-analysis@2026-07-19",
+        "provv-eco-ess-1044-analysis@2026-07-19",
+        "provv-eco-ess-1055-analysis@2026-07-19",
+        "provv-eco-ess-1165-analysis@2026-07-19",
+        "provv-eco-ess-983-analysis@2026-07-19",
+        "provv-evs-5341-modem-hardware-table@2026-07-20",
+        "provv-evs-6400-test-report@2026-07-19",
+        "ri-ds200-pollworker-manual-2021@2026-07-20",
+        "wa-2025-county-system-table@2026-07-19",
+        "wa-evs-6400-application@2026-07-19",
+        "wa-evs-6400-staff-report@2026-07-19"
+      ],
+      "coverage": {
+        "componentCount": 12,
+        "sourcedComponentCount": 12,
+        "technicalSpecificationCount": 13,
+        "establishedTechnicalSpecificationCount": 10,
+        "unknownTechnicalSpecificationCount": 3,
+        "configurationChangeCount": 6,
+        "deploymentObservationCount": 4,
+        "findingCount": 4,
+        "powerRecordCount": 1,
+        "confirmedPowerRecordCount": 1,
+        "sourceCount": 40,
+        "sourceRevisionCount": 40,
+        "componentSecurityReviewCount": 3,
+        "exactApplicableVulnerabilityCount": 0,
+        "nonCveAdvisoryCount": 1,
+        "networkConfigurationCount": 4,
+        "networkSourceImageCount": 7,
+        "fieldObservedNetworkConfigurationCount": 0
+      }
+    },
+    {
+      "id": "ess-evs-6400-ds950",
+      "slug": "ess-evs-6400-ds950",
+      "status": "pilot",
+      "manufacturer": "Election Systems & Software, LLC",
+      "systemName": "EVS",
+      "systemVersion": "6.4.0.0",
+      "deviceName": "DS950",
+      "displayName": "ES&S EVS 6.4.0.0 / DS950",
+      "deviceRole": "High-speed central-count scanner and tabulator",
+      "summary": "A separate source-linked dossier for the certified DS950 central-count scanner/tabulator, including firmware and hardware revisions, documented motherboard and storage changes, output-transport firmware, central-count cart, and certified UPS alternatives.",
+      "certification": {
+        "certificationId": "ESSEVS6400",
+        "standard": "VVSG 1.0",
+        "certifiedOn": "2023-08-18",
+        "vstl": "Pro V&V, Inc.",
+        "scopeKind": "certified_configuration",
+        "sourceIds": [
+          "eac-evs-6400-record",
+          "eac-evs-6400-scope",
+          "provv-evs-6400-test-report"
+        ],
+        "sourceRevisionIds": [
+          "eac-evs-6400-record@2026-07-19",
+          "eac-evs-6400-scope@2026-07-19",
+          "provv-evs-6400-test-report@2026-07-19"
+        ],
+        "caveat": "EAC certification applies only to the evaluated EVS 6.4.0.0 certified configuration. It does not establish the firmware, hardware, accessory selection, condition, or maintenance history of a particular field unit."
+      },
+      "components": [
+        {
+          "id": "ds950-shell",
+          "name": "DS950 scanner and tabulator assembly",
+          "category": "device",
+          "description": "The certified scope describes a central scanner/tabulator that scans both sides of ballots or vote-summary cards in any of four orientations.",
+          "evidenceStatus": "certified_component",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "DS950"
+          ],
+          "hardwareRevisions": [
+            "1.1"
+          ],
+          "versionObservationIds": [
+            "ds950-certified-firmware-4300"
+          ],
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report",
+            "ess-ds950-product-page"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19",
+            "ess-ds950-product-page@2026-07-20"
+          ],
+          "sceneNodeName": "DS950_Shell",
+          "caveat": "The certified revision and firmware are configuration records, not unit-level observations.",
+          "technicalSpecifications": [
+            {
+              "id": "ds950-certified-firmware-spec",
+              "category": "firmware",
+              "label": "Certified DS950 firmware",
+              "value": "4.3.0.0",
+              "knowledgeStatus": "confirmed",
+              "assertionScope": "certified_configuration",
+              "modelContext": "EVS 6.4.0.0 DS950 hardware 1.1",
+              "sourceIds": [
+                "eac-evs-6400-scope",
+                "provv-evs-6400-test-report"
+              ],
+              "sourceRevisionIds": [
+                "eac-evs-6400-scope@2026-07-19",
+                "provv-evs-6400-test-report@2026-07-19"
+              ],
+              "caveat": "This is the certified configuration version, not a field reading or a claim about later releases."
+            },
+            {
+              "id": "ds950-protected-usb-access",
+              "category": "usb",
+              "label": "Protected USB access",
+              "value": "Manufacturer states USB ports are behind clear lockable, sealable doors",
+              "knowledgeStatus": "documented_partial",
+              "assertionScope": "manufacturer_product",
+              "modelContext": "DS950 manufacturer product family",
+              "sourceIds": [
+                "ess-ds950-product-page"
+              ],
+              "sourceRevisionIds": [
+                "ess-ds950-product-page@2026-07-20"
+              ],
+              "caveat": "This establishes an access-control feature, not a connector count or the sealed condition of a field unit."
+            }
+          ],
+          "securityReview": null
+        },
+        {
+          "id": "ds950-input-feeder",
+          "name": "Ballot input feeder",
+          "category": "paper_input",
+          "description": "The manufacturer photograph shows a purpose-built input feeder above the scanner body for central-count ballot batches.",
+          "evidenceStatus": "manufacturer_documented_partial",
+          "scopeKind": "manufacturer_product_documentation",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "ess-ds950-product-page",
+            "ess-ds950-reference-photo"
+          ],
+          "sourceRevisionIds": [
+            "ess-ds950-product-page@2026-07-20",
+            "ess-ds950-reference-photo@2026-07-20"
+          ],
+          "sceneNodeName": "DS950_Input_Feeder",
+          "caveat": "The source supports the external feeder category and form, not exact dimensions or internal transport parts.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds950-scanner-path",
+          "name": "Dual-sided scanner path",
+          "category": "scanner",
+          "description": "The certified scope establishes simultaneous front-and-back scanning and four-orientation ballot handling.",
+          "evidenceStatus": "certified_component",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19"
+          ],
+          "sceneNodeName": "DS950_Scanner_Path",
+          "caveat": "The optical function is certified, but the illustrative path is not a teardown or engineering drawing.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds950-sorting-trays",
+          "name": "Output transport and sorting trays",
+          "category": "paper_output",
+          "description": "The output section receives processed ballots; baseline ECO 1151 records transporter-board firmware affecting when the output tray begins to lower.",
+          "evidenceStatus": "historical_change_record",
+          "scopeKind": "historical_change",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [
+            "ds950-transporter-firmware-c60"
+          ],
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "ess-ds950-reference-photo"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "ess-ds950-reference-photo@2026-07-20"
+          ],
+          "sceneNodeName": "DS950_Sorting_Trays",
+          "caveat": "The change record is not evidence of a jam, field update, unit condition, or exact output geometry.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds950-display",
+          "name": "Operator display",
+          "category": "display",
+          "description": "The manufacturer photograph shows an integrated operator-facing display on the DS950 enclosure.",
+          "evidenceStatus": "manufacturer_documented_partial",
+          "scopeKind": "manufacturer_product_documentation",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "ess-ds950-product-page",
+            "ess-ds950-reference-photo"
+          ],
+          "sourceRevisionIds": [
+            "ess-ds950-product-page@2026-07-20",
+            "ess-ds950-reference-photo@2026-07-20"
+          ],
+          "sceneNodeName": "DS950_Display",
+          "caveat": "The sources do not establish the exact panel model, resolution, connector, or internal placement.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds950-motherboard",
+          "name": "Kontron motherboard with DRAM and TPM capabilities",
+          "category": "compute",
+          "description": "The EVS 6.4.0.0 scope records an updated Kontron motherboard with DRAM and TPM capabilities.",
+          "evidenceStatus": "approved_change_for_evs_6400",
+          "scopeKind": "certified_configuration_change",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-evs-6400-scope"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19"
+          ],
+          "sceneNodeName": "DS950_Motherboard",
+          "caveat": "The scope does not publish the board model, processor, DRAM capacity, TPM version, layout, or field history.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds950-m2-storage",
+          "name": "M.2 storage device",
+          "category": "storage",
+          "description": "The EVS 6.4.0.0 scope records an M.2 hard drive added to the DS950 configuration.",
+          "evidenceStatus": "approved_change_for_evs_6400",
+          "scopeKind": "certified_configuration_change",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-evs-6400-scope"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19"
+          ],
+          "sceneNodeName": "DS950_M2_Storage",
+          "caveat": "The scope does not publish manufacturer, model, interface subtype, capacity, firmware, data, or field history.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds950-smart-card-reader",
+          "name": "Smart-card reader",
+          "category": "authentication_accessory",
+          "description": "The EVS 6.4.0.0 scope records a second-source smart-card reader for the DS950.",
+          "evidenceStatus": "approved_change_for_evs_6400",
+          "scopeKind": "certified_configuration_change",
+          "modelNumbers": [],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-evs-6400-scope"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19"
+          ],
+          "sceneNodeName": "DS950_Smart_Card_Reader",
+          "caveat": "The public scope does not identify the reader model, placement, selected source, or field installation.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds950-central-count-cart",
+          "name": "Central Count Cart",
+          "category": "support_cart",
+          "description": "The certified system includes metal Central Count Cart model 7898 for the DS450, DS850, and DS950.",
+          "evidenceStatus": "certified_component",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "7898"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19"
+          ],
+          "sceneNodeName": "DS950_Central_Count_Cart",
+          "caveat": "Certification identifies the cart option but does not prove its use or setup at a jurisdiction.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        },
+        {
+          "id": "ds950-ups",
+          "name": "External uninterruptible power supply",
+          "category": "power",
+          "description": "The certified COTS hardware table names two CyberPower UPS alternatives that include the DS950.",
+          "evidenceStatus": "certified_component_options",
+          "scopeKind": "certified_configuration",
+          "modelNumbers": [
+            "CyberPower OR1500PFCLCD",
+            "CyberPower CP1500PFCLCD"
+          ],
+          "hardwareRevisions": [],
+          "versionObservationIds": [],
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19"
+          ],
+          "sceneNodeName": "DS950_UPS",
+          "caveat": "The sources do not establish jurisdiction selection, workload runtime, battery health, or replacement history.",
+          "securityReview": null,
+          "technicalSpecifications": []
+        }
+      ],
+      "versionObservations": [
+        {
+          "id": "ds950-certified-firmware-4300",
+          "componentId": "ds950-shell",
+          "label": "Certified DS950 firmware",
+          "value": "4.3.0.0",
+          "assertionScope": "certified",
+          "fieldStatus": "not_established",
+          "observedOn": "2023-08-18",
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19"
+          ],
+          "caveat": "This is the certified configuration version, not a field reading or unit update record."
+        },
+        {
+          "id": "ds950-transporter-firmware-c60",
+          "componentId": "ds950-sorting-trays",
+          "label": "Certified baseline DATAWIN transporter firmware",
+          "value": "C60_20221215_0300",
+          "assertionScope": "certified",
+          "fieldStatus": "not_established",
+          "observedOn": "2023-08-18",
+          "sourceIds": [
+            "eac-evs-6400-scope"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19"
+          ],
+          "caveat": "This is the firmware named in certified baseline ECO 1151, not a live readout or service record."
+        }
+      ],
+      "configurationChanges": [
+        {
+          "id": "ds950-evs-6400-hardware-modification",
+          "changeId": "EVS 6.4.0.0 DS950 hardware modification set",
+          "componentIds": [
+            "ds950-motherboard",
+            "ds950-m2-storage",
+            "ds950-smart-card-reader"
+          ],
+          "submittedOn": "2023-01-24",
+          "eacApprovedOn": "2023-08-18",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "included_in_certified_evs_6400_configuration",
+          "description": "The scope records an updated Kontron motherboard with DRAM/TPM capabilities, updated PC power supply, second-source smart-card reader, and M.2 hard drive.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19"
+          ],
+          "caveat": "This groups certification modifications and is not a claim that one field service event installed them together."
+        },
+        {
+          "id": "ds950-eco-1151",
+          "changeId": "ECO 1151",
+          "componentIds": [
+            "ds950-sorting-trays"
+          ],
+          "submittedOn": "2023-02-21",
+          "eacApprovedOn": "2023-08-18",
+          "vstl": "Pro V&V, Inc.",
+          "relationshipToPilot": "baseline_eco_certified_with_evs_6400",
+          "description": "ECO 1151 updates DATAWIN transporter firmware so the output tray begins lowering sooner, providing more opportunity for incoming ballots to lay flat if a jam occurs.",
+          "fieldDeploymentStatus": "unknown",
+          "sourceIds": [
+            "eac-evs-6400-scope"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19"
+          ],
+          "caveat": "The de minimis ECO is certification history, not evidence of a jam, field update, or election impact."
+        }
+      ],
+      "findings": [
+        {
+          "id": "ds950-evs-6400-test-campaign",
+          "findingType": "vstl_test_campaign_result",
+          "title": "No anomalies reported in the EVS 6.4.0.0 certification campaign",
+          "affectedSystemVersions": [
+            "EVS 6.4.0.0 certified configuration"
+          ],
+          "componentIds": [
+            "ds950-shell",
+            "ds950-scanner-path",
+            "ds950-sorting-trays"
+          ],
+          "publicStatus": "none_reported_in_test_campaign",
+          "description": "Pro V&V reported no anomalies during EVS 6.4.0.0 testing and recommended certification after the system met applicable VVSG 1.0 requirements.",
+          "sourceIds": [
+            "provv-evs-6400-test-report"
+          ],
+          "sourceRevisionIds": [
+            "provv-evs-6400-test-report@2026-07-19"
+          ],
+          "caveat": "A bounded test result is not evidence that every fielded DS950 is defect-free or a claim about misconduct or outcomes."
+        }
+      ],
+      "power": [
+        {
+          "id": "ds950-certified-ups-options",
+          "componentId": "ds950-ups",
+          "knowledgeStatus": "confirmed",
+          "supplyType": "external uninterruptible power supply",
+          "manufacturer": "CyberPower",
+          "model": "OR1500PFCLCD; CP1500PFCLCD",
+          "capacity": null,
+          "runtime": null,
+          "description": "The certified COTS hardware table names two CyberPower UPS alternatives that apply to the DS950.",
+          "sourceIds": [
+            "eac-evs-6400-scope",
+            "provv-evs-6400-test-report"
+          ],
+          "sourceRevisionIds": [
+            "eac-evs-6400-scope@2026-07-19",
+            "provv-evs-6400-test-report@2026-07-19"
+          ],
+          "caveat": "The sources do not state a DS950 workload runtime or establish option selection, battery age, capacity, or condition."
+        }
+      ],
+      "networkEvidence": {
+        "reviewedOn": "2026-07-21",
+        "summary": "The EVS 6.4.0.0 Pro V&V report states that DS950, DS850, and DS450 results were transmitted to the EMS through a closed local area network during accuracy testing. The EAC scope includes the central tabulator, Electionware infrastructure, and a minimum-1-Gb network switch, but it does not establish a jurisdiction's live switch, port, or addressing configuration.",
+        "publicationBoundary": "This view publishes only the laboratory-supported closed-LAN result path and its source limits. It excludes IP addresses, credentials, keys, database details, switch settings, VLANs, hostnames, device identifiers, and site-specific routing.",
+        "configurations": [
+          {
+            "id": "ds950-6400-closed-lan-test-path",
+            "title": "EVS 6.4.0.0 central-tabulator closed-LAN test path",
+            "evidenceLayer": "expected",
+            "assertionScope": "vstl_test_configuration",
+            "knowledgeStatus": "documented_partial",
+            "topologyKind": "closed_wired_lan",
+            "description": "Pro V&V tested DS950 result transmission over a closed LAN to the EMS. The EAC scope separately lists a minimum-1-Gb switch among certified COTS hardware. The public passages support the system-level path but not every physical connector or a field installation.",
+            "observedOn": null,
+            "assertedFor": null,
+            "nodes": [
+              {
+                "id": "ds950-tabulator",
+                "label": "DS950",
+                "role": "High-speed central scanner and tabulator",
+                "componentId": "ds950-shell",
+                "optional": false,
+                "details": "The DS950 generated central-count result data in the exact-version accuracy test."
+              },
+              {
+                "id": "ds950-closed-switch",
+                "label": "Closed-LAN switch",
+                "role": "Central-count Ethernet interconnect",
+                "componentId": null,
+                "optional": false,
+                "details": "The EAC scope lists a D-Link DSG-1005G network switch with a 1-GB minimum, but jurisdiction selection and use are not established."
+              },
+              {
+                "id": "ds950-ems",
+                "label": "Electionware EMS",
+                "role": "Central result consolidation",
+                "componentId": null,
+                "optional": false,
+                "details": "The test report says the transmitted central-tabulator results were compiled in Electionware."
+              }
+            ],
+            "links": [
+              {
+                "id": "ds950-tabulator-lan",
+                "from": "ds950-tabulator",
+                "to": "ds950-closed-switch",
+                "medium": "Closed local area network",
+                "direction": "one_way",
+                "purpose": "Transmit central-tabulator result data",
+                "knowledgeStatus": "documented_partial"
+              },
+              {
+                "id": "ds950-lan-ems",
+                "from": "ds950-closed-switch",
+                "to": "ds950-ems",
+                "medium": "Closed local area network",
+                "direction": "one_way",
+                "purpose": "Deliver transmitted result data to the EMS for compilation",
+                "knowledgeStatus": "confirmed"
+              }
+            ],
+            "controls": [
+              {
+                "id": "ds950-closed-lan",
+                "label": "Closed LAN",
+                "status": "documented",
+                "description": "The VSTL report explicitly identifies the DS950 central-tabulator result path as a closed local area network."
+              },
+              {
+                "id": "ds950-public-network",
+                "label": "Public-network path",
+                "status": "not_publicly_established",
+                "description": "The reviewed DS950 accuracy-test passage does not describe a public-network transmission path."
+              },
+              {
+                "id": "ds950-field-network-state",
+                "label": "Field network state",
+                "status": "not_publicly_established",
+                "description": "No jurisdiction switch, port, address, enabled-service, or cable record is established in this dossier."
+              }
+            ],
+            "sensitiveDetailsWithheld": "No addresses, credentials, keys, database identifiers, switch settings, VLANs, hostnames, device identifiers, or site routing is collected or displayed.",
+            "sourceIds": [
+              "eac-evs-6400-scope",
+              "provv-evs-6400-test-report"
+            ],
+            "sourceRevisionIds": [
+              "eac-evs-6400-scope@2026-07-19",
+              "provv-evs-6400-test-report@2026-07-19"
+            ],
+            "caveat": "A VSTL accuracy-test topology is not proof that a jurisdiction connected a DS950, used the listed switch, or transmitted results over a network in a particular election."
+          }
+        ],
+        "sourceImages": [
+          {
+            "id": "ds950-evs-6400-system-diagram",
+            "assetUrl": "/equipment/network-evidence/evs-6400-system-diagram.png",
+            "assetSha256": "d68f37906c6b91ec937c6f77952d44aded6c97bb17fb07e256e88aa82d51f412",
+            "width": 1055,
+            "height": 690,
+            "kind": "source_topology_diagram",
+            "alt": "EVS 6.4.0.0 certification system diagram showing election-data management, equipment configuration, central tabulation devices, and results-consolidation infrastructure.",
+            "caption": "EVS 6.4.0.0 certified-system overview diagram",
+            "pageOrSection": "EAC scope PDF page 4, document page 3",
+            "derivativeNote": "Rendered at 135 DPI, rotated for readability, and cropped to the diagram boundary; diagram content was not edited.",
+            "caveat": "The system-level figure contains many EVS components and paths. It does not prove that every component or connection is present in a DS950 deployment.",
+            "sourceIds": [
+              "eac-evs-6400-scope"
+            ],
+            "sourceRevisionIds": [
+              "eac-evs-6400-scope@2026-07-19"
+            ]
+          },
+          {
+            "id": "ds950-evs-6400-transmission-test-page",
+            "assetUrl": "/equipment/network-evidence/evs-6400-transmission-test.png",
+            "assetSha256": "71296be17326a584587a366a530559e8d9f9eb3280b93a757486912b583a9736",
+            "width": 1148,
+            "height": 1485,
+            "kind": "source_document_page",
+            "alt": "Pro V and V EVS 6.4.0.0 test-report page stating that DS950, DS850, and DS450 results were transmitted to the EMS through a closed local area network.",
+            "caption": "Pro V&V EVS 6.4.0.0 central-tabulator closed-LAN test statement",
+            "pageOrSection": "Pro V&V test-report PDF page 30, report page 25",
+            "derivativeNote": "Rendered from the archived official PDF at 135 DPI; the source page content was not edited.",
+            "caveat": "This is evidence of a laboratory test configuration and successful result transfer, not a jurisdiction deployment record.",
+            "sourceIds": [
+              "provv-evs-6400-test-report"
+            ],
+            "sourceRevisionIds": [
+              "provv-evs-6400-test-report@2026-07-19"
+            ]
+          }
+        ],
+        "gaps": [
+          {
+            "id": "ds950-interface-map-gap",
+            "label": "Physical interface and switch map",
+            "description": "The reviewed public pages do not enumerate the occupied DS950 connector, switch port assignments, addressing, VLANs, or enabled services for the test or a field installation.",
+            "sourceIds": [
+              "eac-evs-6400-scope",
+              "provv-evs-6400-test-report"
+            ],
+            "sourceRevisionIds": [
+              "eac-evs-6400-scope@2026-07-19",
+              "provv-evs-6400-test-report@2026-07-19"
+            ],
+            "caveat": "System-level closed-LAN evidence must not be expanded into unreported operational details."
+          },
+          {
+            "id": "ds950-field-topology-gap",
+            "label": "Field-observed topology",
+            "description": "No dated jurisdiction network diagram, interface inspection, or switch inventory was collected for a particular DS950.",
+            "sourceIds": [
+              "provv-evs-6400-test-report"
+            ],
+            "sourceRevisionIds": [
+              "provv-evs-6400-test-report@2026-07-19"
+            ],
+            "caveat": "A laboratory path is not a live observation."
+          }
+        ]
+      },
+      "deployments": [],
+      "scene": {
+        "assetUrl": "/equipment/ess-evs-6400-ds950/orthographic-pilot.glb",
+        "assetLicense": "Apache-2.0",
+        "assetAttribution": "Original CivicResultMaps schematic generated from scripts/build-tabulator-models.mjs",
+        "geometryFidelity": "illustrative_not_to_scale",
+        "description": "An original photo-informed DS950 schematic separating the enclosure, feeder, scanner path, output trays, display, documented internal categories, cart, and UPS.",
+        "referenceConfiguration": "DS950 manufacturer product form on the certified Central Count Cart category",
+        "referenceSourceIds": [
+          "ess-ds950-product-page",
+          "ess-ds950-reference-photo",
+          "eac-evs-6400-scope",
+          "provv-evs-6400-test-report"
+        ],
+        "referenceSourceRevisionIds": [
+          "ess-ds950-product-page@2026-07-20",
+          "ess-ds950-reference-photo@2026-07-20",
+          "eac-evs-6400-scope@2026-07-19",
+          "provv-evs-6400-test-report@2026-07-19"
+        ],
+        "referenceNote": "External proportions follow the manufacturer photograph. Internal forms, placement, scale, ports, cabling, paper path, and explosion offsets remain illustrative because no public teardown establishes them.",
+        "referenceImages": [
+          {
+            "id": "ds950-official-product-photo",
+            "assetUrl": "/equipment/ess-evs-6400-ds950/reference-ds950.png",
+            "assetSha256": "c1660e87080f10910a69fbdb797db8e050d6ee32d5cfbd26215b9de6cacf4ba3",
+            "width": 1280,
+            "height": 854,
+            "alt": "Official product photograph of an ES&S DS950 high-speed scanner and tabulator on its wheeled support cart",
+            "caption": "Manufacturer catalog photograph of the DS950 central-count scanner and tabulator.",
+            "kind": "manufacturer_product_photo",
+            "sourceIds": [
+              "ess-ds950-reference-photo"
+            ],
+            "sourceRevisionIds": [
+              "ess-ds950-reference-photo@2026-07-20"
+            ],
+            "pageOrSection": "Original 1280 x 854 catalog photograph",
+            "derivativeNote": "Local PNG conversion of the archived manufacturer JPEG at its original dimensions; no crop or content alteration.",
+            "caveat": "External appearance only; the photograph does not establish dimensions, internal placement, firmware, accessories, or field configuration."
+          }
+        ],
+        "camera": {
+          "position": [
+            6.5,
+            5.5,
+            7.5
+          ],
+          "zoom": 60,
+          "near": 0.1,
+          "far": 100
+        },
+        "nodes": [
+          {
+            "componentId": "ds950-shell",
+            "nodeName": "DS950_Shell",
+            "color": "#8ca3a8",
+            "explodedOffset": [
+              0,
+              0.5,
+              0
+            ]
+          },
+          {
+            "componentId": "ds950-input-feeder",
+            "nodeName": "DS950_Input_Feeder",
+            "color": "#d4d9d8",
+            "explodedOffset": [
+              0,
+              1.25,
+              -0.2
+            ]
+          },
+          {
+            "componentId": "ds950-scanner-path",
+            "nodeName": "DS950_Scanner_Path",
+            "color": "#33c6b5",
+            "explodedOffset": [
+              0,
+              0.65,
+              -0.5
+            ]
+          },
+          {
+            "componentId": "ds950-sorting-trays",
+            "nodeName": "DS950_Sorting_Trays",
+            "color": "#53676d",
+            "explodedOffset": [
+              0,
+              -0.3,
+              1
+            ]
+          },
+          {
+            "componentId": "ds950-display",
+            "nodeName": "DS950_Display",
+            "color": "#78a6ff",
+            "explodedOffset": [
+              0,
+              1.2,
+              0.8
+            ]
+          },
+          {
+            "componentId": "ds950-motherboard",
+            "nodeName": "DS950_Motherboard",
+            "color": "#f0b95a",
+            "explodedOffset": [
+              1.35,
+              0.2,
+              0.2
+            ]
+          },
+          {
+            "componentId": "ds950-m2-storage",
+            "nodeName": "DS950_M2_Storage",
+            "color": "#e87fb3",
+            "explodedOffset": [
+              -1.35,
+              0.25,
+              0.25
+            ]
+          },
+          {
+            "componentId": "ds950-smart-card-reader",
+            "nodeName": "DS950_Smart_Card_Reader",
+            "color": "#ff8c69",
+            "explodedOffset": [
+              1.25,
+              0.65,
+              0.7
+            ]
+          },
+          {
+            "componentId": "ds950-central-count-cart",
+            "nodeName": "DS950_Central_Count_Cart",
+            "color": "#344247",
+            "explodedOffset": [
+              0,
+              -1,
+              0
+            ]
+          },
+          {
+            "componentId": "ds950-ups",
+            "nodeName": "DS950_UPS",
+            "color": "#e87fb3",
+            "explodedOffset": [
+              -1.25,
+              -0.75,
+              -0.2
+            ]
+          }
+        ]
+      },
+      "caveats": [
+        "The DS950 is a separate central-count machine and must not inherit DS200 component claims.",
+        "The 3D scene is a navigation aid, not a teardown, wiring diagram, engineering drawing, installation, or unit inventory.",
+        "Unpublished motherboard, processor, memory, TPM, storage, and port-count details are not guessed.",
+        "Certified UPS alternatives do not establish which model or battery condition applies at a jurisdiction.",
+        "A certification change, ECO, or test result is not evidence of field occurrence, misconduct, or an election outcome effect."
+      ],
+      "claimRevision": 3,
+      "editorialState": "published",
+      "sourceIds": [
+        "eac-evs-6400-record",
+        "eac-evs-6400-scope",
+        "ess-ds950-product-page",
+        "ess-ds950-reference-photo",
+        "provv-evs-6400-test-report"
+      ],
+      "sourceRevisionIds": [
+        "eac-evs-6400-record@2026-07-19",
+        "eac-evs-6400-scope@2026-07-19",
+        "ess-ds950-product-page@2026-07-20",
+        "ess-ds950-reference-photo@2026-07-20",
+        "provv-evs-6400-test-report@2026-07-19"
+      ],
+      "coverage": {
+        "componentCount": 10,
+        "sourcedComponentCount": 10,
+        "technicalSpecificationCount": 2,
+        "establishedTechnicalSpecificationCount": 2,
+        "unknownTechnicalSpecificationCount": 0,
+        "configurationChangeCount": 2,
+        "deploymentObservationCount": 0,
+        "findingCount": 1,
+        "powerRecordCount": 1,
+        "confirmedPowerRecordCount": 1,
+        "sourceCount": 5,
+        "sourceRevisionCount": 5,
+        "componentSecurityReviewCount": 0,
+        "exactApplicableVulnerabilityCount": 0,
+        "nonCveAdvisoryCount": 0,
+        "networkConfigurationCount": 1,
+        "networkSourceImageCount": 2,
+        "fieldObservedNetworkConfigurationCount": 0
+      }
+    }
+  ]
+}

--- a/docs/equipment-evidence-workflow.md
+++ b/docs/equipment-evidence-workflow.md
@@ -6,16 +6,22 @@ It does not infer fraud, misconduct, altered votes, election outcomes, unit cond
 
 ## Current status
 
-The checked-in catalog is a staging pilot. Claims may be `approved` for feature-gated review while public production publication remains a separate editorial and deployment decision.
+Catalog generation produces two checked-in artifacts with different release contracts:
 
-Local and staging access requires both flags:
+- `data/equipment-catalog.public.json` contains only `published` claims and is the only catalog permitted in a production deployment.
+- `data/equipment-catalog.staging.json` contains `approved` and `published` claims for feature-gated editorial and preview review.
+
+The build selects one artifact through `EQUIPMENT_CATALOG_CHANNEL`. Local development and Vercel previews default to `staging`; other builds default to `public`. Production builds fail closed if `staging` is explicitly requested.
+
+Local and preview access requires both feature flags (the channel line is optional when using the default):
 
 ```text
+EQUIPMENT_CATALOG_CHANNEL=staging
 EQUIPMENT_EXPLORER_ENABLED=1
 NEXT_PUBLIC_EQUIPMENT_EXPLORER=1
 ```
 
-The server-side flag makes page and API responses fail closed when disabled. The public-prefixed flag exposes workspace navigation in an enabled build. The 3D scene remains dynamically loaded only after the viewer is opened. Production should leave both flags disabled until all publication gates below pass.
+The server-side flag makes page and API responses fail closed when disabled. The public-prefixed flag exposes workspace navigation in an enabled build. The 3D scene remains dynamically loaded only after the viewer is opened. In production, feature activation additionally requires the selected public catalog to satisfy its publication gate. Production should leave both flags disabled until all publication gates below pass.
 
 ## Evidence boundaries
 
@@ -155,6 +161,7 @@ A component `securityReview` is permitted only when product identity and applica
 
 ```powershell
 npm run equipment:catalog:build
+npm run equipment:catalog:check
 npm run equipment:catalog:coverage
 npm run test:equipment-catalog
 npm run typecheck
@@ -185,7 +192,7 @@ The GLB files are original CivicResultMaps navigation schematics. Their rough ex
 
 Before enabling the feature publicly:
 
-1. All public claims are in `published` state and pin verified source revisions.
+1. The generated public catalog contains only `published` claims, pins verified source revisions, and reports `productionReady: true`.
 2. No affected source comparison remains pending.
 3. The evidence and neutral-language editorial review is complete.
 4. `npm run test:equipment-catalog`, `npm run typecheck`, `npm run test:layout`, and a feature-enabled production build pass.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,9 @@
 import type { NextConfig } from "next";
 
+import { resolveEquipmentCatalogChannel } from "./src/lib/equipment-catalog-channel";
+
+const equipmentCatalogChannel = resolveEquipmentCatalogChannel();
+
 const nextConfig: NextConfig = {
   ...(process.platform === "win32"
     ? {
@@ -24,6 +28,9 @@ const nextConfig: NextConfig = {
   },
   turbopack: {
     root: __dirname,
+    resolveAlias: {
+      "@equipment-catalog-data": `./data/equipment-catalog.${equipmentCatalogChannel}.json`,
+    },
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -199,8 +199,11 @@
     "etl:import:dc": "npm run etl:prepare:dc && python -m civic_etl.cli import --config etl/state-configs/dc.json --out .etl/staging",
     "test:layout": "node --experimental-strip-types tests/api/workspace-layout.test.mjs && node --experimental-strip-types tests/api/workspace-layout-v2.test.mjs && node --experimental-strip-types tests/api/workspace-layout-v3.test.mjs && node --experimental-strip-types tests/api/workspace-layout-editor-reducer.test.mjs && node --experimental-strip-types tests/api/workspace-layout-contrast.test.mjs && node --experimental-strip-types tests/api/workspace-layout-diff.test.mjs && node --experimental-strip-types tests/api/workspace-layout-scheduler-policy.test.mjs && node --experimental-strip-types tests/api/workspace-layout-resolution.test.mjs && node --experimental-strip-types tests/api/workspace-layout-publisher-policy.test.mjs && node --experimental-strip-types tests/api/workspace-layout-visitor.test.mjs && node --experimental-strip-types tests/api/workspace-layout-admin-policy.test.mjs && node --experimental-strip-types tests/api/workspace-layout-agent-operations.test.mjs && node --experimental-strip-types tests/api/workspace-layout-agent-mcp.test.mjs && node --experimental-strip-types tests/api/workspace-source-catalog.test.mjs && node --experimental-strip-types tests/api/workspace-navigation.test.mjs && node tests/api/navigation-tours.test.mjs",
     "test:e2e": "playwright test",
+    "test:e2e:equipment": "playwright test tests/e2e/equipment-catalog.spec.ts tests/e2e/equipment-social-previews.spec.ts --workers=2",
+    "test:e2e:workspace": "playwright test tests/e2e/workspace-layout.spec.ts tests/e2e/workspace-layout-v3.spec.ts tests/e2e/workspace-builder-v4.spec.ts --workers=2",
     "equipment:model:build": "node scripts/build-equipment-model.mjs && node scripts/build-clearaccess-model.mjs && node scripts/build-imagecast-x-model.mjs && node scripts/build-tabulator-models.mjs",
     "equipment:catalog:build": "npm run equipment:model:build && node scripts/build-equipment-catalog.mjs && npm run equipment:usage:build",
+    "equipment:catalog:check": "node scripts/build-equipment-catalog.mjs --check",
     "equipment:catalog:coverage": "node scripts/report-equipment-catalog-coverage.mjs",
     "equipment:usage:build": "node --experimental-strip-types scripts/build-equipment-usage-index.mjs",
     "equipment:usage:coverage": "node --experimental-strip-types scripts/build-equipment-usage-index.mjs --check",
@@ -210,7 +213,7 @@
     "equipment:claims:state": "node scripts/set-equipment-claim-editorial-state.mjs",
     "validate:equipment-editorial": "node scripts/validate-equipment-editorial-workflow.mjs",
     "validate:equipment-catalog": "node scripts/validate-equipment-catalog.mjs",
-    "test:equipment-catalog": "npm run validate:equipment-editorial && npm run validate:equipment-catalog && npm run equipment:usage:coverage && node tests/api/equipment-catalog.test.mjs && node tests/api/equipment-usage.test.mjs && node tests/api/equipment-social-preview.test.mjs && node --experimental-strip-types tests/api/equipment-explorer-config.test.mts && node tests/api/equipment-editorial-state.test.mjs"
+    "test:equipment-catalog": "npm run equipment:catalog:check && npm run validate:equipment-editorial && npm run validate:equipment-catalog && npm run equipment:usage:coverage && node tests/api/equipment-catalog-isolation.test.mjs && node --experimental-strip-types tests/api/equipment-catalog-channel.test.mts && node tests/api/equipment-catalog.test.mjs && node tests/api/equipment-usage.test.mjs && node tests/api/equipment-social-preview.test.mjs && node --experimental-strip-types tests/api/equipment-explorer-config.test.mts && node tests/api/equipment-editorial-state.test.mjs"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.5.18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
           CLERK_SECRET_KEY: "",
           DATABASE_URL: "",
           EDGE_CONFIG: "",
+          EQUIPMENT_CATALOG_CHANNEL: "staging",
           EQUIPMENT_EXPLORER_ENABLED: "1",
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "",
           NEXT_PUBLIC_EQUIPMENT_EXPLORER: "1",

--- a/scripts/build-equipment-catalog.mjs
+++ b/scripts/build-equipment-catalog.mjs
@@ -1,8 +1,13 @@
 import { readdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const sourcePackagePath = "data/equipment-source-packages.json";
 const claimDirectory = "data/equipment-claims";
-const outputPath = "data/equipment-catalog.json";
+const outputPaths = {
+  public: "data/equipment-catalog.public.json",
+  staging: "data/equipment-catalog.staging.json",
+};
 
 function unique(values) {
   return [...new Set(values.filter(Boolean))].sort();
@@ -116,7 +121,48 @@ function withCoverage(system, editorial) {
   };
 }
 
-export async function buildEquipmentCatalog() {
+function catalogSourceIds(sourcePackage, systems) {
+  return new Set([
+    ...(sourcePackage.methodology?.changeControlSourceIds ?? []),
+    ...systems.flatMap((system) => system.sourceIds),
+  ]);
+}
+
+export function createEquipmentCatalog({ channel, claims, sourcePackage }) {
+  if (!Object.hasOwn(outputPaths, channel)) throw new Error(`Unsupported equipment catalog channel: ${channel}`);
+
+  const eligibleStates = channel === "public" ? ["published"] : ["approved", "published"];
+  const eligibleClaims = claims.filter((claim) => eligibleStates.includes(claim.editorial?.state));
+  const systems = eligibleClaims
+    .map((claim) => withCoverage(claim.system, claim.editorial))
+    .sort((left, right) => left.displayName.localeCompare(right.displayName));
+  const includedSourceIds = catalogSourceIds(sourcePackage, systems);
+  const releaseIds = unique(
+    eligibleClaims
+      .filter((claim) => claim.editorial?.state === "published")
+      .map((claim) => claim.editorial?.publicationId),
+  );
+
+  return {
+    schemaVersion: 2,
+    catalogChannel: channel,
+    generatedOn: [sourcePackage.reviewedOn, ...eligibleClaims.map((claim) => claim.reviewedOn)]
+      .filter(Boolean)
+      .sort()
+      .at(-1),
+    status: channel === "public" ? "published_catalog" : "reviewed_pilot",
+    editorialState: channel === "public" ? "public_release" : "staging_review",
+    productionRequirement: sourcePackage.editorialPolicy.publicProductionState,
+    releaseIds,
+    methodology: sourcePackage.methodology,
+    sources: sourcePackage.sources
+      .filter((source) => includedSourceIds.has(source.id))
+      .sort((left, right) => left.id.localeCompare(right.id)),
+    systems,
+  };
+}
+
+export async function createEquipmentCatalogs() {
   const sourcePackage = JSON.parse(await readFile(sourcePackagePath, "utf8"));
   const claimFiles = (await readdir(claimDirectory))
     .filter((name) => name.endsWith(".json"))
@@ -124,23 +170,39 @@ export async function buildEquipmentCatalog() {
   const claims = await Promise.all(
     claimFiles.map(async (name) => JSON.parse(await readFile(`${claimDirectory}/${name}`, "utf8"))),
   );
-  const eligibleClaims = claims.filter((claim) => ["approved", "published"].includes(claim.editorial?.state));
-  const systems = eligibleClaims
-    .map((claim) => withCoverage(claim.system, claim.editorial))
-    .sort((left, right) => left.displayName.localeCompare(right.displayName));
 
   return {
-    schemaVersion: 2,
-    generatedOn: [sourcePackage.reviewedOn, ...claims.map((claim) => claim.reviewedOn)].sort().at(-1),
-    status: "reviewed_pilot",
-    editorialState: "staging_review",
-    productionRequirement: sourcePackage.editorialPolicy.publicProductionState,
-    methodology: sourcePackage.methodology,
-    sources: [...sourcePackage.sources].sort((left, right) => left.id.localeCompare(right.id)),
-    systems,
+    public: createEquipmentCatalog({ channel: "public", claims, sourcePackage }),
+    staging: createEquipmentCatalog({ channel: "staging", claims, sourcePackage }),
   };
 }
 
-const catalog = await buildEquipmentCatalog();
-await writeFile(outputPath, `${JSON.stringify(catalog, null, 2)}\n`, "utf8");
-console.log(`Wrote ${catalog.systems.length} system ${catalog.systems.length === 1 ? "dossier" : "dossiers"} to ${outputPath}.`);
+async function writeOrCheckCatalogs() {
+  const catalogs = await createEquipmentCatalogs();
+  const checkOnly = process.argv.includes("--check");
+  const stalePaths = [];
+
+  for (const [channel, outputPath] of Object.entries(outputPaths)) {
+    const catalog = catalogs[channel];
+    const output = `${JSON.stringify(catalog, null, 2)}\n`;
+    if (checkOnly) {
+      const current = await readFile(outputPath, "utf8").catch(() => "");
+      if (current.replace(/\r\n?/g, "\n") !== output) stalePaths.push(outputPath);
+      continue;
+    }
+
+    await writeFile(outputPath, output, "utf8");
+    console.log(
+      `Wrote ${catalog.systems.length} ${channel} system ${catalog.systems.length === 1 ? "dossier" : "dossiers"} to ${outputPath}.`,
+    );
+  }
+
+  if (stalePaths.length > 0) {
+    throw new Error(`${stalePaths.join(", ")} ${stalePaths.length === 1 ? "is" : "are"} stale. Run npm run equipment:catalog:build.`);
+  }
+  if (checkOnly) console.log("Public and staging equipment catalogs are current.");
+}
+
+const isMain = process.argv[1]
+  && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isMain) await writeOrCheckCatalogs();

--- a/scripts/build-equipment-usage-index.mjs
+++ b/scripts/build-equipment-usage-index.mjs
@@ -3,7 +3,7 @@ import { resolveJurisdictionTag } from "../src/lib/jurisdiction-tags.ts";
 
 const registryPath = "data/admin-source-packages.json";
 const matcherPath = "data/equipment-usage-matchers.json";
-const catalogPath = "data/equipment-catalog.json";
+const catalogPath = "data/equipment-catalog.staging.json";
 const outputPath = "data/equipment-usage-index.json";
 
 function parseCsv(text) {

--- a/scripts/report-equipment-catalog-coverage.mjs
+++ b/scripts/report-equipment-catalog-coverage.mjs
@@ -1,24 +1,25 @@
 import { readFile } from "node:fs/promises";
 
-const catalog = JSON.parse(await readFile("data/equipment-catalog.json", "utf8"));
-
-console.log(
-  `Catalog: ${catalog.systems.length} dossiers, editorial ${catalog.editorialState}, production requires ${catalog.productionRequirement}`,
-);
-for (const system of catalog.systems) {
-  const unknownComponents = system.components.filter((component) => component.evidenceStatus === "not_publicly_confirmed");
-  const unmodeledKnownComponents = system.components.filter(
-    (component) => component.evidenceStatus !== "not_publicly_confirmed" && component.sceneNodeName === null,
+for (const channel of ["public", "staging"]) {
+  const catalog = JSON.parse(await readFile(`data/equipment-catalog.${channel}.json`, "utf8"));
+  console.log(
+    `${channel[0].toUpperCase()}${channel.slice(1)} catalog: ${catalog.systems.length} dossiers, editorial ${catalog.editorialState}, production requires ${catalog.productionRequirement}`,
   );
-  const unknownDeployments = system.deployments.filter((deployment) => deployment.componentsConfirmed.length === 0);
-  console.log(system.displayName);
-  console.log(`  Editorial: ${system.editorialState} claim revision ${system.claimRevision}`);
-  console.log(`  Components: ${system.coverage.sourcedComponentCount}/${system.coverage.componentCount} source-linked`);
-  console.log(`  Configuration changes: ${system.coverage.configurationChangeCount}`);
-  console.log(`  Findings/listing statuses: ${system.coverage.findingCount}`);
-  console.log(`  Sources/revisions: ${system.coverage.sourceCount}/${system.coverage.sourceRevisionCount}`);
-  console.log(`  Deployment observations: ${system.coverage.deploymentObservationCount} (${unknownDeployments.length} without component confirmation)`);
-  console.log(`  Confirmed power records: ${system.coverage.confirmedPowerRecordCount}/${system.coverage.powerRecordCount}`);
-  console.log(`  Explicit evidence gaps: ${unknownComponents.map((component) => component.name).join(", ") || "none"}`);
-  console.log(`  Known but not placed in 3D: ${unmodeledKnownComponents.map((component) => component.name).join(", ") || "none"}`);
+  for (const system of catalog.systems) {
+    const unknownComponents = system.components.filter((component) => component.evidenceStatus === "not_publicly_confirmed");
+    const unmodeledKnownComponents = system.components.filter(
+      (component) => component.evidenceStatus !== "not_publicly_confirmed" && component.sceneNodeName === null,
+    );
+    const unknownDeployments = system.deployments.filter((deployment) => deployment.componentsConfirmed.length === 0);
+    console.log(system.displayName);
+    console.log(`  Editorial: ${system.editorialState} claim revision ${system.claimRevision}`);
+    console.log(`  Components: ${system.coverage.sourcedComponentCount}/${system.coverage.componentCount} source-linked`);
+    console.log(`  Configuration changes: ${system.coverage.configurationChangeCount}`);
+    console.log(`  Findings/listing statuses: ${system.coverage.findingCount}`);
+    console.log(`  Sources/revisions: ${system.coverage.sourceCount}/${system.coverage.sourceRevisionCount}`);
+    console.log(`  Deployment observations: ${system.coverage.deploymentObservationCount} (${unknownDeployments.length} without component confirmation)`);
+    console.log(`  Confirmed power records: ${system.coverage.confirmedPowerRecordCount}/${system.coverage.powerRecordCount}`);
+    console.log(`  Explicit evidence gaps: ${unknownComponents.map((component) => component.name).join(", ") || "none"}`);
+    console.log(`  Known but not placed in 3D: ${unmodeledKnownComponents.map((component) => component.name).join(", ") || "none"}`);
+  }
 }

--- a/scripts/validate-equipment-catalog.mjs
+++ b/scripts/validate-equipment-catalog.mjs
@@ -2,7 +2,8 @@ import { createHash } from "node:crypto";
 import { readFile, readdir } from "node:fs/promises";
 
 const sourcePackage = JSON.parse(await readFile("data/equipment-source-packages.json", "utf8"));
-const catalog = JSON.parse(await readFile("data/equipment-catalog.json", "utf8"));
+const publicCatalog = JSON.parse(await readFile("data/equipment-catalog.public.json", "utf8"));
+const stagingCatalog = JSON.parse(await readFile("data/equipment-catalog.staging.json", "utf8"));
 const claimFiles = (await readdir("data/equipment-claims"))
   .filter((name) => name.endsWith(".json"))
   .sort();
@@ -120,10 +121,9 @@ function readGlbNodeNames(buffer, label) {
   }
 }
 
-if (sourcePackage.schemaVersion !== 2 || catalog.schemaVersion !== 2) {
-  error("Equipment source package and catalog must use schema version 2.");
+if (sourcePackage.schemaVersion !== 2) {
+  error("Equipment source package must use schema version 2.");
 }
-if (catalog.status !== "reviewed_pilot") error("Catalog must retain reviewed_pilot status.");
 
 const sourceById = new Map();
 const revisionById = new Map();
@@ -144,8 +144,6 @@ for (const source of sourcePackage.sources ?? []) {
   await validateArtifact(source);
 }
 
-const eligibleClaims = claims.filter((claim) => ["approved", "published"].includes(claim.editorial?.state));
-const eligibleClaimBySlug = new Map(eligibleClaims.map((claim) => [claim.system?.slug, claim]));
 const slugSet = new Set();
 for (const claim of claims) {
   const system = claim.system;
@@ -636,39 +634,91 @@ for (const claim of claims) {
   }
 }
 
-if (catalog.systems?.length !== eligibleClaims.length) {
-  error("Generated catalog system count does not match approved and published claim inputs.");
-}
-for (const system of catalog.systems ?? []) {
-  const claim = eligibleClaimBySlug.get(system.slug);
-  if (!claim) error(`Generated catalog contains ineligible or unknown system ${system.slug}.`);
-  else {
-    if (system.editorialState !== claim.editorial.state) error(`${system.slug} catalog editorial state is stale.`);
-    if (system.claimRevision !== claim.editorial.revision) error(`${system.slug} catalog claim revision is stale.`);
+function validateGeneratedCatalog(catalog, {
+  channel,
+  eligibleStates,
+  expectedEditorialState,
+  expectedStatus,
+}) {
+  const label = `${channel} catalog`;
+  if (catalog.schemaVersion !== 2) error(`${label} must use schema version 2.`);
+  if (catalog.catalogChannel !== channel) error(`${label} has the wrong catalogChannel.`);
+  if (catalog.status !== expectedStatus) error(`${label} has the wrong status.`);
+  if (catalog.editorialState !== expectedEditorialState) error(`${label} has the wrong editorialState.`);
+  if (catalog.productionRequirement !== sourcePackage.editorialPolicy.publicProductionState) {
+    error(`${label} has a stale production requirement.`);
   }
-  if (system.coverage?.sourcedComponentCount !== system.coverage?.componentCount) {
-    error(`${system.slug} generated coverage reports an unsourced component.`);
+
+  const eligibleClaims = claims.filter((claim) => eligibleStates.includes(claim.editorial?.state));
+  const eligibleClaimBySlug = new Map(eligibleClaims.map((claim) => [claim.system?.slug, claim]));
+  if (catalog.systems?.length !== eligibleClaims.length) {
+    error(`${label} system count does not match its eligible claim inputs.`);
   }
-  const securityReviews = system.components.filter((component) => component.securityReview !== null);
-  const vulnerabilityCount = securityReviews.reduce(
-    (sum, component) => sum + component.securityReview.vulnerabilities.length,
-    0,
-  );
-  const nonCveAdvisoryCount = securityReviews.reduce(
-    (sum, component) => sum + component.securityReview.nonCveAdvisories.length,
-    0,
-  );
-  if (system.coverage?.componentSecurityReviewCount !== securityReviews.length) {
-    error(`${system.slug} generated security-review coverage is stale.`);
+
+  const expectedReleaseIds = [...new Set(eligibleClaims
+    .filter((claim) => claim.editorial?.state === "published")
+    .map((claim) => claim.editorial?.publicationId)
+    .filter(Boolean))]
+    .sort();
+  if (JSON.stringify(catalog.releaseIds ?? []) !== JSON.stringify(expectedReleaseIds)) {
+    error(`${label} release IDs are stale.`);
   }
-  if (system.coverage?.exactApplicableVulnerabilityCount !== vulnerabilityCount) {
-    error(`${system.slug} generated vulnerability coverage is stale.`);
+
+  const expectedSourceIds = new Set([
+    ...(sourcePackage.methodology?.changeControlSourceIds ?? []),
+    ...(catalog.systems ?? []).flatMap((system) => system.sourceIds ?? []),
+  ]);
+  const catalogSourceIds = (catalog.sources ?? []).map((source) => source.id).sort();
+  if (JSON.stringify(catalogSourceIds) !== JSON.stringify([...expectedSourceIds].sort())) {
+    error(`${label} must contain exactly the sources used by its systems and methodology.`);
   }
-  if (system.coverage?.nonCveAdvisoryCount !== nonCveAdvisoryCount) {
-    error(`${system.slug} generated non-CVE advisory coverage is stale.`);
+
+  for (const system of catalog.systems ?? []) {
+    const claim = eligibleClaimBySlug.get(system.slug);
+    if (!claim) error(`${label} contains ineligible or unknown system ${system.slug}.`);
+    else {
+      if (system.editorialState !== claim.editorial.state) error(`${system.slug} ${label} editorial state is stale.`);
+      if (system.claimRevision !== claim.editorial.revision) error(`${system.slug} ${label} claim revision is stale.`);
+    }
+    if (channel === "public" && system.editorialState !== "published") {
+      error(`${system.slug} is not published and must not appear in the public catalog.`);
+    }
+    if (system.coverage?.sourcedComponentCount !== system.coverage?.componentCount) {
+      error(`${system.slug} generated coverage reports an unsourced component.`);
+    }
+    const securityReviews = system.components.filter((component) => component.securityReview !== null);
+    const vulnerabilityCount = securityReviews.reduce(
+      (sum, component) => sum + component.securityReview.vulnerabilities.length,
+      0,
+    );
+    const nonCveAdvisoryCount = securityReviews.reduce(
+      (sum, component) => sum + component.securityReview.nonCveAdvisories.length,
+      0,
+    );
+    if (system.coverage?.componentSecurityReviewCount !== securityReviews.length) {
+      error(`${system.slug} generated security-review coverage is stale.`);
+    }
+    if (system.coverage?.exactApplicableVulnerabilityCount !== vulnerabilityCount) {
+      error(`${system.slug} generated vulnerability coverage is stale.`);
+    }
+    if (system.coverage?.nonCveAdvisoryCount !== nonCveAdvisoryCount) {
+      error(`${system.slug} generated non-CVE advisory coverage is stale.`);
+    }
   }
 }
 
+validateGeneratedCatalog(publicCatalog, {
+  channel: "public",
+  eligibleStates: ["published"],
+  expectedEditorialState: "public_release",
+  expectedStatus: "published_catalog",
+});
+validateGeneratedCatalog(stagingCatalog, {
+  channel: "staging",
+  eligibleStates: ["approved", "published"],
+  expectedEditorialState: "staging_review",
+  expectedStatus: "reviewed_pilot",
+});
 if (errors.length) {
   console.error(`Equipment catalog validation failed with ${errors.length} error(s):`);
   for (const message of errors) console.error(`- ${message}`);
@@ -676,8 +726,8 @@ if (errors.length) {
 }
 
 console.log(
-  `Validated ${catalog.systems.length} equipment system${catalog.systems.length === 1 ? "" : "s"}, ${sourcePackage.sources.length} archived sources, `
-    + `${catalog.systems.reduce((sum, system) => sum + system.components.length, 0)} components, and `
-    + `${catalog.systems.reduce((sum, system) => sum + system.coverage.technicalSpecificationCount, 0)} technical specifications, and `
-    + `${catalog.systems.reduce((sum, system) => sum + system.configurationChanges.length, 0)} configuration changes.`,
+  `Validated ${publicCatalog.systems.length} public and ${stagingCatalog.systems.length} staging equipment systems, ${sourcePackage.sources.length} archived sources, `
+    + `${stagingCatalog.systems.reduce((sum, system) => sum + system.components.length, 0)} staging components, and `
+    + `${stagingCatalog.systems.reduce((sum, system) => sum + system.coverage.technicalSpecificationCount, 0)} technical specifications, and `
+    + `${stagingCatalog.systems.reduce((sum, system) => sum + system.configurationChanges.length, 0)} configuration changes.`,
 );

--- a/scripts/verify-equipment-deployment.mjs
+++ b/scripts/verify-equipment-deployment.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const defaultAttempts = 12;
+const defaultDelayMs = 5_000;
+
+function readArgument(name) {
+  const prefix = `--${name}=`;
+  return process.argv.find((argument) => argument.startsWith(prefix))?.slice(prefix.length);
+}
+
+const baseUrl = (readArgument("base-url") ?? process.env.EQUIPMENT_SMOKE_BASE_URL ?? "")
+  .replace(/\/$/, "");
+const expectedChannel = readArgument("expect-channel") ?? "staging";
+const attempts = Number(readArgument("attempts") ?? defaultAttempts);
+const delayMs = Number(readArgument("delay-ms") ?? defaultDelayMs);
+
+if (!baseUrl || !/^https?:\/\//.test(baseUrl)) {
+  throw new Error("Provide an HTTP(S) base URL with --base-url=<url> or EQUIPMENT_SMOKE_BASE_URL.");
+}
+if (!["public", "staging"].includes(expectedChannel)) {
+  throw new Error("--expect-channel must be public or staging.");
+}
+if (!Number.isInteger(attempts) || attempts < 1 || !Number.isInteger(delayMs) || delayMs < 0) {
+  throw new Error("Smoke retry options must be non-negative integers and attempts must be at least 1.");
+}
+
+const expectedCatalog = JSON.parse(
+  await readFile(`data/equipment-catalog.${expectedChannel}.json`, "utf8"),
+);
+const expectedSlugs = expectedCatalog.systems.map((system) => system.slug).sort();
+assert.ok(expectedSlugs.length > 0, `${expectedChannel} catalog must contain a dossier.`);
+
+function wait(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function fetchResponse(path) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: { "user-agent": "CivicResultMaps-equipment-smoke/1.0" },
+  });
+  assert.equal(response.status, 200, `${path} returned HTTP ${response.status}`);
+  return response;
+}
+
+async function verify() {
+  const pageResponse = await fetchResponse("/equipment");
+  const page = await pageResponse.text();
+  assert.match(page, /U\.S\. election equipment/i);
+  for (const system of expectedCatalog.systems) {
+    assert.match(page, new RegExp(system.deviceName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"));
+  }
+
+  const listResponse = await fetchResponse("/api/v1/equipment-systems");
+  const listPayload = await listResponse.json();
+  assert.equal(listPayload.meta.catalogChannel, expectedChannel, "catalog channel");
+  assert.equal(listPayload.meta.catalogStatus, expectedCatalog.status, "catalog status");
+  assert.deepEqual(
+    listPayload.data.map((system) => system.slug).sort(),
+    expectedSlugs,
+    "deployed dossier slugs",
+  );
+
+  const firstSlug = expectedSlugs[0];
+  const detailResponse = await fetchResponse(`/api/v1/equipment-systems/${firstSlug}`);
+  const detailPayload = await detailResponse.json();
+  assert.equal(detailPayload.meta.catalogChannel, expectedChannel, "detail catalog channel");
+  assert.equal(detailPayload.meta.catalogStatus, expectedCatalog.status, "detail catalog status");
+  assert.equal(detailPayload.data.system.slug, firstSlug, "detail dossier slug");
+  assert.ok(detailPayload.data.sources.length > 0, "detail dossier sources");
+}
+
+let lastError;
+for (let attempt = 1; attempt <= attempts; attempt += 1) {
+  try {
+    await verify();
+    console.log(`Equipment deployment smoke passed for ${baseUrl} using the ${expectedChannel} catalog.`);
+    process.exit(0);
+  } catch (error) {
+    lastError = error;
+    if (attempt === attempts) break;
+    console.warn(`Equipment smoke attempt ${attempt}/${attempts} failed: ${error.message}`);
+    await wait(delayMs);
+  }
+}
+
+throw lastError;

--- a/src/app/api/equipment-states/[state]/route.ts
+++ b/src/app/api/equipment-states/[state]/route.ts
@@ -18,7 +18,7 @@ type RouteContext = {
 };
 
 export async function GET(_request: Request, { params }: RouteContext) {
-  if (!isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady })) {
+  if (!isEquipmentExplorerEnabled({ catalogChannel: equipmentCatalogMetadata.channel, productionReady: equipmentCatalogMetadata.productionReady })) {
     return NextResponse.json(
       apiErrorEnvelope({ code: "equipment_catalog_disabled", message: "The equipment catalog is not enabled." }),
       { headers: publicApiErrorHeaders, status: 404 },
@@ -63,6 +63,7 @@ export async function GET(_request: Request, { params }: RouteContext) {
         caveat: overview.caveat,
       },
       {
+        catalogChannel: equipmentCatalogMetadata.channel,
         generatedOn: equipmentUsageMetadata.generatedOn,
         schemaVersion: equipmentCatalogApiSchemaVersion,
         source: equipmentUsageMetadata.sourcePolicy.authority,

--- a/src/app/api/equipment-systems/[slug]/jurisdictions/route.ts
+++ b/src/app/api/equipment-systems/[slug]/jurisdictions/route.ts
@@ -21,7 +21,7 @@ function integerParameter(value: string | null, fallback: number) {
 }
 
 export async function GET(request: Request, { params }: RouteContext) {
-  if (!isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady })) {
+  if (!isEquipmentExplorerEnabled({ catalogChannel: equipmentCatalogMetadata.channel, productionReady: equipmentCatalogMetadata.productionReady })) {
     return NextResponse.json(
       apiErrorEnvelope({ code: "equipment_catalog_disabled", message: "The equipment catalog is not enabled." }),
       { headers: publicApiErrorHeaders, status: 404 },
@@ -88,6 +88,7 @@ export async function GET(request: Request, { params }: RouteContext) {
         ...result,
       },
       {
+        catalogChannel: equipmentCatalogMetadata.channel,
         generatedOn: equipmentUsageMetadata.generatedOn,
         schemaVersion: equipmentCatalogApiSchemaVersion,
         source: equipmentUsageMetadata.sourcePolicy.authority,

--- a/src/app/api/equipment-systems/[slug]/route.ts
+++ b/src/app/api/equipment-systems/[slug]/route.ts
@@ -14,7 +14,7 @@ type RouteContext = {
 };
 
 export async function GET(_request: Request, { params }: RouteContext) {
-  if (!isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady })) {
+  if (!isEquipmentExplorerEnabled({ catalogChannel: equipmentCatalogMetadata.channel, productionReady: equipmentCatalogMetadata.productionReady })) {
     return NextResponse.json(
       apiErrorEnvelope({ code: "equipment_catalog_disabled", message: "The equipment catalog pilot is not enabled." }),
       { headers: publicApiErrorHeaders, status: 404 },
@@ -34,6 +34,7 @@ export async function GET(_request: Request, { params }: RouteContext) {
     apiEnvelope(
       { system, sources: sourcesForEquipmentSystem(system) },
       {
+        catalogChannel: equipmentCatalogMetadata.channel,
         catalogStatus: equipmentCatalogMetadata.status,
         generatedOn: equipmentCatalogMetadata.generatedOn,
         schemaVersion: equipmentCatalogApiSchemaVersion,

--- a/src/app/api/equipment-systems/compare/route.ts
+++ b/src/app/api/equipment-systems/compare/route.ts
@@ -11,7 +11,7 @@ import {
 import { isEquipmentExplorerEnabled } from "@/lib/equipment-explorer-config";
 
 export function GET(request: Request) {
-  if (!isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady })) {
+  if (!isEquipmentExplorerEnabled({ catalogChannel: equipmentCatalogMetadata.channel, productionReady: equipmentCatalogMetadata.productionReady })) {
     return NextResponse.json(
       apiErrorEnvelope({ code: "equipment_catalog_disabled", message: "The equipment catalog is not enabled." }),
       { headers: publicApiErrorHeaders, status: 404 },
@@ -33,6 +33,7 @@ export function GET(request: Request) {
     apiEnvelope(
       { systems },
       {
+        catalogChannel: equipmentCatalogMetadata.channel,
         catalogStatus: equipmentCatalogMetadata.status,
         generatedOn: equipmentCatalogMetadata.generatedOn,
         schemaVersion: equipmentCatalogApiSchemaVersion,

--- a/src/app/api/equipment-systems/route.ts
+++ b/src/app/api/equipment-systems/route.ts
@@ -6,7 +6,7 @@ import { equipmentCatalogMetadata, listEquipmentSystems } from "@/lib/equipment-
 import { isEquipmentExplorerEnabled } from "@/lib/equipment-explorer-config";
 
 export function GET() {
-  if (!isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady })) {
+  if (!isEquipmentExplorerEnabled({ catalogChannel: equipmentCatalogMetadata.channel, productionReady: equipmentCatalogMetadata.productionReady })) {
     return NextResponse.json(
       apiErrorEnvelope({ code: "equipment_catalog_disabled", message: "The equipment catalog pilot is not enabled." }),
       { headers: publicApiErrorHeaders, status: 404 },
@@ -16,6 +16,7 @@ export function GET() {
   const systems = listEquipmentSystems();
   return NextResponse.json(
     apiEnvelope(systems, {
+      catalogChannel: equipmentCatalogMetadata.channel,
       catalogStatus: equipmentCatalogMetadata.status,
       generatedOn: equipmentCatalogMetadata.generatedOn,
       schemaVersion: equipmentCatalogApiSchemaVersion,

--- a/src/app/equipment/[slug]/dossier-section-nav.client.tsx
+++ b/src/app/equipment/[slug]/dossier-section-nav.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import type { Route } from "next";
+import { usePathname, useRouter } from "next/navigation";
 
 import { equipmentDossierSections } from "./dossier-navigation";
 import upgradeStyles from "../equipment-upgrades.module.css";
@@ -11,6 +12,7 @@ type DossierSectionNavProps = {
 
 export function DossierSectionNav({ slug }: DossierSectionNavProps) {
   const pathname = usePathname();
+  const router = useRouter();
   const basePath = `/equipment/${slug}`;
   const active = equipmentDossierSections.find((section) => `${basePath}${section.path}` === pathname)
     ?? equipmentDossierSections[0];
@@ -21,7 +23,7 @@ export function DossierSectionNav({ slug }: DossierSectionNavProps) {
         <span>Dossier section</span>
         <select
           aria-label="Dossier section"
-          onChange={(event) => window.location.assign(event.currentTarget.value)}
+          onChange={(event) => router.push(event.currentTarget.value as Route)}
           value={`${basePath}${active.path}`}
         >
           {equipmentDossierSections.map((section) => (

--- a/src/app/equipment/[slug]/layout.tsx
+++ b/src/app/equipment/[slug]/layout.tsx
@@ -26,7 +26,7 @@ export default async function EquipmentDossierLayout({
   children,
   params,
 }: EquipmentDossierLayoutProps) {
-  const equipmentEnabled = isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady });
+  const equipmentEnabled = isEquipmentExplorerEnabled({ catalogChannel: equipmentCatalogMetadata.channel, productionReady: equipmentCatalogMetadata.productionReady });
   if (!equipmentEnabled) notFound();
 
   const { slug } = await params;

--- a/src/app/equipment/compare/page.tsx
+++ b/src/app/equipment/compare/page.tsx
@@ -35,7 +35,7 @@ function label(value: string) {
 }
 
 export default async function EquipmentComparePage({ searchParams }: PageProps) {
-  const equipmentEnabled = isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady });
+  const equipmentEnabled = isEquipmentExplorerEnabled({ catalogChannel: equipmentCatalogMetadata.channel, productionReady: equipmentCatalogMetadata.productionReady });
   if (!equipmentEnabled) notFound();
 
   const requested = await searchParams;

--- a/src/app/equipment/equipment-upgrades.module.css
+++ b/src/app/equipment/equipment-upgrades.module.css
@@ -674,6 +674,12 @@
   font-size: 0.7rem;
 }
 
+@media (max-width: 1180px) {
+  .dossierNavWrap {
+    position: static;
+  }
+}
+
 @media (max-width: 1080px) {
   .dossierNav {
     grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/src/app/equipment/page.tsx
+++ b/src/app/equipment/page.tsx
@@ -73,7 +73,7 @@ export const metadata: Metadata = {
 };
 
 export default async function EquipmentIndexPage({ searchParams }: PageProps) {
-  const equipmentEnabled = isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady });
+  const equipmentEnabled = isEquipmentExplorerEnabled({ catalogChannel: equipmentCatalogMetadata.channel, productionReady: equipmentCatalogMetadata.productionReady });
   if (!equipmentEnabled) notFound();
   const requested = await searchParams;
   const systems = listEquipmentSystemTiles();

--- a/src/app/equipment/state/[state]/page.tsx
+++ b/src/app/equipment/state/[state]/page.tsx
@@ -168,7 +168,7 @@ function ManufacturerContextCard({
 }
 
 export default async function EquipmentStatePage({ params }: PageProps) {
-  const equipmentEnabled = isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady });
+  const equipmentEnabled = isEquipmentExplorerEnabled({ catalogChannel: equipmentCatalogMetadata.channel, productionReady: equipmentCatalogMetadata.productionReady });
   if (!equipmentEnabled) notFound();
   const { state } = await params;
   const preview = buildEquipmentStateSocialPreview(state);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -296,6 +296,7 @@ export default async function Home({ searchParams }: HomeProps) {
         },
       };
   const equipmentExplorerEnabled = isEquipmentExplorerEnabled({
+    catalogChannel: equipmentCatalogMetadata.channel,
     productionReady: equipmentCatalogMetadata.productionReady,
   });
 

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -45,7 +45,7 @@ export const metadata: Metadata = {
 export default async function SecurityPage() {
   const report = getNationalSecurityIncidentReport(2024);
   const electionOverlay = buildSecurityElectionOverlay(report.incidents, await loadNationalYearDataset(2024));
-  const equipmentEnabled = isEquipmentExplorerEnabled({ productionReady: equipmentCatalogMetadata.productionReady });
+  const equipmentEnabled = isEquipmentExplorerEnabled({ catalogChannel: equipmentCatalogMetadata.channel, productionReady: equipmentCatalogMetadata.productionReady });
 
   return (
     <main className={baseStyles.shell}>

--- a/src/app/site-header.module.css
+++ b/src/app/site-header.module.css
@@ -52,6 +52,77 @@
   gap: 10px;
 }
 
+.mobileNavigation {
+  position: relative;
+  display: none;
+}
+
+.mobileMenuButton {
+  min-width: 76px;
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid rgba(103, 217, 204, 0.28);
+  border-radius: 12px;
+  background: rgba(103, 217, 204, 0.08);
+  color: #dff7f3;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 780;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+}
+
+.mobileMenuButton:hover,
+.mobileMenuButton:focus-visible,
+.mobileMenuButton[aria-expanded="true"] {
+  border-color: rgba(103, 217, 204, 0.52);
+  background: rgba(103, 217, 204, 0.14);
+  color: #a8f4eb;
+}
+
+.mobileMenuPanel {
+  position: absolute;
+  z-index: 100;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  max-height: calc(100vh - 92px);
+  padding: 8px;
+  overflow-y: auto;
+  border: 1px solid rgba(171, 203, 198, 0.22);
+  border-radius: 16px;
+  background: rgba(5, 18, 20, 0.98);
+  box-shadow: 0 22px 64px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(18px);
+  display: grid;
+  gap: 4px;
+}
+
+.mobileMenuPanel a {
+  min-height: 46px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: 11px;
+  color: #c9dcda;
+  font-size: 0.78rem;
+  font-weight: 760;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.mobileMenuPanel a:hover,
+.mobileMenuPanel a:focus-visible,
+.mobileMenuPanel a[aria-current="page"] {
+  border-color: rgba(103, 217, 204, 0.3);
+  background: rgba(103, 217, 204, 0.1);
+  color: #9cf0e6;
+}
+
 .links {
   gap: 4px;
   flex-wrap: wrap;
@@ -124,26 +195,45 @@
 
 @media (max-width: 680px) {
   .header {
-    position: relative;
-    padding: 12px 16px;
-    align-items: stretch;
-    flex-direction: column;
-    gap: 10px;
+    position: sticky;
+    padding: 10px 16px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px 12px;
+  }
+
+  .brand,
+  .brand > span:last-child {
+    min-width: 0;
+  }
+
+  .brand small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mobileNavigation {
+    display: block;
   }
 
   .navigation {
-    align-items: stretch;
+    grid-column: 1 / -1;
+    align-items: center;
+    justify-content: flex-start;
+    flex-direction: row;
   }
 
   .links {
-    justify-content: flex-start;
-  }
-
-  .links a span {
-    display: inline;
+    display: none;
   }
 
   .utility {
-    justify-content: space-between;
+    justify-content: flex-start;
+  }
+
+  .utility:empty {
+    display: none;
   }
 }

--- a/src/app/site-header.tsx
+++ b/src/app/site-header.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 
 import { BrandMark } from "./brand-mark";
+import { SiteMobileNavigation, type SiteMobileNavigationLink } from "./site-mobile-navigation.client";
 import { TourLaunchButton } from "./tour-launch-button";
 import styles from "./site-header.module.css";
 
@@ -38,6 +39,12 @@ export function SiteHeader({
     { id: "developers", href: "/developers", label: "API", icon: Braces },
     { id: "readiness", href: "/readiness", label: "Readiness", icon: Database },
   ] as const;
+  const mobileLinks = links.map(({ href, id, label }) => ({
+    active: activePage === id,
+    href,
+    id: id as SiteMobileNavigationLink["id"],
+    label,
+  }));
 
   return (
     <header className={styles.header} data-print-hide="true" data-tour="site-header">
@@ -45,6 +52,7 @@ export function SiteHeader({
         <BrandMark />
         <span><strong>Civic Result Maps</strong><small>{subtitle}</small></span>
       </a>
+      <SiteMobileNavigation links={mobileLinks} />
       <div className={styles.navigation}>
         <nav aria-label="Primary navigation" className={styles.links}>
           {links.map(({ href, icon: Icon, id, label }) => (

--- a/src/app/site-mobile-navigation.client.tsx
+++ b/src/app/site-mobile-navigation.client.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import {
+  Archive,
+  Boxes,
+  Braces,
+  Database,
+  GitCompareArrows,
+  Map,
+  Menu,
+  Radar,
+  ShieldAlert,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+
+import styles from "./site-header.module.css";
+
+export type SiteMobileNavigationLink = {
+  active: boolean;
+  href: string;
+  id: "workspace" | "equipment" | "security" | "compare" | "evidence" | "releases" | "developers" | "readiness";
+  label: string;
+};
+
+type SiteMobileNavigationProps = {
+  links: SiteMobileNavigationLink[];
+};
+
+const iconById: Record<SiteMobileNavigationLink["id"], LucideIcon> = {
+  workspace: Map,
+  equipment: Boxes,
+  security: ShieldAlert,
+  compare: GitCompareArrows,
+  evidence: Radar,
+  releases: Archive,
+  developers: Braces,
+  readiness: Database,
+};
+
+export function SiteMobileNavigation({ links }: SiteMobileNavigationProps) {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const navigationId = useId();
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      buttonRef.current?.focus();
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+      if (event.target instanceof Node && !containerRef.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [open]);
+
+  return (
+    <div className={styles.mobileNavigation} ref={containerRef}>
+      <button
+        aria-controls={navigationId}
+        aria-expanded={open}
+        aria-label={open ? "Close primary navigation" : "Open primary navigation"}
+        className={styles.mobileMenuButton}
+        onClick={() => setOpen((current) => !current)}
+        ref={buttonRef}
+        type="button"
+      >
+        {open ? <X aria-hidden size={18} /> : <Menu aria-hidden size={18} />}
+        <span>Menu</span>
+      </button>
+      {open ? (
+        <nav aria-label="Mobile primary navigation" className={styles.mobileMenuPanel} id={navigationId}>
+          {links.map(({ active, href, id, label }) => {
+            const Icon = iconById[id];
+            return (
+              <a
+                aria-current={active ? "page" : undefined}
+                data-tour={id === "equipment" ? "equipment-nav-link" : id === "readiness" ? "readiness-link" : undefined}
+                href={href}
+                key={id}
+                onClick={() => setOpen(false)}
+              >
+                <Icon aria-hidden size={17} />
+                <span>{label}</span>
+              </a>
+            );
+          })}
+        </nav>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/equipment-catalog-channel.ts
+++ b/src/lib/equipment-catalog-channel.ts
@@ -1,0 +1,36 @@
+export type EquipmentCatalogChannel = "public" | "staging";
+
+type EquipmentCatalogEnvironment = Record<string, string | undefined>;
+
+export function isEquipmentProductionEnvironment(
+  environment: EquipmentCatalogEnvironment = process.env,
+) {
+  return environment.VERCEL_ENV === "production"
+    || (
+      environment.NODE_ENV === "production"
+      && environment.VERCEL_ENV !== "preview"
+    );
+}
+
+export function resolveEquipmentCatalogChannel(
+  environment: EquipmentCatalogEnvironment = process.env,
+): EquipmentCatalogChannel {
+  const requested = environment.EQUIPMENT_CATALOG_CHANNEL?.trim().toLowerCase();
+  if (requested && requested !== "public" && requested !== "staging") {
+    throw new Error("EQUIPMENT_CATALOG_CHANNEL must be either public or staging.");
+  }
+
+  const channel = (requested
+    ?? (
+      environment.VERCEL_ENV === "preview"
+      || (environment.NODE_ENV === "development" && !environment.VERCEL)
+        ? "staging"
+        : "public"
+    )) as EquipmentCatalogChannel;
+
+  if (isEquipmentProductionEnvironment(environment) && channel !== "public") {
+    throw new Error("Production deployments may only build the public equipment catalog.");
+  }
+
+  return channel;
+}

--- a/src/lib/equipment-catalog.ts
+++ b/src/lib/equipment-catalog.ts
@@ -1,4 +1,6 @@
-import catalogData from "../../data/equipment-catalog.json";
+import catalogData from "@equipment-catalog-data";
+
+import type { EquipmentCatalogChannel } from "./equipment-catalog-channel";
 
 export type EquipmentCatalog = typeof catalogData;
 export type EquipmentSystem = EquipmentCatalog["systems"][number];
@@ -118,12 +120,16 @@ export type EquipmentSystemTile = EquipmentSystemSummary & {
 };
 
 export const equipmentCatalogMetadata = {
+  channel: catalogData.catalogChannel as EquipmentCatalogChannel,
   editorialState: catalogData.editorialState,
   generatedOn: catalogData.generatedOn,
   productionRequirement: catalogData.productionRequirement,
   productionReady:
-    catalogData.systems.length > 0
-    && catalogData.systems.every((system) => system.editorialState === catalogData.productionRequirement),
+    catalogData.catalogChannel === "public"
+    && catalogData.systems.length > 0
+    && catalogData.systems.every((system) => system.editorialState === catalogData.productionRequirement)
+    && catalogData.releaseIds.length > 0,
+  releaseIds: catalogData.releaseIds,
   methodology: catalogData.methodology,
   schemaVersion: catalogData.schemaVersion,
   status: catalogData.status,

--- a/src/lib/equipment-explorer-config.ts
+++ b/src/lib/equipment-explorer-config.ts
@@ -1,4 +1,7 @@
+import { isEquipmentProductionEnvironment } from "./equipment-catalog-channel.ts";
+
 type EquipmentExplorerOptions = {
+  catalogChannel?: "public" | "staging";
   productionReady?: boolean;
 };
 
@@ -7,7 +10,10 @@ function enabledValue(value: string | undefined) {
   return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
 }
 
-export function isEquipmentExplorerEnabled({ productionReady = false }: EquipmentExplorerOptions = {}) {
+export function isEquipmentExplorerEnabled({
+  catalogChannel = "staging",
+  productionReady = false,
+}: EquipmentExplorerOptions = {}) {
   const serverEnabled = enabledValue(process.env.EQUIPMENT_EXPLORER_ENABLED);
   const publicEnabled = enabledValue(process.env.NEXT_PUBLIC_EQUIPMENT_EXPLORER);
   const hasExplicitFlag = serverEnabled !== null || publicEnabled !== null;
@@ -16,6 +22,9 @@ export function isEquipmentExplorerEnabled({ productionReady = false }: Equipmen
     : process.env.NODE_ENV === "development" && !process.env.VERCEL;
 
   if (!flagsEnabled) return false;
-  if (process.env.VERCEL_ENV === "production" && !productionReady) return false;
+  if (
+    isEquipmentProductionEnvironment()
+    && (catalogChannel !== "public" || !productionReady)
+  ) return false;
   return true;
 }

--- a/src/lib/equipment-usage.ts
+++ b/src/lib/equipment-usage.ts
@@ -1,5 +1,7 @@
 import usageData from "../../data/equipment-usage-index.json";
 
+import { listEquipmentSystemSlugs } from "./equipment-catalog";
+
 export type EquipmentUsageEvidenceKind = "device_family" | "manufacturer_context";
 
 export type EquipmentUsageMapReference = {
@@ -142,7 +144,48 @@ type EquipmentUsageIndex = {
   records: EquipmentUsageStoredRecord[];
 };
 
-const index = usageData as unknown as EquipmentUsageIndex;
+function filterIndexForSelectedCatalog(rawIndex: EquipmentUsageIndex): EquipmentUsageIndex {
+  const allowedSlugs = new Set(listEquipmentSystemSlugs());
+  const systems = rawIndex.systems.filter((system) => allowedSlugs.has(system.slug));
+  const allowedManufacturerIds = new Set(systems.map((system) => system.manufacturerId));
+  const records = rawIndex.records
+    .map((record) => ({
+      ...record,
+      relations: record.relations.filter((relation) => (
+        relation.target.kind === "equipment_system"
+          ? allowedSlugs.has(relation.target.slug)
+          : allowedManufacturerIds.has(relation.target.id)
+      )),
+    }))
+    .filter((record) => record.relations.length > 0);
+  const includedSourceIds = new Set(records.map((record) => record.sourceId));
+  const indexedRelationCount = records.reduce((total, record) => total + record.relations.length, 0);
+  const exactSystemRelationCount = records.reduce(
+    (total, record) => total + record.relations.filter((relation) => relation.target.kind === "equipment_system").length,
+    0,
+  );
+
+  return {
+    ...rawIndex,
+    coverage: {
+      ...rawIndex.coverage,
+      dossierCount: systems.length,
+      manufacturerCount: allowedManufacturerIds.size,
+      indexedObservationCount: records.length,
+      indexedRecordCount: indexedRelationCount,
+      indexedRelationCount,
+      exactSystemRelationCount,
+      manufacturerRelationCount: indexedRelationCount - exactSystemRelationCount,
+    },
+    manufacturers: rawIndex.manufacturers.filter((manufacturer) => allowedManufacturerIds.has(manufacturer.id)),
+    systems,
+    summaries: rawIndex.summaries.filter((summary) => allowedSlugs.has(summary.slug)),
+    sources: rawIndex.sources.filter((source) => includedSourceIds.has(source.id)),
+    records,
+  };
+}
+
+const index = filterIndexForSelectedCatalog(usageData as unknown as EquipmentUsageIndex);
 const sourceById = new Map(index.sources.map((source) => [source.id, source]));
 const manufacturerById = new Map(index.manufacturers.map((manufacturer) => [manufacturer.id, manufacturer]));
 const manufacturerIdBySlug = new Map(index.systems.map((system) => [system.slug, system.manufacturerId]));

--- a/tests/api/equipment-catalog-channel.test.mts
+++ b/tests/api/equipment-catalog-channel.test.mts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+
+import { resolveEquipmentCatalogChannel } from "../../src/lib/equipment-catalog-channel.ts";
+
+assert.equal(resolveEquipmentCatalogChannel({ NODE_ENV: "production" }), "public");
+assert.equal(resolveEquipmentCatalogChannel({ NODE_ENV: "development" }), "staging");
+assert.equal(resolveEquipmentCatalogChannel({ NODE_ENV: "production", VERCEL_ENV: "preview" }), "staging");
+assert.equal(
+  resolveEquipmentCatalogChannel({
+    EQUIPMENT_CATALOG_CHANNEL: "public",
+    NODE_ENV: "production",
+    VERCEL_ENV: "preview",
+  }),
+  "public",
+);
+assert.equal(
+  resolveEquipmentCatalogChannel({
+    EQUIPMENT_CATALOG_CHANNEL: "staging",
+    NODE_ENV: "development",
+  }),
+  "staging",
+);
+assert.equal(
+  resolveEquipmentCatalogChannel({
+    EQUIPMENT_CATALOG_CHANNEL: "staging",
+    NODE_ENV: "production",
+    VERCEL_ENV: "preview",
+  }),
+  "staging",
+);
+assert.throws(
+  () => resolveEquipmentCatalogChannel({
+    EQUIPMENT_CATALOG_CHANNEL: "staging",
+    NODE_ENV: "production",
+  }),
+  /Production deployments may only build the public equipment catalog/,
+);
+
+assert.throws(
+  () => resolveEquipmentCatalogChannel({
+    EQUIPMENT_CATALOG_CHANNEL: "staging",
+    NODE_ENV: "production",
+    VERCEL_ENV: "production",
+  }),
+  /Production deployments may only build the public equipment catalog/,
+);
+assert.throws(
+  () => resolveEquipmentCatalogChannel({ EQUIPMENT_CATALOG_CHANNEL: "review" }),
+  /must be either public or staging/,
+);
+
+console.log("Equipment catalog channel selection passed.");

--- a/tests/api/equipment-catalog-isolation.test.mjs
+++ b/tests/api/equipment-catalog-isolation.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+
+import { createEquipmentCatalog } from "../../scripts/build-equipment-catalog.mjs";
+
+const sourcePackage = JSON.parse(await readFile("data/equipment-source-packages.json", "utf8"));
+const claimFiles = (await readdir("data/equipment-claims"))
+  .filter((name) => name.endsWith(".json"))
+  .sort();
+const claims = await Promise.all(
+  claimFiles.map((name) => readFile(`data/equipment-claims/${name}`, "utf8").then(JSON.parse)),
+);
+const simulatedApprovedSlug = claims[0].system.slug;
+const simulatedClaims = claims.map((claim, index) => index === 0
+  ? {
+      ...claim,
+      editorial: {
+        ...claim.editorial,
+        state: "approved",
+        publicationId: null,
+        publishedOn: null,
+      },
+    }
+  : claim);
+
+const publicCatalog = createEquipmentCatalog({ channel: "public", claims: simulatedClaims, sourcePackage });
+const stagingCatalog = createEquipmentCatalog({ channel: "staging", claims: simulatedClaims, sourcePackage });
+
+assert.equal(publicCatalog.catalogChannel, "public");
+assert.equal(publicCatalog.status, "published_catalog");
+assert.equal(publicCatalog.editorialState, "public_release");
+assert.equal(publicCatalog.systems.length, claims.length - 1);
+assert.ok(publicCatalog.systems.every((system) => system.editorialState === "published"));
+assert.ok(!publicCatalog.systems.some((system) => system.slug === simulatedApprovedSlug));
+
+assert.equal(stagingCatalog.catalogChannel, "staging");
+assert.equal(stagingCatalog.status, "reviewed_pilot");
+assert.equal(stagingCatalog.editorialState, "staging_review");
+assert.equal(stagingCatalog.systems.length, claims.length);
+assert.equal(
+  stagingCatalog.systems.find((system) => system.slug === simulatedApprovedSlug)?.editorialState,
+  "approved",
+);
+assert.throws(
+  () => createEquipmentCatalog({ channel: "private", claims, sourcePackage }),
+  /Unsupported equipment catalog channel/,
+);
+
+for (const catalog of [publicCatalog, stagingCatalog]) {
+  const sourceIds = new Set(catalog.sources.map((source) => source.id));
+  for (const system of catalog.systems) {
+    assert.ok(system.sourceIds.every((sourceId) => sourceIds.has(sourceId)));
+  }
+  assert.ok(sourcePackage.methodology.changeControlSourceIds.every((sourceId) => sourceIds.has(sourceId)));
+}
+
+console.log("Equipment public/staging catalog isolation passed.");

--- a/tests/api/equipment-catalog.test.mjs
+++ b/tests/api/equipment-catalog.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 
 const [
   catalog,
+  stagingCatalog,
   sourcePackage,
   claim,
   apiList,
@@ -27,7 +28,8 @@ const [
   workspace,
   vercelIgnore,
 ] = await Promise.all([
-  readFile("data/equipment-catalog.json", "utf8").then(JSON.parse),
+  readFile("data/equipment-catalog.public.json", "utf8").then(JSON.parse),
+  readFile("data/equipment-catalog.staging.json", "utf8").then(JSON.parse),
   readFile("data/equipment-source-packages.json", "utf8").then(JSON.parse),
   readFile("data/equipment-claims/ess-evs-6400-ds200.json", "utf8").then(JSON.parse),
   readFile("src/app/api/equipment-systems/route.ts", "utf8"),
@@ -54,15 +56,23 @@ const [
 ]);
 
 assert.equal(catalog.schemaVersion, 2);
-assert.equal(catalog.status, "reviewed_pilot");
-assert.equal(catalog.editorialState, "staging_review");
+assert.equal(catalog.catalogChannel, "public");
+assert.equal(catalog.status, "published_catalog");
+assert.equal(catalog.editorialState, "public_release");
 assert.equal(catalog.productionRequirement, "published");
+assert.equal(stagingCatalog.schemaVersion, 2);
+assert.equal(stagingCatalog.catalogChannel, "staging");
+assert.equal(stagingCatalog.status, "reviewed_pilot");
+assert.equal(stagingCatalog.editorialState, "staging_review");
+assert.equal(stagingCatalog.productionRequirement, "published");
 assert.equal(sourcePackage.schemaVersion, 2);
 assert.equal(claim.schemaVersion, 2);
 assert.equal(claim.editorial.state, "published");
 assert.equal(claim.editorial.publicationId, "equipment-explorer-2026-07-22-r1");
 assert.equal(claim.editorial.publishedOn, "2026-07-22");
 assert.equal(catalog.systems.length, 6);
+assert.equal(stagingCatalog.systems.length, 6);
+assert.ok(catalog.systems.every((system) => system.editorialState === "published"));
 assert.equal(sourcePackage.sources.length, 68);
 assert.equal(claim.system.slug, "ess-evs-6400-ds200");
 
@@ -382,6 +392,7 @@ for (const dossier of catalog.systems) {
 }
 
 assert.match(apiList, /listEquipmentSystems/);
+assert.match(apiList, /catalogChannel/);
 assert.match(apiList, /equipment_catalog_disabled/);
 assert.match(apiDetail, /sourcesForEquipmentSystem/);
 assert.match(apiDetail, /equipment_system_not_found/);
@@ -456,6 +467,7 @@ assert.match(networkEvidence, /No field-observed topology collected/);
 assert.match(workspace, /equipmentExplorerEnabled &&/);
 assert.match(workspace, /equipment-catalog-link/);
 assert.match(workspace, /Component catalog/);
-assert.match(vercelIgnore, /!data\/equipment-catalog\.json/);
+assert.match(vercelIgnore, /!data\/equipment-catalog\.public\.json/);
 
+assert.match(vercelIgnore, /!data\/equipment-catalog\.staging\.json/);
 console.log("Equipment catalog contracts passed.");

--- a/tests/api/equipment-explorer-config.test.mts
+++ b/tests/api/equipment-explorer-config.test.mts
@@ -20,20 +20,41 @@ function setEnvironment(values: Record<string, string | undefined>) {
 
 try {
   setEnvironment({ NODE_ENV: "production" });
-  assert.equal(isEquipmentExplorerEnabled({ productionReady: true }), false, "production defaults closed");
+  assert.equal(
+    isEquipmentExplorerEnabled({ catalogChannel: "public", productionReady: true }),
+    false,
+    "production defaults closed",
+  );
 
   setEnvironment({
     NODE_ENV: "production",
     EQUIPMENT_EXPLORER_ENABLED: "1",
     NEXT_PUBLIC_EQUIPMENT_EXPLORER: "1",
   });
-  assert.equal(isEquipmentExplorerEnabled({ productionReady: true }), true, "both flags enable local production preview");
+  assert.equal(
+    isEquipmentExplorerEnabled({ catalogChannel: "public", productionReady: true }),
+    true,
+    "both flags enable a production-ready public catalog",
+  );
+  assert.equal(
+    isEquipmentExplorerEnabled({ catalogChannel: "staging", productionReady: true }),
+    false,
+    "non-Vercel production also rejects the staging catalog",
+  );
 
   setEnvironment({ NODE_ENV: "production", EQUIPMENT_EXPLORER_ENABLED: "1" });
-  assert.equal(isEquipmentExplorerEnabled({ productionReady: true }), false, "server flag alone is insufficient");
+  assert.equal(
+    isEquipmentExplorerEnabled({ catalogChannel: "public", productionReady: true }),
+    false,
+    "server flag alone is insufficient",
+  );
 
   setEnvironment({ NODE_ENV: "production", NEXT_PUBLIC_EQUIPMENT_EXPLORER: "1" });
-  assert.equal(isEquipmentExplorerEnabled({ productionReady: true }), false, "public flag alone is insufficient");
+  assert.equal(
+    isEquipmentExplorerEnabled({ catalogChannel: "public", productionReady: true }),
+    false,
+    "public flag alone is insufficient",
+  );
 
   setEnvironment({
     NODE_ENV: "production",
@@ -42,7 +63,11 @@ try {
     EQUIPMENT_EXPLORER_ENABLED: "1",
     NEXT_PUBLIC_EQUIPMENT_EXPLORER: "1",
   });
-  assert.equal(isEquipmentExplorerEnabled({ productionReady: false }), true, "preview may show approved staging claims");
+  assert.equal(
+    isEquipmentExplorerEnabled({ catalogChannel: "staging", productionReady: false }),
+    true,
+    "preview may show approved staging claims",
+  );
 
   setEnvironment({
     NODE_ENV: "production",
@@ -51,8 +76,21 @@ try {
     EQUIPMENT_EXPLORER_ENABLED: "1",
     NEXT_PUBLIC_EQUIPMENT_EXPLORER: "1",
   });
-  assert.equal(isEquipmentExplorerEnabled({ productionReady: false }), false, "public production rejects unpublished claims");
-  assert.equal(isEquipmentExplorerEnabled({ productionReady: true }), true, "public production accepts published claims");
+  assert.equal(
+    isEquipmentExplorerEnabled({ catalogChannel: "public", productionReady: false }),
+    false,
+    "public production rejects unpublished claims",
+  );
+  assert.equal(
+    isEquipmentExplorerEnabled({ catalogChannel: "staging", productionReady: true }),
+    false,
+    "public production rejects the staging artifact even when its current claims are published",
+  );
+  assert.equal(
+    isEquipmentExplorerEnabled({ catalogChannel: "public", productionReady: true }),
+    true,
+    "public production accepts the published public artifact",
+  );
 
   setEnvironment({ NODE_ENV: "development" });
   assert.equal(isEquipmentExplorerEnabled(), true, "local development defaults open");

--- a/tests/api/equipment-social-preview.test.mjs
+++ b/tests/api/equipment-social-preview.test.mjs
@@ -11,7 +11,7 @@ const [
   socialRoute,
   sitemap,
 ] = await Promise.all([
-  readFile("data/equipment-catalog.json", "utf8").then(JSON.parse),
+  readFile("data/equipment-catalog.public.json", "utf8").then(JSON.parse),
   readFile("data/equipment-usage-index.json", "utf8").then(JSON.parse),
   readFile("src/lib/equipment-social-preview.ts", "utf8"),
   readFile("src/app/equipment/page.tsx", "utf8"),

--- a/tests/e2e/equipment-catalog.spec.ts
+++ b/tests/e2e/equipment-catalog.spec.ts
@@ -151,6 +151,7 @@ test("lists separately scoped jurisdiction evidence with source and map links", 
 });
 
 test("renders confirmed ClearAccess UPS options without inventing runtime", async ({ page, request }) => {
+  test.setTimeout(60_000);
   await page.goto(`${clearAccessPath}/history`);
   await expect(page.getByRole("heading", { name: "Clear Ballot ClearVote 2.5 / ClearAccess" })).toBeVisible();
   await expect(page.getByText("CyberPower; APC", { exact: true })).toBeVisible();
@@ -445,14 +446,43 @@ test("renders central tabulators as three separate sourced systems", async ({ pa
 });
 
 
-test("keeps the equipment evidence layout within a mobile viewport", async ({ page }) => {
+test("keeps equipment navigation compact and keyboard-usable on mobile", async ({ page }) => {
   await page.setViewportSize({ height: 844, width: 390 });
   await page.goto(`${imageCastXPath}/components`);
   await expect(page.getByRole("heading", { name: "Dominion Democracy Suite 5.17 / ImageCast X" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Open 3D view/ })).toBeVisible();
+
+  const openNavigation = page.getByRole("button", { name: "Open primary navigation" });
+  await expect(openNavigation).toBeVisible();
+  await openNavigation.press("Enter");
+  const mobileNavigation = page.getByRole("navigation", { name: "Mobile primary navigation" });
+  await expect(mobileNavigation).toBeVisible();
+  await expect(mobileNavigation.getByRole("link", { name: "U.S. Equipment" })).toHaveAttribute("aria-current", "page");
+
+  const accessibility = await new AxeBuilder({ page }).analyze();
+  expect(accessibility.violations.filter(({ impact }) => impact === "serious" || impact === "critical")).toEqual([]);
+
+  await page.keyboard.press("Escape");
+  await expect(mobileNavigation).toHaveCount(0);
+  await expect(openNavigation).toBeFocused();
+
+  const dossierSection = page.getByLabel("Dossier section", { exact: true });
+  await expect(dossierSection).toHaveValue(`${imageCastXPath}/components`);
+  await dossierSection.selectOption(`${imageCastXPath}/sources`);
+  await expect(page).toHaveURL(`${imageCastXPath}/sources`, { timeout: 15_000 });
+  await expect(page.getByLabel("Dossier section", { exact: true })).toHaveValue(`${imageCastXPath}/sources`);
+
   const viewport = await page.evaluate(() => ({
     clientWidth: document.documentElement.clientWidth,
     scrollWidth: document.documentElement.scrollWidth,
   }));
   expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth);
-  await expect(page.getByRole("button", { name: /Open 3D view/ })).toBeVisible();
+});
+
+test("avoids a second sticky navigation layer at tablet widths", async ({ page }) => {
+  await page.setViewportSize({ height: 1024, width: 900 });
+  await page.goto(`${imageCastXPath}/components`);
+  const dossierNavigation = page.locator("[data-tour='equipment-dossier-navigation']");
+  await expect(dossierNavigation).toBeVisible();
+  await expect(dossierNavigation).toHaveCSS("position", "static");
 });

--- a/tests/e2e/workspace-layout.spec.ts
+++ b/tests/e2e/workspace-layout.spec.ts
@@ -102,7 +102,8 @@ test("workspace navigation and state selector adapt on small screens", async ({ 
   await expect(page.getByRole("region", { name: "Election workspace context" })).toBeVisible();
   await expect(page.getByLabel("Workspace state")).toHaveValue("WA");
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
-  await expect(page.locator("[data-tour='site-header']")).toHaveCSS("position", "relative");
+  await expect(page.locator("[data-tour='site-header']")).toHaveCSS("position", "sticky");
+  await expect(page.getByRole("button", { name: "Open primary navigation" })).toBeVisible();
 
   const stateTrigger = page.getByRole("button", { name: /Choose a state/i });
   await expect(stateTrigger).toBeVisible();
@@ -117,6 +118,7 @@ test("workspace navigation and state selector adapt on small screens", async ({ 
   await electionYear.selectOption("2020");
   await expect(page).toHaveURL(/state=WA&year=2020&tab=map&mode=margin/);
   await expect(page).not.toHaveURL(/fips=/);
+  await page.waitForLoadState("networkidle");
   await expect(electionYear).toHaveValue("2020");
   await expect(page.getByLabel("Workspace geography", { exact: true })).toHaveValue("");
   await expect(page.getByLabel("Workspace map layer", { exact: true })).toHaveValue("margin");
@@ -125,10 +127,12 @@ test("workspace navigation and state selector adapt on small screens", async ({ 
   await expect(workspaceSection).toBeVisible();
   await workspaceSection.selectOption("support");
   await expect(page).toHaveURL(/tab=support/);
+  await page.waitForLoadState("networkidle");
   await expect(workspaceSection).toHaveValue("support");
 
   await workspaceSection.selectOption("review");
   await expect(page).toHaveURL(/tab=review/);
+  await page.waitForLoadState("networkidle");
   const reviewView = page.getByLabel("Review Center view", { exact: true });
   await expect(reviewView).toBeVisible();
   await reviewView.selectOption("indicators");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,9 @@
       }
     ],
     "paths": {
+      "@equipment-catalog-data": [
+        "./data/equipment-catalog.public.json"
+      ],
       "@/*": [
         "./src/*"
       ]


### PR DESCRIPTION
## Summary

- generate isolated public and staging Equipment Explorer catalogs, with public output limited to published claims and production builds rejecting staging data
- select the catalog at build time, expose its channel in equipment API metadata, and filter the shared usage index against the selected catalog
- add catalog freshness/isolation checks, feature-enabled production builds, split Playwright suites, and preview/production deployment smoke coverage
- replace wrapped mobile header links with an accessible disclosure menu, use client routing for dossier sections, and avoid stacked sticky navigation at tablet widths
- document the release contract and environment configuration

## Why

The explorer previously relied on one staging-oriented generated artifact plus feature flags. That made the public/staging boundary implicit, allowed stale generated files to escape CI, and left preview/production deployments without an equipment-specific smoke check. The shared header also became crowded on narrow screens, and the dossier navigation could create a second sticky layer.

## User and developer impact

- local development and Vercel previews default to the staging catalog
- production builds accept only the published public catalog and require an immutable release ID before enabling the explorer
- approved-only dossiers remain available for gated preview review but cannot appear through public catalog or usage APIs
- mobile users receive a keyboard-accessible compact menu and stable dossier section navigation
- CI now exercises catalog validation, both browser surfaces, and deployed catalog-channel assertions

No manual production deployment or data promotion was included in this PR workflow.

## Validation

- `npm run test:equipment-catalog`
- `npm run typecheck`
- `npm run test:layout`
- `npm run test:e2e:workspace` — 13 passed on the current `main` base
- equipment Playwright coverage — 17 cases passed in the final full run; the two responsive cases then passed in a focused run after cold-CI timing hardening
- feature-enabled public production build — passed
- feature-enabled staging preview build — passed
- GitHub workflow YAML parse and `git diff --check` — passed

## Published verification

- PR GitHub Actions run `30269983832`: validation succeeded; Equipment Explorer Chromium suite passed 19/19; workspace suite completed with 11 direct passes and two passing on retry
- Git-linked Vercel preview reached `READY` for commit `4887ac9`: https://civicresultmaps-dxm1i1uhs-camreyn-s-projects.vercel.app
- protected preview checks confirmed `catalogChannel: staging`, `catalogStatus: reviewed_pilot`, all six expected dossier slugs, rendered equipment content, and a source-backed detail response
- protected preview responsive checks passed 2/2 for the keyboard-accessible mobile menu and non-sticky tablet dossier navigation
- Vercel reported no error/fatal runtime entries for the preview during verification
- the workflow's duplicate `vercel-preview` deploy/smoke steps skipped because its Vercel GitHub secrets are not configured; the existing Git-linked preview was verified directly instead

## Post-merge verification

- merge commit `6c22b00` deployed automatically through the repository's Vercel Git integration
- main-branch CI run `30271361887` completed successfully
- production smoke run `30271483339` passed, including `Verify the public Equipment Explorer catalog`
- `https://civicresultmaps.org` passed the committed public-catalog smoke check; the deployed API reports the public channel and matches the generated public catalog
- production responsive checks passed 2/2, and Vercel reported no error/fatal runtime entries during verification
