### PR TITLE
Restore live maps and fix Minnesota JSONB validation

### DIFF
--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -6784,3 +6784,17 @@ evidence against its verified top-level package.
   Existing candidates and evidence must be resealed after this reviewed code
   change; no production mutation or public activation is authorized by the
   template alone.
+
+### 2026-08-09 - Minnesota durable-audit JSONB validation repair
+
+- The first guarded Minnesota hidden-load attempt reached its in-transaction
+  validation and rolled back before commit because the durable release-audit
+  comparison cast serialized JSON parameters directly to `jsonb`. With
+  Postgres.js, that encodes the parameter as a JSON string scalar instead of
+  decoding the serialized object.
+
+- Reporting-unit and import-run audit comparisons now cast the parameters
+  through `text` before `jsonb`. A focused regression test pins both casts and
+  rejects the unsafe direct-cast form. The attempted transaction produced no
+  receipt, public file, canonical activation, or production data change; a new
+  package and evidence chain is required after this repair is merged.

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -6798,3 +6798,12 @@ evidence against its verified top-level package.
   rejects the unsafe direct-cast form. The attempted transaction produced no
   receipt, public file, canonical activation, or production data change; a new
   package and evidence chain is required after this repair is merged.
+
+- The same production investigation found that the public result query joined
+  `reporting_units` even for county rows. Because migration 0008 correctly
+  rolled back with the hidden load, that table did not exist; the caught SQL
+  error silently returned the Minnesota, Washington, and Wisconsin starter
+  rows and left 48 state maps empty. Non-gated county/state queries now use a
+  compatibility path that does not reference precinct-only tables, while both
+  Minnesota precinct paths retain the exact publication gate. The production
+  database was not mutated during this incident response.

