### PR TITLE
Clarify footer review language

### DIFF
--- a/src/app/site-footer.tsx
+++ b/src/app/site-footer.tsx
@@ -4,7 +4,7 @@ import styles from "./site-footer.module.css";
 export function SiteFooter() {
   return (
     <footer className={styles.footer}>
-      <span>Civic Result Maps publishes source-linked public records and advisory review prompts.</span>
+      <span>Civic Result Maps publishes source-linked public records and highlights patterns that may warrant further review.</span>
       <nav aria-label="Site policies">
         <Link href="/privacy">Privacy</Link>
         <Link href="/developers">API</Link>


### PR DESCRIPTION
## Summary

- Replace the ambiguous “advisory review prompts” footer wording.
- Say directly that Civic Result Maps highlights patterns that may warrant further review.

## Why

“Prompts” can be mistaken for AI prompts and does not plainly communicate that these are cues for human review.

## Impact

Copy-only change. No application behavior or election data changes.

## Validation

- `npm run typecheck`
- `git diff --check`