### PR TITLE
Harden Minnesota hidden precinct release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,8 @@ jobs:
       - name: Electronic integrity request workflow validation
         run: npm run validate:electronic-integrity-requests
 
-      - name: Production map join validation
-        run: npm run validate:maps
-
-      - name: Production provenance validation
-        run: npm run validate:provenance
+      - name: Map geometry validation
+        run: npm run validate:map-geometry
 
       - name: Feature-enabled public equipment build
         run: npm run build

--- a/.github/workflows/production-data-smoke.yml
+++ b/.github/workflows/production-data-smoke.yml
@@ -1,0 +1,35 @@
+name: Production data smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 11 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-data-smoke
+  cancel-in-progress: false
+
+jobs:
+  validate-production-data:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Production map join validation
+        run: npm run validate:maps
+
+      - name: Production provenance validation
+        if: ${{ always() }}
+        run: npm run validate:provenance

--- a/docs/developer/mn-precinct-release-runbook.md
+++ b/docs/developer/mn-precinct-release-runbook.md
@@ -182,6 +182,25 @@ The guarded browser rehearsal must additionally pass for all four years with
 `crm_clone_dev` server. A new candidate, overlay, or review hash supersedes the
 earlier confirmation and requires the new review record to be confirmed.
 
+From that clean, fully checked integration tree, generate the deterministic
+project-owner confirmation template. This command writes only a `NO_GO` record
+under `.etl/precinct-release-confirmations/MN/` and refuses a tracked-dirty Git
+tree:
+
+```powershell
+npm.cmd run precinct-gis:production-release:mn -- --package=$PKG --overlay=$OVERLAY --review=$REVIEW --write-confirmation-template
+```
+
+The template pins the exact package, overlay, review, clean `HEAD` commit, Git
+tree, and empty tracked-status hash. After reviewing those exact artifacts, the
+project owner may complete only `decision` (`GO_OWNER_CONFIRMATION`),
+`confirmedAtUtc`, `confirmedBy`, and `review.confirmed` (`true`). Do not alter
+the fixed confirmation text, hashes, Git evidence, or the all-false production,
+publication, activation, deployment, and Git authorization fields. The hidden-
+load runner rechecks the same clean Git tree and requires the confirmer and
+database operator to be different people. This confirmation still authorizes
+no production action by itself.
+
 ## Production-readiness commands
 
 The release-specific preflight defaults to a no-connection plan. It does not
@@ -214,18 +233,30 @@ the following simultaneously:
 - a fresh hash-pinned read-only preflight no more than four hours old;
 - a fresh checksummed backup no more than four hours old with recorded restore
   verification, covering the complete `public` schema with no excluded table
-  data;
+  data; the backup must be created after the approved preflight, and its restore
+  proof must show the exact source table set, archive table-data set, row counts,
+  read-only restored database, and zero invalid constraints. Restore
+  verification must follow backup creation, must not be in the future, and must
+  also be within the four-hour release window;
+- exact hash-pinned overlay, machine review, and project-owner confirmation
+  artifacts whose package/overlay/review relationships all match;
 - a `GO_PRODUCTION` authorization record naming authorizer, operator, verifier,
-  and rollback owner, with at least two independent people;
-- an active deployment window and rollback decision time;
+  and rollback owner, with at least two independent people after Unicode/case
+  normalization;
+- an active deployment window whose rollback decision time has not passed;
 - the exact database scopes for migration 0008, hidden Minnesota load, and
   public-revision increment;
 - `CRM_DATABASE_ENVIRONMENT=production`, the exact package hash in
   `CRM_MN_PRECINCT_PRODUCTION_WRITES`, and the exact authorization ID in
-  `CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_ID`.
+  `CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_ID`; and
+- the SHA-256 of the exact completed authorization file both in
+  `CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256` and the required
+  `--authorization-sha256` option.
 
 When those guards pass, migration 0008 and the four-election hidden load run in
-one PostgreSQL transaction. All source and package hashes are rechecked before
+one PostgreSQL transaction. The evidence freshness, authorization expiry,
+deployment window, rollback cutoff, and clean Git tree are rechecked immediately
+before the first transaction query. All source and package hashes are rechecked before
 connection, every expected database count is validated inside the transaction,
 and any error rolls back both schema and data. The transaction leaves geography
 versions blocked and does not write public files, edit canonical manifests, or
@@ -326,21 +357,23 @@ build, maps validation, provenance validation, source-package validation, and
 the normal Minnesota advisory report. Advisory indicators are review signals,
 not evidence of fraud or misconduct.
 
-### 2. Backup and read-only preflight
+### 2. Read-only preflight and verified backup
 
-Before any write, create the verified production backup and perform the current
-read-only preflight. Stop if the schema, live Minnesota year set, row counts,
+Before any write, perform the current read-only preflight first, then use its
+exact 64-hex endpoint fingerprint to create and restore-verify the full
+production backup. Stop if the schema, live Minnesota year set, row counts,
 source records, or public revision differ from the approved release record.
 
 Compare the live and proposed Minnesota years explicitly. No existing year or
 row may be removed merely because it is absent from a candidate artifact.
 
-### 3. Apply the additive schema
+### 3. Inspect the additive schema preconditions
 
-Apply the exact pinned migration in a single migration transaction. Verify all
+Inspect the exact pinned migration and the read-only preflight evidence for all
 four tables, three nullable reporting-unit foreign-key columns, indexes, unique
-constraints, foreign keys, and check constraints. Stop and roll back if any
-object conflicts with current production.
+constraints, foreign keys, and check constraints. Do not apply the migration in
+this step. The guarded hidden-load command below applies it in the same
+transaction as the data load and stops if any object conflicts with production.
 
 ### 4. Load data while public delivery remains blocked
 
@@ -359,6 +392,48 @@ In one reviewed Minnesota-specific transaction:
 8. verify totals, zero-vote units, same-election links, source provenance, and
    constraints inside the transaction;
 9. commit only if every expected count and semantic hash agrees.
+
+Migration 0008 and the hidden load are coupled in this one transaction; do not
+run the migration separately. After hashing the completed authorization file,
+set the guarded acknowledgements and execute the exact receipt-producing
+command:
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production'
+$env:CRM_MN_PRECINCT_PRODUCTION_WRITES=$PKG_SHA
+$env:CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_ID=$AUTH_ID
+$env:CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256=$AUTH_SHA
+npm.cmd run precinct-gis:production-release:mn -- --package=$PKG --preflight=$PREFLIGHT --backup-manifest=$BACKUP_MANIFEST --authorization=$AUTH --authorization-sha256=$AUTH_SHA --receipt=$HIDDEN_RECEIPT --apply
+```
+
+The authorization must reference the exact `.etl` overlay, review, and
+project-owner confirmation paths and SHA-256 values. The runner re-hashes all
+three, validates their package-to-overlay-to-review relationship, and records
+them plus the exact authorization, preflight, backup, endpoint, transaction
+time, and public-revision audit in both the hidden-load receipt and the loaded
+database metadata. The explicit receipt target is reserved before PostgreSQL is
+opened and finalized with an atomic rename after commit.
+
+If the database transaction commits but the local final receipt cannot be
+written, or if the connection fails after the transaction attempt begins and
+the COMMIT acknowledgement is ambiguous, keep the `.pending` reservation and do
+not rerun `--apply`. Reconcile the outcome by recovering a distinct, explicitly
+marked receipt with a read-only database transaction:
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production-read-only'
+$env:CRM_MN_PRECINCT_RECEIPT_RECOVERY_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256=$AUTH_SHA
+npm.cmd run precinct-gis:production-release:mn -- --package=$PKG --preflight=$PREFLIGHT --backup-manifest=$BACKUP_MANIFEST --authorization=$AUTH --authorization-sha256=$AUTH_SHA --receipt=$HIDDEN_RECEIPT --recover-receipt
+```
+
+Recovery re-hashes every original evidence artifact, evaluates its timing at
+the database-persisted transaction time, requires all four years and every
+loaded metadata surface to retain the exact blocked audit, and requires the
+current public revision to equal the committed hidden-load revision. It opens
+`BEGIN READ ONLY`, performs no production mutation, and fails closed on any
+package, endpoint, authorization, row, provenance, audit, status, or revision
+drift.
 
 The canonical manifests remain blocked throughout this phase, so the public
 manifest and precinct-geometry APIs cannot expose the new layers. Both public
@@ -590,11 +665,12 @@ same-election identity, source term, constraint, API response, or UI result
 differs from the reviewed package.
 
 Before a transaction commits, let the transaction roll back and leave canonical
-manifests blocked. After application cutover, restore the immediately previous
-application deployment so the eligible manifests and geometry endpoints
-disappear together. Restore the verified pre-release database backup, or use a
-separately reviewed Minnesota-only rollback, if committed database changes must
-be reversed.
+manifests blocked. After public cutover, block the database publication state
+first while the activated gate-capable application remains live; both precinct
+endpoints then fail closed. Only afterward restore the exact previous deployment
+pinned in the publication receipt. Restore the verified pre-release database
+backup, or use a separately reviewed Minnesota-only rollback, if the earlier
+hidden-load transaction itself must be reversed.
 
 Do not drop the additive precinct schema during an ordinary Minnesota rollback;
 other states or subsequent work may depend on it. Do not overwrite or reuse the

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -6722,3 +6722,24 @@ evidence against its verified top-level package.
   production release. No production database write, Blob upload, Vercel
   environment mutation, manifest activation, deployment promotion, or public
   data cutover occurred during this checkpoint.
+
+### 2026-08-08 - Production data smoke isolation
+
+- PR #211 exposed a live-environment regression rather than a change-local map
+  failure: the deployed API was reading a newly connected starter Neon database
+  containing only the Wisconsin, Minnesota, and Washington starter county rows.
+  The 51-state geometry validator remained green, while the pull-request job's
+  live request to `civicresultmaps.org` correctly found the other production
+  county joins missing.
+
+- Pull-request CI now gates the deterministic, repository-owned 51-state map
+  geometry validation. Strict live map-join and provenance validation remains
+  enabled in a separate scheduled and manually dispatchable production-data
+  smoke workflow. That workflow has no soft-failure setting, so incomplete live
+  data remains a visible production alarm without making an unrelated pull
+  request's result depend on mutable production state.
+
+- This workflow separation does not authorize or perform a production data
+  promotion, database mutation, environment change, or Minnesota public
+  activation. Restoring the complete production result corpus remains a
+  separate reviewed production operation.

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -6668,3 +6668,57 @@ evidence against its verified top-level package.
   production load, public status change, Blob upload, Vercel environment edit,
   deployment, or Git publication was performed while closing these review
   findings.
+
+### 2026-08-08 - Minnesota hidden-load authorization hardening
+
+- A post-merge release rehearsal stopped before the first production write
+  when independent review found that the hidden-load runner did not bind the
+  exact `GO_PRODUCTION` authorization bytes, treated differently cased versions
+  of one name as distinct release people, and allowed execution after the
+  recorded rollback-decision cutoff. The runner now requires the authorization
+  artifact SHA-256 in both its CLI and environment acknowledgements, normalizes
+  release identities with Unicode normalization plus case folding, and rejects
+  execution after that cutoff.
+
+- The documented release-overlay, release-review, and project-owner
+  confirmation gates are now executable inputs rather than manual prose only.
+  A deterministic `NO_GO_OWNER_CONFIRMATION` template pins the clean integration
+  commit/tree and empty tracked-status hash; the project owner must explicitly
+  complete it, and the runner rechecks the same tree and requires a different
+  database operator.
+  Their exact safe `.etl` paths and SHA-256 values are carried in the
+  authorization, relationship-validated against the sealed package, and
+  written into the hidden-load receipt. Backup evidence now proves that the
+  backup follows preflight and that restore verification occurred at or after
+  backup creation, is not future-dated, exactly matches every public table and
+  row count, uses a read-only restored database, has zero invalid constraints,
+  and remains within the same four-hour freshness window.
+
+- The production release audit is persisted with the loaded Minnesota database
+  metadata, not solely in the local post-commit receipt. It binds the exact
+  authorization, overlay, review, confirmation, preflight, backup/dump,
+  endpoint, authorization ID, transaction time, and public revision.
+  Existing-row validation and the later public-activation transaction require
+  exact semantic equality between the receipt audit and live database audit.
+  The output path is reserved before opening PostgreSQL and finalized atomically
+  after commit. If finalization fails, a separately acknowledged read-only mode
+  can reconstruct a distinct recovery receipt from the exact blocked database
+  audit and artifacts; it rejects revision or metadata drift and never retries
+  the production mutation.
+
+- The runbook now gives the executable order as read-only preflight, full
+  restore-verified backup, exact two-person authorization, and hidden load. It
+  also preserves the fail-closed rollback order: block the database while the
+  gate-capable application is live, then restore only the pinned prior
+  deployment.
+
+- Expanded focused Minnesota release, activation, deterministic projection,
+  and publication-gate tests pass, including authorization-byte tampering,
+  backup/restore timing and exact counts, case-normalized roles, release-
+  evidence binding, transaction-time cutoff revalidation, post-commit receipt
+  failure/read-only recovery, and a mismatched hidden-load audit. TypeScript
+  validation also passes. The candidate
+  sealed before these changes is intentionally stale and cannot be used for a
+  production release. No production database write, Blob upload, Vercel
+  environment mutation, manifest activation, deployment promotion, or public
+  data cutover occurred during this checkpoint.

--- a/docs/native-import-source-packages.md
+++ b/docs/native-import-source-packages.md
@@ -105,7 +105,7 @@ Expected validation:
 | Local release-candidate geometry features | 16,435 |
 | Local release-candidate reviewed exact crosswalks | 16,435 |
 
-Caveat: the ordinary 2024 native staging artifact remains distinct from the four-election release candidate. The 2016 and 2020 LCC election attributes are preliminary and are excluded from public vote data; certified SOS workbooks are the sole vote authority. All four local geometry/result pairs reconcile by exact VTDID. The hidden-load implementation is not enabled: shared-overlay review, a current restoration-verified production backup and read-only preflight, independent transaction review, named deployment/rollback ownership, and explicit authorization are still required. Public file placement and canonical-manifest activation remain separate later decisions.
+Caveat: the ordinary 2024 native staging artifact remains distinct from the four-election release candidate. The 2016 and 2020 LCC election attributes are preliminary and are excluded from public vote data; certified SOS workbooks are the sole vote authority. All four local geometry/result pairs reconcile by exact VTDID. The guarded hidden-load implementation exists but has not been executed in production. It requires a fresh merged-main candidate, exact overlay/review/project-owner-confirmation hashes, a current read-only preflight, a current full-schema restoration-verified backup, two independently named people, an active rollback window, and a SHA-pinned `GO_PRODUCTION` record. Public Blob placement and receipt-bound canonical/database activation remain separate later decisions.
 
 ## Michigan
 

--- a/scripts/apply-mn-precinct-release.mjs
+++ b/scripts/apply-mn-precinct-release.mjs
@@ -2,8 +2,11 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  renameSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import postgres from "postgres";
@@ -14,16 +17,22 @@ import {
   buildMinnesotaPrecinctGisPlan,
 } from "./lib/mn-precinct-gis-plan.mjs";
 import {
+  readMinnesotaPersistedProductionReleaseAudit,
+  validateMinnesotaPrecinctGisClient,
+} from "./lib/mn-precinct-gis-db.mjs";
+import {
   productionEndpointFingerprint,
   sha256,
 } from "./lib/mn-precinct-production-preflight.mjs";
 import {
   applyMinnesotaProductionReleaseTransaction,
+  buildMinnesotaOwnerConfirmationTemplate,
   buildMinnesotaProductionAuthorizationTemplate,
   readAndVerifyEvidenceFile,
   validateMinnesotaProductionAuthorization,
   validateMinnesotaProductionBackupEvidence,
   validateMinnesotaProductionPreflightEvidence,
+  validateMinnesotaProductionReviewEvidence,
 } from "./lib/mn-precinct-production-release.mjs";
 
 // Never load .env.local. A production database write requires an exact package
@@ -38,9 +47,18 @@ function parseArguments(args) {
     "--preflight",
     "--backup-manifest",
     "--authorization",
+    "--authorization-sha256",
+    "--confirmation",
+    "--overlay",
+    "--review",
     "--receipt",
   ]);