--- a/scripts/lib/mn-precinct-gis-db.mjs
+++ b/scripts/lib/mn-precinct-gis-db.mjs
@@ -878,9 +878,11 @@ async function validateStoredProductionAudit(
 ) {
   if (!context.releaseCandidate) return;
   const audit = JSON.stringify(context.productionReleaseAudit);
+  // `audit` is serialized JSON text. Preserve the intermediate text cast so
+  // Postgres.js does not encode the parameter as a JSON string scalar.
   const units = await query(sql, [
     "select count(*)::int total,",
-    " count(*) filter (where metadata->'productionReleaseAudit'=$3::jsonb)::int exact_audit",
+    " count(*) filter (where metadata->'productionReleaseAudit'=$3::text::jsonb)::int exact_audit",
     "from reporting_units where state_code=$1 and election_id=$2::uuid",
     " and reporting_grain='precinct'",
   ], [STATE, electionId, audit]);
@@ -892,7 +894,7 @@ async function validateStoredProductionAudit(
   }
   const imports = await query(sql, [
     "select count(distinct ir.id)::int import_runs,count(rr.id)::int result_rows,",
-    " count(rr.id) filter (where ir.metadata->'productionReleaseAudit'=$4::jsonb)::int exact_audit_rows",
+    " count(rr.id) filter (where ir.metadata->'productionReleaseAudit'=$4::text::jsonb)::int exact_audit_rows",
     "from import_runs ir",
     "join result_rows rr on rr.import_run_id=ir.id and rr.state_code=$1",
     "join contests c on c.id=rr.contest_id and c.election_id=$2::uuid",

--- a/src/lib/data-access.ts
+++ b/src/lib/data-access.ts
@@ -664,7 +664,36 @@ export async function listResults(input: {
           )
         order by result_rows.jurisdiction_name, result_rows.candidate_name
       `) as typeof rows
-      : (await sql`
+      // County/state and other non-gated results must remain readable before
+      // the precinct-only migration 0008 schema is installed.
+      : !requiresPublicationGate
+        ? (await sql`
+          select
+            result_rows.state_code as "stateCode",
+            elections.office,
+            result_rows.level,
+            result_rows.jurisdiction_tag as "jurisdictionTag",
+            result_rows.jurisdiction_code as "jurisdictionCode",
+            result_rows.jurisdiction_name as "jurisdictionName",
+            result_rows.candidate_name as "candidateName",
+            result_rows.party,
+            result_rows.votes,
+            result_rows.source_document_id as "sourceDocumentId",
+            source_documents.slug as "sourceSlug"
+          from result_rows
+          inner join contests on result_rows.contest_id = contests.id
+          inner join elections on contests.election_id = elections.id
+          left join source_documents on result_rows.source_document_id = source_documents.id
+          where result_rows.state_code = ${input.state}
+            and result_rows.level = ${input.level}
+            and elections.year = ${input.year}
+            and (
+              ${normalizedOffice}::text is null
+              or lower(elections.office) = ${normalizedOffice}
+            )
+          order by result_rows.jurisdiction_name, result_rows.candidate_name
+        `) as typeof rows
+        : (await sql`
       select
         result_rows.state_code as "stateCode",
         elections.office,

--- a/tests/api/mn-precinct-production-release.test.mjs
+++ b/tests/api/mn-precinct-production-release.test.mjs
@@ -57,6 +57,25 @@ const EMPTY_STATUS_SHA = sha256(Buffer.from("", "utf8"));
 const PACKAGE_PATH = ".etl/package.json";
 const NOW = new Date("2026-08-08T01:00:00.000Z");
 
+test("Minnesota durable-audit SQL decodes serialized parameters as JSON objects", () => {
+  const source = readFileSync(
+    path.resolve(process.cwd(), "scripts/lib/mn-precinct-gis-db.mjs"),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /metadata->'productionReleaseAudit'=\$3::text::jsonb/,
+  );
+  assert.match(
+    source,
+    /ir\.metadata->'productionReleaseAudit'=\$4::text::jsonb/,
+  );
+  assert.doesNotMatch(
+    source,
+    /(?:ir\.)?metadata->'productionReleaseAudit'=\$[34]::jsonb/,
+  );
+});
+
 function candidateDocument() {
   return {
     schemaVersion: 1,

--- a/tests/api/mn-precinct-result-publication-gate.test.mjs
+++ b/tests/api/mn-precinct-result-publication-gate.test.mjs
@@ -152,6 +152,23 @@ test("both precinct result query paths fail closed until exact DB publication", 
   );
 });
 
+test("non-gated results do not require the precinct-only database schema", () => {
+  const source = readFileSync("src/lib/data-access.ts", "utf8");
+  const start = source.indexOf(
+    "// County/state and other non-gated results must remain readable",
+  );
+  const end = source.indexOf(": (await sql`", start);
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  const compatibilityQuery = source.slice(start, end);
+  assert.match(compatibilityQuery, /: !requiresPublicationGate/);
+  assert.match(compatibilityQuery, /from result_rows/);
+  assert.match(compatibilityQuery, /inner join elections/);
+  assert.doesNotMatch(compatibilityQuery, /reporting_units/);
+  assert.doesNotMatch(compatibilityQuery, /geography_versions/);
+  assert.doesNotMatch(compatibilityQuery, /reporting_unit_geometry_crosswalks/);
+});
+
 test("precinct geometry fails closed on the same database publication state", () => {
   const dataAccess = readFileSync("src/lib/data-access.ts", "utf8");
   const route = readFileSync(


### PR DESCRIPTION
## What changed

- Restore ordinary county, state, and other non-gated result queries when the precinct-only migration 0008 schema is not installed.
- Keep both Minnesota precinct result paths and the precinct geometry endpoint fail-closed behind the exact publication gate.
- Decode serialized durable-audit parameters through `text` before casting to `jsonb` in the Minnesota hidden-load postcondition queries.
- Add regression coverage for the live-map compatibility path and the JSONB validator repair.
- Record both incidents and their no-mutation outcomes in the precinct GIS implementation log.

## Production root cause and impact

The live result query unconditionally joined `reporting_units`, including for county maps. Migration 0008 is intentionally coupled to the guarded Minnesota hidden load, and that transaction rolled back before commit, so the table does not yet exist in production. PostgreSQL raised `42P01 relation reporting_units does not exist`; the application caught the error and returned its four starter rows. That left 48 state county maps empty and made Minnesota, Washington, and Wisconsin appear to have only their starter counties.

The compatibility branch now reads county/state results without any precinct-only table. A strict read-only execution against production returned 174 California candidate rows across all 58 counties. No production database rows or schema were changed during diagnosis.

The Minnesota hidden-load failure was separate: Postgres.js serialized the durable audit parameter as a string, so a direct `::jsonb` cast compared a JSON string scalar with the stored object. Casting through `text` restores object equality. The guarded transaction rolled back and produced no receipt or public activation.

## Validation

- Focused result-gate and production-release suites — 23/23 passed
- `npm.cmd test` — passed (all JavaScript suites; Python 182 passed, 1 skipped)
- `npm.cmd run typecheck` — passed
- `npm.cmd run build` — passed
- Strict read-only production compatibility query — 174 California candidate rows, 58 counties
- `git diff --check` — passed

## Website/API display path

After this PR is merged and the resulting production deployment is ready, county maps should again load from the complete production result set. Minnesota precinct maps remain separately blocked until a freshly resealed evidence chain, hidden load, Blob publication, activation deployment, and final database publication transaction complete.

## Caveats and remaining work

- The previous Minnesota package is intentionally stale because these changes alter package-pinned bytes.
- After merge, regenerate and reconfirm the package, overlay, review, and owner confirmation before retrying the guarded production release.
- This PR does not itself migrate the production database or publicly activate Minnesota precinct data.