### PR TITLE
Fix Minnesota local precinct rehearsal gate

### DIFF
--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -6743,3 +6743,22 @@ evidence against its verified top-level package.
   promotion, database mutation, environment change, or Minnesota public
   activation. Restoring the complete production result corpus remains a
   separate reviewed production operation.
+
+### 2026-08-08 - Minnesota local rehearsal publication-gate repair
+
+- The clean merged-main release rehearsal found that the production
+  publication gate correctly hid blocked Minnesota precinct result rows but
+  also hid them from the explicitly guarded local-only rehearsal. The result
+  API now bypasses that gate only after
+  `resolveMinnesotaPrecinctRehearsal()` proves the process is running in
+  development or test mode, uses the PostgreSQL driver in strict mode, and is
+  connected to the loopback `crm_clone_dev` database on port 54329.
+
+- Canonical manifests remain blocked and public production requests still
+  require the exact reviewed database publication state. The rehearsal test
+  now checks that the result-query path is wired to the guarded local adapter.
+  Rehearsal result reads also bypass the persistent public-result cache so a
+  blocked response cached before the guarded adapter is enabled cannot mask
+  valid clone rows. These checks prevent another production-gate or cache
+  change from silently making the required four-year browser rehearsal
+  impossible.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -167,6 +167,7 @@ export const listReviewRows = cachePublicData(
 export const listResults = cachePublicData(
   uncachedListResults,
   "results",
+  { persistent: process.env.CRM_PRECINCT_REHEARSAL !== "mn" },
 );
 
 export const listSecurityIncidents = cachePublicData(

--- a/src/lib/data-access.ts
+++ b/src/lib/data-access.ts
@@ -6,6 +6,7 @@ import {
   requiresPrecinctGeometryPublicationGate,
   requiresPrecinctResultPublicationGate,
 } from "./precinct-result-publication";
+import { resolveMinnesotaPrecinctRehearsal } from "./mn-precinct-rehearsal-server";
 import type { PrecinctGeometryManifest } from "./precinct-geography";
 import {
   getCoverage,
@@ -546,7 +547,8 @@ export async function listResults(input: {
 }): Promise<ResultRow[]> {
   const normalizedOffice = input.office?.trim().toLowerCase() || null;
   const parentGeoid = input.parentGeoid?.trim() || null;
-  const requiresPublicationGate = requiresPrecinctResultPublicationGate(input);
+  const requiresPublicationGate = requiresPrecinctResultPublicationGate(input)
+    && !resolveMinnesotaPrecinctRehearsal().enabled;
   if (parentGeoid && (input.level !== "precinct" || !/^\d{5}$/.test(parentGeoid))) {
     throw new Error(
       "parentGeoid requires precinct results and a five-digit county GEOID",

--- a/tests/api/mn-precinct-local-rehearsal.test.mjs
+++ b/tests/api/mn-precinct-local-rehearsal.test.mjs
@@ -136,6 +136,8 @@ test("the API and UI use the marked rehearsal path without requesting blocked la
     "utf8",
   );
   const component = readFileSync("src/app/precinct-detail-map.tsx", "utf8");
+  const dataAccess = readFileSync("src/lib/data-access.ts", "utf8");
+  const api = readFileSync("src/lib/api.ts", "utf8");
   assert.match(
     manifestRoute,
     /listPrecinctGeometryManifestViewsWithMinnesotaRehearsal/,
@@ -147,6 +149,15 @@ test("the API and UI use the marked rehearsal path without requesting blocked la
   assert.match(component, /localRehearsal\.publicEligible === false/);
   assert.match(component, /Local rehearsal - not public/);
   assert.doesNotMatch(component, /includeBlocked/);
+  assert.match(dataAccess, /resolveMinnesotaPrecinctRehearsal/);
+  assert.match(
+    dataAccess,
+    /requiresPrecinctResultPublicationGate\(input\)\s*&& !resolveMinnesotaPrecinctRehearsal\(\)\.enabled/,
+  );
+  assert.match(
+    api,
+    /persistent: process\.env\.CRM_PRECINCT_REHEARSAL !== "mn"/,
+  );
 });
 
 test("all four pinned candidates can be read and county-filtered locally", {


### PR DESCRIPTION
## What changed

- Preserve the Minnesota production publication gate for every public request.
- Bypass that gate only after the existing guarded local rehearsal proves it is running against loopback `crm_clone_dev` in strict development/test mode.
- Disable persistent result caching only in that local rehearsal mode so an earlier blocked response cannot mask valid clone rows.
- Add regression coverage and document the release-rehearsal correction.

## Root cause

The guarded public-activation work correctly hid blocked Minnesota precinct rows, but the same condition also hid them from the explicitly local-only rehearsal. A persistent development cache could then retain the pre-fix empty response.

## Validation

- `node --experimental-strip-types --test tests/api/api-contract.test.mjs tests/api/mn-precinct-local-rehearsal.test.mjs tests/api/mn-precinct-result-publication-gate.test.mjs` — 10/10 passed
- `npm test` — passed; Python tail 182 tests, 1 skipped
- `npm run typecheck` — passed
- `npm run build` — passed
- Four-year guarded API rehearsal — exact statewide units 4,102 / 4,120 / 4,110 / 4,103 and Hennepin joins 405 / 422 / 425 / 396
- Chromium E2E — all four years passed with OpenStreetMap tiles and no browser/API errors

No production database, Blob, environment, manifest, or deployment state was changed by this PR.