-  const flags = new Set(["--apply", "--write-authorization-template"]);
+  const flags = new Set([
+    "--apply",
+    "--recover-receipt",
+    "--write-authorization-template",
+    "--write-confirmation-template",
+  ]);
   for (const arg of args) {
     if (flags.has(arg)) continue;
     const name = arg.includes("=") ? arg.slice(0, arg.indexOf("=")) : arg;
@@ -55,9 +73,115 @@ function parseArguments(args) {
     preflightPath: value("--preflight"),
     backupManifestPath: value("--backup-manifest"),
     authorizationPath: value("--authorization"),
+    authorizationSha256: value("--authorization-sha256"),
+    confirmationPath: value("--confirmation"),
+    overlayPath: value("--overlay"),
+    reviewPath: value("--review"),
     receiptPath: value("--receipt"),
     apply: args.includes("--apply"),
+    recoverReceipt: args.includes("--recover-receipt"),
     writeAuthorizationTemplate: args.includes("--write-authorization-template"),
+    writeConfirmationTemplate: args.includes("--write-confirmation-template"),
+  };
+}
+
+function authorizationEvidenceReference(authorization, key, label) {
+  const reference = authorization?.evidence?.[key];
+  if (
+    typeof reference?.path !== "string"
+    || !reference.path
+    || !/^[a-f0-9]{64}$/.test(reference?.sha256 ?? "")
+  ) {
+    throw new Error(`Minnesota production authorization requires ${label} path and SHA-256`);
+  }
+  return reference;
+}
+
+export function assertMinnesotaProductionReleaseEnvironment(
+  expected,
+  environment = process.env,
+) {
+  if (environment.CRM_DATABASE_ENVIRONMENT !== "production") {
+    throw new Error("Minnesota production release requires CRM_DATABASE_ENVIRONMENT=production");
+  }
+  if (environment.CRM_MN_PRECINCT_PRODUCTION_WRITES !== expected.packageSha256) {
+    throw new Error("Minnesota production-write acknowledgement must equal the package SHA-256");
+  }
+  if (
+    environment.CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_ID
+      !== expected.authorizationId
+  ) {
+    throw new Error("Minnesota production authorization-ID acknowledgement is missing");
+  }
+  if (
+    environment.CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256
+      !== expected.authorizationSha256
+  ) {
+    throw new Error("Minnesota production authorization-SHA acknowledgement is missing");
+  }
+}
+
+export function assertMinnesotaReceiptRecoveryEnvironment(
+  expected,
+  environment = process.env,
+) {
+  if (environment.CRM_DATABASE_ENVIRONMENT !== "production-read-only") {
+    throw new Error("Minnesota hidden receipt recovery requires CRM_DATABASE_ENVIRONMENT=production-read-only");
+  }
+  if (
+    environment.CRM_MN_PRECINCT_RECEIPT_RECOVERY_PACKAGE_SHA256
+      !== expected.packageSha256
+  ) {
+    throw new Error("Minnesota hidden receipt recovery package acknowledgement is missing");
+  }
+  if (
+    environment.CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256
+      !== expected.authorizationSha256
+  ) {
+    throw new Error("Minnesota hidden receipt recovery authorization-SHA acknowledgement is missing");
+  }
+}
+
+export function inspectMinnesotaCleanIntegration(
+  root,
+  runner = spawnSync,
+) {
+  const run = (args) => {
+    const result = runner("git", args, {
+      cwd: root,
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    if (result.status !== 0) {
+      throw new Error(
+        "Minnesota clean-integration Git inspection failed: "
+          + String(result.stderr ?? "").trim(),
+      );
+    }
+    return String(result.stdout ?? "").trim();
+  };
+  const gitSha = run(["rev-parse", "HEAD"]);
+  const gitTreeSha = run(["rev-parse", "HEAD^{tree}"]);
+  const trackedStatus = run([
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=no",
+  ]);
+  if (
+    !/^[a-f0-9]{40}$/.test(gitSha)
+    || !/^[a-f0-9]{40}$/.test(gitTreeSha)
+    || trackedStatus
+  ) {
+    throw new Error("Minnesota release confirmation requires a clean tracked Git integration tree");
+  }
+  return {
+    gitSha,
+    gitTreeSha,
+    trackedStatusSha256: sha256(Buffer.from(trackedStatus, "utf8")),
+    trackedStatusClean: true,
+    diffCheckPassed: true,
+    missingPaths: 0,
+    unexpectedPaths: 0,
   };
 }
 
@@ -221,11 +345,122 @@ function writeJson(target, value) {
   };
 }
 
+function jsonBytes(value) {
+  return Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+export function reserveMinnesotaReceiptTarget(
+  target,
+  reservation,
+  options = {},
+) {
+  if (existsSync(target.absolute)) {
+    throw new Error("Minnesota hidden-load receipt target already exists");
+  }
+  mkdirSync(path.dirname(target.absolute), { recursive: true });
+  const pending = {
+    absolute: target.absolute + ".pending",
+    relativePath: target.relativePath + ".pending",
+    bytes: jsonBytes(reservation),
+  };
+  if (existsSync(pending.absolute)) {
+    if (
+      options.allowExisting === true
+      && readFileSync(pending.absolute).equals(pending.bytes)
+    ) {
+      return { ...pending, disposition: "reused" };
+    }
+    throw new Error("Minnesota hidden-load receipt reservation already exists");
+  }
+  try {
+    writeFileSync(pending.absolute, pending.bytes, { flag: "wx" });
+  } catch (error) {
+    throw new Error(
+      "Minnesota hidden-load receipt target could not be reserved before production: "
+        + (error instanceof Error ? error.message : String(error)),
+    );
+  }
+  return { ...pending, disposition: "created" };
+}
+
+export function releaseMinnesotaReceiptReservation(target, pending) {
+  if (
+    existsSync(pending.absolute)
+    && !existsSync(target.absolute)
+    && readFileSync(pending.absolute).equals(pending.bytes)
+  ) {
+    unlinkSync(pending.absolute);
+  }
+}
+
+export function finalizeMinnesotaReceipt(target, pending, value) {
+  const bytes = jsonBytes(value);
+  if (existsSync(target.absolute)) {
+    if (!readFileSync(target.absolute).equals(bytes)) {
+      throw new Error("Refusing to overwrite different Minnesota hidden-load receipt");
+    }
+    let pendingCleanupRequired = false;
+    if (existsSync(pending.absolute) && readFileSync(pending.absolute).equals(pending.bytes)) {
+      try {
+        unlinkSync(pending.absolute);
+      } catch {
+        pendingCleanupRequired = true;
+      }
+    }
+    return {
+      path: target.relativePath,
+      byteCount: bytes.length,
+      sha256: sha256(bytes),
+      disposition: "verified_existing",
+      pendingCleanupRequired,
+    };
+  }
+  if (
+    !existsSync(pending.absolute)
+    || !readFileSync(pending.absolute).equals(pending.bytes)
+  ) {
+    throw new Error("Minnesota hidden-load receipt reservation drifted after commit");
+  }
+  const temporary = target.absolute + ".write-" + sha256(bytes).slice(0, 16) + ".tmp";
+  if (existsSync(temporary)) {
+    if (!readFileSync(temporary).equals(bytes)) {
+      throw new Error("Minnesota hidden-load receipt temporary file drifted");
+    }
+  } else {
+    writeFileSync(temporary, bytes, { flag: "wx" });
+  }
+  renameSync(temporary, target.absolute);
+  let pendingCleanupRequired = false;
+  if (existsSync(pending.absolute) && readFileSync(pending.absolute).equals(pending.bytes)) {
+    try {
+      unlinkSync(pending.absolute);
+    } catch {
+      pendingCleanupRequired = true;
+    }
+  }
+  return {
+    path: target.relativePath,
+    byteCount: bytes.length,
+    sha256: sha256(bytes),
+    disposition: "created",
+    pendingCleanupRequired,
+  };
+}
+
 export async function runMinnesotaProductionRelease(options = {}) {
   const root = path.resolve(options.root ?? process.cwd());
   const parsed = options.packagePath
     ? options
     : parseArguments(process.argv.slice(2));
+  if (parsed.apply && parsed.recoverReceipt) {
+    throw new Error("Minnesota production apply and receipt recovery are mutually exclusive");
+  }
+  if (
+    (parsed.apply || parsed.recoverReceipt)
+    && (parsed.writeAuthorizationTemplate || parsed.writeConfirmationTemplate)
+  ) {
+    throw new Error("Minnesota production template writes cannot accompany apply or recovery");
+  }
   const loaded = safeReleasePackage(root, parsed.packagePath);
   const verifiedInputCount = verifyCurrentReleaseInputs(root, loaded.document);
   const template = buildMinnesotaProductionAuthorizationTemplate(
@@ -241,7 +476,38 @@ export async function runMinnesotaProductionRelease(options = {}) {
     );
     templateArtifact = writeJson(target, template);
   }
-  if (!parsed.apply) {
+  let confirmationTemplateArtifact = null;
+  if (parsed.writeConfirmationTemplate) {
+    if (!parsed.overlayPath || !parsed.reviewPath) {
+      throw new Error("--overlay and --review are required for --write-confirmation-template");
+    }
+    const overlayArtifact = readAndVerifyEvidenceFile(root, parsed.overlayPath);
+    const reviewArtifact = readAndVerifyEvidenceFile(root, parsed.reviewPath);
+    const cleanIntegration = inspectMinnesotaCleanIntegration(
+      root,
+      options.gitRunner ?? spawnSync,
+    );
+    const confirmationTemplate = buildMinnesotaOwnerConfirmationTemplate({
+      releaseCandidate: loaded.releaseCandidate,
+      releaseCandidatePath: parsed.packagePath,
+      overlay: overlayArtifact,
+      overlayDocument: JSON.parse(overlayArtifact.bytes.toString("utf8")),
+      review: reviewArtifact,
+      reviewDocument: JSON.parse(reviewArtifact.bytes.toString("utf8")),
+      cleanIntegration,
+    });
+    const target = outputPath(
+      root,
+      parsed.confirmationPath,
+      "mn-precinct-owner-confirmation-template-"
+        + loaded.artifact.sha256.slice(0, 12) + "-"
+        + overlayArtifact.sha256.slice(0, 12) + "-"
+        + reviewArtifact.sha256.slice(0, 12) + ".json",
+      "precinct-release-confirmations",
+    );
+    confirmationTemplateArtifact = writeJson(target, confirmationTemplate);
+  }
+  if (!parsed.apply && !parsed.recoverReceipt) {
     return {
       mode: "plan",
       state: "MN",
@@ -253,6 +519,7 @@ export async function runMinnesotaProductionRelease(options = {}) {
       publicFileWritten: false,
       canonicalManifestChanged: false,
       authorizationTemplate: templateArtifact,
+      confirmationTemplate: confirmationTemplateArtifact,
       requiredEvidence: [
         "fresh read-only production preflight",
         "fresh checksummed backup with restoration verification",
@@ -262,52 +529,342 @@ export async function runMinnesotaProductionRelease(options = {}) {
     };
   }
 
-  if (!parsed.preflightPath || !parsed.authorizationPath) {
-    throw new Error("--preflight and --authorization are required for --apply");
+  if (
+    !parsed.preflightPath
+    || !parsed.authorizationPath
+    || !/^[a-f0-9]{64}$/.test(parsed.authorizationSha256 ?? "")
+    || !parsed.receiptPath
+  ) {
+    throw new Error(
+      "--preflight, --authorization, --authorization-sha256, and --receipt are required for production apply or recovery",
+    );
   }
   const preflightArtifact = readAndVerifyEvidenceFile(root, parsed.preflightPath);
-  const authorizationArtifact = readAndVerifyEvidenceFile(root, parsed.authorizationPath);
-  const backupArtifact = safeTmpBackupManifest(parsed.backupManifestPath);
-  const now = options.now ?? new Date();
-  const databaseUrl = productionUrl();
+  const authorizationArtifact = readAndVerifyEvidenceFile(
+    root,
+    parsed.authorizationPath,
+    parsed.authorizationSha256,
+  );
+  const backupArtifact = options.backupArtifact
+    ?? safeTmpBackupManifest(parsed.backupManifestPath);
+  const clock = options.nowFactory
+    ?? (() => options.now ?? new Date());
+  const currentTime = () => {
+    const value = clock();
+    const result = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    if (Number.isNaN(result.getTime())) {
+      throw new Error("Minnesota production release clock returned an invalid time");
+    }
+    return result;
+  };
+  const databaseUrl = options.databaseUrl ?? productionUrl();
   const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
   const preflight = JSON.parse(preflightArtifact.bytes.toString("utf8"));
   const backup = backupArtifact.value;
   const authorization = JSON.parse(authorizationArtifact.bytes.toString("utf8"));
-  const context = {
-    now,
-    endpointFingerprint,
-    releaseCandidate: loaded.releaseCandidate,
-  };
-  const preflightEvidence = validateMinnesotaProductionPreflightEvidence(
-    preflight,
-    context,
-  );
-  const backupEvidence = validateMinnesotaProductionBackupEvidence(
-    backup,
-    context,
-  );
-  const backupDump = verifyBackupDump(backupArtifact);
-  const authorizationEvidence = validateMinnesotaProductionAuthorization(
+  const overlayReference = authorizationEvidenceReference(
     authorization,
-    {
-      ...context,
-      preflightSha256: preflightArtifact.sha256,
-      backupManifestSha256: backupArtifact.sha256,
-    },
+    "releaseOverlay",
+    "the release overlay evidence",
   );
-  if (process.env.CRM_DATABASE_ENVIRONMENT !== "production") {
-    throw new Error("Minnesota production release requires CRM_DATABASE_ENVIRONMENT=production");
+  const reviewReference = authorizationEvidenceReference(
+    authorization,
+    "releaseReview",
+    "the release review evidence",
+  );
+  const confirmationReference = authorizationEvidenceReference(
+    authorization,
+    "releaseConfirmation",
+    "the human confirmation evidence",
+  );
+  const overlayArtifact = readAndVerifyEvidenceFile(
+    root,
+    overlayReference.path,
+    overlayReference.sha256,
+  );
+  const reviewArtifact = readAndVerifyEvidenceFile(
+    root,
+    reviewReference.path,
+    reviewReference.sha256,
+  );
+  const confirmationArtifact = readAndVerifyEvidenceFile(
+    root,
+    confirmationReference.path,
+    confirmationReference.sha256,
+  );
+  const overlayDocument = JSON.parse(overlayArtifact.bytes.toString("utf8"));
+  const reviewDocument = JSON.parse(reviewArtifact.bytes.toString("utf8"));
+  const confirmationDocument = JSON.parse(
+    confirmationArtifact.bytes.toString("utf8"),
+  );
+  const backupDump = options.backupDump ?? verifyBackupDump(backupArtifact);
+  const validateEvidenceAt = (now, cleanIntegration) => {
+    const context = {
+      now,
+      endpointFingerprint,
+      releaseCandidate: loaded.releaseCandidate,
+    };
+    const preflightEvidence = validateMinnesotaProductionPreflightEvidence(
+      preflight,
+      context,
+    );
+    const backupEvidence = validateMinnesotaProductionBackupEvidence(
+      backup,
+      {
+        ...context,
+        preflightCapturedAtUtc: preflightEvidence.capturedAtUtc,
+      },
+    );
+    const releaseReviewEvidence = validateMinnesotaProductionReviewEvidence({
+      overlay: overlayDocument,
+      review: reviewDocument,
+      confirmation: confirmationDocument,
+    }, {
+      now,
+      authorizedAtUtc: authorization.authorizedAtUtc,
+      operator: authorization.people?.operator,
+      releaseCandidate: loaded.releaseCandidate,
+      releaseCandidatePath: parsed.packagePath,
+      overlay: overlayArtifact,
+      review: reviewArtifact,
+      confirmation: confirmationArtifact,
+      cleanIntegration,
+    });
+    const authorizationEvidence = validateMinnesotaProductionAuthorization(
+      authorization,
+      {
+        ...context,
+        preflightPath: preflightArtifact.path,
+        preflightSha256: preflightArtifact.sha256,
+        backupManifestPath: backupArtifact.path,
+        backupManifestSha256: backupArtifact.sha256,
+        releaseOverlayPath: overlayArtifact.path,
+        releaseOverlaySha256: overlayArtifact.sha256,
+        releaseReviewPath: reviewArtifact.path,
+        releaseReviewSha256: reviewArtifact.sha256,
+        releaseConfirmationPath: confirmationArtifact.path,
+        releaseConfirmationSha256: confirmationArtifact.sha256,
+      },
+    );
+    return {
+      preflightEvidence,
+      backupEvidence,
+      releaseReviewEvidence,
+      authorizationEvidence,
+    };
+  };
+  const cleanIntegration = () => options.cleanIntegration
+    ?? inspectMinnesotaCleanIntegration(root, options.gitRunner ?? spawnSync);
+  const baseReleaseAudit = (authorizationId) => ({
+    authorization: {
+      path: authorizationArtifact.path,
+      sha256: authorizationArtifact.sha256,
+    },
+    releaseOverlay: {
+      path: overlayArtifact.path,
+      sha256: overlayArtifact.sha256,
+    },
+    releaseReview: {
+      path: reviewArtifact.path,
+      sha256: reviewArtifact.sha256,
+    },
+    releaseConfirmation: {
+      path: confirmationArtifact.path,
+      sha256: confirmationArtifact.sha256,
+    },
+    preflight: {
+      path: preflightArtifact.path,
+      sha256: preflightArtifact.sha256,
+    },
+    backupManifest: {
+      sha256: backupArtifact.sha256,
+      dumpSha256: backupDump.sha256,
+    },
+    authorizationId,
+    endpointFingerprint,
+  });
+  const plan = (options.planBuilder ?? buildMinnesotaPrecinctGisPlan)({ root });
+  const receiptTarget = outputPath(
+    root,
+    parsed.receiptPath,
+    "mn-precinct-production-receipt-"
+      + loaded.artifact.sha256.slice(0, 12) + "-"
+      + authorizationArtifact.sha256.slice(0, 12) + ".json",
+    "production-release-receipts",
+  );
+  const reservationDocument = {
+    schemaVersion: 1,
+    state: "MN",
+    status: "PENDING_HIDDEN_LOAD_RECEIPT",
+    target: receiptTarget.relativePath,
+    releaseCandidate: {
+      id: loaded.releaseCandidate.id,
+      sha256: loaded.releaseCandidate.sha256,
+    },
+    authorization: {
+      path: authorizationArtifact.path,
+      sha256: authorizationArtifact.sha256,
+    },
+    preflight: {
+      path: preflightArtifact.path,
+      sha256: preflightArtifact.sha256,
+    },
+    backupManifestSha256: backupArtifact.sha256,
+  };
+
+  if (parsed.recoverReceipt) {
+    assertMinnesotaReceiptRecoveryEnvironment({
+      packageSha256: loaded.artifact.sha256,
+      authorizationSha256: authorizationArtifact.sha256,
+    }, options.environment ?? process.env);
+    const pending = reserveMinnesotaReceiptTarget(
+      receiptTarget,
+      reservationDocument,
+      { allowExisting: true },
+    );
+    let sql;
+    try {
+      sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+        max: 1,
+        connect_timeout: 10,
+        idle_timeout: 20,
+        connection: {
+          application_name: "civicresultmaps-mn-precinct-hidden-receipt-recovery",
+        },
+      });
+    } catch (error) {
+      if (pending.disposition === "created") {
+        releaseMinnesotaReceiptReservation(receiptTarget, pending);
+      }
+      throw error;
+    }
+    let recovered;
+    try {
+      recovered = await sql.begin("read only", async (tx) => {
+        const persistedAudit = await readMinnesotaPersistedProductionReleaseAudit(
+          tx,
+          loaded.releaseCandidate,
+        );
+        const evidence = validateEvidenceAt(
+          new Date(persistedAudit.transaction.executedAtUtc),
+          confirmationDocument.cleanIntegration,
+        );
+        const { transaction: persistedTransaction, ...persistedBase } = persistedAudit;
+        if (
+          JSON.stringify(persistedBase)
+            !== JSON.stringify(baseReleaseAudit(evidence.authorizationEvidence.authorizationId))
+        ) {
+          throw new Error("Minnesota hidden receipt recovery evidence does not match the durable database audit");
+        }
+        const executionContext = {
+          mode: "production_release",
+          releaseCandidateId: loaded.releaseCandidate.id,
+          releasePackageSha256: loaded.releaseCandidate.sha256,
+          databaseName: evidence.preflightEvidence.databaseName,
+          productionReleaseAudit: {
+            ...persistedBase,
+            transaction: persistedTransaction,
+          },
+        };
+        const validation = await validateMinnesotaPrecinctGisClient(
+          tx,
+          plan,
+          { executionContext, readOnlySession: true },
+        );
+        if (Number(validation.revision) !== persistedTransaction.publicRevision) {
+          throw new Error("Minnesota hidden receipt recovery public revision drifted");
+        }
+        const totals = validation.years.reduce((result, year) => ({
+          reportingUnits: result.reportingUnits + year.reportingUnits,
+          candidateResultRows: result.candidateResultRows + year.resultRows,
+          geometryFeatures: result.geometryFeatures + year.features,
+          reviewedExactCrosswalks:
+            result.reviewedExactCrosswalks + year.reviewedCrosswalks,
+          zeroVoteUnits: result.zeroVoteUnits + year.zeroVoteUnits,
+        }), {
+          reportingUnits: 0,
+          candidateResultRows: 0,
+          geometryFeatures: 0,
+          reviewedExactCrosswalks: 0,
+          zeroVoteUnits: 0,
+        });
+        return {
+          evidence,
+          transaction: {
+            disposition: "recovered_existing",
+            committedAtUtc: persistedTransaction.executedAtUtc,
+            validation,
+            totals,
+            releaseAudit: persistedAudit,
+            canonicalManifestChanged: false,
+            publicFileWritten: false,
+            publicDeliveryAuthorized: false,
+          },
+        };
+      });
+    } catch (error) {
+      if (pending.disposition === "created") {
+        releaseMinnesotaReceiptReservation(receiptTarget, pending);
+      }
+      throw error;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+    const receipt = {
+      schemaVersion: 1,
+      state: "MN",
+      releaseCandidate: loaded.releaseCandidate,
+      committedAtUtc: recovered.transaction.committedAtUtc,
+      endpointFingerprint,
+      authorization: {
+        path: authorizationArtifact.path,
+        sha256: authorizationArtifact.sha256,
+        ...recovered.evidence.authorizationEvidence,
+      },
+      releaseReview: recovered.evidence.releaseReviewEvidence,
+      preflight: {
+        path: preflightArtifact.path,
+        sha256: preflightArtifact.sha256,
+        ...recovered.evidence.preflightEvidence,
+      },
+      backup: {
+        manifestPath: backupArtifact.path,
+        manifestSha256: backupArtifact.sha256,
+        ...recovered.evidence.backupEvidence,
+        dumpByteCount: backupDump.byteCount,
+      },
+      transaction: recovered.transaction,
+      recovery: {
+        recoveredAtUtc: currentTime().toISOString(),
+        productionMutationPerformed: false,
+      },
+      productionMutationPerformed: true,
+      publicFileWritten: false,
+      canonicalManifestChanged: false,
+      publicDeliveryAuthorized: false,
+    };
+    return {
+      mode: "production_hidden_load_receipt_recovery",
+      state: "MN",
+      decision: "RECOVERED_HIDDEN_RECEIPT",
+      receipt: (options.receiptFinalizer ?? finalizeMinnesotaReceipt)(
+        receiptTarget,
+        pending,
+        receipt,
+      ),
+      productionMutationPerformed: false,
+      publicFileWritten: false,
+      canonicalManifestChanged: false,
+      publicDeliveryAuthorized: false,
+    };
   }
-  if (process.env.CRM_MN_PRECINCT_PRODUCTION_WRITES !== loaded.artifact.sha256) {
-    throw new Error("Minnesota production-write acknowledgement must equal the package SHA-256");
-  }
-  if (
-    process.env.CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_ID
-      !== authorizationEvidence.authorizationId
-  ) {
-    throw new Error("Minnesota production authorization-ID acknowledgement is missing");
-  }
+
+  const initialEvidence = validateEvidenceAt(currentTime(), cleanIntegration());
+  assertMinnesotaProductionReleaseEnvironment({
+    packageSha256: loaded.artifact.sha256,
+    authorizationId: initialEvidence.authorizationEvidence.authorizationId,
+    authorizationSha256: authorizationArtifact.sha256,
+  }, options.environment ?? process.env);
   const migration = inspectReleaseArtifact(
     root,
     loaded.document.databaseActivationContract.migration.path,
@@ -316,27 +873,56 @@ export async function runMinnesotaProductionRelease(options = {}) {
       sha256: loaded.document.databaseActivationContract.migration.sha256,
     },
   );
-  const plan = buildMinnesotaPrecinctGisPlan({ root });
-  const sql = (options.postgresFactory ?? postgres)(databaseUrl, {
-    max: 1,
-    connect_timeout: 10,
-    idle_timeout: 20,
-    connection: {
-      application_name: "civicresultmaps-mn-precinct-production-release",
-    },
-  });
-  let transaction;
+  const pending = reserveMinnesotaReceiptTarget(
+    receiptTarget,
+    reservationDocument,
+  );
+  let sql;
   try {
-    transaction = await sql.begin((tx) =>
-      applyMinnesotaProductionReleaseTransaction(tx, {
+    sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+      max: 1,
+      connect_timeout: 10,
+      idle_timeout: 20,
+      connection: {
+        application_name: "civicresultmaps-mn-precinct-production-release",
+      },
+    });
+  } catch (error) {
+    releaseMinnesotaReceiptReservation(receiptTarget, pending);
+    throw error;
+  }
+  let transaction;
+  let transactionBodyCompleted = false;
+  try {
+    transaction = await sql.begin(async (tx) => {
+      const transactionNow = currentTime();
+      const finalEvidence = validateEvidenceAt(
+        transactionNow,
+        cleanIntegration(),
+      );
+      const transactionRunner = options.transactionRunner
+        ?? applyMinnesotaProductionReleaseTransaction;
+      const result = await transactionRunner(tx, {
         releaseCandidate: loaded.releaseCandidate,
         packageDocument: loaded.document,
         migrationBytes: migration.bytes,
-        databaseName: preflightEvidence.databaseName,
+        databaseName: finalEvidence.preflightEvidence.databaseName,
         preflightReport: preflight,
         plan,
+        releaseAudit: baseReleaseAudit(
+          finalEvidence.authorizationEvidence.authorizationId,
+        ),
+        transactionAtUtc: transactionNow.toISOString(),
         testOnlyFailBeforeCommit: options.testOnlyFailBeforeCommit,
-      }));
+      });
+      transactionBodyCompleted = true;
+      return result;
+    });
+  } catch (error) {
+    if (!transactionBodyCompleted) {
+      releaseMinnesotaReceiptReservation(receiptTarget, pending);
+    }
+    throw error;
   } finally {
     await sql.end({ timeout: 5 });
   }
@@ -344,18 +930,23 @@ export async function runMinnesotaProductionRelease(options = {}) {
     schemaVersion: 1,
     state: "MN",
     releaseCandidate: loaded.releaseCandidate,
-    committedAtUtc: new Date().toISOString(),
+    committedAtUtc: transaction.committedAtUtc,
     endpointFingerprint,
-    authorization: authorizationEvidence,
+    authorization: {
+      path: authorizationArtifact.path,
+      sha256: authorizationArtifact.sha256,
+      ...initialEvidence.authorizationEvidence,
+    },
+    releaseReview: initialEvidence.releaseReviewEvidence,
     preflight: {
       path: preflightArtifact.path,
       sha256: preflightArtifact.sha256,
-      ...preflightEvidence,
+      ...initialEvidence.preflightEvidence,
     },
     backup: {
       manifestPath: backupArtifact.path,
       manifestSha256: backupArtifact.sha256,
-      ...backupEvidence,
+      ...initialEvidence.backupEvidence,
       dumpByteCount: backupDump.byteCount,
     },
     transaction,
@@ -364,17 +955,18 @@ export async function runMinnesotaProductionRelease(options = {}) {
     canonicalManifestChanged: false,
     publicDeliveryAuthorized: false,
   };
-  const receiptTarget = outputPath(
-    root,
-    parsed.receiptPath,
-    `mn-precinct-production-receipt-${loaded.artifact.sha256.slice(0, 12)}-${sha256(Buffer.from(JSON.stringify(receipt))).slice(0, 12)}.json`,
-    "production-release-receipts",
-  );
+  if (options.testOnlyFailReceiptWrite === true) {
+    throw new Error("Intentional Minnesota hidden-load receipt write failure after commit");
+  }
   return {
     mode: "production_hidden_load",
     state: "MN",
     decision: "COMMITTED_HIDDEN_NOT_PUBLIC",
-    receipt: writeJson(receiptTarget, receipt),
+    receipt: (options.receiptFinalizer ?? finalizeMinnesotaReceipt)(
+      receiptTarget,
+      pending,
+      receipt,
+    ),
     productionMutationPerformed: true,
     publicFileWritten: false,
     canonicalManifestChanged: false,

--- a/scripts/lib/mn-precinct-gis-db.mjs
+++ b/scripts/lib/mn-precinct-gis-db.mjs
@@ -23,7 +23,83 @@ const LOCAL_EXECUTION_CONTEXT = Object.freeze({
     name: "crm_clone_dev",
   },
   releaseCandidate: null,
+  productionReleaseAudit: null,
 });
+
+const PRODUCTION_RELEASE_AUDIT_KEYS = Object.freeze([
+  "authorization",
+  "releaseOverlay",
+  "releaseReview",
+  "releaseConfirmation",
+  "preflight",
+  "backupManifest",
+  "authorizationId",
+  "endpointFingerprint",
+  "transaction",
+]);
+
+const PRODUCTION_RELEASE_AUDIT_ARTIFACT_KEYS = Object.freeze([
+  "authorization",
+  "releaseOverlay",
+  "releaseReview",
+  "releaseConfirmation",
+  "preflight",
+]);
+
+function validatedProductionReleaseAudit(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Production Minnesota execution requires durable release-audit metadata");
+  }
+  const output = {};
+  for (const key of PRODUCTION_RELEASE_AUDIT_ARTIFACT_KEYS) {
+    const item = value[key];
+    if (
+      typeof item?.path !== "string"
+      || !item.path.startsWith(".etl/")
+      || item.path.includes("\\")
+      || item.path.split("/").includes("..")
+      || !/^[a-f0-9]{64}$/.test(item?.sha256 ?? "")
+    ) {
+      throw new Error("Production Minnesota execution release-audit metadata is invalid: " + key);
+    }
+    output[key] = Object.freeze({
+      path: item.path,
+      sha256: item.sha256,
+    });
+  }
+  if (
+    !value.backupManifest
+    || Object.keys(value.backupManifest).sort().join(",") !== "dumpSha256,sha256"
+    || !/^[a-f0-9]{64}$/.test(value.backupManifest.sha256 ?? "")
+    || !/^[a-f0-9]{64}$/.test(value.backupManifest.dumpSha256 ?? "")
+    || typeof value.authorizationId !== "string"
+    || !value.authorizationId.trim()
+    || !/^[a-f0-9]{64}$/.test(value.endpointFingerprint ?? "")
+    || !value.transaction
+    || Object.keys(value.transaction).sort().join(",")
+      !== "executedAtUtc,publicRevision"
+    || typeof value.transaction.executedAtUtc !== "string"
+    || Number.isNaN(Date.parse(value.transaction.executedAtUtc))
+    || !Number.isInteger(Number(value.transaction.publicRevision))
+    || Number(value.transaction.publicRevision) < 1
+  ) {
+    throw new Error("Production Minnesota execution release-audit metadata is invalid");
+  }
+  output.backupManifest = Object.freeze({
+    sha256: value.backupManifest.sha256,
+    dumpSha256: value.backupManifest.dumpSha256,
+  });
+  output.authorizationId = value.authorizationId.trim();
+  output.endpointFingerprint = value.endpointFingerprint;
+  output.transaction = Object.freeze({
+    executedAtUtc: value.transaction.executedAtUtc,
+    publicRevision: Number(value.transaction.publicRevision),
+  });
+  if (Object.keys(value).length !== PRODUCTION_RELEASE_AUDIT_KEYS.length) {
+    throw new Error("Production Minnesota execution release-audit metadata has extra fields");
+  }
+  return Object.freeze(output);
+}
 
 export function buildMinnesotaPrecinctExecutionContext(options = {}) {
   if (!options.mode || options.mode === "local") return LOCAL_EXECUTION_CONTEXT;
@@ -59,12 +135,18 @@ export function buildMinnesotaPrecinctExecutionContext(options = {}) {
       sha256: options.releasePackageSha256,
       publicDeliveryAuthorized: false,
     }),
+    productionReleaseAudit: validatedProductionReleaseAudit(
+      options.productionReleaseAudit,
+    ),
   });
 }
 
 function executionMetadata(context) {
   return context.releaseCandidate
-    ? { releaseCandidate: context.releaseCandidate }
+    ? {
+      releaseCandidate: context.releaseCandidate,
+      productionReleaseAudit: context.productionReleaseAudit,
+    }
     : {};
 }
 
@@ -682,6 +764,7 @@ export async function applyMinnesotaPrecinctGisTransaction(
     productionMutationPerformed: context.mode === "production_release",
     publicDeliveryAuthorized: false,
     releaseCandidate: context.releaseCandidate,
+    productionReleaseAudit: context.productionReleaseAudit,
     revision: Number(revisions[0].revision),
     years,
   };
@@ -741,6 +824,8 @@ async function validateSourceDocumentRecords(sql, yearPlan, context) {
     || resultMetadata.publicDeliveryAuthorized !== false
     || JSON.stringify(canonicalJson(resultMetadata.releaseCandidate ?? null))
       !== JSON.stringify(canonicalJson(context.releaseCandidate))
+    || JSON.stringify(canonicalJson(resultMetadata.productionReleaseAudit ?? null))
+      !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
   ) {
     throw new Error("Minnesota " + yearPlan.year + " result provenance drifted");
   }
@@ -774,6 +859,8 @@ async function validateSourceDocumentRecords(sql, yearPlan, context) {
     || geometryMetadata.publicDeliveryAuthorized !== false
     || JSON.stringify(canonicalJson(geometryMetadata.releaseCandidate ?? null))
       !== JSON.stringify(canonicalJson(context.releaseCandidate))
+    || JSON.stringify(canonicalJson(geometryMetadata.productionReleaseAudit ?? null))
+      !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
   ) {
     throw new Error("Minnesota " + yearPlan.year + " geometry provenance drifted");
   }
@@ -781,6 +868,44 @@ async function validateSourceDocumentRecords(sql, yearPlan, context) {
     resultSourceSlug: yearPlan.resultSource.slug,
     geometrySourceSlug: yearPlan.geometrySourceSlug,
   };
+}
+
+async function validateStoredProductionAudit(
+  sql,
+  yearPlan,
+  electionId,
+  context,
+) {
+  if (!context.releaseCandidate) return;
+  const audit = JSON.stringify(context.productionReleaseAudit);
+  const units = await query(sql, [
+    "select count(*)::int total,",
+    " count(*) filter (where metadata->'productionReleaseAudit'=$3::jsonb)::int exact_audit",
+    "from reporting_units where state_code=$1 and election_id=$2::uuid",
+    " and reporting_grain='precinct'",
+  ], [STATE, electionId, audit]);
+  if (
+    Number(units[0]?.total) !== yearPlan.reportingUnits.length
+    || Number(units[0]?.exact_audit) !== yearPlan.reportingUnits.length
+  ) {
+    throw new Error("Minnesota " + yearPlan.year + " reporting-unit release audit drifted");
+  }
+  const imports = await query(sql, [
+    "select count(distinct ir.id)::int import_runs,count(rr.id)::int result_rows,",
+    " count(rr.id) filter (where ir.metadata->'productionReleaseAudit'=$4::jsonb)::int exact_audit_rows",
+    "from import_runs ir",
+    "join result_rows rr on rr.import_run_id=ir.id and rr.state_code=$1",
+    "join contests c on c.id=rr.contest_id and c.election_id=$2::uuid",
+    "where ir.state_code=$1 and ir.election_year=$3 and ir.parser=$5",
+    " and rr.level='precinct'",
+  ], [STATE, electionId, yearPlan.year, audit, context.importParser]);
+  if (
+    Number(imports[0]?.import_runs) !== 1
+    || Number(imports[0]?.result_rows) !== yearPlan.resultRows.length
+    || Number(imports[0]?.exact_audit_rows) !== yearPlan.resultRows.length
+  ) {
+    throw new Error("Minnesota " + yearPlan.year + " import-run release audit drifted");
+  }
 }
 
 async function validateStoredGeometryRecords(sql, yearPlan, electionId, context) {
@@ -909,12 +1034,61 @@ async function validateStoredGeometryRecords(sql, yearPlan, electionId, context)
       || metadata.publicDeliveryAuthorized !== false
       || JSON.stringify(canonicalJson(metadata.releaseCandidate ?? null))
         !== JSON.stringify(canonicalJson(context.releaseCandidate))
+      || JSON.stringify(canonicalJson(metadata.productionReleaseAudit ?? null))
+        !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
     ) {
       throw new Error("Minnesota " + yearPlan.year + " stored crosswalk drifted at " + reportingCode);
     }
     seenCrosswalks.add(reportingCode);
   }
   return { exactFeatures: features.length, exactCrosswalks: crosswalks.length };
+}
+
+export async function readMinnesotaPersistedProductionReleaseAudit(
+  sql,
+  releaseCandidate,
+) {
+  if (
+    typeof releaseCandidate?.id !== "string"
+    || !/^[a-f0-9]{64}$/.test(releaseCandidate?.sha256 ?? "")
+  ) {
+    throw new Error("Minnesota hidden receipt recovery requires an exact release candidate");
+  }
+  const rows = await query(sql, [
+    "select e.year,gv.status,gv.metadata",
+    "from geography_versions gv",
+    "join elections e on e.id=gv.election_id",
+    "where gv.state_code='MN' and gv.geography_type='precinct'",
+    " and gv.metadata->'releaseCandidate'->>'id'=$1",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$2",
+    "order by e.year",
+  ], [releaseCandidate.id, releaseCandidate.sha256]);
+  const expectedYears = [2012, 2016, 2020, 2024];
+  if (
+    rows.length !== expectedYears.length
+    || rows.some((row, index) => Number(row.year) !== expectedYears[index])
+  ) {
+    throw new Error("Minnesota hidden receipt recovery found an incomplete year set");
+  }
+  const firstAudit = rows[0]?.metadata?.productionReleaseAudit;
+  const audit = validatedProductionReleaseAudit(firstAudit);
+  for (const row of rows) {
+    if (
+      String(row.status) !== "blocked"
+      || row.metadata?.publicDeliveryAuthorized !== false
+      || JSON.stringify(canonicalJson(row.metadata?.releaseCandidate ?? null))
+        !== JSON.stringify(canonicalJson({
+          id: releaseCandidate.id,
+          sha256: releaseCandidate.sha256,
+          publicDeliveryAuthorized: false,
+        }))
+      || JSON.stringify(canonicalJson(row.metadata?.productionReleaseAudit ?? null))
+        !== JSON.stringify(canonicalJson(audit))
+    ) {
+      throw new Error("Minnesota hidden receipt recovery audit drifted across years");
+    }
+  }
+  return audit;
 }
 
 export async function validateMinnesotaPrecinctGisClient(
@@ -995,6 +1169,12 @@ export async function validateMinnesotaPrecinctGisClient(
       const provenance = await validateSourceDocumentRecords(
         sql,
         yearPlan,
+        context,
+      );
+      await validateStoredProductionAudit(
+        sql,
+        yearPlan,
+        row.election_id,
         context,
       );
       const exactGeometry = await validateStoredGeometryRecords(
@@ -1085,6 +1265,7 @@ export async function validateMinnesotaPrecinctGisClient(
       productionMutationPerformed: context.mode === "production_release",
       publicDeliveryAuthorized: false,
       releaseCandidate: context.releaseCandidate,
+      productionReleaseAudit: context.productionReleaseAudit,
       invalidConstraints: 0,
       revision: revision.length ? Number(revision[0].revision) : null,
       years: output,

--- a/scripts/lib/mn-precinct-production-release.mjs
+++ b/scripts/lib/mn-precinct-production-release.mjs
@@ -18,6 +18,9 @@ export const MINNESOTA_PRODUCTION_DATABASE_SCOPES = Object.freeze([
 
 const MAX_EVIDENCE_AGE_MS = 4 * 60 * 60 * 1000;
 
+export const MINNESOTA_OWNER_CONFIRMATION_TEXT =
+  "I confirm the exact hash-pinned Minnesota release review and clean integration tree. This confirmation does not authorize a production write, public geometry publication, canonical activation, deployment, or Git publication.";
+
 function query(client, lines, params = []) {
   return client.unsafe(Array.isArray(lines) ? lines.join("\n") : lines, params);
 }
@@ -38,11 +41,24 @@ function validIso(value) {
   return typeof value === "string" && !Number.isNaN(Date.parse(value));
 }
 
+function validSha256(value) {
+  return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+}
+
 function requireNonEmpty(value, label) {
   if (typeof value !== "string" || !value.trim()) {
     throw new Error("Minnesota production authorization requires " + label);
   }
   return value.trim();
+}
+
+export function normalizeMinnesotaReleaseIdentity(value) {
+  if (typeof value !== "string") return "";
+  return value
+    .normalize("NFKC")
+    .trim()
+    .replace(/\s+/gu, " ")
+    .toLocaleLowerCase("en-US");
 }
 
 export function buildMinnesotaProductionAuthorizationTemplate(
@@ -73,6 +89,9 @@ export function buildMinnesotaProductionAuthorizationTemplate(
     evidence: {
       preflight: { path: null, sha256: null },
       backupManifest: { path: null, sha256: null },
+      releaseOverlay: { path: null, sha256: null },
+      releaseReview: { path: null, sha256: null },
+      releaseConfirmation: { path: null, sha256: null },
     },
     scopes: [...MINNESOTA_PRODUCTION_DATABASE_SCOPES],
     exclusions: [
@@ -102,6 +121,8 @@ export function validateMinnesotaProductionPreflightEvidence(
     || !/^[a-f0-9]{64}$/.test(report?.endpointFingerprint ?? "")
     || !/^[a-f0-9]{64}$/.test(context.endpointFingerprint ?? "")
     || report?.endpointFingerprint !== context.endpointFingerprint
+    || !Number.isInteger(Number(report?.publicRevision))
+    || Number(report.publicRevision) < 0
   ) {
     throw new Error("Minnesota production preflight evidence is incompatible");
   }
@@ -126,7 +147,8 @@ export function validateMinnesotaProductionBackupEvidence(
   context,
 ) {
   if (
-    Number(manifest?.manifestVersion) < 3
+    !Number.isInteger(manifest?.manifestVersion)
+    || manifest.manifestVersion < 3
     || manifest?.backupPurpose !== "mn-precinct-production-release-rollback"
     || !/^[a-f0-9]{64}$/.test(manifest?.dumpSha256 ?? "")
     || !/^[a-f0-9]{64}$/.test(manifest?.sourceEndpointFingerprint ?? "")
@@ -135,11 +157,31 @@ export function validateMinnesotaProductionBackupEvidence(
     || manifest?.releaseCandidate?.id !== context.releaseCandidate.id
     || manifest?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
     || manifest?.remoteMutationPerformed !== false
+    || manifest?.dumpFormat !== "custom"
+    || Number(manifest?.pgClientMajor) !== 17
+    || Math.trunc(Number(manifest?.sourceServerVersionNum) / 10_000) !== 17
     || JSON.stringify(manifest?.includedSchemas) !== JSON.stringify(["public"])
     || !Array.isArray(manifest?.excludedTableDataPatterns)
     || manifest.excludedTableDataPatterns.length !== 0
+    || !Number.isInteger(Number(manifest?.sourcePublicTableCount))
+    || Number(manifest.sourcePublicTableCount) < 1
+    || !manifest?.sourcePublicTableRowCounts
+    || typeof manifest.sourcePublicTableRowCounts !== "object"
+    || Array.isArray(manifest.sourcePublicTableRowCounts)
+    || Number(manifest?.sourceInvalidConstraints) !== 0
     || manifest?.restoreVerification?.verified !== true
     || !validIso(manifest?.restoreVerification?.verifiedAtUtc)
+    || typeof manifest?.restoreVerification?.database !== "string"
+    || !manifest.restoreVerification.database.trim()
+    || manifest?.restoreVerification?.defaultTransactionReadOnly !== true
+    || manifest?.restoreVerification?.exactSourceTableSet !== true
+    || manifest?.restoreVerification?.exactSourceRowCounts !== true
+    || Number(manifest?.restoreVerification?.invalidConstraints) !== 0
+    || !Number.isInteger(Number(manifest?.restoreVerification?.publicTableCount))
+    || !Number.isInteger(Number(manifest?.restoreVerification?.tableDataEntryCount))
+    || !manifest?.restoreVerification?.publicTableRowCounts
+    || typeof manifest.restoreVerification.publicTableRowCounts !== "object"
+    || Array.isArray(manifest.restoreVerification.publicTableRowCounts)
     || !validIso(manifest?.createdAtUtc)
   ) {
     throw new Error("Minnesota production backup evidence is incomplete or incompatible");
@@ -148,12 +190,235 @@ export function validateMinnesotaProductionBackupEvidence(
   if (age < 0 || age > MAX_EVIDENCE_AGE_MS) {
     throw new Error("Minnesota production backup is outside the four-hour release window");
   }
+  const createdAt = Date.parse(manifest.createdAtUtc);
+  const preflightCapturedAt = Date.parse(context.preflightCapturedAtUtc ?? "");
+  const restoreVerifiedAt = Date.parse(
+    manifest.restoreVerification.verifiedAtUtc,
+  );
+  const restoreAge = context.now.getTime() - restoreVerifiedAt;
+  if (
+    restoreVerifiedAt < createdAt
+    || Number.isNaN(preflightCapturedAt)
+    || createdAt <= preflightCapturedAt
+    || restoreAge < 0
+    || restoreAge > MAX_EVIDENCE_AGE_MS
+  ) {
+    throw new Error(
+      "Minnesota production backup restore verification is outside the four-hour release window, predates the backup, or the backup predates preflight",
+    );
+  }
+  const sourceTableCount = Number(manifest.sourcePublicTableCount);
+  const restoredTableCount = Number(manifest.restoreVerification.publicTableCount);
+  const tableDataEntryCount = Number(manifest.restoreVerification.tableDataEntryCount);
+  const validCounts = (value) => Object.values(value).every(
+    (count) => Number.isInteger(Number(count)) && Number(count) >= 0,
+  );
+  if (
+    sourceTableCount !== restoredTableCount
+    || sourceTableCount !== tableDataEntryCount
+    || Object.keys(manifest.sourcePublicTableRowCounts).length !== sourceTableCount
+    || Object.keys(manifest.restoreVerification.publicTableRowCounts).length
+      !== restoredTableCount
+    || !validCounts(manifest.sourcePublicTableRowCounts)
+    || !validCounts(manifest.restoreVerification.publicTableRowCounts)
+    || !semanticallyEqual(
+      manifest.sourcePublicTableRowCounts,
+      manifest.restoreVerification.publicTableRowCounts,
+    )
+  ) {
+    throw new Error("Minnesota production backup exact table or row-count proof drifted");
+  }
   return {
     dumpFile: requireNonEmpty(manifest.dumpFile, "the backup dump filename"),
     dumpSha256: manifest.dumpSha256,
     createdAtUtc: manifest.createdAtUtc,
     restoreVerifiedAtUtc: manifest.restoreVerification.verifiedAtUtc,
+    sourcePublicTableCount: sourceTableCount,
     releaseCandidateSha256: manifest.releaseCandidate.sha256,
+  };
+}
+
+export function buildMinnesotaOwnerConfirmationTemplate(context) {
+  if (
+    context?.overlayDocument?.schemaVersion !== 1
+    || context.overlayDocument.state !== "MN"
+    || context.overlayDocument.decision !== "REVIEW_REQUIRED"
+    || context.overlayDocument.sourceReleaseCandidate?.path
+      !== context.releaseCandidatePath
+    || context.overlayDocument.sourceReleaseCandidate?.sha256
+      !== context.releaseCandidate.sha256
+    || context?.reviewDocument?.schemaVersion !== 1
+    || context.reviewDocument.state !== "MN"
+    || context.reviewDocument.decision !== "READY_FOR_HUMAN_CONFIRMATION"
+    || context.reviewDocument.sourceReleaseCandidate?.path
+      !== context.releaseCandidatePath
+    || context.reviewDocument.sourceReleaseCandidate?.sha256
+      !== context.releaseCandidate.sha256
+    || context.reviewDocument.sourceOverlay?.path !== context.overlay.path
+    || context.reviewDocument.sourceOverlay?.sha256 !== context.overlay.sha256
+    || context.reviewDocument.isolatedDiffGate?.machineClassificationsComplete
+      !== true
+    || context.reviewDocument.isolatedDiffGate?.unclassifiedReviewFiles !== 0
+    || context.reviewDocument.safety?.productionContacted !== false
+    || context.reviewDocument.safety?.productionMutationPerformed !== false
+    || context.reviewDocument.safety?.publicFileWritten !== false
+    || context.reviewDocument.safety?.canonicalManifestChanged !== false
+    || context.reviewDocument.safety?.gitMutationPerformed !== false
+  ) {
+    throw new Error("Minnesota owner-confirmation template requires the exact reviewed release chain");
+  }
+  if (
+    !/^[a-f0-9]{40}$/.test(context?.cleanIntegration?.gitSha ?? "")
+    || !/^[a-f0-9]{40}$/.test(context?.cleanIntegration?.gitTreeSha ?? "")
+    || !validSha256(context?.cleanIntegration?.trackedStatusSha256)
+    || context.cleanIntegration.trackedStatusClean !== true
+  ) {
+    throw new Error("Minnesota owner-confirmation template requires a clean tracked integration tree");
+  }
+  return {
+    schemaVersion: 1,
+    state: "MN",
+    decision: "NO_GO_OWNER_CONFIRMATION",
+    confirmedAtUtc: null,
+    confirmedBy: null,
+    confirmationText: MINNESOTA_OWNER_CONFIRMATION_TEXT,
+    candidate: {
+      path: context.releaseCandidatePath,
+      sha256: context.releaseCandidate.sha256,
+    },
+    overlay: {
+      path: context.overlay.path,
+      sha256: context.overlay.sha256,
+    },
+    review: {
+      path: context.review.path,
+      sha256: context.review.sha256,
+      decisionBeforeConfirmation: "READY_FOR_HUMAN_CONFIRMATION",
+      confirmed: false,
+    },
+    cleanIntegration: {
+      gitSha: context.cleanIntegration.gitSha,
+      gitTreeSha: context.cleanIntegration.gitTreeSha,
+      trackedStatusSha256: context.cleanIntegration.trackedStatusSha256,
+      trackedStatusClean: true,
+      diffCheckPassed: true,
+      missingPaths: 0,
+      unexpectedPaths: 0,
+    },
+    authorization: {
+      productionMutation: false,
+      publicGeometryPublication: false,
+      canonicalEligibilityActivation: false,
+      deployment: false,
+      gitPublication: false,
+    },
+    acknowledgement:
+      "This deterministic template is not confirmation. The project owner must review the exact artifacts and clean Git tree, then set decision, confirmedAtUtc, confirmedBy, and review.confirmed explicitly.",
+  };
+}
+
+export function validateMinnesotaProductionReviewEvidence(
+  evidence,
+  context,
+) {
+  const { overlay, review, confirmation } = evidence;
+  if (
+    overlay?.schemaVersion !== 1
+    || overlay?.state !== "MN"
+    || overlay?.decision !== "REVIEW_REQUIRED"
+    || overlay?.sourceReleaseCandidate?.path !== context.releaseCandidatePath
+    || overlay?.sourceReleaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || overlay?.productionMutationPerformed !== false
+    || overlay?.publicFileWritten !== false
+    || overlay?.canonicalManifestChanged !== false
+    || overlay?.gitMutationPerformed !== false
+  ) {
+    throw new Error("Minnesota release overlay evidence is incompatible");
+  }
+  if (
+    review?.schemaVersion !== 1
+    || review?.state !== "MN"
+    || review?.decision !== "READY_FOR_HUMAN_CONFIRMATION"
+    || review?.sourceReleaseCandidate?.path !== context.releaseCandidatePath
+    || review?.sourceReleaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || review?.sourceOverlay?.path !== context.overlay.path
+    || review?.sourceOverlay?.sha256 !== context.overlay.sha256
+    || review?.isolatedDiffGate?.machineClassificationsComplete !== true
+    || review?.isolatedDiffGate?.unclassifiedReviewFiles !== 0
+    || review?.safety?.productionContacted !== false
+    || review?.safety?.productionMutationPerformed !== false
+    || review?.safety?.publicFileWritten !== false
+    || review?.safety?.canonicalManifestChanged !== false
+    || review?.safety?.gitMutationPerformed !== false
+  ) {
+    throw new Error("Minnesota release review evidence is incompatible");
+  }
+  if (
+    confirmation?.schemaVersion !== 1
+    || confirmation?.state !== "MN"
+    || confirmation?.decision !== "GO_OWNER_CONFIRMATION"
+    || !validIso(confirmation?.confirmedAtUtc)
+    || confirmation?.confirmationText !== MINNESOTA_OWNER_CONFIRMATION_TEXT
+    || !confirmation?.confirmedBy?.trim?.()
+    || confirmation?.candidate?.path !== context.releaseCandidatePath
+    || confirmation?.candidate?.sha256 !== context.releaseCandidate.sha256
+    || confirmation?.overlay?.path !== context.overlay.path
+    || confirmation?.overlay?.sha256 !== context.overlay.sha256
+    || confirmation?.review?.path !== context.review.path
+    || confirmation?.review?.sha256 !== context.review.sha256
+    || confirmation?.review?.decisionBeforeConfirmation
+      !== "READY_FOR_HUMAN_CONFIRMATION"
+    || confirmation?.review?.confirmed !== true
+    || confirmation?.cleanIntegration?.diffCheckPassed !== true
+    || confirmation?.cleanIntegration?.trackedStatusClean !== true
+    || !validSha256(confirmation?.cleanIntegration?.trackedStatusSha256)
+    || !/^[a-f0-9]{40}$/.test(confirmation?.cleanIntegration?.gitSha ?? "")
+    || !/^[a-f0-9]{40}$/.test(confirmation?.cleanIntegration?.gitTreeSha ?? "")
+    || !semanticallyEqual(confirmation.cleanIntegration, context.cleanIntegration)
+    || confirmation?.cleanIntegration?.missingPaths !== 0
+    || confirmation?.cleanIntegration?.unexpectedPaths !== 0
+    || confirmation?.authorization?.productionMutation !== false
+    || confirmation?.authorization?.publicGeometryPublication !== false
+    || confirmation?.authorization?.canonicalEligibilityActivation !== false
+    || confirmation?.authorization?.deployment !== false
+    || confirmation?.authorization?.gitPublication !== false
+  ) {
+    throw new Error("Minnesota release human-confirmation evidence is incompatible");
+  }
+  const confirmedAt = Date.parse(confirmation.confirmedAtUtc);
+  if (
+    confirmedAt > context.now.getTime()
+    || (
+      validIso(context.authorizedAtUtc)
+      && confirmedAt > Date.parse(context.authorizedAtUtc)
+    )
+  ) {
+    throw new Error("Minnesota release confirmation postdates its authorization");
+  }
+  if (
+    typeof context.operator === "string"
+    && context.operator.trim()
+    && normalizeMinnesotaReleaseIdentity(confirmation.confirmedBy)
+      === normalizeMinnesotaReleaseIdentity(context.operator)
+  ) {
+    throw new Error("Minnesota release owner confirmer and production operator must be different people");
+  }
+  return {
+    overlay: {
+      path: context.overlay.path,
+      sha256: context.overlay.sha256,
+    },
+    review: {
+      path: context.review.path,
+      sha256: context.review.sha256,
+      decision: review.decision,
+    },
+    confirmation: {
+      path: context.confirmation.path,
+      sha256: context.confirmation.sha256,
+      confirmedAtUtc: confirmation.confirmedAtUtc,
+      confirmedBy: confirmation.confirmedBy.trim(),
+    },
   };
 }
 
@@ -201,6 +466,7 @@ export function validateMinnesotaProductionAuthorization(
     || expires < now
     || rollback < start
     || rollback > end
+    || rollback < now
   ) {
     throw new Error("Minnesota production authorization is outside its deployment window");
   }
@@ -210,15 +476,32 @@ export function validateMinnesotaProductionAuthorization(
     verifier: requireNonEmpty(authorization.people?.verifier, "verifier"),
     rollbackOwner: requireNonEmpty(authorization.people?.rollbackOwner, "rollbackOwner"),
   };
-  if (new Set(Object.values(people)).size < 2) {
+  const identityKeys = Object.values(people).map(normalizeMinnesotaReleaseIdentity);
+  if (new Set(identityKeys).size < 2) {
     throw new Error("Minnesota production authorization requires independent named roles");
   }
-  if (people.operator === people.verifier) {
+  if (
+    normalizeMinnesotaReleaseIdentity(people.operator)
+      === normalizeMinnesotaReleaseIdentity(people.verifier)
+  ) {
     throw new Error("Minnesota production operator and verifier must be different people");
   }
   if (
-    authorization.evidence?.preflight?.sha256 !== context.preflightSha256
+    authorization.evidence?.preflight?.path !== context.preflightPath
+    || authorization.evidence?.preflight?.sha256 !== context.preflightSha256
+    || authorization.evidence?.backupManifest?.path !== context.backupManifestPath
     || authorization.evidence?.backupManifest?.sha256 !== context.backupManifestSha256
+    || authorization.evidence?.releaseOverlay?.path !== context.releaseOverlayPath
+    || authorization.evidence?.releaseOverlay?.sha256 !== context.releaseOverlaySha256
+    || authorization.evidence?.releaseReview?.path !== context.releaseReviewPath
+    || authorization.evidence?.releaseReview?.sha256 !== context.releaseReviewSha256
+    || authorization.evidence?.releaseConfirmation?.path
+      !== context.releaseConfirmationPath
+    || authorization.evidence?.releaseConfirmation?.sha256
+      !== context.releaseConfirmationSha256
+    || !validSha256(context.releaseOverlaySha256)
+    || !validSha256(context.releaseReviewSha256)
+    || !validSha256(context.releaseConfirmationSha256)
   ) {
     throw new Error("Minnesota production authorization evidence hashes do not match");
   }
@@ -449,6 +732,20 @@ export async function applyMinnesotaProductionReleaseTransaction(
     tx,
     options.preflightReport,
   );
+  if (
+    !validIso(options.transactionAtUtc)
+    || !Number.isInteger(Number(preconditions.publicRevision))
+    || Number(preconditions.publicRevision) < 0
+  ) {
+    throw new Error("Minnesota production transaction requires a pinned execution time and revision");
+  }
+  const releaseAudit = {
+    ...options.releaseAudit,
+    transaction: {
+      executedAtUtc: options.transactionAtUtc,
+      publicRevision: Number(preconditions.publicRevision) + 1,
+    },
+  };
   const schema = await ensureMinnesotaPrecinctSchema(
     tx,
     options.migrationBytes,
@@ -459,6 +756,7 @@ export async function applyMinnesotaProductionReleaseTransaction(
     releaseCandidateId: packageContract.id,
     releasePackageSha256: packageSha256,
     databaseName: options.databaseName,
+    productionReleaseAudit: releaseAudit,
   };
   const applied = await applyMinnesotaPrecinctGisTransaction(
     tx,
@@ -470,6 +768,12 @@ export async function applyMinnesotaProductionReleaseTransaction(
     options.plan,
     { executionContext, readOnlySession: false },
   );
+  if (
+    Number(applied.revision) !== releaseAudit.transaction.publicRevision
+    || Number(validation.revision) !== releaseAudit.transaction.publicRevision
+  ) {
+    throw new Error("Minnesota production public revision did not match the durable release audit");
+  }
   const totals = validation.years.reduce((result, year) => ({
     reportingUnits: result.reportingUnits + year.reportingUnits,
     candidateResultRows: result.candidateResultRows + year.resultRows,
@@ -499,6 +803,8 @@ export async function applyMinnesotaProductionReleaseTransaction(
     applied,
     validation,
     totals,
+    committedAtUtc: releaseAudit.transaction.executedAtUtc,
+    releaseAudit,
     canonicalManifestChanged: false,
     publicFileWritten: false,
     publicDeliveryAuthorized: false,

--- a/scripts/lib/mn-precinct-public-activation.mjs
+++ b/scripts/lib/mn-precinct-public-activation.mjs
@@ -8,6 +8,9 @@ import {
   inspectMinnesotaPrecinctBlobPublicationPlan,
 } from "./mn-precinct-blob-publication.mjs";
 import {
+  normalizeMinnesotaReleaseIdentity,
+} from "./mn-precinct-production-release.mjs";
+import {
   inspectPrecinctGeometryManifest,
   inspectPrecinctGeometryRegistry,
 } from "../../src/lib/precinct-geography.ts";
@@ -212,6 +215,45 @@ function draftManifests(root, loaded) {
 
 export function validateMinnesotaHiddenLoadReceipt(value, context) {
   const expectedTotals = context.packageDocument.totals;
+  const releaseAudit = {
+    authorization: {
+      path: value?.authorization?.path,
+      sha256: value?.authorization?.sha256,
+    },
+    releaseOverlay: {
+      path: value?.releaseReview?.overlay?.path,
+      sha256: value?.releaseReview?.overlay?.sha256,
+    },
+    releaseReview: {
+      path: value?.releaseReview?.review?.path,
+      sha256: value?.releaseReview?.review?.sha256,
+    },
+    releaseConfirmation: {
+      path: value?.releaseReview?.confirmation?.path,
+      sha256: value?.releaseReview?.confirmation?.sha256,
+    },
+    preflight: {
+      path: value?.preflight?.path,
+      sha256: value?.preflight?.sha256,
+    },
+    backupManifest: {
+      sha256: value?.backup?.manifestSha256,
+      dumpSha256: value?.backup?.dumpSha256,
+    },
+    authorizationId: value?.authorization?.authorizationId,
+    endpointFingerprint: value?.endpointFingerprint,
+    transaction: {
+      executedAtUtc: value?.committedAtUtc,
+      publicRevision: value?.transaction?.validation?.revision,
+    },
+  };
+  const validAuditItem = (item) => (
+    typeof item?.path === "string"
+    && item.path.startsWith(".etl/")
+    && !item.path.includes("\\")
+    && !item.path.split("/").includes("..")
+    && /^[a-f0-9]{64}$/.test(item?.sha256 ?? "")
+  );
   if (
     value?.schemaVersion !== 1
     || value?.state !== "MN"
@@ -230,6 +272,21 @@ export function validateMinnesotaHiddenLoadReceipt(value, context) {
     || value?.transaction?.canonicalManifestChanged !== false
     || value?.transaction?.publicFileWritten !== false
     || value?.transaction?.publicDeliveryAuthorized !== false
+    || value?.transaction?.committedAtUtc !== value?.committedAtUtc
+    || ![
+      releaseAudit.authorization,
+      releaseAudit.releaseOverlay,
+      releaseAudit.releaseReview,
+      releaseAudit.releaseConfirmation,
+      releaseAudit.preflight,
+    ].every(validAuditItem)
+    || !/^[a-f0-9]{64}$/.test(releaseAudit.backupManifest.sha256 ?? "")
+    || !/^[a-f0-9]{64}$/.test(releaseAudit.backupManifest.dumpSha256 ?? "")
+    || typeof releaseAudit.authorizationId !== "string"
+    || !releaseAudit.authorizationId.trim()
+    || !Number.isInteger(Number(releaseAudit.transaction.publicRevision))
+    || Number(releaseAudit.transaction.publicRevision) < 1
+    || !semanticallyEqual(value?.transaction?.releaseAudit, releaseAudit)
   ) {
     throw new Error("Minnesota hidden-load receipt is incomplete or incompatible");
   }
@@ -258,6 +315,7 @@ export function validateMinnesotaHiddenLoadReceipt(value, context) {
     databaseName: value.preflight.databaseName,
     endpointFingerprint: value.endpointFingerprint,
     authorizationId: value.authorization?.authorizationId ?? null,
+    productionReleaseAudit: releaseAudit,
     totals: value.transaction.totals,
   };
 }
@@ -849,8 +907,11 @@ export function validateMinnesotaPublicActivationAuthorization(
     rollbackOwner: requiredPerson(value, "rollbackOwner"),
   };
   if (
-    people.operator.toLocaleLowerCase() === people.verifier.toLocaleLowerCase()
-    || new Set(Object.values(people).map((person) => person.toLocaleLowerCase())).size < 2
+    normalizeMinnesotaReleaseIdentity(people.operator)
+      === normalizeMinnesotaReleaseIdentity(people.verifier)
+    || new Set(
+      Object.values(people).map(normalizeMinnesotaReleaseIdentity),
+    ).size < 2
   ) {
     throw new Error("Minnesota public activation requires two independent people");
   }
@@ -962,8 +1023,11 @@ export function validateMinnesotaPublicRollbackAuthorization(value, context) {
     rollbackOwner: requiredPerson(value, "rollbackOwner"),
   };
   if (
-    people.operator.toLocaleLowerCase() === people.verifier.toLocaleLowerCase()
-    || new Set(Object.values(people).map((person) => person.toLocaleLowerCase())).size < 2
+    normalizeMinnesotaReleaseIdentity(people.operator)
+      === normalizeMinnesotaReleaseIdentity(people.verifier)
+    || new Set(
+      Object.values(people).map(normalizeMinnesotaReleaseIdentity),
+    ).size < 2
   ) {
     throw new Error("Minnesota rollback requires two independent people");
   }

--- a/scripts/lib/mn-precinct-release-review.mjs
+++ b/scripts/lib/mn-precinct-release-review.mjs
@@ -234,7 +234,7 @@ const POLICY = Object.freeze([
     requiredMarkers: [
       "Local four-election GIS release candidate",
       "Local release-candidate precinct units, four elections",
-      "hidden-load implementation is not enabled",
+      "guarded hidden-load implementation exists but has not been executed in production",
     ],
     excludedMarkers: [
       "## 2024 Precinct Geometry Wave 17 Closeout",

--- a/scripts/publish-mn-precinct-geography-status.mjs
+++ b/scripts/publish-mn-precinct-geography-status.mjs
@@ -751,6 +751,8 @@ export async function applyMinnesotaGeographyPublicationTransaction(
         releaseCandidateId: context.plan.releaseCandidate.id,
         releasePackageSha256: context.plan.releaseCandidate.sha256,
         databaseName: context.databaseName,
+        productionReleaseAudit:
+          context.plan.productionHiddenLoad.productionReleaseAudit,
       },
       readOnlySession: false,
     });

--- a/tests/api/api-contract.test.mjs
+++ b/tests/api/api-contract.test.mjs
@@ -589,6 +589,25 @@ test("production domains force HTTPS through proxy", () => {
   assert.match(proxy, /NextResponse\.redirect/);
 });
 
+test("pull-request CI stays hermetic while production data checks remain strict", () => {
+  const ciWorkflow = readFileSync(".github/workflows/ci.yml", "utf8");
+  const productionWorkflow = readFileSync(
+    ".github/workflows/production-data-smoke.yml",
+    "utf8",
+  );
+
+  assert.match(ciWorkflow, /npm run validate:map-geometry(?:\r?\n|$)/);
+  assert.doesNotMatch(ciWorkflow, /npm run validate:maps(?:\r?\n|$)/);
+  assert.doesNotMatch(ciWorkflow, /npm run validate:provenance(?:\r?\n|$)/);
+
+  assert.match(productionWorkflow, /workflow_dispatch:/);
+  assert.match(productionWorkflow, /schedule:/);
+  assert.match(productionWorkflow, /npm run validate:maps(?:\r?\n|$)/);
+  assert.match(productionWorkflow, /npm run validate:provenance(?:\r?\n|$)/);
+  assert.doesNotMatch(productionWorkflow, /pull_request:/);
+  assert.doesNotMatch(productionWorkflow, /continue-on-error/);
+});
+
 test("native source package handoff is validated in CI", () => {
   const packageScripts = JSON.parse(readFileSync("package.json", "utf8")).scripts;
   const workflow = readFileSync(".github/workflows/ci.yml", "utf8");

--- a/tests/api/mn-precinct-production-release.test.mjs
+++ b/tests/api/mn-precinct-production-release.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -10,6 +11,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
+  assertMinnesotaReceiptRecoveryEnvironment,
+  assertMinnesotaProductionReleaseEnvironment,
+  finalizeMinnesotaReceipt,
+  inspectMinnesotaCleanIntegration,
+  reserveMinnesotaReceiptTarget,
+  runMinnesotaProductionRelease,
   verifyBackupDump,
 } from "../../scripts/apply-mn-precinct-release.mjs";
 import {
@@ -23,15 +30,30 @@ import {
 } from "../../scripts/lib/mn-precinct-production-preflight.mjs";
 import {
   buildMinnesotaProductionAuthorizationTemplate,
+  buildMinnesotaOwnerConfirmationTemplate,
   ensureMinnesotaPrecinctSchema,
+  MINNESOTA_OWNER_CONFIRMATION_TEXT,
   MINNESOTA_PRODUCTION_DATABASE_SCOPES,
+  readAndVerifyEvidenceFile,
   validateMinnesotaProductionAuthorization,
   validateMinnesotaProductionBackupEvidence,
   validateMinnesotaProductionPreflightEvidence,
+  validateMinnesotaProductionReviewEvidence,
 } from "../../scripts/lib/mn-precinct-production-release.mjs";
 
 const PACKAGE_SHA = "a".repeat(64);
 const ENDPOINT = "1".repeat(64);
+const OVERLAY_SHA = "2".repeat(64);
+const REVIEW_SHA = "3".repeat(64);
+const CONFIRMATION_SHA = "4".repeat(64);
+const AUTHORIZATION_SHA = "5".repeat(64);
+const PREFLIGHT_SHA = "6".repeat(64);
+const BACKUP_SHA = "7".repeat(64);
+const DUMP_SHA = "8".repeat(64);
+const GIT_SHA = "9".repeat(40);
+const GIT_TREE_SHA = "a".repeat(40);
+const EMPTY_STATUS_SHA = sha256(Buffer.from("", "utf8"));
+const PACKAGE_PATH = ".etl/package.json";
 const NOW = new Date("2026-08-08T01:00:00.000Z");
 
 function candidateDocument() {
@@ -109,6 +131,358 @@ function preflightReport() {
   });
 }
 
+function reviewedReleaseEvidence() {
+  return {
+    overlay: {
+      schemaVersion: 1,
+      state: "MN",
+      decision: "REVIEW_REQUIRED",
+      sourceReleaseCandidate: { path: PACKAGE_PATH, sha256: PACKAGE_SHA },
+      productionMutationPerformed: false,
+      publicFileWritten: false,
+      canonicalManifestChanged: false,
+      gitMutationPerformed: false,
+    },
+    review: {
+      schemaVersion: 1,
+      state: "MN",
+      decision: "READY_FOR_HUMAN_CONFIRMATION",
+      sourceReleaseCandidate: { path: PACKAGE_PATH, sha256: PACKAGE_SHA },
+      sourceOverlay: { path: ".etl/overlay.json", sha256: OVERLAY_SHA },
+      isolatedDiffGate: {
+        machineClassificationsComplete: true,
+        unclassifiedReviewFiles: 0,
+      },
+      safety: {
+        productionContacted: false,
+        productionMutationPerformed: false,
+        publicFileWritten: false,
+        canonicalManifestChanged: false,
+        gitMutationPerformed: false,
+      },
+    },
+    confirmation: {
+      schemaVersion: 1,
+      state: "MN",
+      decision: "GO_OWNER_CONFIRMATION",
+      confirmedAtUtc: "2026-08-08T00:10:00.000Z",
+      confirmedBy: "Project owner",
+      confirmationText: MINNESOTA_OWNER_CONFIRMATION_TEXT,
+      candidate: { path: PACKAGE_PATH, sha256: PACKAGE_SHA },
+      overlay: { path: ".etl/overlay.json", sha256: OVERLAY_SHA },
+      review: {
+        path: ".etl/review.json",
+        sha256: REVIEW_SHA,
+        decisionBeforeConfirmation: "READY_FOR_HUMAN_CONFIRMATION",
+        confirmed: true,
+      },
+      cleanIntegration: {
+        gitSha: GIT_SHA,
+        gitTreeSha: GIT_TREE_SHA,
+        trackedStatusSha256: EMPTY_STATUS_SHA,
+        trackedStatusClean: true,
+        diffCheckPassed: true,
+        missingPaths: 0,
+        unexpectedPaths: 0,
+      },
+      authorization: {
+        productionMutation: false,
+        publicGeometryPublication: false,
+        canonicalEligibilityActivation: false,
+        deployment: false,
+        gitPublication: false,
+      },
+    },
+  };
+}
+
+function reviewContext() {
+  return {
+    now: NOW,
+    authorizedAtUtc: "2026-08-08T00:15:00.000Z",
+    operator: "Database operator",
+    releaseCandidate: releaseCandidate(),
+    releaseCandidatePath: PACKAGE_PATH,
+    overlay: { path: ".etl/overlay.json", sha256: OVERLAY_SHA },
+    review: { path: ".etl/review.json", sha256: REVIEW_SHA },
+    confirmation: {
+      path: ".etl/confirmation.json",
+      sha256: CONFIRMATION_SHA,
+    },
+    cleanIntegration: {
+      gitSha: GIT_SHA,
+      gitTreeSha: GIT_TREE_SHA,
+      trackedStatusSha256: EMPTY_STATUS_SHA,
+      trackedStatusClean: true,
+      diffCheckPassed: true,
+      missingPaths: 0,
+      unexpectedPaths: 0,
+    },
+  };
+}
+
+function productionReleaseAudit() {
+  return {
+    authorization: {
+      path: ".etl/authorization.json",
+      sha256: AUTHORIZATION_SHA,
+    },
+    releaseOverlay: { path: ".etl/overlay.json", sha256: OVERLAY_SHA },
+    releaseReview: { path: ".etl/review.json", sha256: REVIEW_SHA },
+    releaseConfirmation: {
+      path: ".etl/confirmation.json",
+      sha256: CONFIRMATION_SHA,
+    },
+    preflight: { path: ".etl/preflight.json", sha256: PREFLIGHT_SHA },
+    backupManifest: { sha256: BACKUP_SHA, dumpSha256: DUMP_SHA },
+    authorizationId: "mn-release-window-001",
+    endpointFingerprint: ENDPOINT,
+    transaction: {
+      executedAtUtc: "2026-08-08T01:00:00.000Z",
+      publicRevision: 22,
+    },
+  };
+}
+
+function writeJsonArtifact(root, relativePath, value) {
+  const bytes = Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+  const absolute = path.join(root, ...relativePath.split("/"));
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, bytes);
+  return { path: relativePath, absolute, bytes, sha256: sha256(bytes) };
+}
+
+function productionRunnerFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "crm-mn-production-runner-"));
+  const databaseUrl = "postgresql://user:pass@db.example.com/crm_production?sslmode=require";
+  const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
+  const migrationPath = "drizzle/0008_fixture.sql";
+  const migrationBytes = Buffer.from("select 1;\n", "utf8");
+  const migrationAbsolute = path.join(root, ...migrationPath.split("/"));
+  mkdirSync(path.dirname(migrationAbsolute), { recursive: true });
+  writeFileSync(migrationAbsolute, migrationBytes);
+  const packagePath = ".etl/precinct-release-candidates/MN/fixture/release-candidate.json";
+  const packageDocument = {
+    schemaVersion: 1,
+    id: "mn-precinct-gis-four-election-v1",
+    state: "MN",
+    decision: "NO_GO_PRODUCTION",
+    safety: {
+      explicitProductionAuthorizationRequired: true,
+      productionMutationPerformed: false,
+      publicFileWritten: false,
+      canonicalManifestChanged: false,
+      canonicalRegistryChanged: false,
+    },
+    totals: {
+      elections: 4,
+      reportingUnits: 16_435,
+      candidateResultRows: 49_305,
+      zeroVoteUnits: 125,
+      geometryFeatures: 16_435,
+      reviewedExactCrosswalks: 16_435,
+    },
+    scopedFileInventory: {
+      releaseDependencies: [],
+      sharedReviewFiles: [],
+      sourceAndDataArtifacts: [],
+    },
+    databaseActivationContract: {
+      migration: {
+        path: migrationPath,
+        byteCount: migrationBytes.length,
+        sha256: sha256(migrationBytes),
+      },
+    },
+    years: [],
+  };
+  const packageArtifact = writeJsonArtifact(root, packagePath, packageDocument);
+  const candidate = {
+    id: packageDocument.id,
+    sha256: packageArtifact.sha256,
+  };
+  const overlayPath = ".etl/precinct-release-overlays/MN/fixture/overlay.json";
+  const overlayArtifact = writeJsonArtifact(root, overlayPath, {
+    schemaVersion: 1,
+    state: "MN",
+    decision: "REVIEW_REQUIRED",
+    sourceReleaseCandidate: { path: packagePath, sha256: candidate.sha256 },
+    productionMutationPerformed: false,
+    publicFileWritten: false,
+    canonicalManifestChanged: false,
+    gitMutationPerformed: false,
+  });
+  const reviewPath = ".etl/precinct-release-reviews/MN/fixture/review.json";
+  const reviewArtifact = writeJsonArtifact(root, reviewPath, {
+    schemaVersion: 1,
+    state: "MN",
+    decision: "READY_FOR_HUMAN_CONFIRMATION",
+    sourceReleaseCandidate: { path: packagePath, sha256: candidate.sha256 },
+    sourceOverlay: { path: overlayPath, sha256: overlayArtifact.sha256 },
+    isolatedDiffGate: {
+      machineClassificationsComplete: true,
+      unclassifiedReviewFiles: 0,
+    },
+    safety: {
+      productionContacted: false,
+      productionMutationPerformed: false,
+      publicFileWritten: false,
+      canonicalManifestChanged: false,
+      gitMutationPerformed: false,
+    },
+  });
+  const cleanIntegration = {
+    gitSha: GIT_SHA,
+    gitTreeSha: GIT_TREE_SHA,
+    trackedStatusSha256: EMPTY_STATUS_SHA,
+    trackedStatusClean: true,
+    diffCheckPassed: true,
+    missingPaths: 0,
+    unexpectedPaths: 0,
+  };
+  const confirmationPath =
+    ".etl/precinct-release-confirmations/MN/fixture/confirmation.json";
+  const confirmationArtifact = writeJsonArtifact(root, confirmationPath, {
+    schemaVersion: 1,
+    state: "MN",
+    decision: "GO_OWNER_CONFIRMATION",
+    confirmedAtUtc: "2026-08-08T00:20:00.000Z",
+    confirmedBy: "Project owner",
+    confirmationText: MINNESOTA_OWNER_CONFIRMATION_TEXT,
+    candidate: { path: packagePath, sha256: candidate.sha256 },
+    overlay: { path: overlayPath, sha256: overlayArtifact.sha256 },
+    review: {
+      path: reviewPath,
+      sha256: reviewArtifact.sha256,
+      decisionBeforeConfirmation: "READY_FOR_HUMAN_CONFIRMATION",
+      confirmed: true,
+    },
+    cleanIntegration,
+    authorization: {
+      productionMutation: false,
+      publicGeometryPublication: false,
+      canonicalEligibilityActivation: false,
+      deployment: false,
+      gitPublication: false,
+    },
+  });
+  const preflightPath = ".etl/production-preflight-candidates/MN/fixture.json";
+  const preflightArtifact = writeJsonArtifact(root, preflightPath, {
+    schemaVersion: 1,
+    state: "MN",
+    capturedAtUtc: "2026-08-08T00:30:00.000Z",
+    endpointFingerprint,
+    releaseCandidate: candidate,
+    database: { name: "crm_production", transactionReadOnly: true },
+    invalidConstraints: 0,
+    migration0008: { status: "absent" },
+    publicRevision: 21,
+    productionMutationPerformed: false,
+  });
+  const backupValue = {
+    manifestVersion: 3,
+    backupPurpose: "mn-precinct-production-release-rollback",
+    createdAtUtc: "2026-08-08T00:35:00.000Z",
+    dumpFile: "fixture.dump",
+    dumpSha256: DUMP_SHA,
+    dumpFormat: "custom",
+    releaseCandidate: candidate,
+    sourceEndpointFingerprint: endpointFingerprint,
+    includedSchemas: ["public"],
+    excludedTableDataPatterns: [],
+    sourcePublicTableCount: 2,
+    sourcePublicTableRowCounts: { elections: 4, result_rows: 261 },
+    sourceInvalidConstraints: 0,
+    sourceServerVersionNum: 170010,
+    pgClientMajor: 17,
+    remoteMutationPerformed: false,
+    restoreVerification: {
+      verified: true,
+      verifiedAtUtc: "2026-08-08T00:45:00.000Z",
+      database: "crm_mn_precinct_restore_verify",
+      defaultTransactionReadOnly: true,
+      publicTableCount: 2,
+      publicTableRowCounts: { elections: 4, result_rows: 261 },
+      invalidConstraints: 0,
+      tableDataEntryCount: 2,
+      exactSourceTableSet: true,
+      exactSourceRowCounts: true,
+    },
+  };
+  const backupBytes = Buffer.from(JSON.stringify(backupValue, null, 2) + "\n");
+  const backupArtifact = {
+    path: "C:\\tmp\\crm-db-clone\\mn-release-backups\\fixture.manifest.json",
+    bytes: backupBytes,
+    sha256: sha256(backupBytes),
+    value: backupValue,
+  };
+  const authorizationPath = ".etl/production-authorizations/MN/fixture.json";
+  const authorizationArtifact = writeJsonArtifact(root, authorizationPath, {
+    schemaVersion: 1,
+    state: "MN",
+    decision: "GO_PRODUCTION",
+    authorizationId: "fixture-hidden-release",
+    releaseCandidate: candidate,
+    authorizedAtUtc: "2026-08-08T00:50:00.000Z",
+    expiresAtUtc: "2026-08-08T02:00:00.000Z",
+    people: {
+      authorizedBy: "Project owner",
+      operator: "Database operator",
+      verifier: "Independent verifier",
+      rollbackOwner: "Project owner",
+    },
+    deploymentWindow: {
+      startsAtUtc: "2026-08-08T00:55:00.000Z",
+      endsAtUtc: "2026-08-08T01:50:00.000Z",
+      rollbackDecisionAtUtc: "2026-08-08T01:40:00.000Z",
+    },
+    evidence: {
+      preflight: { path: preflightPath, sha256: preflightArtifact.sha256 },
+      backupManifest: {
+        path: backupArtifact.path,
+        sha256: backupArtifact.sha256,
+      },
+      releaseOverlay: { path: overlayPath, sha256: overlayArtifact.sha256 },
+      releaseReview: { path: reviewPath, sha256: reviewArtifact.sha256 },
+      releaseConfirmation: {
+        path: confirmationPath,
+        sha256: confirmationArtifact.sha256,
+      },
+    },
+    scopes: [...MINNESOTA_PRODUCTION_DATABASE_SCOPES],
+  });
+  return {
+    root,
+    cleanIntegration,
+    endpointFingerprint,
+    backupArtifact,
+    backupDump: { path: "fixture.dump", byteCount: 42, sha256: DUMP_SHA },
+    authorizationArtifact,
+    options: {
+      root,
+      packagePath,
+      preflightPath,
+      backupManifestPath: backupArtifact.path,
+      authorizationPath,
+      authorizationSha256: authorizationArtifact.sha256,
+      receiptPath: ".etl/production-release-receipts/MN/fixture.json",
+      apply: true,
+      recoverReceipt: false,
+      backupArtifact,
+      backupDump: { path: "fixture.dump", byteCount: 42, sha256: DUMP_SHA },
+      databaseUrl,
+      cleanIntegration,
+      planBuilder: () => ({ years: [] }),
+      environment: {
+        CRM_DATABASE_ENVIRONMENT: "production",
+        CRM_MN_PRECINCT_PRODUCTION_WRITES: packageArtifact.sha256,
+        CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_ID: "fixture-hidden-release",
+        CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256: authorizationArtifact.sha256,
+      },
+    },
+  };
+}
+
 test("Minnesota production execution context is separate and package pinned", () => {
   assert.throws(
     () => buildMinnesotaPrecinctExecutionContext({ mode: "production_release" }),
@@ -119,11 +493,22 @@ test("Minnesota production execution context is separate and package pinned", ()
     releaseCandidateId: "mn-precinct-gis-four-election-v1",
     releasePackageSha256: PACKAGE_SHA,
     databaseName: "crm_production",
+    productionReleaseAudit: productionReleaseAudit(),
   });
   assert.equal(context.mode, "production_release");
   assert.equal(context.database.name, "crm_production");
   assert.equal(context.releaseCandidate.sha256, PACKAGE_SHA);
   assert.equal(context.releaseCandidate.publicDeliveryAuthorized, false);
+  assert.deepEqual(context.productionReleaseAudit, productionReleaseAudit());
+  assert.throws(
+    () => buildMinnesotaPrecinctExecutionContext({
+      mode: "production_release",
+      releaseCandidateId: "mn-precinct-gis-four-election-v1",
+      releasePackageSha256: PACKAGE_SHA,
+      databaseName: "crm_production",
+    }),
+    /durable release-audit metadata/,
+  );
 });
 
 test("Minnesota preflight requires a remote read-only exact package", () => {
@@ -204,16 +589,182 @@ test("Minnesota authorization template is no-go and approval requires evidence a
     evidence: {
       preflight: { path: ".etl/preflight.json", sha256: "d".repeat(64) },
       backupManifest: { path: "C:/tmp/backup.json", sha256: "e".repeat(64) },
+      releaseOverlay: { path: ".etl/overlay.json", sha256: OVERLAY_SHA },
+      releaseReview: { path: ".etl/review.json", sha256: REVIEW_SHA },
+      releaseConfirmation: {
+        path: ".etl/confirmation.json",
+        sha256: CONFIRMATION_SHA,
+      },
     },
   };
   const checked = validateMinnesotaProductionAuthorization(authorization, {
     now: NOW,
     releaseCandidate: candidate,
+    preflightPath: ".etl/preflight.json",
     preflightSha256: "d".repeat(64),
+    backupManifestPath: "C:/tmp/backup.json",
     backupManifestSha256: "e".repeat(64),
+    releaseOverlayPath: ".etl/overlay.json",
+    releaseOverlaySha256: OVERLAY_SHA,
+    releaseReviewPath: ".etl/review.json",
+    releaseReviewSha256: REVIEW_SHA,
+    releaseConfirmationPath: ".etl/confirmation.json",
+    releaseConfirmationSha256: CONFIRMATION_SHA,
   });
   assert.equal(checked.authorizationId, "mn-release-window-001");
   assert.equal(checked.people.rollbackOwner, "Rollback owner");
+  assert.throws(
+    () => validateMinnesotaProductionAuthorization({
+      ...authorization,
+      people: {
+        ...authorization.people,
+        operator: "Alice",
+        verifier: " alice ",
+      },
+    }, {
+      now: NOW,
+      releaseCandidate: candidate,
+      preflightPath: ".etl/preflight.json",
+      preflightSha256: "d".repeat(64),
+      backupManifestPath: "C:/tmp/backup.json",
+      backupManifestSha256: "e".repeat(64),
+      releaseOverlayPath: ".etl/overlay.json",
+      releaseOverlaySha256: OVERLAY_SHA,
+      releaseReviewPath: ".etl/review.json",
+      releaseReviewSha256: REVIEW_SHA,
+      releaseConfirmationPath: ".etl/confirmation.json",
+      releaseConfirmationSha256: CONFIRMATION_SHA,
+    }),
+    /operator and verifier must be different/,
+  );
+  assert.throws(
+    () => validateMinnesotaProductionAuthorization({
+      ...authorization,
+      people: {
+        ...authorization.people,
+        operator: "Ａｌｉｃｅ　Ｓｍｉｔｈ",
+        verifier: "alice  smith",
+      },
+    }, {
+      now: NOW,
+      releaseCandidate: candidate,
+      preflightPath: ".etl/preflight.json",
+      preflightSha256: "d".repeat(64),
+      backupManifestPath: "C:/tmp/backup.json",
+      backupManifestSha256: "e".repeat(64),
+      releaseOverlayPath: ".etl/overlay.json",
+      releaseOverlaySha256: OVERLAY_SHA,
+      releaseReviewPath: ".etl/review.json",
+      releaseReviewSha256: REVIEW_SHA,
+      releaseConfirmationPath: ".etl/confirmation.json",
+      releaseConfirmationSha256: CONFIRMATION_SHA,
+    }),
+    /operator and verifier must be different/,
+  );
+  assert.throws(
+    () => validateMinnesotaProductionAuthorization({
+      ...authorization,
+      deploymentWindow: {
+        ...authorization.deploymentWindow,
+        rollbackDecisionAtUtc: "2026-08-08T00:55:00.000Z",
+      },
+    }, {
+      now: NOW,
+      releaseCandidate: candidate,
+      preflightPath: ".etl/preflight.json",
+      preflightSha256: "d".repeat(64),
+      backupManifestPath: "C:/tmp/backup.json",
+      backupManifestSha256: "e".repeat(64),
+      releaseOverlayPath: ".etl/overlay.json",
+      releaseOverlaySha256: OVERLAY_SHA,
+      releaseReviewPath: ".etl/review.json",
+      releaseReviewSha256: REVIEW_SHA,
+      releaseConfirmationPath: ".etl/confirmation.json",
+      releaseConfirmationSha256: CONFIRMATION_SHA,
+    }),
+    /outside its deployment window/,
+  );
+});
+
+test("Minnesota hidden release requires exact overlay, review, and human confirmation", () => {
+  const evidence = reviewedReleaseEvidence();
+  const checked = validateMinnesotaProductionReviewEvidence(
+    evidence,
+    reviewContext(),
+  );
+  assert.equal(checked.overlay.sha256, OVERLAY_SHA);
+  assert.equal(checked.review.sha256, REVIEW_SHA);
+  assert.equal(checked.confirmation.sha256, CONFIRMATION_SHA);
+  assert.throws(
+    () => validateMinnesotaProductionReviewEvidence({
+      ...evidence,
+      review: {
+        ...evidence.review,
+        sourceOverlay: { sha256: "0".repeat(64) },
+      },
+    }, reviewContext()),
+    /review evidence is incompatible/,
+  );
+  assert.throws(
+    () => validateMinnesotaProductionReviewEvidence({
+      ...evidence,
+      confirmation: {
+        ...evidence.confirmation,
+        review: {
+          ...evidence.confirmation.review,
+          sha256: "0".repeat(64),
+        },
+      },
+    }, reviewContext()),
+    /human-confirmation evidence is incompatible/,
+  );
+  assert.throws(
+    () => validateMinnesotaProductionReviewEvidence({
+      ...evidence,
+      confirmation: {
+        ...evidence.confirmation,
+        confirmedBy: "Ｄａｔａｂａｓｅ   ＯＰＥＲＡＴＯＲ",
+      },
+    }, reviewContext()),
+    /owner confirmer and production operator must be different/,
+  );
+});
+
+test("Minnesota owner confirmation starts no-go and pins a clean Git tree", () => {
+  const evidence = reviewedReleaseEvidence();
+  const cleanIntegration = reviewContext().cleanIntegration;
+  const template = buildMinnesotaOwnerConfirmationTemplate({
+    releaseCandidate: releaseCandidate(),
+    releaseCandidatePath: PACKAGE_PATH,
+    overlay: reviewContext().overlay,
+    overlayDocument: evidence.overlay,
+    review: reviewContext().review,
+    reviewDocument: evidence.review,
+    cleanIntegration,
+  });
+  assert.equal(template.decision, "NO_GO_OWNER_CONFIRMATION");
+  assert.equal(template.review.confirmed, false);
+  assert.equal(template.cleanIntegration.gitTreeSha, GIT_TREE_SHA);
+  assert.equal(template.authorization.productionMutation, false);
+  const calls = [];
+  const inspected = inspectMinnesotaCleanIntegration("C:/fixture", (_command, args) => {
+    calls.push(args.join(" "));
+    if (args[0] === "status") return { status: 0, stdout: "", stderr: "" };
+    if (args[1] === "HEAD^{tree}") {
+      return { status: 0, stdout: GIT_TREE_SHA + "\n", stderr: "" };
+    }
+    return { status: 0, stdout: GIT_SHA + "\n", stderr: "" };
+  });
+  assert.deepEqual(inspected, cleanIntegration);
+  assert.equal(calls.length, 3);
+  assert.throws(
+    () => inspectMinnesotaCleanIntegration("C:/fixture", (_command, args) => (
+      args[0] === "status"
+        ? { status: 0, stdout: " M scripts/file.mjs\n", stderr: "" }
+        : { status: 0, stdout: GIT_SHA + "\n", stderr: "" }
+    )),
+    /clean tracked Git integration tree/,
+  );
 });
 
 test("Minnesota backup evidence requires a fresh restoration verification", () => {
@@ -223,6 +774,7 @@ test("Minnesota backup evidence requires a fresh restoration verification", () =
     createdAtUtc: "2026-08-08T00:20:00.000Z",
     dumpFile: "public-sanitized.dump",
     dumpSha256: "f".repeat(64),
+    dumpFormat: "custom",
     releaseCandidate: {
       id: "mn-precinct-gis-four-election-v1",
       sha256: PACKAGE_SHA,
@@ -230,29 +782,49 @@ test("Minnesota backup evidence requires a fresh restoration verification", () =
     sourceEndpointFingerprint: ENDPOINT,
     includedSchemas: ["public"],
     excludedTableDataPatterns: [],
+    sourcePublicTableCount: 2,
+    sourcePublicTableRowCounts: { elections: 4, result_rows: 261 },
+    sourceInvalidConstraints: 0,
+    sourceServerVersionNum: 170010,
+    pgClientMajor: 17,
     remoteMutationPerformed: false,
     restoreVerification: {
       verified: true,
       verifiedAtUtc: "2026-08-08T00:40:00.000Z",
+      database: "crm_mn_precinct_restore_verify",
+      defaultTransactionReadOnly: true,
+      publicTableCount: 2,
+      publicTableRowCounts: { elections: 4, result_rows: 261 },
+      invalidConstraints: 0,
+      tableDataEntryCount: 2,
+      exactSourceTableSet: true,
+      exactSourceRowCounts: true,
     },
   };
+  const context = {
+    now: NOW,
+    endpointFingerprint: ENDPOINT,
+    releaseCandidate: releaseCandidate(),
+    preflightCapturedAtUtc: "2026-08-08T00:10:00.000Z",
+  };
   assert.equal(
-    validateMinnesotaProductionBackupEvidence(manifest, {
-      now: NOW,
-      endpointFingerprint: ENDPOINT,
-      releaseCandidate: releaseCandidate(),
-    }).dumpSha256,
+    validateMinnesotaProductionBackupEvidence(manifest, context).dumpSha256,
     "f".repeat(64),
   );
+  for (const manifestVersion of [undefined, "garbage"]) {
+    assert.throws(
+      () => validateMinnesotaProductionBackupEvidence({
+        ...manifest,
+        manifestVersion,
+      }, context),
+      /incomplete or incompatible/,
+    );
+  }
   assert.throws(
     () => validateMinnesotaProductionBackupEvidence({
       ...manifest,
       restoreVerification: { verified: false },
-    }, {
-      now: NOW,
-      endpointFingerprint: ENDPOINT,
-      releaseCandidate: releaseCandidate(),
-    }),
+    }, context),
     /incomplete or incompatible/,
   );
   assert.throws(
@@ -262,13 +834,148 @@ test("Minnesota backup evidence requires a fresh restoration verification", () =
         ...manifest.releaseCandidate,
         sha256: "0".repeat(64),
       },
-    }, {
-      now: NOW,
-      endpointFingerprint: ENDPOINT,
-      releaseCandidate: releaseCandidate(),
-    }),
+    }, context),
     /incomplete or incompatible/,
   );
+  assert.throws(
+    () => validateMinnesotaProductionBackupEvidence({
+      ...manifest,
+      restoreVerification: {
+        ...manifest.restoreVerification,
+        verifiedAtUtc: "2026-08-08T00:10:00.000Z",
+      },
+    }, context),
+    /predates the backup/,
+  );
+  assert.throws(
+    () => validateMinnesotaProductionBackupEvidence({
+      ...manifest,
+      restoreVerification: {
+        ...manifest.restoreVerification,
+        verifiedAtUtc: "2026-08-08T01:10:00.000Z",
+      },
+    }, context),
+    /outside the four-hour release window/,
+  );
+  assert.throws(
+    () => validateMinnesotaProductionBackupEvidence(manifest, {
+      ...context,
+      preflightCapturedAtUtc: "2026-08-08T00:30:00.000Z",
+    }),
+    /backup predates preflight/,
+  );
+  assert.throws(
+    () => validateMinnesotaProductionBackupEvidence(manifest, {
+      ...context,
+      preflightCapturedAtUtc: manifest.createdAtUtc,
+    }),
+    /backup predates preflight/,
+  );
+  assert.throws(
+    () => validateMinnesotaProductionBackupEvidence({
+      ...manifest,
+      restoreVerification: {
+        ...manifest.restoreVerification,
+        publicTableRowCounts: { elections: 4, result_rows: 260 },
+      },
+    }, context),
+    /exact table or row-count proof drifted/,
+  );
+});
+
+test("Minnesota production environment pins package, authorization ID, and authorization bytes", () => {
+  const expected = {
+    packageSha256: PACKAGE_SHA,
+    authorizationId: "mn-release-window-001",
+    authorizationSha256: AUTHORIZATION_SHA,
+  };
+  const environment = {
+    CRM_DATABASE_ENVIRONMENT: "production",
+    CRM_MN_PRECINCT_PRODUCTION_WRITES: PACKAGE_SHA,
+    CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_ID: "mn-release-window-001",
+    CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256: AUTHORIZATION_SHA,
+  };
+  assert.doesNotThrow(() => assertMinnesotaProductionReleaseEnvironment(
+    expected,
+    environment,
+  ));
+  assert.throws(
+    () => assertMinnesotaProductionReleaseEnvironment(expected, {
+      ...environment,
+      CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256: "0".repeat(64),
+    }),
+    /authorization-SHA acknowledgement/,
+  );
+});
+
+test("Minnesota receipt recovery is read-only, package pinned, and atomically reserved", () => {
+  const recoveryEnvironment = {
+    CRM_DATABASE_ENVIRONMENT: "production-read-only",
+    CRM_MN_PRECINCT_RECEIPT_RECOVERY_PACKAGE_SHA256: PACKAGE_SHA,
+    CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256: AUTHORIZATION_SHA,
+  };
+  assert.doesNotThrow(() => assertMinnesotaReceiptRecoveryEnvironment({
+    packageSha256: PACKAGE_SHA,
+    authorizationSha256: AUTHORIZATION_SHA,
+  }, recoveryEnvironment));
+  assert.throws(
+    () => assertMinnesotaReceiptRecoveryEnvironment({
+      packageSha256: PACKAGE_SHA,
+      authorizationSha256: AUTHORIZATION_SHA,
+    }, { ...recoveryEnvironment, CRM_DATABASE_ENVIRONMENT: "production" }),
+    /production-read-only/,
+  );
+  const root = mkdtempSync(path.join(tmpdir(), "crm-mn-receipt-reservation-"));
+  try {
+    const target = {
+      relativePath: ".etl/production-release-receipts/MN/fixture.json",
+      absolute: path.join(root, ".etl", "production-release-receipts", "MN", "fixture.json"),
+    };
+    const reservation = { schemaVersion: 1, packageSha256: PACKAGE_SHA };
+    const pending = reserveMinnesotaReceiptTarget(target, reservation);
+    assert.equal(existsSync(pending.absolute), true);
+    assert.throws(
+      () => reserveMinnesotaReceiptTarget(target, reservation),
+      /reservation already exists/,
+    );
+    assert.equal(
+      reserveMinnesotaReceiptTarget(target, reservation, { allowExisting: true }).absolute,
+      pending.absolute,
+    );
+    const receipt = { schemaVersion: 1, state: "MN", committed: true };
+    const written = finalizeMinnesotaReceipt(target, pending, receipt);
+    assert.equal(written.disposition, "created");
+    assert.equal(existsSync(target.absolute), true);
+    assert.equal(existsSync(pending.absolute), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Minnesota production authorization bytes cannot change after SHA review", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "crm-mn-production-auth-"));
+  try {
+    mkdirSync(path.join(root, ".etl"), { recursive: true });
+    const relativePath = ".etl/authorization.json";
+    const authorizationPath = path.join(root, ".etl", "authorization.json");
+    const reviewedBytes = Buffer.from('{"decision":"GO_PRODUCTION","authorizationId":"one"}\n');
+    writeFileSync(authorizationPath, reviewedBytes);
+    const reviewedSha = sha256(reviewedBytes);
+    assert.equal(
+      readAndVerifyEvidenceFile(root, relativePath, reviewedSha).sha256,
+      reviewedSha,
+    );
+    writeFileSync(
+      authorizationPath,
+      Buffer.from('{"decision":"GO_PRODUCTION","authorizationId":"two"}\n'),
+    );
+    assert.throws(
+      () => readAndVerifyEvidenceFile(root, relativePath, reviewedSha),
+      /evidence SHA-256 drifted/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("Minnesota production runner verifies a dump beside its backup manifest", () => {
@@ -343,6 +1050,274 @@ test("migration 0008 is hash checked and applied inside the supplied transaction
   assert.ok(statements.length >= 20);
 });
 
+test("Minnesota production runner carries every pinned audit input into one receipt", async () => {
+  const item = productionRunnerFixture();
+  try {
+    let transactionCalls = 0;
+    const result = await runMinnesotaProductionRelease({
+      ...item.options,
+      now: NOW,
+      postgresFactory: () => ({
+        begin: async (callback) => callback({}),
+        end: async () => {},
+      }),
+      transactionRunner: async (_tx, options) => {
+        transactionCalls += 1;
+        const releaseAudit = {
+          ...options.releaseAudit,
+          transaction: {
+            executedAtUtc: options.transactionAtUtc,
+            publicRevision: 22,
+          },
+        };
+        return {
+          committedAtUtc: options.transactionAtUtc,
+          validation: { revision: 22, years: [] },
+          totals: candidateDocument().totals,
+          releaseAudit,
+          canonicalManifestChanged: false,
+          publicFileWritten: false,
+          publicDeliveryAuthorized: false,
+        };
+      },
+    });
+    assert.equal(result.decision, "COMMITTED_HIDDEN_NOT_PUBLIC");
+    assert.equal(transactionCalls, 1);
+    const receipt = JSON.parse(readFileSync(
+      path.join(item.root, ...result.receipt.path.split("/")),
+      "utf8",
+    ));
+    assert.equal(
+      receipt.transaction.releaseAudit.authorization.sha256,
+      item.authorizationArtifact.sha256,
+    );
+    assert.equal(receipt.transaction.releaseAudit.preflight.path, item.options.preflightPath);
+    assert.equal(receipt.transaction.releaseAudit.backupManifest.dumpSha256, DUMP_SHA);
+    assert.equal(receipt.transaction.releaseAudit.transaction.publicRevision, 22);
+  } finally {
+    rmSync(item.root, { recursive: true, force: true });
+  }
+});
+
+test("Minnesota production runner rechecks the active window inside the transaction", async () => {
+  const item = productionRunnerFixture();
+  try {
+    const times = [
+      new Date("2026-08-08T01:00:00.000Z"),
+      new Date("2026-08-08T01:41:00.000Z"),
+    ];
+    let transactionCalls = 0;
+    await assert.rejects(
+      () => runMinnesotaProductionRelease({
+        ...item.options,
+        nowFactory: () => times.shift(),
+        postgresFactory: () => ({
+          begin: async (callback) => callback({}),
+          end: async () => {},
+        }),
+        transactionRunner: async () => {
+          transactionCalls += 1;
+          return {};
+        },
+      }),
+      /outside its deployment window/,
+    );
+    assert.equal(transactionCalls, 0);
+    assert.equal(existsSync(
+      path.join(item.root, ...item.options.receiptPath.split("/")) + ".pending",
+    ), false);
+  } finally {
+    rmSync(item.root, { recursive: true, force: true });
+  }
+});
+
+test("Minnesota post-commit receipt failure is recoverable through a read-only DB audit", async () => {
+  const item = productionRunnerFixture();
+  try {
+    let persistedAudit;
+    const transactionRunner = async (_tx, options) => {
+      persistedAudit = {
+        ...options.releaseAudit,
+        transaction: {
+          executedAtUtc: options.transactionAtUtc,
+          publicRevision: 22,
+        },
+      };
+      return {
+        committedAtUtc: options.transactionAtUtc,
+        validation: { revision: 22, years: [] },
+        totals: candidateDocument().totals,
+        releaseAudit: persistedAudit,
+        canonicalManifestChanged: false,
+        publicFileWritten: false,
+        publicDeliveryAuthorized: false,
+      };
+    };
+    await assert.rejects(
+      () => runMinnesotaProductionRelease({
+        ...item.options,
+        now: NOW,
+        testOnlyFailReceiptWrite: true,
+        postgresFactory: () => ({
+          begin: async (callback) => callback({}),
+          end: async () => {},
+        }),
+        transactionRunner,
+      }),
+      /receipt write failure after commit/,
+    );
+    const pendingPath =
+      path.join(item.root, ...item.options.receiptPath.split("/")) + ".pending";
+    assert.equal(existsSync(pendingPath), true);
+    const packageBytes = readFileSync(path.join(
+      item.root,
+      ...item.options.packagePath.split("/"),
+    ));
+    const releaseCandidateMetadata = {
+      id: "mn-precinct-gis-four-election-v1",
+      sha256: sha256(packageBytes),
+      publicDeliveryAuthorized: false,
+    };
+    let readOnlyMode = null;
+    const recoveryPostgresFactory = (revision) => () => ({
+      begin: async (mode, callback) => {
+        readOnlyMode = mode;
+        return callback({
+          unsafe: async (sql) => {
+            if (sql.includes("from geography_versions gv")) {
+              return [2012, 2016, 2020, 2024].map((year) => ({
+                year,
+                status: "blocked",
+                metadata: {
+                  publicDeliveryAuthorized: false,
+                  releaseCandidate: releaseCandidateMetadata,
+                  productionReleaseAudit: persistedAudit,
+                },
+              }));
+            }
+            if (sql.includes("not convalidated")) return [{ count: 0 }];
+            if (sql.includes("public_data_revisions")) return [{ revision }];
+            throw new Error("Unexpected recovery SQL: " + sql);
+          },
+        });
+      },
+      end: async () => {},
+    });
+    const recoveryOptions = {
+      ...item.options,
+      apply: false,
+      recoverReceipt: true,
+      now: new Date("2026-08-08T01:10:00.000Z"),
+      environment: {
+        CRM_DATABASE_ENVIRONMENT: "production-read-only",
+        CRM_MN_PRECINCT_RECEIPT_RECOVERY_PACKAGE_SHA256:
+          releaseCandidateMetadata.sha256,
+        CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256:
+          item.authorizationArtifact.sha256,
+      },
+    };
+    const pendingBytes = readFileSync(pendingPath);
+    await assert.rejects(
+      () => runMinnesotaProductionRelease({
+        ...recoveryOptions,
+        postgresFactory: recoveryPostgresFactory(23),
+      }),
+      /public revision drifted/,
+    );
+    assert.equal(existsSync(pendingPath), true);
+    assert.equal(readFileSync(pendingPath).equals(pendingBytes), true);
+    const recovery = await runMinnesotaProductionRelease({
+      ...recoveryOptions,
+      postgresFactory: recoveryPostgresFactory(22),
+    });
+    assert.equal(readOnlyMode, "read only");
+    assert.equal(recovery.decision, "RECOVERED_HIDDEN_RECEIPT");
+    assert.equal(recovery.productionMutationPerformed, false);
+    assert.equal(existsSync(pendingPath), false);
+    const receipt = JSON.parse(readFileSync(
+      path.join(item.root, ...recovery.receipt.path.split("/")),
+      "utf8",
+    ));
+    assert.equal(receipt.recovery.productionMutationPerformed, false);
+    assert.equal(receipt.productionMutationPerformed, true);
+    assert.equal(receipt.transaction.releaseAudit.transaction.publicRevision, 22);
+  } finally {
+    rmSync(item.root, { recursive: true, force: true });
+  }
+});
+
+test("Minnesota ambiguous commit acknowledgement preserves the recovery marker", async () => {
+  const item = productionRunnerFixture();
+  try {
+    let callbackCompleted = false;
+    let durableAudit;
+    await assert.rejects(
+      () => runMinnesotaProductionRelease({
+        ...item.options,
+        now: NOW,
+        postgresFactory: () => ({
+          begin: async (callback) => {
+            await callback({});
+            callbackCompleted = true;
+            throw new Error("connection lost after possible commit");
+          },
+          end: async () => {},
+        }),
+        transactionRunner: async (_tx, options) => {
+          durableAudit = {
+            ...options.releaseAudit,
+            transaction: {
+              executedAtUtc: options.transactionAtUtc,
+              publicRevision: 22,
+            },
+          };
+          return {
+            committedAtUtc: options.transactionAtUtc,
+            validation: { revision: 22, years: [] },
+            totals: candidateDocument().totals,
+            releaseAudit: durableAudit,
+            canonicalManifestChanged: false,
+            publicFileWritten: false,
+            publicDeliveryAuthorized: false,
+          };
+        },
+      }),
+      /connection lost after possible commit/,
+    );
+    assert.equal(callbackCompleted, true);
+    assert.equal(durableAudit.transaction.publicRevision, 22);
+    const receiptAbsolute = path.join(
+      item.root,
+      ...item.options.receiptPath.split("/"),
+    );
+    assert.equal(existsSync(receiptAbsolute), false);
+    assert.equal(existsSync(receiptAbsolute + ".pending"), true);
+  } finally {
+    rmSync(item.root, { recursive: true, force: true });
+  }
+});
+
+test("Minnesota production runner rejects altered authorization bytes before connecting", async () => {
+  const item = productionRunnerFixture();
+  try {
+    let factoryCalls = 0;
+    await assert.rejects(
+      () => runMinnesotaProductionRelease({
+        ...item.options,
+        authorizationSha256: "0".repeat(64),
+        postgresFactory: () => {
+          factoryCalls += 1;
+          return {};
+        },
+      }),
+      /evidence SHA-256 drifted/,
+    );
+    assert.equal(factoryCalls, 0);
+  } finally {
+    rmSync(item.root, { recursive: true, force: true });
+  }
+});
+
 test("Minnesota production CLIs do not load env files or authorize public cutover", () => {
   const applySource = readFileSync("scripts/apply-mn-precinct-release.mjs", "utf8");
   const preflightSource = readFileSync(
@@ -352,6 +1327,8 @@ test("Minnesota production CLIs do not load env files or authorize public cutove
   assert.doesNotMatch(applySource + preflightSource, /--env-file|dotenv\.config/);
   assert.match(applySource, /CRM_MN_PRECINCT_PRODUCTION_WRITES/);
   assert.match(applySource, /CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_ID/);
+  assert.match(applySource, /CRM_MN_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256/);
+  assert.match(applySource, /--authorization-sha256/);
   assert.match(preflightSource, /CRM_MN_PRODUCTION_PREFLIGHT_ACK/);
   assert.match(applySource, /publicDeliveryAuthorized: false/);
   const backupSource = readFileSync(

--- a/tests/api/mn-precinct-public-activation.test.mjs
+++ b/tests/api/mn-precinct-public-activation.test.mjs
@@ -422,14 +422,79 @@ function fixture() {
     },
     committedAtUtc: "2026-08-08T00:20:00.000Z",
     endpointFingerprint: "a".repeat(64),
-    authorization: { authorizationId: "fixture-db" },
-    preflight: { databaseName: "crm_production" },
+    authorization: {
+      path: ".etl/production-authorizations/MN/fixture.json",
+      sha256: "b".repeat(64),
+      authorizationId: "fixture-db",
+    },
+    releaseReview: {
+      overlay: {
+        path: ".etl/precinct-release-overlays/MN/fixture/overlay.json",
+        sha256: "c".repeat(64),
+      },
+      review: {
+        path: ".etl/precinct-release-reviews/MN/fixture/review.json",
+        sha256: "d".repeat(64),
+        decision: "READY_FOR_HUMAN_CONFIRMATION",
+      },
+      confirmation: {
+        path: ".etl/precinct-release-confirmations/MN/fixture/confirmation.json",
+        sha256: "e".repeat(64),
+        confirmedAtUtc: "2026-08-08T00:10:00.000Z",
+        confirmedBy: "Project owner",
+      },
+    },
+    preflight: {
+      path: ".etl/production-preflight-candidates/MN/fixture.json",
+      sha256: "f".repeat(64),
+      databaseName: "crm_production",
+    },
+    backup: {
+      manifestSha256: "0".repeat(64),
+      dumpSha256: "1".repeat(64),
+    },
     transaction: {
+      committedAtUtc: "2026-08-08T00:20:00.000Z",
       totals: packageDocument.totals,
-      validation: { years: YEARS.map((year) => ({ year })) },
+      validation: {
+        revision: 29,
+        years: YEARS.map((year) => ({ year })),
+      },
       canonicalManifestChanged: false,
       publicFileWritten: false,
       publicDeliveryAuthorized: false,
+      releaseAudit: {
+        authorization: {
+          path: ".etl/production-authorizations/MN/fixture.json",
+          sha256: "b".repeat(64),
+        },
+        releaseOverlay: {
+          path: ".etl/precinct-release-overlays/MN/fixture/overlay.json",
+          sha256: "c".repeat(64),
+        },
+        releaseReview: {
+          path: ".etl/precinct-release-reviews/MN/fixture/review.json",
+          sha256: "d".repeat(64),
+        },
+        releaseConfirmation: {
+          path: ".etl/precinct-release-confirmations/MN/fixture/confirmation.json",
+          sha256: "e".repeat(64),
+        },
+        preflight: {
+          path: ".etl/production-preflight-candidates/MN/fixture.json",
+          sha256: "f".repeat(64),
+        },
+        backupManifest: {
+          sha256: "0".repeat(64),
+          dumpSha256: "1".repeat(64),
+        },
+        authorizationId: "fixture-db",
+        endpointFingerprint: "a".repeat(64),
+        transaction: {
+          executedAtUtc: "2026-08-08T00:20:00.000Z",
+          publicRevision: 29,
+        },
+      },
     },
     productionMutationPerformed: true,
     publicFileWritten: false,
@@ -541,6 +606,21 @@ test("Minnesota public authorization requires verified preview and production de
       "dpl_fixture_production",
     );
     assert.equal(checked.rollbackTarget.deploymentId, "dpl_fixture_previous");
+    assert.throws(
+      () => validateMinnesotaPublicActivationAuthorization({
+        ...authorization,
+        people: {
+          ...authorization.people,
+          operator: "Ｒｅｌｅａｓｅ　Ｏｐｅｒａｔｏｒ",
+          verifier: "release  operator",
+        },
+      }, {
+        now: Date.parse("2026-08-08T01:00:00.000Z"),
+        plan: built.plan,
+        activationSha256: built.sha256,
+      }),
+      /requires two independent people/,
+    );
     assert.throws(
       () => validateMinnesotaPublicActivationAuthorization(
         { ...authorization, productionDeployment: template.productionDeployment },
@@ -666,6 +746,22 @@ test("Minnesota rollback requires a separate decision bound to the publish recei
     assert.equal(
       checked.applicationRollback.target.deploymentId,
       "dpl_previous",
+    );
+    assert.throws(
+      () => validateMinnesotaPublicRollbackAuthorization({
+        ...authorization,
+        people: {
+          ...authorization.people,
+          operator: "Ｒｅｌｅａｓｅ　Ｏｐｅｒａｔｏｒ",
+          verifier: "release  operator",
+        },
+      }, {
+        now: Date.parse("2026-08-08T01:20:00.000Z"),
+        plan: built.plan,
+        activationSha256: built.sha256,
+        publicationReceipt,
+      }),
+      /requires two independent people/,
     );
     assert.throws(
       () => validateMinnesotaPublicRollbackAuthorization({
@@ -1389,6 +1485,29 @@ test("Minnesota activation receipts reject Blob or package tampering", () => {
         blobEvidenceSha256: digest(tamperedBytes),
       }),
       /artifact set drifted/,
+    );
+  } finally {
+    rmSync(item.root, { recursive: true, force: true });
+  }
+});
+
+test("Minnesota activation rejects a hidden-load receipt with mismatched release audit", () => {
+  const item = fixture();
+  try {
+    const receiptPath = path.resolve(
+      item.root,
+      ...item.options.productionReceiptPath.split("/"),
+    );
+    const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+    receipt.transaction.releaseAudit.authorization.sha256 = "0".repeat(64);
+    const tamperedBytes = serialize(receipt);
+    writeFileSync(receiptPath, tamperedBytes);
+    assert.throws(
+      () => inspectMinnesotaPublicActivationPlan({
+        ...item.options,
+        productionReceiptSha256: digest(tamperedBytes),
+      }),
+      /hidden-load receipt is incomplete or incompatible/,
     );
   } finally {
     rmSync(item.root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- hardens the Minnesota hidden precinct database release with exact SHA-pinned authorization and reviewed evidence
- adds deterministic owner confirmation, normalized two-person identity checks, strict preflight/backup/restore ordering, and in-transaction time revalidation
- persists the full production release audit in database metadata
- reserves the receipt before PostgreSQL work and adds fail-closed read-only receipt recovery, including ambiguous COMMIT handling
- carries the expanded hidden-load audit into later public-activation validation
- updates the Minnesota release runbook and implementation inventory

## Why

The post-merge production rehearsal found that the existing guarded path was not yet strong enough for a first production load. In particular, reviewed authorization bytes and owner-review evidence were not fully bound to the transaction, backup evidence had edge cases, and a receipt-write or ambiguous COMMIT failure could leave operators without a safe reconciliation path.

## Safety and impact

- No production database, Blob, Vercel environment, deployment, canonical manifest, or public eligibility state was changed.
- Minnesota precinct results and geometry remain fail-closed on the live site.
- The hidden load still requires a fresh sealed candidate, fresh read-only production preflight, full restore-verified backup, a project-owner confirmation, and a real two-person GO_PRODUCTION record.
- Public Blob publication and canonical activation remain separate later decisions.

## Validation

- `node --experimental-strip-types --test tests/api/mn-precinct-production-release.test.mjs tests/api/mn-precinct-public-activation.test.mjs` — 32/32 passed
- `npm.cmd run test:precinct-geometry:mn` — all 24 test files passed
- `npm.cmd run typecheck` — passed
- `npm.cmd run build` — passed
- `git diff --check` — passed (line-ending notices only)
- two independent read-only safety reviews reported no remaining actionable blocker

## Website/API path checked

The focused and full Minnesota suites cover the precinct result publication gate, precinct geography gate, parent-scoped map delivery, and OpenStreetMap-backed precinct UI. Live display is intentionally still unavailable until the later reviewed public cutover.

## Remaining operational work after merge

1. reseal the four-year Minnesota release candidate from the merged commit
2. generate/review the overlay and owner-confirmation evidence
3. run a fresh read-only production preflight and restore-verified backup
4. obtain the real two-person GO_PRODUCTION authorization and perform the hidden load
5. publish the 352 immutable Blob assets, configure the exact geography origin, verify protected preview/production gates, and perform the separate public activation
