### PR TITLE
Document source-bounded external topology pathways

### DIFF
--- a/data/equipment-catalog.public.json
+++ b/data/equipment-catalog.public.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 2,
   "catalogChannel": "public",
-  "generatedOn": "2026-07-21",
+  "generatedOn": "2026-07-28",
   "status": "published_catalog",
   "editorialState": "public_release",
   "productionRequirement": "published",
   "releaseIds": [
-    "equipment-explorer-2026-07-22-r1"
+    "equipment-explorer-2026-07-28-r1"
   ],
   "methodology": {
     "title": "Election equipment catalog evidence policy",
@@ -3289,7 +3289,7 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
+        "reviewedOn": "2026-07-28",
         "summary": "The reviewed ClearVote 2.5 record identifies the ClearAccess station and its local peripherals, while Clear Ballot's current security policy says certified products are never attached to modems, the Internet, Wi-Fi, or Bluetooth. The exact port occupation and field wiring of a particular station are not established.",
         "publicationBoundary": "This public view records device roles, connection media, evidence scope, and isolation controls. It intentionally excludes IP addresses, credentials, keys, access codes, APNs, SIM identifiers, serial numbers, and site-specific routing details.",
         "configurations": [
@@ -3403,7 +3403,27 @@
               "clearballot-security@2026-07-21"
             ],
             "caveat": "A product-level communications policy and a certified component list do not prove the state of a particular port, cable, station, polling place, or election deployment.",
-            "focusNodeId": "clearaccess-station"
+            "focusNodeId": "clearaccess-station",
+            "externalPathway": {
+              "status": "no_external_path_documented",
+              "internetReachability": "explicitly_excluded",
+              "focusConnectionStatus": "no_connection_documented",
+              "summary": "No path beyond the ClearAccess station's local peripherals is documented. Clear Ballot's reviewed policy says certified products are not attached to modems, the Internet, Wi-Fi, or Bluetooth.",
+              "originNodeIds": [],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [],
+              "caveat": "This is a product-policy and certified-configuration boundary, not a field inspection of a particular station, port, cable, or polling place.",
+              "sourceIds": [
+                "eac-clearvote-25-scope",
+                "clearballot-security"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19",
+                "clearballot-security@2026-07-21"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -3607,7 +3627,7 @@
         "The UPS models are confirmed configuration options, but capacity, load-specific runtime, maintenance condition, and field topology remain unknown.",
         "Test findings are time- and version-scoped. They do not prove a field incident, exploitation, altered votes, fraud, misconduct, or an incorrect election outcome."
       ],
-      "claimRevision": 5,
+      "claimRevision": 6,
       "editorialState": "published",
       "sourceIds": [
         "clearballot-clearaccess-product-page",
@@ -4046,7 +4066,7 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
+        "reviewedOn": "2026-07-28",
         "summary": "The ClearVote 2.5 EAC scope documents ClearCount as a wired, closed, isolated Ethernet system linking the CountServer, ScanStations, and CountStations through a certified switch alternative. COTS scanners attach to ScanStations; field cabling and switch settings remain installation-specific.",
         "publicationBoundary": "The module publishes only source-supported roles, media, direction, and isolation controls. It excludes IP addressing, credentials, keys, switch-management values, VLAN details, hostnames, serial numbers, and site diagrams.",
         "configurations": [
@@ -4240,7 +4260,29 @@
               "clearballot-security@2026-07-21"
             ],
             "caveat": "This is the certified architecture, not proof that a jurisdiction selected every alternative, used the maximum number of stations, or installed a particular switch or cabling layout.",
-            "focusNodeId": "clearcount-server"
+            "focusNodeId": "clearcount-server",
+            "externalPathway": {
+              "status": "no_external_path_documented",
+              "internetReachability": "explicitly_excluded",
+              "focusConnectionStatus": "no_connection_documented",
+              "summary": "The documented ClearCount path remains inside its closed Ethernet system. The reviewed scope says that network is not connected to other systems or the Internet.",
+              "originNodeIds": [],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [],
+              "caveat": "The reviewed sources define the certified closed-network boundary; they do not establish the field state of a jurisdiction's switch, cabling, ports, or services.",
+              "sourceIds": [
+                "eac-clearvote-25-scope",
+                "provv-clearvote-25-test-plan",
+                "clearballot-security"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19",
+                "provv-clearvote-25-test-plan@2026-07-19",
+                "clearballot-security@2026-07-21"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -4443,7 +4485,7 @@
         "The 3D scene is a navigation aid, not a wiring diagram, teardown, exact installation, or claim about a jurisdiction's selected hardware.",
         "A certification change or test finding is not evidence of field occurrence, misconduct, exploitation, or an election outcome effect."
       ],
-      "claimRevision": 3,
+      "claimRevision": 4,
       "editorialState": "published",
       "sourceIds": [
         "clearballot-clearcount-product-page",
@@ -4870,7 +4912,7 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
+        "reviewedOn": "2026-07-28",
         "summary": "Colorado's exact 5.17-CO technical data connects the ImageCast Central scanner locally to an ICC workstation by USB and describes ICC workstations using a Gigabit Ethernet port on a closed LAN to the EMS data-center network. The ICC user guide makes additional central-repository infrastructure conditional and requires election computers to remain isolated from the Internet and other networks.",
         "publicationBoundary": "This view publishes only the documented system roles, connection media, conditionality, and isolation controls. It omits addressing, credentials, database identifiers, cryptographic keys, switch settings, hostnames, and jurisdiction cable routes.",
         "configurations": [
@@ -5031,7 +5073,29 @@
               "provv-dsuite-517-test-plan@2026-07-20"
             ],
             "caveat": "The documents describe permitted 5.17-CO architectures. They do not establish that a particular jurisdiction uses the optional repository, which COTS alternatives it selected, or the live state of a network.",
-            "focusNodeId": "icc-workstation"
+            "focusNodeId": "icc-workstation",
+            "externalPathway": {
+              "status": "no_external_path_documented",
+              "internetReachability": "explicitly_excluded",
+              "focusConnectionStatus": "no_connection_documented",
+              "summary": "The conditional ICC-to-EMS path is documented only as a closed election LAN. The reviewed Colorado guide requires election computers to remain isolated from the Internet and other networks.",
+              "originNodeIds": [],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [],
+              "caveat": "This classification applies to the reviewed 5.17-CO documentation and does not substitute for a dated inspection of a jurisdiction installation.",
+              "sourceIds": [
+                "co-dvs-517-system-overview",
+                "co-dvs-517-icc-user-guide",
+                "provv-dsuite-517-test-plan"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-system-overview@2026-07-21",
+                "co-dvs-517-icc-user-guide@2026-07-20",
+                "provv-dsuite-517-test-plan@2026-07-20"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -5233,7 +5297,7 @@
         "The 3D scene is a navigation aid, not a teardown, wiring diagram, exact installation, or unit inventory.",
         "A certification change or test result is not evidence of field occurrence, misconduct, exploitation, or an election outcome effect."
       ],
-      "claimRevision": 3,
+      "claimRevision": 4,
       "editorialState": "published",
       "sourceIds": [
         "co-dvs-517-icc-user-guide",
@@ -6172,7 +6236,7 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
+        "reviewedOn": "2026-07-28",
         "summary": "The certified ICX hardware profile includes a physical 10/100 RJ-45 interface on the SID-21V platform, but the Democracy Suite 5.17 test plan says the evaluated system does not use public networks, does not support transmission over public networks, and uses no wireless technology. No external network peer or field connection is established for this ICX dossier.",
         "publicationBoundary": "The module distinguishes physical interface capability from an enabled or used connection. It excludes addresses, credentials, keys, activation-card contents, port settings, hostnames, and site-specific topology.",
         "configurations": [
@@ -6310,7 +6374,33 @@
               "co-dvs-517-avalue-sid21-manual@2026-07-20"
             ],
             "caveat": "An RJ-45 connector is capability evidence only. It does not prove that Ethernet is enabled, cabled, assigned an address, attached to a network, or used during an election.",
-            "focusNodeId": "icx-station"
+            "focusNodeId": "icx-station",
+            "externalPathway": {
+              "status": "physical_interface_only",
+              "internetReachability": "explicitly_excluded",
+              "focusConnectionStatus": "no_connection_documented",
+              "summary": "A physical RJ-45 interface is documented, but no attached peer or external path is established. The evaluated 5.17 system is described as not using or supporting transmission over public networks.",
+              "originNodeIds": [
+                "icx-rj45-interface"
+              ],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [],
+              "caveat": "Connector presence is capability evidence only. It does not establish an enabled port, cable, address, network session, Internet route, or field use.",
+              "sourceIds": [
+                "eac-dsuite-517-scope",
+                "provv-dsuite-517-test-plan",
+                "co-dvs-517-system-overview",
+                "co-dvs-517-avalue-sid21-manual"
+              ],
+              "sourceRevisionIds": [
+                "eac-dsuite-517-scope@2026-07-20",
+                "provv-dsuite-517-test-plan@2026-07-20",
+                "co-dvs-517-system-overview@2026-07-21",
+                "co-dvs-517-avalue-sid21-manual@2026-07-20"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -6558,7 +6648,7 @@
         "The UPS alternatives are confirmed configuration options, but capacity, load-specific runtime, maintenance condition, and field topology remain unknown.",
         "Advisory notices are time-, version-, scenario-, and sometimes jurisdiction-scoped. They do not prove an election incident, altered votes, fraud, misconduct, or an incorrect outcome."
       ],
-      "claimRevision": 5,
+      "claimRevision": 6,
       "editorialState": "published",
       "sourceIds": [
         "co-dvs-517-avalue-sid21-manual",
@@ -7705,8 +7795,8 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
-        "summary": "For EVS 6.4.0.0, the EAC scope defines Regional Results as a separate application at a regional sending site, and Pro V&V tested transmission of DS200 result files through Regional Results over a VPN. The reviewed exact-version text does not establish that the DS200 itself was the VPN endpoint. Older federal and state records separately document a Unity 3.4.0.0 wireline SFTP reference design, a Michigan EVS 5.3.2.0 wireless-carrier and SFTP path, and optional DS200 cellular hardware families without proving EVS 6.4 certification, firmware, activation, or field use.",
+        "reviewedOn": "2026-07-28",
+        "summary": "For EVS 6.4.0.0, the EAC scope defines Regional Results as a separate application at a regional sending site, and Pro V&V tested transmission of DS200 result files through Regional Results over a VPN. The reviewed exact-version text does not establish that the DS200 itself was the VPN endpoint or that the VPN used the public Internet. Older federal and state records separately document a Unity 3.4.0.0 wireline SFTP reference design, optional cellular hardware families, and a Michigan EVS 5.3.2.0 diagram that explicitly shows DS200 units and Regional Results connected through a wireless carrier and the Internet without proving current certification, activation, field use, or an election transmission.",
         "publicationBoundary": "The module publishes roles, high-level paths, connection media when established, and evidence boundaries. It excludes IP addresses, credentials, VPN parameters, keys, APNs, SIM identifiers, carrier accounts, device identifiers, and jurisdiction routing details.",
         "configurations": [
           {
@@ -7856,7 +7946,36 @@
               "provv-evs-6400-test-report@2026-07-19"
             ],
             "caveat": "A successful VSTL system test is not evidence that a jurisdiction enabled Regional Results, used the same network design, or transmitted results in a particular election.",
-            "focusNodeId": "ds200-tabulator"
+            "focusNodeId": "ds200-tabulator",
+            "externalPathway": {
+              "status": "documented_indirect_path",
+              "internetReachability": "not_documented",
+              "focusConnectionStatus": "indirect_result_handoff",
+              "summary": "The exact EVS 6.4 test record documents Regional Results sending result files through a customer-dedicated VPN to Electionware EMS. The reviewed passage does not make the DS200 the VPN endpoint or say that the VPN traverses the public Internet.",
+              "originNodeIds": [
+                "ds200-regional-client"
+              ],
+              "externalTransportNodeIds": [
+                "ds200-customer-network"
+              ],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [
+                "ds200-ems"
+              ],
+              "linkIds": [
+                "ds200-vpn-send",
+                "ds200-vpn-receive"
+              ],
+              "caveat": "This is an exact-version VSTL test path. The DS200-to-Regional Results handoff medium, public-network transit, jurisdiction deployment, and election use are not established.",
+              "sourceIds": [
+                "eac-evs-6400-scope",
+                "provv-evs-6400-test-report"
+              ],
+              "sourceRevisionIds": [
+                "eac-evs-6400-scope@2026-07-19",
+                "provv-evs-6400-test-report@2026-07-19"
+              ]
+            }
           },
           {
             "id": "ds200-historical-optional-cellular-context",
@@ -8054,7 +8173,37 @@
               "multitech-universal-socket-guide@2026-07-20"
             ],
             "caveat": "Historical optional hardware is not evidence that EVS 6.4.0.0 certified, a jurisdiction purchased, or a fielded DS200 contains or uses either modem.",
-            "focusNodeId": "ds200-historical-unit"
+            "focusNodeId": "ds200-historical-unit",
+            "externalPathway": {
+              "status": "optional_capability_only",
+              "internetReachability": "not_documented",
+              "focusConnectionStatus": "optional_hardware_not_established",
+              "summary": "Older reviewed records identify optional DS200 modem alternatives with cellular-carrier capability. They do not establish an installed modem, active carrier service, receiving system, complete DS200-to-network chain, or Internet route.",
+              "originNodeIds": [
+                "ds200-c2",
+                "ds200-lvw3"
+              ],
+              "externalTransportNodeIds": [
+                "ds200-carrier-service"
+              ],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [
+                "ds200-c2-cellular-link",
+                "ds200-lvw3-cellular-link"
+              ],
+              "caveat": "These are historical hardware-family alternatives from earlier EVS campaigns, not proof that EVS 6.4.0.0 certified or a fielded DS200 contains or uses either modem.",
+              "sourceIds": [
+                "fl-evs-4500-v4-modem-report",
+                "provv-evs-5341-modem-hardware-table",
+                "multitech-universal-socket-guide"
+              ],
+              "sourceRevisionIds": [
+                "fl-evs-4500-v4-modem-report@2026-07-20",
+                "provv-evs-5341-modem-hardware-table@2026-07-20",
+                "multitech-universal-socket-guide@2026-07-20"
+              ]
+            }
           },
           {
             "id": "ds200-unity-3400-landline-sftp-reference",
@@ -8199,7 +8348,36 @@
               "eac-unity-3400-test-plan@2026-07-21"
             ],
             "caveat": "This is a historical wireline test-plan reference, not a cellular design, current EVS 6.4.0.0 certification record, field inspection, or evidence of election-night use.",
-            "focusNodeId": "unity-3400-ds200"
+            "focusNodeId": "unity-3400-ds200",
+            "externalPathway": {
+              "status": "documented_reference_path",
+              "internetReachability": "not_documented",
+              "focusConnectionStatus": "direct_in_reference_path",
+              "summary": "The historical Unity 3.4 test-plan figure shows a DS200 leaving the local device boundary over a wireline modem connection to a RAS/SFTP receiver in a DMZ, then crossing a firewall toward ERM. It does not label the public Internet.",
+              "originNodeIds": [
+                "unity-3400-ds200"
+              ],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [
+                "unity-3400-firewall"
+              ],
+              "receivingNodeIds": [
+                "unity-3400-ras-sftp",
+                "unity-3400-erm"
+              ],
+              "linkIds": [
+                "unity-3400-modem-line",
+                "unity-3400-dmz-boundary",
+                "unity-3400-inside-erm"
+              ],
+              "caveat": "This is a historical test-plan reference configuration, not a current EVS 6.4 topology, field inspection, or evidence of election-night use.",
+              "sourceIds": [
+                "eac-unity-3400-test-plan"
+              ],
+              "sourceRevisionIds": [
+                "eac-unity-3400-test-plan@2026-07-21"
+              ]
+            }
           },
           {
             "id": "ds200-michigan-evs-5320-wireless-sftp-path",
@@ -8208,7 +8386,7 @@
             "assertionScope": "state_certification_documentation",
             "knowledgeStatus": "documented_partial",
             "topologyKind": "results_transmission_service",
-            "description": "Michigan's official state-hosted ES&S contract response depicts DS200 units reaching a communications server through a wireless carrier, customer interface, firewall, and DMZ. The accompanying vendor response says a poll worker could initiate an SFTP transfer after polls closed, after which an encrypted result file was deposited and the connection terminated before ERM processed received files.",
+            "description": "Michigan's official state-hosted ES&S contract response depicts configured DS200 units reaching a communications server through an optional wireless modem, wireless carrier, explicitly labeled Internet segment, customer interface, firewall, and DMZ. The diagram also shows Regional Results connected to the Internet. The accompanying vendor response says a poll worker could initiate an SFTP transfer after polls closed, after which an encrypted result file was deposited and the connection terminated before ERM processed received files.",
             "observedOn": null,
             "assertedFor": null,
             "nodes": [
@@ -8247,6 +8425,34 @@
                 "componentId": null,
                 "optional": true,
                 "details": "The diagram labels a wireless-carrier path; carrier, account, APN, SIM, and activation state are not published here.",
+                "sourceIds": [
+                  "mi-ess-voting-system-contract"
+                ],
+                "sourceRevisionIds": [
+                  "mi-ess-voting-system-contract@2026-07-21"
+                ]
+              },
+              {
+                "id": "mi-5320-internet",
+                "label": "Internet",
+                "role": "Public-network transport shown in the historical vendor diagram",
+                "componentId": null,
+                "optional": false,
+                "details": "The source diagram explicitly labels an Internet segment between the wireless carrier / Regional Results and the customer interface. Provider, route, public address, field deployment, and election use are not established.",
+                "sourceIds": [
+                  "mi-ess-voting-system-contract"
+                ],
+                "sourceRevisionIds": [
+                  "mi-ess-voting-system-contract@2026-07-21"
+                ]
+              },
+              {
+                "id": "mi-5320-regional-results",
+                "label": "Regional Results",
+                "role": "Results application shown connected to the Internet",
+                "componentId": null,
+                "optional": false,
+                "details": "The historical vendor diagram shows a Regional Results system with a bidirectional Internet connection; its hosting, exact configuration, and deployment state are not established here.",
                 "sourceIds": [
                   "mi-ess-voting-system-contract"
                 ],
@@ -8343,13 +8549,43 @@
                 ]
               },
               {
-                "id": "mi-5320-carrier-customer",
+                "id": "mi-5320-carrier-internet",
                 "from": "mi-5320-wireless-carrier",
-                "to": "mi-5320-customer-interface",
-                "medium": "External carrier and network path",
+                "to": "mi-5320-internet",
+                "medium": "Carrier-to-Internet path shown in the vendor diagram",
                 "direction": "bidirectional",
-                "purpose": "Reach the county-side customer interface",
-                "knowledgeStatus": "documented_partial",
+                "purpose": "Reach the public-network segment shown in the historical wireless-results design",
+                "knowledgeStatus": "confirmed",
+                "sourceIds": [
+                  "mi-ess-voting-system-contract"
+                ],
+                "sourceRevisionIds": [
+                  "mi-ess-voting-system-contract@2026-07-21"
+                ]
+              },
+              {
+                "id": "mi-5320-regional-results-internet",
+                "from": "mi-5320-regional-results",
+                "to": "mi-5320-internet",
+                "medium": "Internet connection shown in the vendor diagram",
+                "direction": "bidirectional",
+                "purpose": "Connect Regional Results to the historical public-network segment",
+                "knowledgeStatus": "confirmed",
+                "sourceIds": [
+                  "mi-ess-voting-system-contract"
+                ],
+                "sourceRevisionIds": [
+                  "mi-ess-voting-system-contract@2026-07-21"
+                ]
+              },
+              {
+                "id": "mi-5320-internet-customer",
+                "from": "mi-5320-internet",
+                "to": "mi-5320-customer-interface",
+                "medium": "Public Internet path shown in the vendor diagram",
+                "direction": "bidirectional",
+                "purpose": "Reach the county-side customer interface from the public-network segment",
+                "knowledgeStatus": "confirmed",
                 "sourceIds": [
                   "mi-ess-voting-system-contract"
                 ],
@@ -8423,6 +8659,12 @@
                 "description": "The response states that the connection was terminated after the encrypted result file was deposited on the receiving server."
               },
               {
+                "id": "mi-5320-public-internet-segment",
+                "label": "Public Internet segment",
+                "status": "documented",
+                "description": "The historical vendor diagram explicitly labels the Internet between the wireless carrier / Regional Results and the county-side customer interface."
+              },
+              {
                 "id": "mi-5320-dmz-boundary",
                 "label": "Firewall and DMZ boundary",
                 "status": "documented",
@@ -8437,7 +8679,47 @@
               "mi-ess-voting-system-contract@2026-07-21"
             ],
             "caveat": "This is a historical Michigan procurement response for EVS 5.3.2.0, which the source says was not EAC certified. It is not evidence of EVS 6.4.0.0 certification, a current county design, an installed modem or firmware, a live connection, or a transmission during any election.",
-            "focusNodeId": "mi-5320-ds200"
+            "focusNodeId": "mi-5320-ds200",
+            "externalPathway": {
+              "status": "documented_reference_path",
+              "internetReachability": "documented_in_reference_path",
+              "focusConnectionStatus": "direct_in_reference_path",
+              "summary": "The historical Michigan vendor diagram explicitly shows configured DS200 units reaching a wireless carrier and the Internet before a customer interface, firewall/DMZ, communications server, and local EMS. It also shows Regional Results connected to the Internet.",
+              "originNodeIds": [
+                "mi-5320-ds200",
+                "mi-5320-internal-modem"
+              ],
+              "externalTransportNodeIds": [
+                "mi-5320-wireless-carrier",
+                "mi-5320-internet",
+                "mi-5320-regional-results"
+              ],
+              "boundaryNodeIds": [
+                "mi-5320-customer-interface",
+                "mi-5320-firewall"
+              ],
+              "receivingNodeIds": [
+                "mi-5320-communications-server",
+                "mi-5320-local-ems"
+              ],
+              "linkIds": [
+                "mi-5320-modem-interface",
+                "mi-5320-cellular-path",
+                "mi-5320-carrier-internet",
+                "mi-5320-regional-results-internet",
+                "mi-5320-internet-customer",
+                "mi-5320-customer-firewall",
+                "mi-5320-firewall-server",
+                "mi-5320-server-erm"
+              ],
+              "caveat": "The diagram is a historical 2017 procurement response for EVS 5.3.2.0, which the source says was not EAC certified. It does not establish a current design, installed modem, active connection, or transmission during an election.",
+              "sourceIds": [
+                "mi-ess-voting-system-contract"
+              ],
+              "sourceRevisionIds": [
+                "mi-ess-voting-system-contract@2026-07-21"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -8486,11 +8768,11 @@
             "width": 1600,
             "height": 1236,
             "kind": "source_topology_diagram",
-            "alt": "Historical Michigan vendor diagram showing DS200 units, a wireless carrier, customer interface, firewall and DMZ, communications server, and local election-management network.",
-            "caption": "Michigan contract exhibit: historical DS200 wireless results network",
+            "alt": "Historical Michigan vendor diagram showing configured DS200 units, wireless modems, a wireless carrier, the Internet, Regional Results, a customer interface, firewall and DMZ, communications server, and local election-management network.",
+            "caption": "Michigan contract exhibit: historical DS200 wireless results path through the Internet",
             "pageOrSection": "Michigan contract PDF page 101, contract page 62, Wireless Results Network",
             "derivativeNote": "Rendered from the archived official state-hosted PDF with PDF.js at 1600 pixels wide; the source page content was not edited.",
-            "caveat": "The diagram belongs to a historical Michigan procurement response and does not establish EVS 6.4.0.0 certification, a current county topology, an installed modem, or election use.",
+            "caveat": "The diagram explicitly shows an Internet segment, but it belongs to a historical Michigan procurement response and does not establish EVS 6.4.0.0 certification, a current county topology, an installed modem, an active connection, or election use.",
             "sourceIds": [
               "mi-ess-voting-system-contract"
             ],
@@ -8822,7 +9104,7 @@
         "Public findings and modem vulnerability reviews are presented with exact product, firmware, date, and source scope. A zero-match catalog review is not evidence that no bug, vulnerability, incident, or service bulletin exists.",
         "The manufacturer documents DS200 battery backup, but its model, chemistry, capacity, runtime, internal placement, condition, and county-level power topology remain unknown."
       ],
-      "claimRevision": 8,
+      "claimRevision": 9,
       "editorialState": "published",
       "sourceIds": [
         "cisa-kev-catalog",
@@ -9363,7 +9645,7 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
+        "reviewedOn": "2026-07-28",
         "summary": "The EVS 6.4.0.0 Pro V&V report states that DS950, DS850, and DS450 results were transmitted to the EMS through a closed local area network during accuracy testing. The EAC scope includes the central tabulator, Electionware infrastructure, and a minimum-1-Gb network switch, but it does not establish a jurisdiction's live switch, port, or addressing configuration.",
         "publicationBoundary": "This view publishes only the laboratory-supported closed-LAN result path and its source limits. It excludes IP addresses, credentials, keys, database details, switch settings, VLANs, hostnames, device identifiers, and site-specific routing.",
         "configurations": [
@@ -9489,7 +9771,27 @@
               "provv-evs-6400-test-report@2026-07-19"
             ],
             "caveat": "A VSTL accuracy-test topology is not proof that a jurisdiction connected a DS950, used the listed switch, or transmitted results over a network in a particular election.",
-            "focusNodeId": "ds950-tabulator"
+            "focusNodeId": "ds950-tabulator",
+            "externalPathway": {
+              "status": "no_external_path_documented",
+              "internetReachability": "not_documented",
+              "focusConnectionStatus": "no_connection_documented",
+              "summary": "The exact-version DS950 test path is documented only across a closed LAN to Electionware EMS. The reviewed passage does not identify a public-network or Internet segment.",
+              "originNodeIds": [],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [],
+              "caveat": "This is a VSTL accuracy-test path, not proof of a jurisdiction's switch, cabling, enabled services, external connectivity, or election use.",
+              "sourceIds": [
+                "eac-evs-6400-scope",
+                "provv-evs-6400-test-report"
+              ],
+              "sourceRevisionIds": [
+                "eac-evs-6400-scope@2026-07-19",
+                "provv-evs-6400-test-report@2026-07-19"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -9723,7 +10025,7 @@
         "Certified UPS alternatives do not establish which model or battery condition applies at a jurisdiction.",
         "A certification change, ECO, or test result is not evidence of field occurrence, misconduct, or an election outcome effect."
       ],
-      "claimRevision": 3,
+      "claimRevision": 4,
       "editorialState": "published",
       "sourceIds": [
         "eac-evs-6400-record",

--- a/data/equipment-catalog.staging.json
+++ b/data/equipment-catalog.staging.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 2,
   "catalogChannel": "staging",
-  "generatedOn": "2026-07-21",
+  "generatedOn": "2026-07-28",
   "status": "reviewed_pilot",
   "editorialState": "staging_review",
   "productionRequirement": "published",
   "releaseIds": [
-    "equipment-explorer-2026-07-22-r1"
+    "equipment-explorer-2026-07-28-r1"
   ],
   "methodology": {
     "title": "Election equipment catalog evidence policy",
@@ -3289,7 +3289,7 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
+        "reviewedOn": "2026-07-28",
         "summary": "The reviewed ClearVote 2.5 record identifies the ClearAccess station and its local peripherals, while Clear Ballot's current security policy says certified products are never attached to modems, the Internet, Wi-Fi, or Bluetooth. The exact port occupation and field wiring of a particular station are not established.",
         "publicationBoundary": "This public view records device roles, connection media, evidence scope, and isolation controls. It intentionally excludes IP addresses, credentials, keys, access codes, APNs, SIM identifiers, serial numbers, and site-specific routing details.",
         "configurations": [
@@ -3403,7 +3403,27 @@
               "clearballot-security@2026-07-21"
             ],
             "caveat": "A product-level communications policy and a certified component list do not prove the state of a particular port, cable, station, polling place, or election deployment.",
-            "focusNodeId": "clearaccess-station"
+            "focusNodeId": "clearaccess-station",
+            "externalPathway": {
+              "status": "no_external_path_documented",
+              "internetReachability": "explicitly_excluded",
+              "focusConnectionStatus": "no_connection_documented",
+              "summary": "No path beyond the ClearAccess station's local peripherals is documented. Clear Ballot's reviewed policy says certified products are not attached to modems, the Internet, Wi-Fi, or Bluetooth.",
+              "originNodeIds": [],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [],
+              "caveat": "This is a product-policy and certified-configuration boundary, not a field inspection of a particular station, port, cable, or polling place.",
+              "sourceIds": [
+                "eac-clearvote-25-scope",
+                "clearballot-security"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19",
+                "clearballot-security@2026-07-21"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -3607,7 +3627,7 @@
         "The UPS models are confirmed configuration options, but capacity, load-specific runtime, maintenance condition, and field topology remain unknown.",
         "Test findings are time- and version-scoped. They do not prove a field incident, exploitation, altered votes, fraud, misconduct, or an incorrect election outcome."
       ],
-      "claimRevision": 5,
+      "claimRevision": 6,
       "editorialState": "published",
       "sourceIds": [
         "clearballot-clearaccess-product-page",
@@ -4046,7 +4066,7 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
+        "reviewedOn": "2026-07-28",
         "summary": "The ClearVote 2.5 EAC scope documents ClearCount as a wired, closed, isolated Ethernet system linking the CountServer, ScanStations, and CountStations through a certified switch alternative. COTS scanners attach to ScanStations; field cabling and switch settings remain installation-specific.",
         "publicationBoundary": "The module publishes only source-supported roles, media, direction, and isolation controls. It excludes IP addressing, credentials, keys, switch-management values, VLAN details, hostnames, serial numbers, and site diagrams.",
         "configurations": [
@@ -4240,7 +4260,29 @@
               "clearballot-security@2026-07-21"
             ],
             "caveat": "This is the certified architecture, not proof that a jurisdiction selected every alternative, used the maximum number of stations, or installed a particular switch or cabling layout.",
-            "focusNodeId": "clearcount-server"
+            "focusNodeId": "clearcount-server",
+            "externalPathway": {
+              "status": "no_external_path_documented",
+              "internetReachability": "explicitly_excluded",
+              "focusConnectionStatus": "no_connection_documented",
+              "summary": "The documented ClearCount path remains inside its closed Ethernet system. The reviewed scope says that network is not connected to other systems or the Internet.",
+              "originNodeIds": [],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [],
+              "caveat": "The reviewed sources define the certified closed-network boundary; they do not establish the field state of a jurisdiction's switch, cabling, ports, or services.",
+              "sourceIds": [
+                "eac-clearvote-25-scope",
+                "provv-clearvote-25-test-plan",
+                "clearballot-security"
+              ],
+              "sourceRevisionIds": [
+                "eac-clearvote-25-scope@2026-07-19",
+                "provv-clearvote-25-test-plan@2026-07-19",
+                "clearballot-security@2026-07-21"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -4443,7 +4485,7 @@
         "The 3D scene is a navigation aid, not a wiring diagram, teardown, exact installation, or claim about a jurisdiction's selected hardware.",
         "A certification change or test finding is not evidence of field occurrence, misconduct, exploitation, or an election outcome effect."
       ],
-      "claimRevision": 3,
+      "claimRevision": 4,
       "editorialState": "published",
       "sourceIds": [
         "clearballot-clearcount-product-page",
@@ -4870,7 +4912,7 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
+        "reviewedOn": "2026-07-28",
         "summary": "Colorado's exact 5.17-CO technical data connects the ImageCast Central scanner locally to an ICC workstation by USB and describes ICC workstations using a Gigabit Ethernet port on a closed LAN to the EMS data-center network. The ICC user guide makes additional central-repository infrastructure conditional and requires election computers to remain isolated from the Internet and other networks.",
         "publicationBoundary": "This view publishes only the documented system roles, connection media, conditionality, and isolation controls. It omits addressing, credentials, database identifiers, cryptographic keys, switch settings, hostnames, and jurisdiction cable routes.",
         "configurations": [
@@ -5031,7 +5073,29 @@
               "provv-dsuite-517-test-plan@2026-07-20"
             ],
             "caveat": "The documents describe permitted 5.17-CO architectures. They do not establish that a particular jurisdiction uses the optional repository, which COTS alternatives it selected, or the live state of a network.",
-            "focusNodeId": "icc-workstation"
+            "focusNodeId": "icc-workstation",
+            "externalPathway": {
+              "status": "no_external_path_documented",
+              "internetReachability": "explicitly_excluded",
+              "focusConnectionStatus": "no_connection_documented",
+              "summary": "The conditional ICC-to-EMS path is documented only as a closed election LAN. The reviewed Colorado guide requires election computers to remain isolated from the Internet and other networks.",
+              "originNodeIds": [],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [],
+              "caveat": "This classification applies to the reviewed 5.17-CO documentation and does not substitute for a dated inspection of a jurisdiction installation.",
+              "sourceIds": [
+                "co-dvs-517-system-overview",
+                "co-dvs-517-icc-user-guide",
+                "provv-dsuite-517-test-plan"
+              ],
+              "sourceRevisionIds": [
+                "co-dvs-517-system-overview@2026-07-21",
+                "co-dvs-517-icc-user-guide@2026-07-20",
+                "provv-dsuite-517-test-plan@2026-07-20"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -5233,7 +5297,7 @@
         "The 3D scene is a navigation aid, not a teardown, wiring diagram, exact installation, or unit inventory.",
         "A certification change or test result is not evidence of field occurrence, misconduct, exploitation, or an election outcome effect."
       ],
-      "claimRevision": 3,
+      "claimRevision": 4,
       "editorialState": "published",
       "sourceIds": [
         "co-dvs-517-icc-user-guide",
@@ -6172,7 +6236,7 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
+        "reviewedOn": "2026-07-28",
         "summary": "The certified ICX hardware profile includes a physical 10/100 RJ-45 interface on the SID-21V platform, but the Democracy Suite 5.17 test plan says the evaluated system does not use public networks, does not support transmission over public networks, and uses no wireless technology. No external network peer or field connection is established for this ICX dossier.",
         "publicationBoundary": "The module distinguishes physical interface capability from an enabled or used connection. It excludes addresses, credentials, keys, activation-card contents, port settings, hostnames, and site-specific topology.",
         "configurations": [
@@ -6310,7 +6374,33 @@
               "co-dvs-517-avalue-sid21-manual@2026-07-20"
             ],
             "caveat": "An RJ-45 connector is capability evidence only. It does not prove that Ethernet is enabled, cabled, assigned an address, attached to a network, or used during an election.",
-            "focusNodeId": "icx-station"
+            "focusNodeId": "icx-station",
+            "externalPathway": {
+              "status": "physical_interface_only",
+              "internetReachability": "explicitly_excluded",
+              "focusConnectionStatus": "no_connection_documented",
+              "summary": "A physical RJ-45 interface is documented, but no attached peer or external path is established. The evaluated 5.17 system is described as not using or supporting transmission over public networks.",
+              "originNodeIds": [
+                "icx-rj45-interface"
+              ],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [],
+              "caveat": "Connector presence is capability evidence only. It does not establish an enabled port, cable, address, network session, Internet route, or field use.",
+              "sourceIds": [
+                "eac-dsuite-517-scope",
+                "provv-dsuite-517-test-plan",
+                "co-dvs-517-system-overview",
+                "co-dvs-517-avalue-sid21-manual"
+              ],
+              "sourceRevisionIds": [
+                "eac-dsuite-517-scope@2026-07-20",
+                "provv-dsuite-517-test-plan@2026-07-20",
+                "co-dvs-517-system-overview@2026-07-21",
+                "co-dvs-517-avalue-sid21-manual@2026-07-20"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -6558,7 +6648,7 @@
         "The UPS alternatives are confirmed configuration options, but capacity, load-specific runtime, maintenance condition, and field topology remain unknown.",
         "Advisory notices are time-, version-, scenario-, and sometimes jurisdiction-scoped. They do not prove an election incident, altered votes, fraud, misconduct, or an incorrect outcome."
       ],
-      "claimRevision": 5,
+      "claimRevision": 6,
       "editorialState": "published",
       "sourceIds": [
         "co-dvs-517-avalue-sid21-manual",
@@ -7705,8 +7795,8 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
-        "summary": "For EVS 6.4.0.0, the EAC scope defines Regional Results as a separate application at a regional sending site, and Pro V&V tested transmission of DS200 result files through Regional Results over a VPN. The reviewed exact-version text does not establish that the DS200 itself was the VPN endpoint. Older federal and state records separately document a Unity 3.4.0.0 wireline SFTP reference design, a Michigan EVS 5.3.2.0 wireless-carrier and SFTP path, and optional DS200 cellular hardware families without proving EVS 6.4 certification, firmware, activation, or field use.",
+        "reviewedOn": "2026-07-28",
+        "summary": "For EVS 6.4.0.0, the EAC scope defines Regional Results as a separate application at a regional sending site, and Pro V&V tested transmission of DS200 result files through Regional Results over a VPN. The reviewed exact-version text does not establish that the DS200 itself was the VPN endpoint or that the VPN used the public Internet. Older federal and state records separately document a Unity 3.4.0.0 wireline SFTP reference design, optional cellular hardware families, and a Michigan EVS 5.3.2.0 diagram that explicitly shows DS200 units and Regional Results connected through a wireless carrier and the Internet without proving current certification, activation, field use, or an election transmission.",
         "publicationBoundary": "The module publishes roles, high-level paths, connection media when established, and evidence boundaries. It excludes IP addresses, credentials, VPN parameters, keys, APNs, SIM identifiers, carrier accounts, device identifiers, and jurisdiction routing details.",
         "configurations": [
           {
@@ -7856,7 +7946,36 @@
               "provv-evs-6400-test-report@2026-07-19"
             ],
             "caveat": "A successful VSTL system test is not evidence that a jurisdiction enabled Regional Results, used the same network design, or transmitted results in a particular election.",
-            "focusNodeId": "ds200-tabulator"
+            "focusNodeId": "ds200-tabulator",
+            "externalPathway": {
+              "status": "documented_indirect_path",
+              "internetReachability": "not_documented",
+              "focusConnectionStatus": "indirect_result_handoff",
+              "summary": "The exact EVS 6.4 test record documents Regional Results sending result files through a customer-dedicated VPN to Electionware EMS. The reviewed passage does not make the DS200 the VPN endpoint or say that the VPN traverses the public Internet.",
+              "originNodeIds": [
+                "ds200-regional-client"
+              ],
+              "externalTransportNodeIds": [
+                "ds200-customer-network"
+              ],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [
+                "ds200-ems"
+              ],
+              "linkIds": [
+                "ds200-vpn-send",
+                "ds200-vpn-receive"
+              ],
+              "caveat": "This is an exact-version VSTL test path. The DS200-to-Regional Results handoff medium, public-network transit, jurisdiction deployment, and election use are not established.",
+              "sourceIds": [
+                "eac-evs-6400-scope",
+                "provv-evs-6400-test-report"
+              ],
+              "sourceRevisionIds": [
+                "eac-evs-6400-scope@2026-07-19",
+                "provv-evs-6400-test-report@2026-07-19"
+              ]
+            }
           },
           {
             "id": "ds200-historical-optional-cellular-context",
@@ -8054,7 +8173,37 @@
               "multitech-universal-socket-guide@2026-07-20"
             ],
             "caveat": "Historical optional hardware is not evidence that EVS 6.4.0.0 certified, a jurisdiction purchased, or a fielded DS200 contains or uses either modem.",
-            "focusNodeId": "ds200-historical-unit"
+            "focusNodeId": "ds200-historical-unit",
+            "externalPathway": {
+              "status": "optional_capability_only",
+              "internetReachability": "not_documented",
+              "focusConnectionStatus": "optional_hardware_not_established",
+              "summary": "Older reviewed records identify optional DS200 modem alternatives with cellular-carrier capability. They do not establish an installed modem, active carrier service, receiving system, complete DS200-to-network chain, or Internet route.",
+              "originNodeIds": [
+                "ds200-c2",
+                "ds200-lvw3"
+              ],
+              "externalTransportNodeIds": [
+                "ds200-carrier-service"
+              ],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [
+                "ds200-c2-cellular-link",
+                "ds200-lvw3-cellular-link"
+              ],
+              "caveat": "These are historical hardware-family alternatives from earlier EVS campaigns, not proof that EVS 6.4.0.0 certified or a fielded DS200 contains or uses either modem.",
+              "sourceIds": [
+                "fl-evs-4500-v4-modem-report",
+                "provv-evs-5341-modem-hardware-table",
+                "multitech-universal-socket-guide"
+              ],
+              "sourceRevisionIds": [
+                "fl-evs-4500-v4-modem-report@2026-07-20",
+                "provv-evs-5341-modem-hardware-table@2026-07-20",
+                "multitech-universal-socket-guide@2026-07-20"
+              ]
+            }
           },
           {
             "id": "ds200-unity-3400-landline-sftp-reference",
@@ -8199,7 +8348,36 @@
               "eac-unity-3400-test-plan@2026-07-21"
             ],
             "caveat": "This is a historical wireline test-plan reference, not a cellular design, current EVS 6.4.0.0 certification record, field inspection, or evidence of election-night use.",
-            "focusNodeId": "unity-3400-ds200"
+            "focusNodeId": "unity-3400-ds200",
+            "externalPathway": {
+              "status": "documented_reference_path",
+              "internetReachability": "not_documented",
+              "focusConnectionStatus": "direct_in_reference_path",
+              "summary": "The historical Unity 3.4 test-plan figure shows a DS200 leaving the local device boundary over a wireline modem connection to a RAS/SFTP receiver in a DMZ, then crossing a firewall toward ERM. It does not label the public Internet.",
+              "originNodeIds": [
+                "unity-3400-ds200"
+              ],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [
+                "unity-3400-firewall"
+              ],
+              "receivingNodeIds": [
+                "unity-3400-ras-sftp",
+                "unity-3400-erm"
+              ],
+              "linkIds": [
+                "unity-3400-modem-line",
+                "unity-3400-dmz-boundary",
+                "unity-3400-inside-erm"
+              ],
+              "caveat": "This is a historical test-plan reference configuration, not a current EVS 6.4 topology, field inspection, or evidence of election-night use.",
+              "sourceIds": [
+                "eac-unity-3400-test-plan"
+              ],
+              "sourceRevisionIds": [
+                "eac-unity-3400-test-plan@2026-07-21"
+              ]
+            }
           },
           {
             "id": "ds200-michigan-evs-5320-wireless-sftp-path",
@@ -8208,7 +8386,7 @@
             "assertionScope": "state_certification_documentation",
             "knowledgeStatus": "documented_partial",
             "topologyKind": "results_transmission_service",
-            "description": "Michigan's official state-hosted ES&S contract response depicts DS200 units reaching a communications server through a wireless carrier, customer interface, firewall, and DMZ. The accompanying vendor response says a poll worker could initiate an SFTP transfer after polls closed, after which an encrypted result file was deposited and the connection terminated before ERM processed received files.",
+            "description": "Michigan's official state-hosted ES&S contract response depicts configured DS200 units reaching a communications server through an optional wireless modem, wireless carrier, explicitly labeled Internet segment, customer interface, firewall, and DMZ. The diagram also shows Regional Results connected to the Internet. The accompanying vendor response says a poll worker could initiate an SFTP transfer after polls closed, after which an encrypted result file was deposited and the connection terminated before ERM processed received files.",
             "observedOn": null,
             "assertedFor": null,
             "nodes": [
@@ -8247,6 +8425,34 @@
                 "componentId": null,
                 "optional": true,
                 "details": "The diagram labels a wireless-carrier path; carrier, account, APN, SIM, and activation state are not published here.",
+                "sourceIds": [
+                  "mi-ess-voting-system-contract"
+                ],
+                "sourceRevisionIds": [
+                  "mi-ess-voting-system-contract@2026-07-21"
+                ]
+              },
+              {
+                "id": "mi-5320-internet",
+                "label": "Internet",
+                "role": "Public-network transport shown in the historical vendor diagram",
+                "componentId": null,
+                "optional": false,
+                "details": "The source diagram explicitly labels an Internet segment between the wireless carrier / Regional Results and the customer interface. Provider, route, public address, field deployment, and election use are not established.",
+                "sourceIds": [
+                  "mi-ess-voting-system-contract"
+                ],
+                "sourceRevisionIds": [
+                  "mi-ess-voting-system-contract@2026-07-21"
+                ]
+              },
+              {
+                "id": "mi-5320-regional-results",
+                "label": "Regional Results",
+                "role": "Results application shown connected to the Internet",
+                "componentId": null,
+                "optional": false,
+                "details": "The historical vendor diagram shows a Regional Results system with a bidirectional Internet connection; its hosting, exact configuration, and deployment state are not established here.",
                 "sourceIds": [
                   "mi-ess-voting-system-contract"
                 ],
@@ -8343,13 +8549,43 @@
                 ]
               },
               {
-                "id": "mi-5320-carrier-customer",
+                "id": "mi-5320-carrier-internet",
                 "from": "mi-5320-wireless-carrier",
-                "to": "mi-5320-customer-interface",
-                "medium": "External carrier and network path",
+                "to": "mi-5320-internet",
+                "medium": "Carrier-to-Internet path shown in the vendor diagram",
                 "direction": "bidirectional",
-                "purpose": "Reach the county-side customer interface",
-                "knowledgeStatus": "documented_partial",
+                "purpose": "Reach the public-network segment shown in the historical wireless-results design",
+                "knowledgeStatus": "confirmed",
+                "sourceIds": [
+                  "mi-ess-voting-system-contract"
+                ],
+                "sourceRevisionIds": [
+                  "mi-ess-voting-system-contract@2026-07-21"
+                ]
+              },
+              {
+                "id": "mi-5320-regional-results-internet",
+                "from": "mi-5320-regional-results",
+                "to": "mi-5320-internet",
+                "medium": "Internet connection shown in the vendor diagram",
+                "direction": "bidirectional",
+                "purpose": "Connect Regional Results to the historical public-network segment",
+                "knowledgeStatus": "confirmed",
+                "sourceIds": [
+                  "mi-ess-voting-system-contract"
+                ],
+                "sourceRevisionIds": [
+                  "mi-ess-voting-system-contract@2026-07-21"
+                ]
+              },
+              {
+                "id": "mi-5320-internet-customer",
+                "from": "mi-5320-internet",
+                "to": "mi-5320-customer-interface",
+                "medium": "Public Internet path shown in the vendor diagram",
+                "direction": "bidirectional",
+                "purpose": "Reach the county-side customer interface from the public-network segment",
+                "knowledgeStatus": "confirmed",
                 "sourceIds": [
                   "mi-ess-voting-system-contract"
                 ],
@@ -8423,6 +8659,12 @@
                 "description": "The response states that the connection was terminated after the encrypted result file was deposited on the receiving server."
               },
               {
+                "id": "mi-5320-public-internet-segment",
+                "label": "Public Internet segment",
+                "status": "documented",
+                "description": "The historical vendor diagram explicitly labels the Internet between the wireless carrier / Regional Results and the county-side customer interface."
+              },
+              {
                 "id": "mi-5320-dmz-boundary",
                 "label": "Firewall and DMZ boundary",
                 "status": "documented",
@@ -8437,7 +8679,47 @@
               "mi-ess-voting-system-contract@2026-07-21"
             ],
             "caveat": "This is a historical Michigan procurement response for EVS 5.3.2.0, which the source says was not EAC certified. It is not evidence of EVS 6.4.0.0 certification, a current county design, an installed modem or firmware, a live connection, or a transmission during any election.",
-            "focusNodeId": "mi-5320-ds200"
+            "focusNodeId": "mi-5320-ds200",
+            "externalPathway": {
+              "status": "documented_reference_path",
+              "internetReachability": "documented_in_reference_path",
+              "focusConnectionStatus": "direct_in_reference_path",
+              "summary": "The historical Michigan vendor diagram explicitly shows configured DS200 units reaching a wireless carrier and the Internet before a customer interface, firewall/DMZ, communications server, and local EMS. It also shows Regional Results connected to the Internet.",
+              "originNodeIds": [
+                "mi-5320-ds200",
+                "mi-5320-internal-modem"
+              ],
+              "externalTransportNodeIds": [
+                "mi-5320-wireless-carrier",
+                "mi-5320-internet",
+                "mi-5320-regional-results"
+              ],
+              "boundaryNodeIds": [
+                "mi-5320-customer-interface",
+                "mi-5320-firewall"
+              ],
+              "receivingNodeIds": [
+                "mi-5320-communications-server",
+                "mi-5320-local-ems"
+              ],
+              "linkIds": [
+                "mi-5320-modem-interface",
+                "mi-5320-cellular-path",
+                "mi-5320-carrier-internet",
+                "mi-5320-regional-results-internet",
+                "mi-5320-internet-customer",
+                "mi-5320-customer-firewall",
+                "mi-5320-firewall-server",
+                "mi-5320-server-erm"
+              ],
+              "caveat": "The diagram is a historical 2017 procurement response for EVS 5.3.2.0, which the source says was not EAC certified. It does not establish a current design, installed modem, active connection, or transmission during an election.",
+              "sourceIds": [
+                "mi-ess-voting-system-contract"
+              ],
+              "sourceRevisionIds": [
+                "mi-ess-voting-system-contract@2026-07-21"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -8486,11 +8768,11 @@
             "width": 1600,
             "height": 1236,
             "kind": "source_topology_diagram",
-            "alt": "Historical Michigan vendor diagram showing DS200 units, a wireless carrier, customer interface, firewall and DMZ, communications server, and local election-management network.",
-            "caption": "Michigan contract exhibit: historical DS200 wireless results network",
+            "alt": "Historical Michigan vendor diagram showing configured DS200 units, wireless modems, a wireless carrier, the Internet, Regional Results, a customer interface, firewall and DMZ, communications server, and local election-management network.",
+            "caption": "Michigan contract exhibit: historical DS200 wireless results path through the Internet",
             "pageOrSection": "Michigan contract PDF page 101, contract page 62, Wireless Results Network",
             "derivativeNote": "Rendered from the archived official state-hosted PDF with PDF.js at 1600 pixels wide; the source page content was not edited.",
-            "caveat": "The diagram belongs to a historical Michigan procurement response and does not establish EVS 6.4.0.0 certification, a current county topology, an installed modem, or election use.",
+            "caveat": "The diagram explicitly shows an Internet segment, but it belongs to a historical Michigan procurement response and does not establish EVS 6.4.0.0 certification, a current county topology, an installed modem, an active connection, or election use.",
             "sourceIds": [
               "mi-ess-voting-system-contract"
             ],
@@ -8822,7 +9104,7 @@
         "Public findings and modem vulnerability reviews are presented with exact product, firmware, date, and source scope. A zero-match catalog review is not evidence that no bug, vulnerability, incident, or service bulletin exists.",
         "The manufacturer documents DS200 battery backup, but its model, chemistry, capacity, runtime, internal placement, condition, and county-level power topology remain unknown."
       ],
-      "claimRevision": 8,
+      "claimRevision": 9,
       "editorialState": "published",
       "sourceIds": [
         "cisa-kev-catalog",
@@ -9363,7 +9645,7 @@
         }
       ],
       "networkEvidence": {
-        "reviewedOn": "2026-07-21",
+        "reviewedOn": "2026-07-28",
         "summary": "The EVS 6.4.0.0 Pro V&V report states that DS950, DS850, and DS450 results were transmitted to the EMS through a closed local area network during accuracy testing. The EAC scope includes the central tabulator, Electionware infrastructure, and a minimum-1-Gb network switch, but it does not establish a jurisdiction's live switch, port, or addressing configuration.",
         "publicationBoundary": "This view publishes only the laboratory-supported closed-LAN result path and its source limits. It excludes IP addresses, credentials, keys, database details, switch settings, VLANs, hostnames, device identifiers, and site-specific routing.",
         "configurations": [
@@ -9489,7 +9771,27 @@
               "provv-evs-6400-test-report@2026-07-19"
             ],
             "caveat": "A VSTL accuracy-test topology is not proof that a jurisdiction connected a DS950, used the listed switch, or transmitted results over a network in a particular election.",
-            "focusNodeId": "ds950-tabulator"
+            "focusNodeId": "ds950-tabulator",
+            "externalPathway": {
+              "status": "no_external_path_documented",
+              "internetReachability": "not_documented",
+              "focusConnectionStatus": "no_connection_documented",
+              "summary": "The exact-version DS950 test path is documented only across a closed LAN to Electionware EMS. The reviewed passage does not identify a public-network or Internet segment.",
+              "originNodeIds": [],
+              "externalTransportNodeIds": [],
+              "boundaryNodeIds": [],
+              "receivingNodeIds": [],
+              "linkIds": [],
+              "caveat": "This is a VSTL accuracy-test path, not proof of a jurisdiction's switch, cabling, enabled services, external connectivity, or election use.",
+              "sourceIds": [
+                "eac-evs-6400-scope",
+                "provv-evs-6400-test-report"
+              ],
+              "sourceRevisionIds": [
+                "eac-evs-6400-scope@2026-07-19",
+                "provv-evs-6400-test-report@2026-07-19"
+              ]
+            }
           }
         ],
         "sourceImages": [
@@ -9723,7 +10025,7 @@
         "Certified UPS alternatives do not establish which model or battery condition applies at a jurisdiction.",
         "A certification change, ECO, or test result is not evidence of field occurrence, misconduct, or an election outcome effect."
       ],
-      "claimRevision": 3,
+      "claimRevision": 4,
       "editorialState": "published",
       "sourceIds": [
         "eac-evs-6400-record",

--- a/data/equipment-claims/clear-ballot-clearvote-25-clearaccess.json
+++ b/data/equipment-claims/clear-ballot-clearvote-25-clearaccess.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "reviewedOn": "2026-07-21",
+  "reviewedOn": "2026-07-28",
   "system": {
     "id": "clear-ballot-clearvote-25-clearaccess",
     "slug": "clear-ballot-clearvote-25-clearaccess",
@@ -640,7 +640,7 @@
       }
     ],
     "networkEvidence": {
-      "reviewedOn": "2026-07-21",
+      "reviewedOn": "2026-07-28",
       "summary": "The reviewed ClearVote 2.5 record identifies the ClearAccess station and its local peripherals, while Clear Ballot's current security policy says certified products are never attached to modems, the Internet, Wi-Fi, or Bluetooth. The exact port occupation and field wiring of a particular station are not established.",
       "publicationBoundary": "This public view records device roles, connection media, evidence scope, and isolation controls. It intentionally excludes IP addresses, credentials, keys, access codes, APNs, SIM identifiers, serial numbers, and site-specific routing details.",
       "configurations": [
@@ -754,7 +754,27 @@
             "clearballot-security@2026-07-21"
           ],
           "caveat": "A product-level communications policy and a certified component list do not prove the state of a particular port, cable, station, polling place, or election deployment.",
-          "focusNodeId": "clearaccess-station"
+          "focusNodeId": "clearaccess-station",
+          "externalPathway": {
+            "status": "no_external_path_documented",
+            "internetReachability": "explicitly_excluded",
+            "focusConnectionStatus": "no_connection_documented",
+            "summary": "No path beyond the ClearAccess station's local peripherals is documented. Clear Ballot's reviewed policy says certified products are not attached to modems, the Internet, Wi-Fi, or Bluetooth.",
+            "originNodeIds": [],
+            "externalTransportNodeIds": [],
+            "boundaryNodeIds": [],
+            "receivingNodeIds": [],
+            "linkIds": [],
+            "caveat": "This is a product-policy and certified-configuration boundary, not a field inspection of a particular station, port, cable, or polling place.",
+            "sourceIds": [
+              "eac-clearvote-25-scope",
+              "clearballot-security"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19",
+              "clearballot-security@2026-07-21"
+            ]
+          }
         }
       ],
       "sourceImages": [
@@ -961,12 +981,12 @@
   },
   "editorial": {
     "state": "published",
-    "revision": 5,
+    "revision": 6,
     "createdOn": "2026-07-19",
-    "updatedOn": "2026-07-22",
-    "reviewedOn": "2026-07-21",
+    "updatedOn": "2026-07-28",
+    "reviewedOn": "2026-07-28",
     "reviewedBy": "project_editorial_review",
-    "publishedOn": "2026-07-22",
+    "publishedOn": "2026-07-28",
     "sourceRevisionIds": [
       "eac-clearvote-25-record@2026-07-19",
       "eac-clearvote-25-scope@2026-07-19",
@@ -980,8 +1000,9 @@
     "reviewNotes": [
       "Approved for feature-gated staging. Public production activation remains a separate review decision.",
       "Added source-scoped network configuration evidence without inferring a live station or publishing sensitive configuration values.",
+      "Added source-bounded external-pathway classification so closed networks, physical interfaces, optional transport hardware, and documented routes beyond a local boundary remain visibly distinct.",
       "project_owner: Production publication authorized after source, editorial, build, and browser validation."
     ],
-    "publicationId": "equipment-explorer-2026-07-22-r1"
+    "publicationId": "equipment-explorer-2026-07-28-r1"
   }
 }

--- a/data/equipment-claims/clear-ballot-clearvote-25-clearcount.json
+++ b/data/equipment-claims/clear-ballot-clearvote-25-clearcount.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "reviewedOn": "2026-07-21",
+  "reviewedOn": "2026-07-28",
   "system": {
     "id": "clear-ballot-clearvote-25-clearcount",
     "slug": "clear-ballot-clearvote-25-clearcount",
@@ -387,7 +387,7 @@
       }
     ],
     "networkEvidence": {
-      "reviewedOn": "2026-07-21",
+      "reviewedOn": "2026-07-28",
       "summary": "The ClearVote 2.5 EAC scope documents ClearCount as a wired, closed, isolated Ethernet system linking the CountServer, ScanStations, and CountStations through a certified switch alternative. COTS scanners attach to ScanStations; field cabling and switch settings remain installation-specific.",
       "publicationBoundary": "The module publishes only source-supported roles, media, direction, and isolation controls. It excludes IP addressing, credentials, keys, switch-management values, VLAN details, hostnames, serial numbers, and site diagrams.",
       "configurations": [
@@ -581,7 +581,29 @@
             "clearballot-security@2026-07-21"
           ],
           "caveat": "This is the certified architecture, not proof that a jurisdiction selected every alternative, used the maximum number of stations, or installed a particular switch or cabling layout.",
-          "focusNodeId": "clearcount-server"
+          "focusNodeId": "clearcount-server",
+          "externalPathway": {
+            "status": "no_external_path_documented",
+            "internetReachability": "explicitly_excluded",
+            "focusConnectionStatus": "no_connection_documented",
+            "summary": "The documented ClearCount path remains inside its closed Ethernet system. The reviewed scope says that network is not connected to other systems or the Internet.",
+            "originNodeIds": [],
+            "externalTransportNodeIds": [],
+            "boundaryNodeIds": [],
+            "receivingNodeIds": [],
+            "linkIds": [],
+            "caveat": "The reviewed sources define the certified closed-network boundary; they do not establish the field state of a jurisdiction's switch, cabling, ports, or services.",
+            "sourceIds": [
+              "eac-clearvote-25-scope",
+              "provv-clearvote-25-test-plan",
+              "clearballot-security"
+            ],
+            "sourceRevisionIds": [
+              "eac-clearvote-25-scope@2026-07-19",
+              "provv-clearvote-25-test-plan@2026-07-19",
+              "clearballot-security@2026-07-21"
+            ]
+          }
         }
       ],
       "sourceImages": [
@@ -787,12 +809,12 @@
   },
   "editorial": {
     "state": "published",
-    "revision": 3,
+    "revision": 4,
     "createdOn": "2026-07-20",
-    "updatedOn": "2026-07-22",
-    "reviewedOn": "2026-07-21",
+    "updatedOn": "2026-07-28",
+    "reviewedOn": "2026-07-28",
     "reviewedBy": "project_editorial_review",
-    "publishedOn": "2026-07-22",
+    "publishedOn": "2026-07-28",
     "sourceRevisionIds": [
       "clearballot-clearcount-product-page@2026-07-20",
       "clearballot-clearcount-reference-photo@2026-07-20",
@@ -805,8 +827,9 @@
     "reviewNotes": [
       "Approved for feature-gated staging as a separate central-tabulation dossier. Public production activation remains a separate decision.",
       "Added the exact certified ClearCount closed-LAN topology and source-page previews without publishing operational settings.",
+      "Added source-bounded external-pathway classification so closed networks, physical interfaces, optional transport hardware, and documented routes beyond a local boundary remain visibly distinct.",
       "project_owner: Production publication authorized after source, editorial, build, and browser validation."
     ],
-    "publicationId": "equipment-explorer-2026-07-22-r1"
+    "publicationId": "equipment-explorer-2026-07-28-r1"
   }
 }

--- a/data/equipment-claims/dominion-democracy-suite-517-imagecast-central.json
+++ b/data/equipment-claims/dominion-democracy-suite-517-imagecast-central.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "reviewedOn": "2026-07-21",
+  "reviewedOn": "2026-07-28",
   "system": {
     "id": "dominion-democracy-suite-517-imagecast-central",
     "slug": "dominion-democracy-suite-517-imagecast-central",
@@ -376,7 +376,7 @@
       }
     ],
     "networkEvidence": {
-      "reviewedOn": "2026-07-21",
+      "reviewedOn": "2026-07-28",
       "summary": "Colorado's exact 5.17-CO technical data connects the ImageCast Central scanner locally to an ICC workstation by USB and describes ICC workstations using a Gigabit Ethernet port on a closed LAN to the EMS data-center network. The ICC user guide makes additional central-repository infrastructure conditional and requires election computers to remain isolated from the Internet and other networks.",
       "publicationBoundary": "This view publishes only the documented system roles, connection media, conditionality, and isolation controls. It omits addressing, credentials, database identifiers, cryptographic keys, switch settings, hostnames, and jurisdiction cable routes.",
       "configurations": [
@@ -537,7 +537,29 @@
             "provv-dsuite-517-test-plan@2026-07-20"
           ],
           "caveat": "The documents describe permitted 5.17-CO architectures. They do not establish that a particular jurisdiction uses the optional repository, which COTS alternatives it selected, or the live state of a network.",
-          "focusNodeId": "icc-workstation"
+          "focusNodeId": "icc-workstation",
+          "externalPathway": {
+            "status": "no_external_path_documented",
+            "internetReachability": "explicitly_excluded",
+            "focusConnectionStatus": "no_connection_documented",
+            "summary": "The conditional ICC-to-EMS path is documented only as a closed election LAN. The reviewed Colorado guide requires election computers to remain isolated from the Internet and other networks.",
+            "originNodeIds": [],
+            "externalTransportNodeIds": [],
+            "boundaryNodeIds": [],
+            "receivingNodeIds": [],
+            "linkIds": [],
+            "caveat": "This classification applies to the reviewed 5.17-CO documentation and does not substitute for a dated inspection of a jurisdiction installation.",
+            "sourceIds": [
+              "co-dvs-517-system-overview",
+              "co-dvs-517-icc-user-guide",
+              "provv-dsuite-517-test-plan"
+            ],
+            "sourceRevisionIds": [
+              "co-dvs-517-system-overview@2026-07-21",
+              "co-dvs-517-icc-user-guide@2026-07-20",
+              "provv-dsuite-517-test-plan@2026-07-20"
+            ]
+          }
         }
       ],
       "sourceImages": [
@@ -742,12 +764,12 @@
   },
   "editorial": {
     "state": "published",
-    "revision": 3,
+    "revision": 4,
     "createdOn": "2026-07-20",
-    "updatedOn": "2026-07-22",
-    "reviewedOn": "2026-07-21",
+    "updatedOn": "2026-07-28",
+    "reviewedOn": "2026-07-28",
     "reviewedBy": "project_editorial_review",
-    "publishedOn": "2026-07-22",
+    "publishedOn": "2026-07-28",
     "sourceRevisionIds": [
       "co-dvs-517-icc-user-guide@2026-07-20",
       "co-dvs-517-system-overview@2026-07-21",
@@ -759,8 +781,9 @@
     "reviewNotes": [
       "Approved for feature-gated staging as a separate central-tabulation dossier. Public production activation remains a separate decision.",
       "Added exact 5.17-CO network documentation while retaining the conditional repository and no-field-observation boundaries.",
+      "Added source-bounded external-pathway classification so closed networks, physical interfaces, optional transport hardware, and documented routes beyond a local boundary remain visibly distinct.",
       "project_owner: Production publication authorized after source, editorial, build, and browser validation."
     ],
-    "publicationId": "equipment-explorer-2026-07-22-r1"
+    "publicationId": "equipment-explorer-2026-07-28-r1"
   }
 }

--- a/data/equipment-claims/dominion-democracy-suite-517-imagecast-x.json
+++ b/data/equipment-claims/dominion-democracy-suite-517-imagecast-x.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "reviewedOn": "2026-07-21",
+  "reviewedOn": "2026-07-28",
   "system": {
     "id": "dominion-democracy-suite-517-imagecast-x",
     "slug": "dominion-democracy-suite-517-imagecast-x",
@@ -881,7 +881,7 @@
       }
     ],
     "networkEvidence": {
-      "reviewedOn": "2026-07-21",
+      "reviewedOn": "2026-07-28",
       "summary": "The certified ICX hardware profile includes a physical 10/100 RJ-45 interface on the SID-21V platform, but the Democracy Suite 5.17 test plan says the evaluated system does not use public networks, does not support transmission over public networks, and uses no wireless technology. No external network peer or field connection is established for this ICX dossier.",
       "publicationBoundary": "The module distinguishes physical interface capability from an enabled or used connection. It excludes addresses, credentials, keys, activation-card contents, port settings, hostnames, and site-specific topology.",
       "configurations": [
@@ -1019,7 +1019,33 @@
             "co-dvs-517-avalue-sid21-manual@2026-07-20"
           ],
           "caveat": "An RJ-45 connector is capability evidence only. It does not prove that Ethernet is enabled, cabled, assigned an address, attached to a network, or used during an election.",
-          "focusNodeId": "icx-station"
+          "focusNodeId": "icx-station",
+          "externalPathway": {
+            "status": "physical_interface_only",
+            "internetReachability": "explicitly_excluded",
+            "focusConnectionStatus": "no_connection_documented",
+            "summary": "A physical RJ-45 interface is documented, but no attached peer or external path is established. The evaluated 5.17 system is described as not using or supporting transmission over public networks.",
+            "originNodeIds": [
+              "icx-rj45-interface"
+            ],
+            "externalTransportNodeIds": [],
+            "boundaryNodeIds": [],
+            "receivingNodeIds": [],
+            "linkIds": [],
+            "caveat": "Connector presence is capability evidence only. It does not establish an enabled port, cable, address, network session, Internet route, or field use.",
+            "sourceIds": [
+              "eac-dsuite-517-scope",
+              "provv-dsuite-517-test-plan",
+              "co-dvs-517-system-overview",
+              "co-dvs-517-avalue-sid21-manual"
+            ],
+            "sourceRevisionIds": [
+              "eac-dsuite-517-scope@2026-07-20",
+              "provv-dsuite-517-test-plan@2026-07-20",
+              "co-dvs-517-system-overview@2026-07-21",
+              "co-dvs-517-avalue-sid21-manual@2026-07-20"
+            ]
+          }
         }
       ],
       "sourceImages": [
@@ -1270,12 +1296,12 @@
   },
   "editorial": {
     "state": "published",
-    "revision": 5,
+    "revision": 6,
     "createdOn": "2026-07-20",
-    "updatedOn": "2026-07-22",
-    "reviewedOn": "2026-07-21",
+    "updatedOn": "2026-07-28",
+    "reviewedOn": "2026-07-28",
     "reviewedBy": "project_editorial_review",
-    "publishedOn": "2026-07-22",
+    "publishedOn": "2026-07-28",
     "sourceRevisionIds": [
       "dvs-icx-prime-ssd-advisory@2026-07-20",
       "dvs-icx-straight-party-advisory@2026-07-20",
@@ -1294,8 +1320,9 @@
       "Approved for feature-gated staging. Public production activation remains a separate review decision.",
       "Certification-era manufacturer naming is preserved separately from the current EAC ownership note.",
       "Added network-boundary evidence that distinguishes the ICX physical RJ-45 capability from an enabled or field-used connection.",
+      "Added source-bounded external-pathway classification so closed networks, physical interfaces, optional transport hardware, and documented routes beyond a local boundary remain visibly distinct.",
       "project_owner: Production publication authorized after source, editorial, build, and browser validation."
     ],
-    "publicationId": "equipment-explorer-2026-07-22-r1"
+    "publicationId": "equipment-explorer-2026-07-28-r1"
   }
 }

--- a/data/equipment-claims/ess-evs-6400-ds200.json
+++ b/data/equipment-claims/ess-evs-6400-ds200.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "reviewedOn": "2026-07-21",
+  "reviewedOn": "2026-07-28",
   "system": {
     "id": "ess-evs-6400-ds200",
     "slug": "ess-evs-6400-ds200",
@@ -1082,8 +1082,8 @@
       }
     ],
     "networkEvidence": {
-      "reviewedOn": "2026-07-21",
-      "summary": "For EVS 6.4.0.0, the EAC scope defines Regional Results as a separate application at a regional sending site, and Pro V&V tested transmission of DS200 result files through Regional Results over a VPN. The reviewed exact-version text does not establish that the DS200 itself was the VPN endpoint. Older federal and state records separately document a Unity 3.4.0.0 wireline SFTP reference design, a Michigan EVS 5.3.2.0 wireless-carrier and SFTP path, and optional DS200 cellular hardware families without proving EVS 6.4 certification, firmware, activation, or field use.",
+      "reviewedOn": "2026-07-28",
+      "summary": "For EVS 6.4.0.0, the EAC scope defines Regional Results as a separate application at a regional sending site, and Pro V&V tested transmission of DS200 result files through Regional Results over a VPN. The reviewed exact-version text does not establish that the DS200 itself was the VPN endpoint or that the VPN used the public Internet. Older federal and state records separately document a Unity 3.4.0.0 wireline SFTP reference design, optional cellular hardware families, and a Michigan EVS 5.3.2.0 diagram that explicitly shows DS200 units and Regional Results connected through a wireless carrier and the Internet without proving current certification, activation, field use, or an election transmission.",
       "publicationBoundary": "The module publishes roles, high-level paths, connection media when established, and evidence boundaries. It excludes IP addresses, credentials, VPN parameters, keys, APNs, SIM identifiers, carrier accounts, device identifiers, and jurisdiction routing details.",
       "configurations": [
         {
@@ -1233,7 +1233,36 @@
             "provv-evs-6400-test-report@2026-07-19"
           ],
           "caveat": "A successful VSTL system test is not evidence that a jurisdiction enabled Regional Results, used the same network design, or transmitted results in a particular election.",
-          "focusNodeId": "ds200-tabulator"
+          "focusNodeId": "ds200-tabulator",
+          "externalPathway": {
+            "status": "documented_indirect_path",
+            "internetReachability": "not_documented",
+            "focusConnectionStatus": "indirect_result_handoff",
+            "summary": "The exact EVS 6.4 test record documents Regional Results sending result files through a customer-dedicated VPN to Electionware EMS. The reviewed passage does not make the DS200 the VPN endpoint or say that the VPN traverses the public Internet.",
+            "originNodeIds": [
+              "ds200-regional-client"
+            ],
+            "externalTransportNodeIds": [
+              "ds200-customer-network"
+            ],
+            "boundaryNodeIds": [],
+            "receivingNodeIds": [
+              "ds200-ems"
+            ],
+            "linkIds": [
+              "ds200-vpn-send",
+              "ds200-vpn-receive"
+            ],
+            "caveat": "This is an exact-version VSTL test path. The DS200-to-Regional Results handoff medium, public-network transit, jurisdiction deployment, and election use are not established.",
+            "sourceIds": [
+              "eac-evs-6400-scope",
+              "provv-evs-6400-test-report"
+            ],
+            "sourceRevisionIds": [
+              "eac-evs-6400-scope@2026-07-19",
+              "provv-evs-6400-test-report@2026-07-19"
+            ]
+          }
         },
         {
           "id": "ds200-historical-optional-cellular-context",
@@ -1431,7 +1460,37 @@
             "multitech-universal-socket-guide@2026-07-20"
           ],
           "caveat": "Historical optional hardware is not evidence that EVS 6.4.0.0 certified, a jurisdiction purchased, or a fielded DS200 contains or uses either modem.",
-          "focusNodeId": "ds200-historical-unit"
+          "focusNodeId": "ds200-historical-unit",
+          "externalPathway": {
+            "status": "optional_capability_only",
+            "internetReachability": "not_documented",
+            "focusConnectionStatus": "optional_hardware_not_established",
+            "summary": "Older reviewed records identify optional DS200 modem alternatives with cellular-carrier capability. They do not establish an installed modem, active carrier service, receiving system, complete DS200-to-network chain, or Internet route.",
+            "originNodeIds": [
+              "ds200-c2",
+              "ds200-lvw3"
+            ],
+            "externalTransportNodeIds": [
+              "ds200-carrier-service"
+            ],
+            "boundaryNodeIds": [],
+            "receivingNodeIds": [],
+            "linkIds": [
+              "ds200-c2-cellular-link",
+              "ds200-lvw3-cellular-link"
+            ],
+            "caveat": "These are historical hardware-family alternatives from earlier EVS campaigns, not proof that EVS 6.4.0.0 certified or a fielded DS200 contains or uses either modem.",
+            "sourceIds": [
+              "fl-evs-4500-v4-modem-report",
+              "provv-evs-5341-modem-hardware-table",
+              "multitech-universal-socket-guide"
+            ],
+            "sourceRevisionIds": [
+              "fl-evs-4500-v4-modem-report@2026-07-20",
+              "provv-evs-5341-modem-hardware-table@2026-07-20",
+              "multitech-universal-socket-guide@2026-07-20"
+            ]
+          }
         },
         {
           "id": "ds200-unity-3400-landline-sftp-reference",
@@ -1576,7 +1635,36 @@
             "eac-unity-3400-test-plan@2026-07-21"
           ],
           "caveat": "This is a historical wireline test-plan reference, not a cellular design, current EVS 6.4.0.0 certification record, field inspection, or evidence of election-night use.",
-          "focusNodeId": "unity-3400-ds200"
+          "focusNodeId": "unity-3400-ds200",
+          "externalPathway": {
+            "status": "documented_reference_path",
+            "internetReachability": "not_documented",
+            "focusConnectionStatus": "direct_in_reference_path",
+            "summary": "The historical Unity 3.4 test-plan figure shows a DS200 leaving the local device boundary over a wireline modem connection to a RAS/SFTP receiver in a DMZ, then crossing a firewall toward ERM. It does not label the public Internet.",
+            "originNodeIds": [
+              "unity-3400-ds200"
+            ],
+            "externalTransportNodeIds": [],
+            "boundaryNodeIds": [
+              "unity-3400-firewall"
+            ],
+            "receivingNodeIds": [
+              "unity-3400-ras-sftp",
+              "unity-3400-erm"
+            ],
+            "linkIds": [
+              "unity-3400-modem-line",
+              "unity-3400-dmz-boundary",
+              "unity-3400-inside-erm"
+            ],
+            "caveat": "This is a historical test-plan reference configuration, not a current EVS 6.4 topology, field inspection, or evidence of election-night use.",
+            "sourceIds": [
+              "eac-unity-3400-test-plan"
+            ],
+            "sourceRevisionIds": [
+              "eac-unity-3400-test-plan@2026-07-21"
+            ]
+          }
         },
         {
           "id": "ds200-michigan-evs-5320-wireless-sftp-path",
@@ -1585,7 +1673,7 @@
           "assertionScope": "state_certification_documentation",
           "knowledgeStatus": "documented_partial",
           "topologyKind": "results_transmission_service",
-          "description": "Michigan's official state-hosted ES&S contract response depicts DS200 units reaching a communications server through a wireless carrier, customer interface, firewall, and DMZ. The accompanying vendor response says a poll worker could initiate an SFTP transfer after polls closed, after which an encrypted result file was deposited and the connection terminated before ERM processed received files.",
+          "description": "Michigan's official state-hosted ES&S contract response depicts configured DS200 units reaching a communications server through an optional wireless modem, wireless carrier, explicitly labeled Internet segment, customer interface, firewall, and DMZ. The diagram also shows Regional Results connected to the Internet. The accompanying vendor response says a poll worker could initiate an SFTP transfer after polls closed, after which an encrypted result file was deposited and the connection terminated before ERM processed received files.",
           "observedOn": null,
           "assertedFor": null,
           "nodes": [
@@ -1624,6 +1712,34 @@
               "componentId": null,
               "optional": true,
               "details": "The diagram labels a wireless-carrier path; carrier, account, APN, SIM, and activation state are not published here.",
+              "sourceIds": [
+                "mi-ess-voting-system-contract"
+              ],
+              "sourceRevisionIds": [
+                "mi-ess-voting-system-contract@2026-07-21"
+              ]
+            },
+            {
+              "id": "mi-5320-internet",
+              "label": "Internet",
+              "role": "Public-network transport shown in the historical vendor diagram",
+              "componentId": null,
+              "optional": false,
+              "details": "The source diagram explicitly labels an Internet segment between the wireless carrier / Regional Results and the customer interface. Provider, route, public address, field deployment, and election use are not established.",
+              "sourceIds": [
+                "mi-ess-voting-system-contract"
+              ],
+              "sourceRevisionIds": [
+                "mi-ess-voting-system-contract@2026-07-21"
+              ]
+            },
+            {
+              "id": "mi-5320-regional-results",
+              "label": "Regional Results",
+              "role": "Results application shown connected to the Internet",
+              "componentId": null,
+              "optional": false,
+              "details": "The historical vendor diagram shows a Regional Results system with a bidirectional Internet connection; its hosting, exact configuration, and deployment state are not established here.",
               "sourceIds": [
                 "mi-ess-voting-system-contract"
               ],
@@ -1720,13 +1836,43 @@
               ]
             },
             {
-              "id": "mi-5320-carrier-customer",
+              "id": "mi-5320-carrier-internet",
               "from": "mi-5320-wireless-carrier",
-              "to": "mi-5320-customer-interface",
-              "medium": "External carrier and network path",
+              "to": "mi-5320-internet",
+              "medium": "Carrier-to-Internet path shown in the vendor diagram",
               "direction": "bidirectional",
-              "purpose": "Reach the county-side customer interface",
-              "knowledgeStatus": "documented_partial",
+              "purpose": "Reach the public-network segment shown in the historical wireless-results design",
+              "knowledgeStatus": "confirmed",
+              "sourceIds": [
+                "mi-ess-voting-system-contract"
+              ],
+              "sourceRevisionIds": [
+                "mi-ess-voting-system-contract@2026-07-21"
+              ]
+            },
+            {
+              "id": "mi-5320-regional-results-internet",
+              "from": "mi-5320-regional-results",
+              "to": "mi-5320-internet",
+              "medium": "Internet connection shown in the vendor diagram",
+              "direction": "bidirectional",
+              "purpose": "Connect Regional Results to the historical public-network segment",
+              "knowledgeStatus": "confirmed",
+              "sourceIds": [
+                "mi-ess-voting-system-contract"
+              ],
+              "sourceRevisionIds": [
+                "mi-ess-voting-system-contract@2026-07-21"
+              ]
+            },
+            {
+              "id": "mi-5320-internet-customer",
+              "from": "mi-5320-internet",
+              "to": "mi-5320-customer-interface",
+              "medium": "Public Internet path shown in the vendor diagram",
+              "direction": "bidirectional",
+              "purpose": "Reach the county-side customer interface from the public-network segment",
+              "knowledgeStatus": "confirmed",
               "sourceIds": [
                 "mi-ess-voting-system-contract"
               ],
@@ -1800,6 +1946,12 @@
               "description": "The response states that the connection was terminated after the encrypted result file was deposited on the receiving server."
             },
             {
+              "id": "mi-5320-public-internet-segment",
+              "label": "Public Internet segment",
+              "status": "documented",
+              "description": "The historical vendor diagram explicitly labels the Internet between the wireless carrier / Regional Results and the county-side customer interface."
+            },
+            {
               "id": "mi-5320-dmz-boundary",
               "label": "Firewall and DMZ boundary",
               "status": "documented",
@@ -1814,7 +1966,47 @@
             "mi-ess-voting-system-contract@2026-07-21"
           ],
           "caveat": "This is a historical Michigan procurement response for EVS 5.3.2.0, which the source says was not EAC certified. It is not evidence of EVS 6.4.0.0 certification, a current county design, an installed modem or firmware, a live connection, or a transmission during any election.",
-          "focusNodeId": "mi-5320-ds200"
+          "focusNodeId": "mi-5320-ds200",
+          "externalPathway": {
+            "status": "documented_reference_path",
+            "internetReachability": "documented_in_reference_path",
+            "focusConnectionStatus": "direct_in_reference_path",
+            "summary": "The historical Michigan vendor diagram explicitly shows configured DS200 units reaching a wireless carrier and the Internet before a customer interface, firewall/DMZ, communications server, and local EMS. It also shows Regional Results connected to the Internet.",
+            "originNodeIds": [
+              "mi-5320-ds200",
+              "mi-5320-internal-modem"
+            ],
+            "externalTransportNodeIds": [
+              "mi-5320-wireless-carrier",
+              "mi-5320-internet",
+              "mi-5320-regional-results"
+            ],
+            "boundaryNodeIds": [
+              "mi-5320-customer-interface",
+              "mi-5320-firewall"
+            ],
+            "receivingNodeIds": [
+              "mi-5320-communications-server",
+              "mi-5320-local-ems"
+            ],
+            "linkIds": [
+              "mi-5320-modem-interface",
+              "mi-5320-cellular-path",
+              "mi-5320-carrier-internet",
+              "mi-5320-regional-results-internet",
+              "mi-5320-internet-customer",
+              "mi-5320-customer-firewall",
+              "mi-5320-firewall-server",
+              "mi-5320-server-erm"
+            ],
+            "caveat": "The diagram is a historical 2017 procurement response for EVS 5.3.2.0, which the source says was not EAC certified. It does not establish a current design, installed modem, active connection, or transmission during an election.",
+            "sourceIds": [
+              "mi-ess-voting-system-contract"
+            ],
+            "sourceRevisionIds": [
+              "mi-ess-voting-system-contract@2026-07-21"
+            ]
+          }
         }
       ],
       "sourceImages": [
@@ -1863,11 +2055,11 @@
           "width": 1600,
           "height": 1236,
           "kind": "source_topology_diagram",
-          "alt": "Historical Michigan vendor diagram showing DS200 units, a wireless carrier, customer interface, firewall and DMZ, communications server, and local election-management network.",
-          "caption": "Michigan contract exhibit: historical DS200 wireless results network",
+          "alt": "Historical Michigan vendor diagram showing configured DS200 units, wireless modems, a wireless carrier, the Internet, Regional Results, a customer interface, firewall and DMZ, communications server, and local election-management network.",
+          "caption": "Michigan contract exhibit: historical DS200 wireless results path through the Internet",
           "pageOrSection": "Michigan contract PDF page 101, contract page 62, Wireless Results Network",
           "derivativeNote": "Rendered from the archived official state-hosted PDF with PDF.js at 1600 pixels wide; the source page content was not edited.",
-          "caveat": "The diagram belongs to a historical Michigan procurement response and does not establish EVS 6.4.0.0 certification, a current county topology, an installed modem, or election use.",
+          "caveat": "The diagram explicitly shows an Internet segment, but it belongs to a historical Michigan procurement response and does not establish EVS 6.4.0.0 certification, a current county topology, an installed modem, an active connection, or election use.",
           "sourceIds": [
             "mi-ess-voting-system-contract"
           ],
@@ -2202,12 +2394,12 @@
   },
   "editorial": {
     "state": "published",
-    "revision": 8,
+    "revision": 9,
     "createdOn": "2026-07-19",
-    "updatedOn": "2026-07-22",
-    "reviewedOn": "2026-07-21",
+    "updatedOn": "2026-07-28",
+    "reviewedOn": "2026-07-28",
     "reviewedBy": "project_editorial_review",
-    "publishedOn": "2026-07-22",
+    "publishedOn": "2026-07-28",
     "sourceRevisionIds": [
       "cisa-kev-catalog@2026-07-20",
       "eac-eco-ess-1035-approval@2026-07-19",
@@ -2255,8 +2447,10 @@
       "Historical DS200 modem identities and dated public-vulnerability coverage are separately scoped; no modem firmware or field deployment is inferred.",
       "Added exact-version Regional Results/VPN test evidence and a separately labeled historical optional-cellular topology without publishing operational configuration values.",
       "Added separately scoped historical Unity 3.4.0.0 wireline and Michigan EVS 5.3.2.0 wireless SFTP paths plus address-free vendor reference imagery; no field deployment, firmware, carrier, or current-version state is inferred.",
+      "Added source-bounded external-pathway classification so closed networks, physical interfaces, optional transport hardware, and documented routes beyond a local boundary remain visibly distinct.",
+      "The historical Michigan topology now reproduces the source-labeled Internet segment and Regional Results connection while retaining version, deployment, and operational caveats.",
       "project_owner: Production publication authorized after source, editorial, build, and browser validation."
     ],
-    "publicationId": "equipment-explorer-2026-07-22-r1"
+    "publicationId": "equipment-explorer-2026-07-28-r1"
   }
 }

--- a/data/equipment-claims/ess-evs-6400-ds950.json
+++ b/data/equipment-claims/ess-evs-6400-ds950.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "reviewedOn": "2026-07-21",
+  "reviewedOn": "2026-07-28",
   "system": {
     "id": "ess-evs-6400-ds950",
     "slug": "ess-evs-6400-ds950",
@@ -416,7 +416,7 @@
       }
     ],
     "networkEvidence": {
-      "reviewedOn": "2026-07-21",
+      "reviewedOn": "2026-07-28",
       "summary": "The EVS 6.4.0.0 Pro V&V report states that DS950, DS850, and DS450 results were transmitted to the EMS through a closed local area network during accuracy testing. The EAC scope includes the central tabulator, Electionware infrastructure, and a minimum-1-Gb network switch, but it does not establish a jurisdiction's live switch, port, or addressing configuration.",
       "publicationBoundary": "This view publishes only the laboratory-supported closed-LAN result path and its source limits. It excludes IP addresses, credentials, keys, database details, switch settings, VLANs, hostnames, device identifiers, and site-specific routing.",
       "configurations": [
@@ -542,7 +542,27 @@
             "provv-evs-6400-test-report@2026-07-19"
           ],
           "caveat": "A VSTL accuracy-test topology is not proof that a jurisdiction connected a DS950, used the listed switch, or transmitted results over a network in a particular election.",
-          "focusNodeId": "ds950-tabulator"
+          "focusNodeId": "ds950-tabulator",
+          "externalPathway": {
+            "status": "no_external_path_documented",
+            "internetReachability": "not_documented",
+            "focusConnectionStatus": "no_connection_documented",
+            "summary": "The exact-version DS950 test path is documented only across a closed LAN to Electionware EMS. The reviewed passage does not identify a public-network or Internet segment.",
+            "originNodeIds": [],
+            "externalTransportNodeIds": [],
+            "boundaryNodeIds": [],
+            "receivingNodeIds": [],
+            "linkIds": [],
+            "caveat": "This is a VSTL accuracy-test path, not proof of a jurisdiction's switch, cabling, enabled services, external connectivity, or election use.",
+            "sourceIds": [
+              "eac-evs-6400-scope",
+              "provv-evs-6400-test-report"
+            ],
+            "sourceRevisionIds": [
+              "eac-evs-6400-scope@2026-07-19",
+              "provv-evs-6400-test-report@2026-07-19"
+            ]
+          }
         }
       ],
       "sourceImages": [
@@ -779,12 +799,12 @@
   },
   "editorial": {
     "state": "published",
-    "revision": 3,
+    "revision": 4,
     "createdOn": "2026-07-20",
-    "updatedOn": "2026-07-22",
-    "reviewedOn": "2026-07-21",
+    "updatedOn": "2026-07-28",
+    "reviewedOn": "2026-07-28",
     "reviewedBy": "project_editorial_review",
-    "publishedOn": "2026-07-22",
+    "publishedOn": "2026-07-28",
     "sourceRevisionIds": [
       "eac-evs-6400-record@2026-07-19",
       "eac-evs-6400-scope@2026-07-19",
@@ -795,8 +815,9 @@
     "reviewNotes": [
       "Approved for feature-gated staging as a separate central-tabulation dossier. Public production activation remains a separate decision.",
       "Added the exact-version closed-LAN VSTL test path without inferring a field switch or operational network configuration.",
+      "Added source-bounded external-pathway classification so closed networks, physical interfaces, optional transport hardware, and documented routes beyond a local boundary remain visibly distinct.",
       "project_owner: Production publication authorized after source, editorial, build, and browser validation."
     ],
-    "publicationId": "equipment-explorer-2026-07-22-r1"
+    "publicationId": "equipment-explorer-2026-07-28-r1"
   }
 }

--- a/docs/equipment-evidence-workflow.md
+++ b/docs/equipment-evidence-workflow.md
@@ -132,6 +132,20 @@ A physical Ethernet, USB, Wi-Fi, Bluetooth, or cellular interface is capability 
 
 Each configuration must include source-bounded nodes, paths, controls, immutable source revisions, a topology classification, and a caveat. Unknown peers, field switch state, enabled services, optional deployment choices, and exact endpoint roles remain explicit evidence gaps. Vendor diagrams that show multiple deployment alternatives must retain the vendor's applicability warning.
 
+Each configuration also requires an `externalPathway` classification. Its `status` distinguishes:
+
+- `no_external_path_documented`: the reviewed configuration does not document a path beyond its closed or local boundary;
+- `physical_interface_only`: a connector or interface exists, but an attached peer and external route are not established;
+- `documented_indirect_path`: an external transport is documented only after a separate handoff, so the dossier device is not itself the external endpoint;
+- `optional_capability_only`: optional transport hardware or service is documented without a complete installed route; and
+- `documented_reference_path`: a complete path appears in a separately scoped historical, vendor, state, or test reference.
+
+`internetReachability` must be `explicitly_excluded`, `not_documented`, or `documented_in_reference_path`. A VPN, cellular carrier, modem, firewall, DMZ, or external transport is not labeled as public-Internet reachability unless the reviewed source explicitly names or depicts the Internet. `focusConnectionStatus` separately records whether the dossier equipment has no documented connection, participates only through a result handoff, has optional hardware without an established path, or appears directly in the scoped reference path.
+
+`originNodeIds`, `externalTransportNodeIds`, `boundaryNodeIds`, `receivingNodeIds`, and `linkIds` must resolve inside the same configuration. They drive the amber route and role highlights in the interactive and accessible topology views; they do not add inferred nodes or connections. The classification carries its own source IDs, immutable source revisions, summary, and caveat.
+
+An external-path label is evidence about the reviewed document and version only. It is not a statement that a route is currently installed, active during an election, reachable from an arbitrary Internet host, exploitable, or associated with a security incident or incorrect result.
+
 Every topology node and connection must carry its own nonempty `sourceIds` and `sourceRevisionIds`, limited to the parent configuration's reviewed source corpus. `focusNodeId` identifies the dossier subject in that configuration; it is a presentation aid, not an assertion that the subject is physically central. The deterministic layered layout, dragging, zoom, and optional force view change presentation only. They never create, delete, persist, or infer an equipment connection.
 
 Rendered source pages and diagrams live under `public/equipment/network-evidence/`. Every image carries a local asset hash, dimensions, page or section, derivative note, source IDs, source-revision IDs, alt text, and scope caveat. Rendering a page for legibility does not convert it into an original topology claim.

--- a/scripts/build-equipment-catalog.mjs
+++ b/scripts/build-equipment-catalog.mjs
@@ -38,6 +38,8 @@ function collectSourceIds(system) {
     ...(system.deployments ?? []).flatMap((record) => record.sourceIds ?? []),
     ...(system.networkEvidence?.configurations ?? []).flatMap((record) => record.sourceIds ?? []),
     ...(system.networkEvidence?.configurations ?? []).flatMap((record) =>
+      record.externalPathway?.sourceIds ?? []),
+    ...(system.networkEvidence?.configurations ?? []).flatMap((record) =>
       (record.nodes ?? []).flatMap((node) => node.sourceIds ?? [])),
     ...(system.networkEvidence?.configurations ?? []).flatMap((record) =>
       (record.links ?? []).flatMap((link) => link.sourceIds ?? [])),
@@ -62,6 +64,8 @@ function collectSourceRevisionIds(system) {
     ...(system.power ?? []).flatMap((record) => record.sourceRevisionIds ?? []),
     ...(system.deployments ?? []).flatMap((record) => record.sourceRevisionIds ?? []),
     ...(system.networkEvidence?.configurations ?? []).flatMap((record) => record.sourceRevisionIds ?? []),
+    ...(system.networkEvidence?.configurations ?? []).flatMap((record) =>
+      record.externalPathway?.sourceRevisionIds ?? []),
     ...(system.networkEvidence?.configurations ?? []).flatMap((record) =>
       (record.nodes ?? []).flatMap((node) => node.sourceRevisionIds ?? [])),
     ...(system.networkEvidence?.configurations ?? []).flatMap((record) =>

--- a/scripts/validate-equipment-catalog.mjs
+++ b/scripts/validate-equipment-catalog.mjs
@@ -512,6 +512,112 @@ for (const claim of claims) {
         error(`${configurationLabel} focusNodeId references unknown node ${configuration.focusNodeId}.`);
       }
 
+      const externalPathway = configuration.externalPathway;
+      if (!externalPathway) {
+        error(`${configurationLabel} needs an externalPathway classification.`);
+      } else {
+        const pathwayStatuses = [
+          "no_external_path_documented",
+          "physical_interface_only",
+          "documented_indirect_path",
+          "optional_capability_only",
+          "documented_reference_path",
+        ];
+        const internetReachabilityStatuses = [
+          "explicitly_excluded",
+          "not_documented",
+          "documented_in_reference_path",
+        ];
+        const focusConnectionStatuses = [
+          "no_connection_documented",
+          "indirect_result_handoff",
+          "optional_hardware_not_established",
+          "direct_in_reference_path",
+        ];
+        if (!pathwayStatuses.includes(externalPathway.status)) {
+          error(`${configurationLabel} externalPathway has an invalid status.`);
+        }
+        if (!internetReachabilityStatuses.includes(externalPathway.internetReachability)) {
+          error(`${configurationLabel} externalPathway has an invalid internetReachability.`);
+        }
+        if (!focusConnectionStatuses.includes(externalPathway.focusConnectionStatus)) {
+          error(`${configurationLabel} externalPathway has an invalid focusConnectionStatus.`);
+        }
+        requireNonEmpty(externalPathway.summary, `${configurationLabel} externalPathway summary`);
+        requireNonEmpty(externalPathway.caveat, `${configurationLabel} externalPathway caveat`);
+        requireSourceIds(
+          externalPathway,
+          `${configurationLabel} externalPathway`,
+          sourceById,
+          revisionById,
+        );
+        for (const sourceId of externalPathway.sourceIds ?? []) {
+          if (!configuration.sourceIds.includes(sourceId)) {
+            error(`${configurationLabel} externalPathway source ${sourceId} is outside its configuration evidence.`);
+          }
+        }
+        for (const revisionId of externalPathway.sourceRevisionIds ?? []) {
+          if (!configuration.sourceRevisionIds.includes(revisionId)) {
+            error(`${configurationLabel} externalPathway revision ${revisionId} is outside its configuration evidence.`);
+          }
+        }
+
+        const pathwayNodeGroups = [
+          ["originNodeIds", externalPathway.originNodeIds],
+          ["externalTransportNodeIds", externalPathway.externalTransportNodeIds],
+          ["boundaryNodeIds", externalPathway.boundaryNodeIds],
+          ["receivingNodeIds", externalPathway.receivingNodeIds],
+        ];
+        const pathwayNodeIds = new Set();
+        for (const [groupName, ids] of pathwayNodeGroups) {
+          if (!Array.isArray(ids)) {
+            error(`${configurationLabel} externalPathway ${groupName} must be an array.`);
+            continue;
+          }
+          for (const nodeId of ids) {
+            if (!nodeIds.has(nodeId)) {
+              error(`${configurationLabel} externalPathway ${groupName} references unknown node ${nodeId}.`);
+            }
+            if (pathwayNodeIds.has(nodeId)) {
+              error(`${configurationLabel} externalPathway assigns node ${nodeId} to more than one pathway role.`);
+            }
+            pathwayNodeIds.add(nodeId);
+          }
+        }
+        if (!Array.isArray(externalPathway.linkIds)) {
+          error(`${configurationLabel} externalPathway linkIds must be an array.`);
+        } else {
+          for (const linkId of externalPathway.linkIds) {
+            if (!linkIds.has(linkId)) {
+              error(`${configurationLabel} externalPathway references unknown link ${linkId}.`);
+            }
+          }
+        }
+
+        const pathwayNodeCount = pathwayNodeIds.size;
+        const pathwayLinkCount = externalPathway.linkIds?.length ?? 0;
+        if (externalPathway.status === "no_external_path_documented"
+            && (pathwayNodeCount !== 0 || pathwayLinkCount !== 0)) {
+          error(`${configurationLabel} no-external-path classification must not highlight pathway nodes or links.`);
+        }
+        if (externalPathway.status === "physical_interface_only"
+            && ((externalPathway.originNodeIds?.length ?? 0) === 0 || pathwayLinkCount !== 0)) {
+          error(`${configurationLabel} physical-interface-only classification needs origin nodes and no pathway links.`);
+        }
+        if ([
+          "documented_indirect_path",
+          "optional_capability_only",
+          "documented_reference_path",
+        ].includes(externalPathway.status)
+            && ((externalPathway.originNodeIds?.length ?? 0) === 0 || pathwayLinkCount === 0)) {
+          error(`${configurationLabel} external-path classification needs at least one origin node and pathway link.`);
+        }
+        if (externalPathway.internetReachability === "documented_in_reference_path"
+            && externalPathway.status !== "documented_reference_path") {
+          error(`${configurationLabel} may document Internet reachability only inside a scoped reference path.`);
+        }
+      }
+
       for (const control of configuration.controls ?? []) {
         const controlLabel = `${configurationLabel} control ${control.id ?? "unknown"}`;
         requireNonEmpty(control.id, `${controlLabel} id`);

--- a/src/app/equipment/[slug]/dossier-navigation.ts
+++ b/src/app/equipment/[slug]/dossier-navigation.ts
@@ -1,7 +1,7 @@
 export const equipmentDossierSections = [
   { key: "overview", label: "Overview", path: "", description: "Scope, certification, and dossier coverage" },
   { key: "components", label: "Components", path: "/components", description: "Accessible parts list and optional 3D schematic" },
-  { key: "topology", label: "Topology", path: "/topology", description: "Source-linked nodes, paths, controls, and evidence gaps" },
+  { key: "topology", label: "Topology", path: "/topology", description: "Source-linked topology, external pathways, controls, and gaps" },
   { key: "history", label: "History", path: "/history", description: "Versions, changes, findings, power, and deployments" },
   { key: "usage", label: "Usage", path: "/usage", description: "2024 product-family and manufacturer context" },
   { key: "sources", label: "Sources", path: "/sources", description: "Grouped archived source manifest" },

--- a/src/app/equipment/[slug]/equipment-network-evidence.client.tsx
+++ b/src/app/equipment/[slug]/equipment-network-evidence.client.tsx
@@ -13,6 +13,7 @@ import {
   Link2,
   Maximize2,
   Network,
+  Route,
   ShieldCheck,
 } from "lucide-react";
 import { useState } from "react";
@@ -42,6 +43,66 @@ const EquipmentTopologyGraph = dynamic<EquipmentTopologyGraphProps>(
 
 function label(value: string) {
   return value.replaceAll("_", " ");
+}
+
+function externalPathwayStatusLabel(value: string) {
+  switch (value) {
+    case "no_external_path_documented":
+      return "No external path documented";
+    case "physical_interface_only":
+      return "Interface documented; no external peer";
+    case "documented_indirect_path":
+      return "External transport documented after a separate handoff";
+    case "optional_capability_only":
+      return "Optional external capability; complete path not established";
+    case "documented_reference_path":
+      return "External path documented in a scoped reference";
+    default:
+      return label(value);
+  }
+}
+
+function internetReachabilityLabel(value: string) {
+  switch (value) {
+    case "explicitly_excluded":
+      return "Explicitly excluded by reviewed sources";
+    case "not_documented":
+      return "Not documented in this configuration";
+    case "documented_in_reference_path":
+      return "Shown in this scoped source";
+    default:
+      return label(value);
+  }
+}
+
+function focusConnectionStatusLabel(value: string) {
+  switch (value) {
+    case "no_connection_documented":
+      return "No external connection documented";
+    case "indirect_result_handoff":
+      return "Separate result handoff; dossier device is not the endpoint";
+    case "optional_hardware_not_established":
+      return "Optional hardware; complete path not established";
+    case "direct_in_reference_path":
+      return "Direct path in this scoped reference";
+    default:
+      return label(value);
+  }
+}
+
+function pathwayRoleLabel(value: string) {
+  switch (value) {
+    case "origin":
+      return "Path origin";
+    case "transport":
+      return "External transport";
+    case "boundary":
+      return "Boundary control";
+    case "receiving":
+      return "Receiving system";
+    default:
+      return label(value);
+  }
 }
 
 function EvidenceSources({
@@ -108,6 +169,30 @@ export function EquipmentTopologyEvidencePanel({
   const expandedImage = evidence.sourceImages.find((image) => image.id === expandedImageId) ?? null;
   const observedCount = evidence.configurations.filter((record) => record.evidenceLayer === "observed").length;
   const nodeById = new Map(configuration.nodes.map((node) => [node.id, node]));
+  const pathway = configuration.externalPathway;
+  const pathwayNodeGroups: Array<{
+    ids: readonly string[];
+    label: string;
+    role: "boundary" | "origin" | "receiving" | "transport";
+  }> = [
+    { ids: pathway.originNodeIds, label: "Path origin", role: "origin" },
+    {
+      ids: pathway.externalTransportNodeIds,
+      label: "External transport / Internet-linked systems",
+      role: "transport",
+    },
+    { ids: pathway.boundaryNodeIds, label: "Boundary controls", role: "boundary" },
+    { ids: pathway.receivingNodeIds, label: "Receiving systems", role: "receiving" },
+  ];
+  const pathwayNodeRoleById = new Map<string, string>();
+  for (const group of pathwayNodeGroups) {
+    for (const nodeId of group.ids) pathwayNodeRoleById.set(nodeId, group.role);
+  }
+  const pathwayLinkIds = new Set(pathway.linkIds);
+  const pathwayNodeCount = pathwayNodeRoleById.size;
+  const explicitInternetConfigurationCount = evidence.configurations.filter(
+    (record) => record.externalPathway.internetReachability === "documented_in_reference_path",
+  ).length;
 
   function selectConfiguration(nextId: string) {
     const next = evidence.configurations.find((record) => record.id === nextId);
@@ -128,7 +213,7 @@ export function EquipmentTopologyEvidencePanel({
           <p className={styles.eyebrow}><Network aria-hidden size={14} /> Source-bounded topology</p>
           <h2 id="topology-evidence-heading">Documented topology, controls, and unknowns</h2>
         </div>
-        <p>Expected, documented, and observed configurations remain separate. Physical port capability is not treated as an active connection.</p>
+        <p>Expected, documented, and observed configurations remain separate. Physical port capability is not treated as an active connection, and public-Internet reachability is shown only when a reviewed source says so.</p>
       </div>
 
       <article className={styles.networkBoundary}>
@@ -147,6 +232,9 @@ export function EquipmentTopologyEvidencePanel({
         <span>{evidence.configurations.length} sourced configuration {evidence.configurations.length === 1 ? "view" : "views"}</span>
         <span>{evidence.sourceImages.length} source {evidence.sourceImages.length === 1 ? "image" : "images"}</span>
         <span>{observedCount === 0 ? "No field-observed topology collected" : `${observedCount} field-observed topology records`}</span>
+        <span>{explicitInternetConfigurationCount === 0
+          ? "No source explicitly shows an Internet path"
+          : `${explicitInternetConfigurationCount} scoped source ${explicitInternetConfigurationCount === 1 ? "shows" : "show"} an Internet path`}</span>
       </div>
 
       {evidence.configurations.length > 1 && (
@@ -183,6 +271,101 @@ export function EquipmentTopologyEvidencePanel({
           </div>
         </header>
 
+        <article
+          className={styles.externalPathwayCard}
+          data-external-pathway
+          data-internet-reachability={pathway.internetReachability}
+          data-pathway-status={pathway.status}
+        >
+          <header className={styles.externalPathwayHead}>
+            <div>
+              <Route aria-hidden size={19} />
+              <span>
+                <small>External pathway evidence</small>
+                <strong>{externalPathwayStatusLabel(pathway.status)}</strong>
+              </span>
+            </div>
+            <span>{pathwayLinkIds.size === 0
+              ? "No highlighted route"
+              : `${pathwayLinkIds.size} highlighted ${pathwayLinkIds.size === 1 ? "connection" : "connections"}`}</span>
+          </header>
+
+          <p className={styles.externalPathwaySummary}>{pathway.summary}</p>
+          <div className={styles.externalPathwayFacts}>
+            <div>
+              <span>Public Internet</span>
+              <strong>{internetReachabilityLabel(pathway.internetReachability)}</strong>
+            </div>
+            <div>
+              <span>Dossier connection</span>
+              <strong>{focusConnectionStatusLabel(pathway.focusConnectionStatus)}</strong>
+            </div>
+          </div>
+
+          {pathwayNodeCount > 0 && (
+            <div className={styles.externalPathwayNodeGroups}>
+              {pathwayNodeGroups.filter((group) => group.ids.length > 0).map((group) => (
+                <div key={group.role}>
+                  <span>{group.label}</span>
+                  <div>
+                    {group.ids.map((nodeId) => {
+                      const node = nodeById.get(nodeId);
+                      return (
+                        <button
+                          aria-pressed={activeSelection.kind === "node" && activeSelection.id === nodeId}
+                          data-pathway-role={group.role}
+                          key={nodeId}
+                          onClick={() => setSelection({ id: nodeId, kind: "node" })}
+                          type="button"
+                        >
+                          {node?.label ?? nodeId}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {pathwayLinkIds.size > 0 && (
+            <div className={styles.externalPathwayLinks}>
+              <span>Highlighted connections</span>
+              <div>
+                {pathway.linkIds.map((linkId) => {
+                  const link = configuration.links.find((record) => record.id === linkId);
+                  if (!link) return null;
+                  return (
+                    <button
+                      aria-pressed={activeSelection.kind === "link" && activeSelection.id === linkId}
+                      key={linkId}
+                      onClick={() => setSelection({ id: linkId, kind: "link" })}
+                      type="button"
+                    >
+                      <Link2 aria-hidden size={13} />
+                      <span>
+                        <strong>{nodeById.get(link.from)?.label ?? link.from} → {nodeById.get(link.to)?.label ?? link.to}</strong>
+                        <small>{link.medium}</small>
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          <div className={styles.externalPathwayBoundary}>
+            <AlertTriangle aria-hidden size={15} />
+            <p>Evidence classification only. It does not establish a live connection, current deployment, attack path, or security finding.</p>
+          </div>
+          <p className={styles.externalPathwayCaveat}>{pathway.caveat}</p>
+          <EvidenceSources
+            sourceIds={pathway.sourceIds}
+            sourceRevisionIds={pathway.sourceRevisionIds}
+            sources={sources}
+          />
+        </article>
+
         <div className={styles.networkInteractiveGrid}>
           <EquipmentTopologyGraph
             configuration={configuration}
@@ -201,6 +384,7 @@ export function EquipmentTopologyEvidencePanel({
                   <div><dt>Medium</dt><dd>{selectedLink.medium}</dd></div>
                   <div><dt>Direction</dt><dd>{label(selectedLink.direction)}</dd></div>
                   <div><dt>Evidence status</dt><dd>{label(selectedLink.knowledgeStatus)}</dd></div>
+                  <div><dt>External-path segment</dt><dd>{pathwayLinkIds.has(selectedLink.id) ? "Yes — source-highlighted" : "No"}</dd></div>
                 </dl>
                 <small>These citations support this connection within this configuration; they do not establish a live field network.</small>
                 <EvidenceSources
@@ -218,6 +402,12 @@ export function EquipmentTopologyEvidencePanel({
                   <div><dt>Role</dt><dd>{selectedNode.role}</dd></div>
                   {selectedNode.componentId && <div><dt>Dossier component</dt><dd>{selectedNode.componentId}</dd></div>}
                   <div><dt>Optional</dt><dd>{selectedNode.optional ? "Yes" : "No"}</dd></div>
+                  {pathwayNodeRoleById.has(selectedNode.id) && (
+                    <div>
+                      <dt>External-path role</dt>
+                      <dd>{pathwayRoleLabel(pathwayNodeRoleById.get(selectedNode.id) ?? "")}</dd>
+                    </div>
+                  )}
                 </dl>
                 <small>Select a node or connection in the topology to inspect the exact source revisions supporting it.</small>
                 <EvidenceSources
@@ -244,15 +434,24 @@ export function EquipmentTopologyEvidencePanel({
               {configuration.nodes.map((node) => (
                 <button
                   aria-pressed={activeSelection.kind === "node" && node.id === activeSelection.id}
-                  className={activeSelection.kind === "node" && node.id === activeSelection.id
-                    ? styles.networkNodeActive
-                    : undefined}
+                  className={[
+                    activeSelection.kind === "node" && node.id === activeSelection.id
+                      ? styles.networkNodeActive
+                      : "",
+                    pathwayNodeRoleById.has(node.id) ? styles.networkNodePathway : "",
+                  ].filter(Boolean).join(" ") || undefined}
+                  data-pathway-role={pathwayNodeRoleById.get(node.id)}
                   key={node.id}
                   onClick={() => setSelection({ id: node.id, kind: "node" })}
                   type="button"
                 >
                   <Network aria-hidden size={16} />
-                  <span><strong>{node.label}</strong><small>{node.role}</small></span>
+                  <span>
+                    <strong>{node.label}</strong>
+                    <small>{node.role}{pathwayNodeRoleById.has(node.id)
+                      ? ` · ${pathwayRoleLabel(pathwayNodeRoleById.get(node.id) ?? "")}`
+                      : ""}</small>
+                  </span>
                   {node.optional && <em>Optional</em>}
                 </button>
               ))}
@@ -266,7 +465,11 @@ export function EquipmentTopologyEvidencePanel({
                 return (
                   <button
                     aria-pressed={active}
-                    className={active ? styles.networkLinkActive : undefined}
+                    className={[
+                      active ? styles.networkLinkActive : "",
+                      pathwayLinkIds.has(link.id) ? styles.networkLinkPathway : "",
+                    ].filter(Boolean).join(" ") || undefined}
+                    data-external-path-segment={pathwayLinkIds.has(link.id) || undefined}
                     key={link.id}
                     onClick={() => setSelection({ id: link.id, kind: "link" })}
                     type="button"
@@ -281,6 +484,7 @@ export function EquipmentTopologyEvidencePanel({
                     </div>
                     <p>{link.medium}</p>
                     <small>{link.purpose} — {label(link.knowledgeStatus)}</small>
+                    {pathwayLinkIds.has(link.id) && <em>External-path evidence</em>}
                   </button>
                 );
               })}

--- a/src/app/equipment/[slug]/equipment-topology-graph.client.tsx
+++ b/src/app/equipment/[slug]/equipment-topology-graph.client.tsx
@@ -53,17 +53,23 @@ const NODE_WIDTH = 224;
 const NODE_HEIGHT = 104;
 const elk = new ELK();
 
+type PathwayNodeRole = "boundary" | "origin" | "receiving" | "transport";
+
 type TopologyNodeData = {
   componentMapped: boolean;
   evidenceCount: number;
   focus: boolean;
   label: string;
   optional: boolean;
+  pathwayRole: PathwayNodeRole | null;
   role: string;
 };
 
 type TopologyFlowNode = Node<TopologyNodeData, "evidence">;
-type TopologyFlowEdge = Edge<{ knowledgeStatus: string }, "smoothstep">;
+type TopologyFlowEdge = Edge<{
+  externalPathway: boolean;
+  knowledgeStatus: string;
+}, "smoothstep">;
 
 type ForceNode = SimulationNodeDatum & {
   anchorX: number;
@@ -104,26 +110,49 @@ function edgeLabel(link: EquipmentNetworkLink) {
   return `${medium.slice(0, 25).trimEnd()}…`;
 }
 
+function pathwayRoleForNode(
+  configuration: EquipmentNetworkConfiguration,
+  nodeId: string,
+): PathwayNodeRole | null {
+  const pathway = configuration.externalPathway;
+  if (pathway.originNodeIds.includes(nodeId)) return "origin";
+  if (pathway.externalTransportNodeIds.includes(nodeId)) return "transport";
+  if (pathway.boundaryNodeIds.includes(nodeId)) return "boundary";
+  if (pathway.receivingNodeIds.includes(nodeId)) return "receiving";
+  return null;
+}
+
+function pathwayRoleLabel(role: PathwayNodeRole) {
+  if (role === "origin") return "path origin";
+  if (role === "transport") return "external transport";
+  if (role === "boundary") return "boundary control";
+  return "receiving system";
+}
+
 function initialNodes(configuration: EquipmentNetworkConfiguration): TopologyFlowNode[] {
-  return configuration.nodes.map((node, index) => ({
-    id: node.id,
-    type: "evidence",
-    position: {
-      x: (index % 3) * (NODE_WIDTH + 70),
-      y: Math.floor(index / 3) * (NODE_HEIGHT + 70),
-    },
-    sourcePosition: Position.Right,
-    targetPosition: Position.Left,
-    ariaLabel: `${node.label}. ${node.role}.${node.optional ? " Optional." : ""}`,
-    data: {
-      componentMapped: node.componentId !== null,
-      evidenceCount: node.sourceRevisionIds.length,
-      focus: node.id === configuration.focusNodeId,
-      label: node.label,
-      optional: node.optional,
-      role: node.role,
-    },
-  }));
+  return configuration.nodes.map((node, index) => {
+    const pathwayRole = pathwayRoleForNode(configuration, node.id);
+    return {
+      id: node.id,
+      type: "evidence",
+      position: {
+        x: (index % 3) * (NODE_WIDTH + 70),
+        y: Math.floor(index / 3) * (NODE_HEIGHT + 70),
+      },
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
+      ariaLabel: `${node.label}. ${node.role}.${node.optional ? " Optional." : ""}${pathwayRole ? ` External-path role: ${pathwayRoleLabel(pathwayRole)}.` : ""}`,
+      data: {
+        componentMapped: node.componentId !== null,
+        evidenceCount: node.sourceRevisionIds.length,
+        focus: node.id === configuration.focusNodeId,
+        label: node.label,
+        optional: node.optional,
+        pathwayRole,
+        role: node.role,
+      },
+    };
+  });
 }
 
 function evidenceNodeClass(data: TopologyNodeData, selected: boolean) {
@@ -132,6 +161,7 @@ function evidenceNodeClass(data: TopologyNodeData, selected: boolean) {
     data.focus ? styles.topologyNodeFocus : "",
     data.optional ? styles.topologyNodeOptional : "",
     !data.componentMapped ? styles.topologyNodeExternal : "",
+    data.pathwayRole ? styles.topologyNodePathway : "",
     selected ? styles.topologyNodeSelected : "",
   ].filter(Boolean).join(" ");
 }
@@ -140,8 +170,17 @@ const EvidenceTopologyNode = memo(function EvidenceTopologyNode({
   data,
   selected,
 }: NodeProps<TopologyFlowNode>) {
+  const nodeKind = data.focus
+    ? "This dossier"
+    : data.componentMapped
+      ? "Dossier component"
+      : "External role";
+  const pathwayLabel = data.pathwayRole ? pathwayRoleLabel(data.pathwayRole) : null;
   return (
-    <div className={evidenceNodeClass(data, selected)}>
+    <div
+      className={evidenceNodeClass(data, selected)}
+      data-pathway-role={data.pathwayRole ?? undefined}
+    >
       <Handle
         className={styles.topologyHandle}
         isConnectable={false}
@@ -152,7 +191,9 @@ const EvidenceTopologyNode = memo(function EvidenceTopologyNode({
         {data.focus ? <Focus aria-hidden size={15} /> : data.componentMapped
           ? <Box aria-hidden size={15} />
           : <Network aria-hidden size={15} />}
-        <span>{data.focus ? "This dossier" : data.componentMapped ? "Dossier component" : "External role"}</span>
+        <span title={pathwayLabel ? `${nodeKind} · ${pathwayLabel}` : nodeKind}>
+          {nodeKind}{pathwayLabel ? ` · ${pathwayLabel}` : ""}
+        </span>
         {data.optional && <em>Optional</em>}
       </div>
       <strong>{data.label}</strong>
@@ -172,19 +213,25 @@ const nodeTypes = {
   evidence: EvidenceTopologyNode,
 } as const;
 
-function edgeStyle(link: EquipmentNetworkLink, active: boolean) {
+function edgeStyle(
+  link: EquipmentNetworkLink,
+  active: boolean,
+  externalPathway: boolean,
+) {
   const status = link.knowledgeStatus;
-  const color = status === "confirmed"
-    ? "#67d9cc"
-    : status === "documented_partial"
-      ? "#e2bd73"
-      : "#8e9aa8";
+  const color = externalPathway
+    ? "#f0b95a"
+    : status === "confirmed"
+      ? "#67d9cc"
+      : status === "documented_partial"
+        ? "#e2bd73"
+        : "#8e9aa8";
   return {
-    opacity: active ? 1 : 0.72,
+    opacity: active || externalPathway ? 1 : 0.72,
     stroke: color,
     strokeDasharray: status === "confirmed" ? undefined : status === "documented_partial" ? "8 5" : "2 7",
     strokeLinecap: "round" as const,
-    strokeWidth: active ? 3 : 1.8,
+    strokeWidth: active ? 3.4 : externalPathway ? 2.7 : 1.8,
   };
 }
 
@@ -196,25 +243,28 @@ function graphEdges(
     const active = selection.kind === "link"
       ? selection.id === link.id
       : link.from === selection.id || link.to === selection.id;
-    const marker = { color: edgeStyle(link, active).stroke, type: MarkerType.ArrowClosed };
+    const externalPathway = configuration.externalPathway.linkIds.includes(link.id);
+    const style = edgeStyle(link, active, externalPathway);
+    const marker = { color: style.stroke, type: MarkerType.ArrowClosed };
     return {
       id: link.id,
       source: link.from,
       target: link.to,
       type: "smoothstep",
       label: edgeLabel(link),
-      ariaLabel: `${link.purpose}. ${link.medium}. ${evidenceStatusLabel(link.knowledgeStatus)}.`,
-      data: { knowledgeStatus: link.knowledgeStatus },
+      ariaLabel: `${link.purpose}. ${link.medium}. ${evidenceStatusLabel(link.knowledgeStatus)}.${externalPathway ? " Source-classified external-path segment." : ""}`,
+      className: externalPathway ? "external-pathway-edge" : undefined,
+      data: { externalPathway, knowledgeStatus: link.knowledgeStatus },
       markerEnd: link.direction === "one_way" || link.direction === "bidirectional" ? marker : undefined,
       markerStart: link.direction === "bidirectional" ? marker : undefined,
       pathOptions: { borderRadius: 3, offset: 24 },
       selected: selection.kind === "link" && selection.id === link.id,
-      style: edgeStyle(link, active),
+      style,
       labelBgBorderRadius: 5,
       labelBgPadding: [5, 3],
       labelBgStyle: { fill: "#07191c", fillOpacity: 0.94 },
       labelStyle: {
-        fill: active ? "#e9fffb" : "#94aaa7",
+        fill: active ? "#e9fffb" : externalPathway ? "#f0c77d" : "#94aaa7",
         fontSize: 10,
         fontWeight: 720,
       },
@@ -431,7 +481,7 @@ export function EquipmentTopologyGraph({
         <div>
           <span>Interactive topology</span>
           <strong>Documented shape, exploratory placement</strong>
-          <small>Dragging changes this view only. Reset restores the deterministic source layout.</small>
+          <small>Dragging changes this view only. Amber highlights mark source-classified external-path evidence; reset restores the deterministic layout.</small>
         </div>
         <div className={styles.topologyGraphActions}>
           <button
@@ -490,6 +540,7 @@ export function EquipmentTopologyGraph({
         <span><i data-status="confirmed" /> Confirmed path</span>
         <span><i data-status="partial" /> Documented partial</span>
         <span><i data-status="unknown" /> Medium or path not established</span>
+        <span><i data-status="external" /> External-path evidence</span>
         <span><b /> This dossier</span>
       </div>
     </section>

--- a/src/app/equipment/equipment.module.css
+++ b/src/app/equipment/equipment.module.css
@@ -1654,6 +1654,258 @@
   line-height: 1.35;
   text-transform: capitalize;
 }
+.externalPathwayCard {
+  margin-top: 16px;
+  padding: 15px;
+  border: 1px solid rgba(240, 185, 90, 0.28);
+  border-radius: 16px;
+  background:
+    linear-gradient(135deg, rgba(240, 185, 90, 0.09), rgba(39, 30, 16, 0.1)),
+    rgba(5, 22, 25, 0.7);
+}
+
+.externalPathwayCard[data-pathway-status="no_external_path_documented"] {
+  border-color: rgba(103, 217, 204, 0.2);
+  background:
+    linear-gradient(135deg, rgba(103, 217, 204, 0.06), rgba(30, 56, 61, 0.05)),
+    rgba(5, 22, 25, 0.7);
+}
+
+.externalPathwayCard[data-pathway-status="physical_interface_only"] {
+  border-color: rgba(121, 158, 255, 0.28);
+}
+
+.externalPathwayCard[data-internet-reachability="documented_in_reference_path"] {
+  border-color: rgba(240, 185, 90, 0.52);
+  box-shadow: inset 3px 0 rgba(240, 185, 90, 0.76);
+}
+
+.externalPathwayHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.externalPathwayHead > div {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+}
+
+.externalPathwayHead svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: #f0b95a;
+}
+
+.externalPathwayCard[data-pathway-status="no_external_path_documented"] .externalPathwayHead svg {
+  color: #72d7cc;
+}
+
+.externalPathwayHead > div > span {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.externalPathwayHead small,
+.externalPathwayHead > span,
+.externalPathwayFacts span,
+.externalPathwayNodeGroups > div > span,
+.externalPathwayLinks > span {
+  color: #9c8460;
+  font-size: 0.54rem;
+  font-weight: 820;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+}
+
+.externalPathwayHead strong {
+  color: #f6e7c8;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.externalPathwayHead > span {
+  flex: 0 0 auto;
+  padding: 5px 7px;
+  border: 1px solid rgba(240, 185, 90, 0.2);
+  border-radius: 999px;
+}
+
+.externalPathwaySummary {
+  margin: 10px 0 0;
+  color: #a9b8b4;
+  font-size: 0.7rem;
+  line-height: 1.55;
+}
+
+.externalPathwayFacts {
+  margin-top: 11px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 7px;
+}
+
+.externalPathwayFacts > div {
+  padding: 9px 10px;
+  border: 1px solid rgba(240, 185, 90, 0.14);
+  border-radius: 10px;
+  background: rgba(240, 185, 90, 0.035);
+  display: grid;
+  gap: 3px;
+}
+
+.externalPathwayFacts strong {
+  color: #e5d7bb;
+  font-size: 0.65rem;
+  line-height: 1.4;
+}
+
+.externalPathwayNodeGroups {
+  margin-top: 11px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(175px, 1fr));
+  gap: 7px;
+}
+
+.externalPathwayNodeGroups > div {
+  min-width: 0;
+  padding: 9px;
+  border: 1px solid rgba(240, 185, 90, 0.12);
+  border-radius: 10px;
+  background: rgba(3, 17, 20, 0.42);
+}
+
+.externalPathwayNodeGroups > div > div {
+  margin-top: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.externalPathwayNodeGroups button,
+.externalPathwayLinks button {
+  border: 1px solid rgba(240, 185, 90, 0.2);
+  border-radius: 8px;
+  background: rgba(240, 185, 90, 0.055);
+  color: #d9cab0;
+  cursor: pointer;
+  font: inherit;
+}
+
+.externalPathwayNodeGroups button {
+  min-height: 29px;
+  padding: 5px 7px;
+  font-size: 0.57rem;
+  line-height: 1.3;
+}
+
+.externalPathwayNodeGroups button[aria-pressed="true"],
+.externalPathwayLinks button[aria-pressed="true"] {
+  border-color: #f0b95a;
+  background: rgba(240, 185, 90, 0.14);
+  color: #fff0d1;
+}
+
+.externalPathwayLinks {
+  margin-top: 11px;
+}
+
+.externalPathwayLinks > div {
+  margin-top: 6px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 6px;
+}
+
+.externalPathwayLinks button {
+  min-width: 0;
+  padding: 8px;
+  text-align: left;
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.externalPathwayLinks button > svg {
+  flex: 0 0 auto;
+  margin-top: 2px;
+  color: #f0b95a;
+}
+
+.externalPathwayLinks button > span {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.externalPathwayLinks strong {
+  overflow-wrap: anywhere;
+  font-size: 0.59rem;
+  line-height: 1.35;
+}
+
+.externalPathwayLinks small {
+  color: #9d8c70;
+  font-size: 0.52rem;
+  line-height: 1.35;
+}
+
+.externalPathwayBoundary {
+  margin-top: 11px;
+  padding: 8px 9px;
+  border: 1px solid rgba(121, 158, 255, 0.15);
+  border-radius: 9px;
+  background: rgba(37, 48, 82, 0.13);
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+}
+
+.externalPathwayBoundary svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: #aebfff;
+}
+
+.externalPathwayBoundary p,
+.externalPathwayCaveat {
+  margin: 0;
+  color: #8e9aac;
+  font-size: 0.59rem;
+  line-height: 1.48;
+}
+
+.externalPathwayCaveat {
+  margin-top: 8px;
+  color: #a89576;
+}
+
+.networkNodes button.networkNodePathway {
+  border-color: rgba(240, 185, 90, 0.5);
+  background: rgba(240, 185, 90, 0.07);
+}
+
+.networkLinks button.networkLinkPathway {
+  border-left-color: #f0b95a;
+  background: rgba(240, 185, 90, 0.065);
+  opacity: 1;
+}
+
+.networkLinks button > em {
+  margin-top: 5px;
+  color: #d9a94f;
+  font-size: 0.51rem;
+  font-style: normal;
+  font-weight: 820;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+  display: block;
+}
+
 
 .networkInteractiveGrid {
   margin-top: 17px;
@@ -3299,6 +3551,10 @@
   stroke-width: 4;
 }
 
+.topologyGraphCanvas :global(.external-pathway-edge .react-flow__edge-path) {
+  filter: drop-shadow(0 0 4px rgba(240, 185, 90, 0.32));
+}
+
 .topologyGraphCanvas :global(.react-flow__controls) {
   overflow: hidden;
   border: 1px solid rgba(103, 217, 204, 0.2);
@@ -3384,6 +3640,36 @@
   background:
     linear-gradient(145deg, rgba(121, 158, 255, 0.1), rgba(11, 28, 48, 0.96)),
     #091a2d;
+}
+
+.topologyNodePathway {
+  border-color: rgba(240, 185, 90, 0.78);
+  box-shadow:
+    inset 0 0 0 1px rgba(240, 185, 90, 0.14),
+    0 0 26px rgba(240, 185, 90, 0.09),
+    0 13px 32px rgba(0, 0, 0, 0.24);
+}
+
+.topologyNodePathway[data-pathway-role="transport"] {
+  background:
+    linear-gradient(145deg, rgba(240, 185, 90, 0.17), rgba(47, 35, 17, 0.96)),
+    #291f12;
+}
+
+.topologyNodePathway[data-pathway-role="boundary"] {
+  background:
+    linear-gradient(145deg, rgba(121, 158, 255, 0.15), rgba(24, 31, 55, 0.96)),
+    #111b30;
+}
+
+.topologyNodePathway[data-pathway-role="receiving"] {
+  background:
+    linear-gradient(145deg, rgba(160, 208, 139, 0.13), rgba(20, 43, 34, 0.96)),
+    #102a21;
+}
+
+.topologyNodePathway .topologyNodeTopline {
+  color: #f0c572;
 }
 
 .topologyNodeSelected {
@@ -3484,6 +3770,11 @@
 .topologyLegend i[data-status="unknown"] {
   border-color: #8e9aa8;
   border-top-style: dotted;
+}
+
+.topologyLegend i[data-status="external"] {
+  border-color: #f0b95a;
+  box-shadow: 0 0 5px rgba(240, 185, 90, 0.28);
 }
 
 .topologyLegend b {

--- a/src/app/tour-manifests.ts
+++ b/src/app/tour-manifests.ts
@@ -66,7 +66,7 @@ export const equipmentDetailTourSteps: TourStep[] = [
     id: "equipment-detail-navigation",
     target: "[data-tour='equipment-dossier-navigation']",
     title: "Use the shareable dossier sections",
-    body: "Components, interactive topology, history, jurisdiction context, and sources have stable URLs. The topology keeps documented configurations separate from live field observations. On smaller screens, use the dossier-section menu.",
+    body: "Components, interactive topology, history, jurisdiction context, and sources have stable URLs. The topology separates closed networks, physical interfaces, optional transport, and source-documented external routes from live field observations. Amber paths identify only the reviewed configuration in view. On smaller screens, use the dossier-section menu.",
   },
   {
     chapter: "Review",

--- a/src/lib/equipment-catalog.ts
+++ b/src/lib/equipment-catalog.ts
@@ -3,14 +3,42 @@ import catalogData from "@equipment-catalog-data";
 import type { EquipmentCatalogChannel } from "./equipment-catalog-channel";
 
 export type EquipmentCatalog = typeof catalogData;
-export type EquipmentSystem = EquipmentCatalog["systems"][number];
+type EquipmentCatalogSystem = EquipmentCatalog["systems"][number];
+type EquipmentCatalogNetworkEvidence = EquipmentCatalogSystem["networkEvidence"];
+type EquipmentCatalogNetworkConfiguration =
+  EquipmentCatalogNetworkEvidence["configurations"][number];
+
+export type EquipmentNetworkExternalPathway = {
+  status: string;
+  internetReachability: string;
+  focusConnectionStatus: string;
+  summary: string;
+  originNodeIds: readonly string[];
+  externalTransportNodeIds: readonly string[];
+  boundaryNodeIds: readonly string[];
+  receivingNodeIds: readonly string[];
+  linkIds: readonly string[];
+  caveat: string;
+  sourceIds: readonly string[];
+  sourceRevisionIds: readonly string[];
+};
+
+export type EquipmentNetworkConfiguration =
+  Omit<EquipmentCatalogNetworkConfiguration, "externalPathway"> & {
+    externalPathway: EquipmentNetworkExternalPathway;
+  };
+export type EquipmentNetworkEvidence =
+  Omit<EquipmentCatalogNetworkEvidence, "configurations"> & {
+    configurations: EquipmentNetworkConfiguration[];
+  };
+export type EquipmentSystem = Omit<EquipmentCatalogSystem, "networkEvidence"> & {
+  networkEvidence: EquipmentNetworkEvidence;
+};
 export type EquipmentComponent = EquipmentSystem["components"][number];
 export type EquipmentSource = EquipmentCatalog["sources"][number];
 export type EquipmentScene = EquipmentSystem["scene"];
 export type EquipmentSceneNode = EquipmentScene["nodes"][number];
 export type EquipmentReferenceImage = EquipmentScene["referenceImages"][number];
-export type EquipmentNetworkEvidence = EquipmentSystem["networkEvidence"];
-export type EquipmentNetworkConfiguration = EquipmentNetworkEvidence["configurations"][number];
 export type EquipmentNetworkNode = EquipmentNetworkConfiguration["nodes"][number];
 export type EquipmentNetworkLink = EquipmentNetworkConfiguration["links"][number];
 export type EquipmentNetworkSourceImage = EquipmentNetworkEvidence["sourceImages"][number];

--- a/tests/api/equipment-catalog.test.mjs
+++ b/tests/api/equipment-catalog.test.mjs
@@ -74,8 +74,8 @@ assert.equal(stagingCatalog.productionRequirement, "published");
 assert.equal(sourcePackage.schemaVersion, 2);
 assert.equal(claim.schemaVersion, 2);
 assert.equal(claim.editorial.state, "published");
-assert.equal(claim.editorial.publicationId, "equipment-explorer-2026-07-22-r1");
-assert.equal(claim.editorial.publishedOn, "2026-07-22");
+assert.equal(claim.editorial.publicationId, "equipment-explorer-2026-07-28-r1");
+assert.equal(claim.editorial.publishedOn, "2026-07-28");
 assert.equal(catalog.systems.length, 6);
 assert.equal(stagingCatalog.systems.length, 6);
 assert.ok(catalog.systems.every((system) => system.editorialState === "published"));
@@ -116,6 +116,26 @@ assert.ok(sourceIds.has("mi-ess-voting-system-contract"));
 const ds200NetworkConfigurationIds = new Set(system.networkEvidence.configurations.map((record) => record.id));
 assert.ok(ds200NetworkConfigurationIds.has("ds200-unity-3400-landline-sftp-reference"));
 assert.ok(ds200NetworkConfigurationIds.has("ds200-michigan-evs-5320-wireless-sftp-path"));
+const ds200NetworkConfigurations = new Map(
+  system.networkEvidence.configurations.map((record) => [record.id, record]),
+);
+const exactRegionalResultsPath = ds200NetworkConfigurations.get("ds200-6400-regional-results-test-path");
+assert.equal(exactRegionalResultsPath.externalPathway.status, "documented_indirect_path");
+assert.equal(exactRegionalResultsPath.externalPathway.internetReachability, "not_documented");
+assert.equal(exactRegionalResultsPath.externalPathway.focusConnectionStatus, "indirect_result_handoff");
+assert.ok(exactRegionalResultsPath.externalPathway.linkIds.includes("ds200-vpn-send"));
+const michiganInternetPath = ds200NetworkConfigurations.get("ds200-michigan-evs-5320-wireless-sftp-path");
+assert.equal(michiganInternetPath.externalPathway.status, "documented_reference_path");
+assert.equal(
+  michiganInternetPath.externalPathway.internetReachability,
+  "documented_in_reference_path",
+);
+assert.ok(michiganInternetPath.nodes.some((node) => node.id === "mi-5320-internet"));
+assert.ok(michiganInternetPath.nodes.some((node) => node.id === "mi-5320-regional-results"));
+assert.ok(michiganInternetPath.links.some((link) => link.id === "mi-5320-carrier-internet"));
+assert.ok(michiganInternetPath.links.some((link) => link.id === "mi-5320-regional-results-internet"));
+assert.ok(michiganInternetPath.links.some((link) => link.id === "mi-5320-internet-customer"));
+assert.ok(!michiganInternetPath.links.some((link) => link.id === "mi-5320-carrier-customer"));
 const ds200NetworkImageIds = new Set(system.networkEvidence.sourceImages.map((record) => record.id));
 assert.ok(ds200NetworkImageIds.has("ds200-mi-wireless-results-network"));
 assert.ok(ds200NetworkImageIds.has("ds200-multitech-developer-board-block-diagram"));
@@ -376,6 +396,27 @@ for (const dossier of catalog.systems) {
     );
     const configurationSourceIds = new Set(configuration.sourceIds);
     const configurationSourceRevisionIds = new Set(configuration.sourceRevisionIds);
+    const pathway = configuration.externalPathway;
+    assert.ok(pathway.summary.length > 40, `${dossier.slug}/${configuration.id} needs a pathway summary`);
+    assert.ok(pathway.caveat.length > 40, `${dossier.slug}/${configuration.id} needs a pathway caveat`);
+    assert.ok(pathway.sourceIds.every((sourceId) => configurationSourceIds.has(sourceId)));
+    assert.ok(pathway.sourceRevisionIds.every((revisionId) =>
+      configurationSourceRevisionIds.has(revisionId)));
+    const configurationNodeIds = new Set(configuration.nodes.map((node) => node.id));
+    const configurationLinkIds = new Set(configuration.links.map((link) => link.id));
+    const pathwayNodeIds = [
+      ...pathway.originNodeIds,
+      ...pathway.externalTransportNodeIds,
+      ...pathway.boundaryNodeIds,
+      ...pathway.receivingNodeIds,
+    ];
+    assert.equal(
+      new Set(pathwayNodeIds).size,
+      pathwayNodeIds.length,
+      `${dossier.slug}/${configuration.id} must assign one role per pathway node`,
+    );
+    assert.ok(pathwayNodeIds.every((nodeId) => configurationNodeIds.has(nodeId)));
+    assert.ok(pathway.linkIds.every((linkId) => configurationLinkIds.has(linkId)));
     for (const node of configuration.nodes) {
       assert.ok(node.sourceIds.length > 0, `${dossier.slug}/${configuration.id}/${node.id} needs sources`);
       assert.ok(node.sourceRevisionIds.length > 0, `${dossier.slug}/${configuration.id}/${node.id} needs revisions`);
@@ -423,6 +464,31 @@ for (const dossier of catalog.systems) {
     }
   }
 }
+
+const explicitInternetPaths = catalog.systems.flatMap((dossier) =>
+  dossier.networkEvidence.configurations
+    .filter((configuration) =>
+      configuration.externalPathway.internetReachability === "documented_in_reference_path")
+    .map((configuration) => `${dossier.slug}/${configuration.id}`));
+assert.deepEqual(explicitInternetPaths, [
+  "ess-evs-6400-ds200/ds200-michigan-evs-5320-wireless-sftp-path",
+]);
+assert.equal(
+  clearCount.networkEvidence.configurations[0].externalPathway.status,
+  "no_external_path_documented",
+);
+assert.equal(
+  clearCount.networkEvidence.configurations[0].externalPathway.internetReachability,
+  "explicitly_excluded",
+);
+assert.equal(
+  imageCastX.networkEvidence.configurations[0].externalPathway.status,
+  "physical_interface_only",
+);
+assert.equal(
+  ds950.networkEvidence.configurations[0].externalPathway.internetReachability,
+  "not_documented",
+);
 
 assert.match(apiList, /listEquipmentSystems/);
 assert.match(apiList, /catalogChannel/);
@@ -501,12 +567,19 @@ assert.match(networkEvidence, /Operational details withheld/);
 assert.match(networkEvidence, /EquipmentReferenceLightbox/);
 assert.match(networkEvidence, /No field-observed topology collected/);
 assert.match(networkEvidence, /sourceRevisionIds=\{selectedLink\.sourceRevisionIds\}/);
+assert.match(networkEvidence, /External pathway evidence/);
+assert.match(networkEvidence, /public-Internet reachability is shown only when a reviewed source says so/);
+assert.match(networkEvidence, /It does not establish a live connection, current deployment, attack path, or security finding/);
+assert.match(networkEvidence, /data-internet-reachability/);
 assert.match(topologyGraph, /ReactFlow/);
 assert.match(topologyGraph, /elk\.layout/);
 assert.match(topologyGraph, /Explore with force/);
 assert.match(topologyGraph, /Reset layout/);
 assert.match(topologyGraph, /prefers-reduced-motion/);
 assert.match(topologyGraph, /Dragging changes this view only/);
+assert.match(topologyGraph, /external-pathway-edge/);
+assert.match(topologyGraph, /External-path evidence/);
+assert.match(topologyGraph, /data-pathway-role/);
 assert.match(workspace, /equipmentExplorerEnabled &&/);
 assert.match(workspace, /equipment-catalog-link/);
 assert.match(workspace, /Component catalog/);

--- a/tests/e2e/equipment-catalog.spec.ts
+++ b/tests/e2e/equipment-catalog.spec.ts
@@ -423,6 +423,19 @@ test("keeps network topology claims source-bounded and interactive", async ({ pa
   await expect(networkEvidence.getByRole("heading", { name: "Documented topology, controls, and unknowns" })).toBeVisible();
   await expect(networkEvidence.getByText("1 sourced configuration view", { exact: true })).toBeVisible();
   await expect(networkEvidence.getByText("No field-observed topology collected", { exact: true })).toBeVisible();
+  const externalPathway = networkEvidence.locator("[data-external-pathway]");
+  await expect(externalPathway).toHaveAttribute("data-pathway-status", "no_external_path_documented");
+  await expect(externalPathway).toHaveAttribute("data-internet-reachability", "explicitly_excluded");
+  await expect(externalPathway.getByText("External pathway evidence", { exact: true })).toBeVisible();
+  await expect(externalPathway.getByText("No external path documented", { exact: true })).toBeVisible();
+  await expect(externalPathway.getByText(
+    "Explicitly excluded by reviewed sources",
+    { exact: true },
+  )).toBeVisible();
+  await expect(externalPathway.getByText(
+    "Evidence classification only. It does not establish a live connection, current deployment, attack path, or security finding.",
+    { exact: true },
+  )).toBeVisible();
   await expect(networkEvidence.getByText("Operational details withheld", { exact: true })).toBeVisible();
   await expect(networkEvidence.getByLabel("Interactive documented topology")).toBeVisible();
   const forceButton = networkEvidence.getByRole("button", { name: "Explore with force" });
@@ -491,12 +504,56 @@ test("keeps network topology claims source-bounded and interactive", async ({ pa
   const certifiedPath = ds200NetworkEvidence.getByRole("button", { name: /EVS 6.4.0.0 Regional Results test path/ });
   const optionalCellular = ds200NetworkEvidence.getByRole("button", { name: /Historical optional cellular hardware context/ });
   await expect(certifiedPath).toHaveAttribute("aria-pressed", "true");
+  const ds200PathwayEvidence = ds200NetworkEvidence.locator("[data-external-pathway]");
+  await expect(ds200PathwayEvidence).toHaveAttribute(
+    "data-pathway-status",
+    "documented_indirect_path",
+  );
+  await expect(ds200PathwayEvidence.getByText(
+    "External transport documented after a separate handoff",
+    { exact: true },
+  )).toBeVisible();
+  await expect(ds200PathwayEvidence.getByText(
+    "Not documented in this configuration",
+    { exact: true },
+  )).toBeVisible();
+  await expect(ds200PathwayEvidence.getByText(
+    "Separate result handoff; dossier device is not the endpoint",
+    { exact: true },
+  )).toBeVisible();
   await optionalCellular.click();
   await expect(optionalCellular).toHaveAttribute("aria-pressed", "true");
   await expect(ds200NetworkEvidence.getByRole("button", {
-    name: "MultiTech MTSMC-LVW3 Historical optional LTE alternative Optional",
+    name: /MultiTech MTSMC-LVW3 Historical optional LTE alternative.*Optional/,
   })).toBeVisible();
   await expect(ds200NetworkEvidence.getByText(/not evidence that EVS 6.4.0.0 certified/)).toBeVisible();
+  const historicalInternetPath = ds200NetworkEvidence.getByRole("button", {
+    name: /Michigan EVS 5\.3\.2\.0 wireless SFTP result path/,
+  });
+  await historicalInternetPath.click();
+  await expect(historicalInternetPath).toHaveAttribute("aria-pressed", "true");
+  await expect(ds200PathwayEvidence).toHaveAttribute(
+    "data-internet-reachability",
+    "documented_in_reference_path",
+  );
+  await expect(ds200PathwayEvidence.getByText(
+    "External path documented in a scoped reference",
+    { exact: true },
+  )).toBeVisible();
+  await expect(ds200PathwayEvidence.getByText(
+    "Shown in this scoped source",
+    { exact: true },
+  )).toBeVisible();
+  await expect(ds200PathwayEvidence.getByRole("button", { name: "Internet", exact: true }))
+    .toBeVisible();
+  await expect(ds200PathwayEvidence.getByRole("button", { name: "Regional Results", exact: true }))
+    .toBeVisible();
+  const ds200TopologyGraph = ds200NetworkEvidence.getByLabel("Interactive documented topology");
+  await expect(ds200TopologyGraph.locator("[data-pathway-role='transport']")).toHaveCount(3);
+  await expect(ds200TopologyGraph.locator(".external-pathway-edge")).toHaveCount(8);
+  await expect(ds200NetworkEvidence.getByText(
+    /historical 2017 procurement response for EVS 5\.3\.2\.0/,
+  )).toBeVisible();
 });
 
 test("renders central tabulators as three separate sourced systems", async ({ page, request }) => {


### PR DESCRIPTION
## What changed

- Added a required, source-bounded `externalPathway` classification to all nine reviewed topology configurations.
- Kept closed networks, physical interfaces, separate result handoffs, optional transport hardware, historical reference paths, and explicitly documented Internet paths distinct.
- Restored the Internet and Regional Results nodes and connections shown in the historical 2017 Michigan EVS 5.3.2.0 vendor/procurement diagram.
- Added an “External pathway evidence” panel with Internet reachability, dossier-connection status, role-grouped nodes, exact highlighted connections, source revisions, and scope caveats.
- Added amber external-path highlights to the draggable/zoomable topology while retaining deterministic layout, optional force exploration, accessible node/link controls, and mobile behavior.
- Updated catalog generation, validation, shared catalog types, tour copy, navigation copy, workflow documentation, generated public/staging catalogs, and API/browser contracts.

## Why

Equipment topology should make any reviewed route beyond a closed local boundary easy to find without converting connector presence, a VPN, cellular capability, or a historical vendor diagram into a claim about a current field deployment. This update documents the crucial external-path question while keeping each statement pinned to its exact source and version.

The reviewed corpus contains one configuration that explicitly names or depicts the Internet: the historical Michigan EVS 5.3.2.0 reference. The exact EVS 6.4.0.0 Regional Results test path documents a customer-dedicated VPN but does not identify public-Internet transit or make the DS200 the VPN endpoint.

## Public evidence boundary

The new labels do not establish a live connection, current deployment, attack path, exploitability, election use, security incident, or incorrect result. Site-specific addresses, credentials, keys, APNs, SIM identifiers, carrier accounts, firewall rules, and routing details remain excluded.

## Validation

- `npm run equipment:catalog:build`
- `npm run test:equipment-catalog`
- `npm run typecheck`
- `npm run build`
- Focused topology Playwright test: 1 passed
- Full Equipment Explorer Playwright suite: 19 passed
- Desktop Chromium: closed path = 0 highlighted external edges; Michigan reference = 8; no console errors, framework overlay, or horizontal overflow
- Mobile Chromium at 390 px: no console errors, framework overlay, or horizontal overflow
