### PR TITLE
Activate Minnesota precinct maps for 2012-2024

### DIFF
--- a/data/precinct-geometry-coverage-inventory-2012.json
+++ b/data/precinct-geometry-coverage-inventory-2012.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-06T22:26:35.991Z",
+  "updatedAt": "2026-08-10T01:20:59.259Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2012-11-06-general",
@@ -34,12 +34,12 @@
     },
     "disposition": {
       "undecided": 0,
-      "mapped": 0,
+      "mapped": 1,
       "partial": 0,
       "official_geometry_unavailable": 0,
-      "blocked": 1
+      "blocked": 0
     },
-    "publicEligibleJurisdictions": 0
+    "publicEligibleJurisdictions": 1
   },
   "states": [
     {
@@ -48,8 +48,8 @@
       "electionId": "2012-11-06-general",
       "programStatus": "reviewed",
       "wave": 2,
-      "disposition": "blocked",
-      "checkedAt": "2026-08-06T22:26:35.991Z",
+      "disposition": "mapped",
+      "checkedAt": "2026-08-10T01:20:59.259Z",
       "sourceTiers": [
         "tier_1_official_export_database"
       ],
@@ -81,7 +81,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 4102,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 4102,
@@ -91,10 +91,8 @@
         "nonGeographicResultUnits": 0,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Geometry and exact result identity are reviewed, but public delivery remains null until separately authorized production result activation and immutable delivery review."
-      ],
-      "nextAction": "Resolve the listed election-vintage, source-coverage, and result-to-feature blockers; do not publish until every fail-closed eligibility gate passes.",
+      "blockers": [],
+      "nextAction": "Verify the protected deployment and post-cutover APIs against the exact hidden-load and immutable-delivery receipts.",
       "notes": []
     }
   ]

--- a/data/precinct-geometry-coverage-inventory-2016.json
+++ b/data/precinct-geometry-coverage-inventory-2016.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-04T05:16:40.6785927Z",
+  "updatedAt": "2026-08-10T01:20:59.259Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2016-11-08-general",
@@ -34,12 +34,12 @@
     },
     "disposition": {
       "undecided": 0,
-      "mapped": 0,
+      "mapped": 1,
       "partial": 0,
       "official_geometry_unavailable": 0,
-      "blocked": 1
+      "blocked": 0
     },
-    "publicEligibleJurisdictions": 0
+    "publicEligibleJurisdictions": 1
   },
   "states": [
     {
@@ -48,8 +48,8 @@
       "electionId": "2016-11-08-general",
       "programStatus": "reviewed",
       "wave": 2,
-      "disposition": "blocked",
-      "checkedAt": "2026-08-03T06:45:00.000Z",
+      "disposition": "mapped",
+      "checkedAt": "2026-08-10T01:20:59.259Z",
       "sourceTiers": [
         "tier_1_official_export_database"
       ],
@@ -81,7 +81,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 4120,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 4120,
@@ -91,10 +91,8 @@
         "nonGeographicResultUnits": 0,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "The 4,120 one-to-one VTDID relationships are reviewed and the certified SOS workbook reconciles across all 87 county parents and statewide, but relationship review establishes identity—not a public certified-result activation path. The retained LCC elec2016 layer is an unofficial November 9 snapshot with 2,938,405 presidential votes, 6,408 fewer than the certified/recount-inclusive SOS workbook, and differs in 261 VTDs. Delivery remains null until a separately reviewed importer/display path explicitly uses the certified SOS workbook, excludes LCC vote fields, preserves zero-vote units, and is authorized for public activation."
-      ],
-      "nextAction": "Resolve the listed election-vintage, source-coverage, and result-to-feature blockers; do not publish until every fail-closed eligibility gate passes.",
+      "blockers": [],
+      "nextAction": "Verify the protected deployment and post-cutover APIs against the exact hidden-load and immutable-delivery receipts.",
       "notes": []
     }
   ]

--- a/data/precinct-geometry-coverage-inventory-2020.json
+++ b/data/precinct-geometry-coverage-inventory-2020.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-06T22:26:35.991Z",
+  "updatedAt": "2026-08-10T01:20:59.259Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2020-11-03-general",
@@ -34,12 +34,12 @@
     },
     "disposition": {
       "undecided": 0,
-      "mapped": 0,
+      "mapped": 1,
       "partial": 0,
       "official_geometry_unavailable": 0,
-      "blocked": 1
+      "blocked": 0
     },
-    "publicEligibleJurisdictions": 0
+    "publicEligibleJurisdictions": 1
   },
   "states": [
     {
@@ -48,8 +48,8 @@
       "electionId": "2020-11-03-general",
       "programStatus": "reviewed",
       "wave": 3,
-      "disposition": "blocked",
-      "checkedAt": "2026-08-06T22:26:35.991Z",
+      "disposition": "mapped",
+      "checkedAt": "2026-08-10T01:20:59.259Z",
       "sourceTiers": [
         "tier_1_official_export_database"
       ],
@@ -81,7 +81,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 4110,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 4110,
@@ -91,10 +91,8 @@
         "nonGeographicResultUnits": 0,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Public delivery remains null until separately authorized activation using certified SOS result rows."
-      ],
-      "nextAction": "Resolve the listed election-vintage, source-coverage, and result-to-feature blockers; do not publish until every fail-closed eligibility gate passes.",
+      "blockers": [],
+      "nextAction": "Verify the protected deployment and post-cutover APIs against the exact hidden-load and immutable-delivery receipts.",
       "notes": []
     }
   ]

--- a/data/precinct-geometry-coverage-inventory.json
+++ b/data/precinct-geometry-coverage-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-06T23:34:01.344Z",
+  "updatedAt": "2026-08-10T01:20:59.259Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2024-11-05-general",
@@ -34,12 +34,12 @@
     },
     "disposition": {
       "undecided": 0,
-      "mapped": 0,
+      "mapped": 1,
       "partial": 0,
       "official_geometry_unavailable": 0,
-      "blocked": 1
+      "blocked": 0
     },
-    "publicEligibleJurisdictions": 0
+    "publicEligibleJurisdictions": 1
   },
   "states": [
     {
@@ -48,8 +48,8 @@
       "electionId": "2024-11-05-general",
       "programStatus": "reviewed",
       "wave": 5,
-      "disposition": "blocked",
-      "checkedAt": "2026-08-02T06:00:00.000Z",
+      "disposition": "mapped",
+      "checkedAt": "2026-08-10T01:20:59.259Z",
       "sourceTiers": [
         "tier_1_official_export_database"
       ],
@@ -81,7 +81,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 4103,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 4103,
@@ -91,10 +91,8 @@
         "nonGeographicResultUnits": 0,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "The independently reviewed local Minnesota importer retains 87 county aggregates and emits 4,103 precinct ResultRows keyed to the reviewed VTDIDs; zero-vote outcomes and source-disclaimer delivery are covered by regression tests. Public geometry delivery remains null until an explicitly authorized production promotion and geometry release are coordinated, because deploying geometry before those result rows exist would render uncolored precincts."
-      ],
-      "nextAction": "Resolve the listed election-vintage, source-coverage, and result-to-feature blockers; do not publish until every fail-closed eligibility gate passes.",
+      "blockers": [],
+      "nextAction": "Verify the protected deployment and post-cutover APIs against the exact hidden-load and immutable-delivery receipts.",
       "notes": []
     }
   ]

--- a/data/precinct-geometry-manifests.json
+++ b/data/precinct-geometry-manifests.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-06T23:33:53.561Z",
+  "updatedAt": "2026-08-10T01:20:59.259Z",
   "manifests": [
     {
       "schemaVersion": 1,
@@ -73,26 +73,33 @@
         ]
       },
       "validation": {
-        "status": "blocked",
+        "status": "reviewed",
         "geometryValid": true,
-        "rowLevelRenderingSafe": false,
+        "rowLevelRenderingSafe": true,
         "parentTotalsReconciled": true,
-        "errors": [
-          "Geometry and exact result identity are reviewed, but public delivery remains null until separately authorized production result activation and immutable delivery review."
-        ],
+        "errors": [],
         "warnings": [
           "All 4,102 VTDIDs are reviewed exact one-to-one relationships across 87 county parents and statewide.",
-          "The 33 zero-presidential-vote VTDs remain geographic reporting units."
+          "The 33 zero-presidential-vote VTDs remain geographic reporting units.",
+          "LCC-GIS attribution and the complete disclaimer must accompany every delivered copy."
         ]
       },
-      "delivery": null,
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/mn/2012-11-06/precinct/mn-2012-11-06-lcc-2012generalresults-v1-c02f663a25c5/index.json",
+        "sha256": "c02f663a25c51329d88df67d003e4b19c0fa2b2c3292189f4d2300e378aba482",
+        "byteCount": 18116,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 87,
+        "featureCount": 4102
+      },
       "caveats": [
-        "The SOS certified workbook is the sole authority for result values; LCC election-result attributes are retained only for exact source reconciliation.",
-        "Two source PCTNAME values differ from the certified workbook. They are display-only, retained in evidence, and do not affect exact VTDID/PCTCODE/county-parent identity.",
-        "LCC-GIS metadata contains historical spelling/field-description typos; such prose is nonbinding and is not used for identity or vote assignment.",
-        "No election values are emitted in normalized geometry or crosswalk rows.",
-        "Public delivery remains null pending separately authorized public data activation and delivery review.",
-        "Geometry and exact result identity are reviewed, but public delivery remains null until separately authorized production result activation and immutable delivery review."
+        "The certified Minnesota Secretary of State workbook is the sole authority for vote values; LCC election-result attributes are retained only for source reconciliation.",
+        "Two source PCTNAME values differ from the certified workbook. They are display-only differences and do not affect VTDID, PCTCODE, county parent, or result assignment.",
+        "LCC-GIS metadata contains historical spelling and field-description typos; those descriptions are not used for identity or vote assignment.",
+        "The public delivery is presentation-only geometry joined by exact VTDID to certified result rows and contains no election values."
       ]
     },
     {
@@ -166,26 +173,33 @@
         ]
       },
       "validation": {
-        "status": "blocked",
+        "status": "reviewed",
         "geometryValid": true,
-        "rowLevelRenderingSafe": false,
+        "rowLevelRenderingSafe": true,
         "parentTotalsReconciled": true,
-        "errors": [
-          "The 4,120 one-to-one VTDID relationships are reviewed and the certified SOS workbook reconciles across all 87 county parents and statewide, but relationship review establishes identity—not a public certified-result activation path. The retained LCC elec2016 layer is an unofficial November 9 snapshot with 2,938,405 presidential votes, 6,408 fewer than the certified/recount-inclusive SOS workbook, and differs in 261 VTDs. Delivery remains null until a separately reviewed importer/display path explicitly uses the certified SOS workbook, excludes LCC vote fields, preserves zero-vote units, and is authorized for public activation."
-        ],
+        "errors": [],
         "warnings": [
-          "The LCC preliminary election layer is retained only to prove the exact three-way VTDID relationship and document its pre-canvass difference; none of its election values enter normalized geometry, crosswalk relationships, or certified reconciliation.",
+          "The LCC preliminary election layer is retained only for geometry and exact identity review; none of its election values enter normalized geometry, delivery, or certified result rows.",
           "The 31 official zero-presidential-vote VTDIDs remain geographic one-to-one result units.",
-          "LCC attribution, disclaimer, and redistribution terms must accompany any future public geometry delivery."
+          "LCC-GIS attribution and the complete disclaimer must accompany every delivered copy."
         ]
       },
-      "delivery": null,
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/mn/2016-11-08/precinct/mn-2016-11-08-lcc-vtd2016general-v1-df59572f067e/index.json",
+        "sha256": "df59572f067e51645b9871d334beb141bb5cf89053bbea0d6b5e1c5dfc57f5e8",
+        "byteCount": 18063,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 87,
+        "featureCount": 4120
+      },
       "caveats": [
-        "The 4,120 one-to-one VTDID relationships are reviewed and the certified SOS workbook reconciles across all 87 county parents and statewide, but relationship review establishes identity—not a public certified-result activation path. The retained LCC elec2016 layer is an unofficial November 9 snapshot with 2,938,405 presidential votes, 6,408 fewer than the certified/recount-inclusive SOS workbook, and differs in 261 VTDs. Delivery remains null until a separately reviewed importer/display path explicitly uses the certified SOS workbook, excludes LCC vote fields, preserves zero-vote units, and is authorized for public activation.",
-        "The reviewed one-to-one relationship proves identity and cardinality only. It does not make the preliminary LCC vote fields certified and does not authorize public delivery without an explicitly reviewed certified-result importer/display path.",
-        "All election values are confined to retained source evidence and reconciliation summaries. Normalized geometry and crosswalk relationship rows contain no election values.",
-        "PCTNAME and MCDNAME display strings differ in some boundary/workbook rows; exact official IDs, county parents, and PCTCODE—not names—govern every relationship.",
-        "The retained SOS landing-page HTML is one byte-pinned official response captured during this task. The upstream page is dynamically regenerated, so retrievedAt records this retained response's collection context and does not assert that later upstream HTML bytes will remain identical."
+        "The certified and recount-inclusive Minnesota Secretary of State workbook is the sole authority for vote values. The LCC election snapshot is 6,408 votes below the certified total and is never used as a public vote source.",
+        "All 4,120 public relationships use reviewed exact VTDID identity; PCTNAME and MCDNAME differences do not determine result assignment.",
+        "The public delivery is presentation-only geometry and contains no election values.",
+        "The retained SOS landing-page HTML is a byte-pinned response; later upstream HTML may be regenerated without changing the retained evidence."
       ]
     },
     {
@@ -259,23 +273,32 @@
         ]
       },
       "validation": {
-        "status": "blocked",
+        "status": "reviewed",
         "geometryValid": true,
-        "rowLevelRenderingSafe": false,
+        "rowLevelRenderingSafe": true,
         "parentTotalsReconciled": true,
-        "errors": [
-          "Public delivery remains null until separately authorized activation using certified SOS result rows."
-        ],
+        "errors": [],
         "warnings": [
-          "The 4,110 reviewed relationships use LCC geometry/identity only. No preliminary election values are present in normalized geometry or crosswalk relationships.",
-          "The 33 certified zero-vote VTDs remain geographic one-to-one units."
+          "All 4,110 relationships use LCC geometry and identity only. Preliminary election values are excluded from normalized geometry, delivery, and public results.",
+          "The 33 certified zero-vote VTDs remain geographic one-to-one units.",
+          "LCC-GIS attribution and the complete disclaimer must accompany every delivered copy."
         ]
       },
-      "delivery": null,
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/mn/2020-11-03/precinct/mn-2020-11-03-lcc-preliminary-identity-geometry-v1-871a8df40d68/index.json",
+        "sha256": "871a8df40d682ebf790aa8f755ecf3b995b7a8a7c8569d10807b26ca26a5cb9d",
+        "byteCount": 17041,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 87,
+        "featureCount": 4110
+      },
       "caveats": [
-        "PCTNAME display/capitalization differences (4,110), MCDNAME differences (133), and COUNTYNAME differences (46) are nonbinding; exact VTDID and county/precinct-code construction govern relationships.",
-        "The preliminary LCC archive is not a vote source. Certified SOS results are the only vote authority.",
-        "Public delivery remains blocked pending separately authorized activation."
+        "PCTNAME, MCDNAME, and COUNTYNAME display differences are nonbinding; exact VTDID and county/precinct-code construction govern every relationship.",
+        "The preliminary LCC archive is not a vote source. The certified Minnesota Secretary of State workbook is the sole authority for vote values.",
+        "The public delivery is presentation-only geometry joined by exact VTDID and contains no election values."
       ]
     },
     {
@@ -347,23 +370,32 @@
         ]
       },
       "validation": {
-        "status": "blocked",
+        "status": "reviewed",
         "geometryValid": true,
-        "rowLevelRenderingSafe": false,
+        "rowLevelRenderingSafe": true,
         "parentTotalsReconciled": true,
-        "errors": [
-          "The independently reviewed local Minnesota importer retains 87 county aggregates and emits 4,103 precinct ResultRows keyed to the reviewed VTDIDs; zero-vote outcomes and source-disclaimer delivery are covered by regression tests. Public geometry delivery remains null until an explicitly authorized production promotion and geometry release are coordinated, because deploying geometry before those result rows exist would render uncolored precincts."
-        ],
+        "errors": [],
         "warnings": [
-          "All 4,103 official VTDID relationships are reviewed one-to-one and reconcile across all 87 counties and statewide; the remaining blocker is independent importer review and public-data activation, not geometry or vote reconciliation.",
-          "The 28 official zero-presidential-vote precincts remain geographic reporting units and are retained in the crosswalk."
+          "All 4,103 official VTDID relationships are reviewed one-to-one and reconcile across all 87 counties and statewide.",
+          "The 28 official zero-presidential-vote precincts remain geographic reporting units.",
+          "LCC-GIS attribution and the complete disclaimer must accompany every delivered copy."
         ]
       },
-      "delivery": null,
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/mn/2024-11-05/precinct/mn-2024-11-05-lcc-vtd2024general-v1-436ed4d5ca13/index.json",
+        "sha256": "436ed4d5ca1328a7d7c1505daf4137b96cb9efc608d354b4da6747a31b0af40a",
+        "byteCount": 17006,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 87,
+        "featureCount": 4103
+      },
       "caveats": [
-        "The independently reviewed local Minnesota importer retains 87 county aggregates and emits 4,103 precinct ResultRows keyed to the reviewed VTDIDs; zero-vote outcomes and source-disclaimer delivery are covered by regression tests. Public geometry delivery remains null until an explicitly authorized production promotion and geometry release are coordinated, because deploying geometry before those result rows exist would render uncolored precincts.",
-        "One zero-vote VTD has a County Commissioner District attribute difference; exact precinct identity fields still agree and no result assignment depends on that district attribute.",
-        "The LCC-GIS source disclaimer and attribution requirements must accompany any future public delivery."
+        "The certified Minnesota Secretary of State workbook is the sole authority for vote values; delivery geometry contains no election values.",
+        "One zero-vote VTD has a County Commissioner District attribute difference. Exact precinct identity fields still agree and result assignment does not depend on that district attribute.",
+        "Public precinct geometry and certified result rows must remain coordinated so every delivered feature resolves to its exact reporting unit."
       ]
     }
   ]

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -6859,3 +6859,37 @@ evidence against its verified top-level package.
   chain are superseded. A fresh clean commit, local validation, package seal,
   preflight, and restore-verified backup are required before another production
   attempt.
+
+### 2026-08-09 - Minnesota hidden load and immutable delivery completed
+
+- Corrected release package `d0804cf50313...` passed strict loopback
+  validation, the complete repository test suite, TypeScript validation, and
+  the production build. A fresh production read-only preflight found migration
+  0008 absent and zero invalid constraints. The subsequent full `public`
+  backup restored and exactly matched all 27 tables before the guarded write.
+
+- The coupled migration and four-election load committed as
+  `COMMITTED_HIDDEN_NOT_PUBLIC` under receipt `fe5fc5cede9...`. Production now
+  contains 16,435 Minnesota precinct reporting units, 49,305 certified
+  candidate rows, 16,435 geometry features, and 16,435 reviewed exact-ID
+  crosswalks. The transaction retained blocked geography-version status and
+  `publicDeliveryAuthorized=false`; live Hennepin checks returned zero precinct
+  rows and 404 geometry responses for 2012, 2016, 2020, and 2024.
+
+- All 352 parent-scoped delivery objects (348 county GeoJSON files and four
+  indexes, 124,197,990 bytes total) were uploaded to the existing public Vercel
+  Blob store, downloaded again, and SHA-256 verified. Publication evidence
+  `83ff6a673fdb...` records the single credential-free origin
+  `https://ehnlruzhgkm5byoi.public.blob.vercel-storage.com`; canonical manifests
+  and database publication status remained unchanged by the upload.
+
+- The receipt-bound activation generator updated exactly the four annual
+  coverage inventories and canonical manifest registry. Local rehearsal tests
+  now prove that the obsolete blocked-manifest rehearsal cannot override an
+  activated canonical manifest, and the release-candidate test proves an
+  activated registry cannot be resealed as a blocked preimage. The 24-file
+  Minnesota suite, national map/provenance validators, and production build
+  pass. Public access remains fail-closed until the activation branch has a
+  protected preview, is merged and deployed with the exact Blob origin, and a
+  separately authorized database publication transaction completes the final
+  cutover.

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -6837,3 +6837,25 @@ evidence against its verified top-level package.
   is intentionally superseded by the final reseal after this entry is
   committed. No production database write, Blob upload, Vercel environment
   change, canonical activation, deployment, or Git publication occurred.
+
+### 2026-08-09 - Minnesota import-run durable-audit schema repair
+
+- The next guarded hidden-load attempt passed migration execution and reached
+  the in-transaction durable-audit checks, where it rolled back because the
+  import-run audit query referenced a nonexistent `import_runs.metadata`
+  column. The established import-run JSON document is stored in the required
+  `summary` column, and the loader already writes `productionReleaseAudit`
+  there.
+
+- The validator now reads `import_runs.summary` while retaining the serialized
+  text-to-`jsonb` comparison required by the prior repair. The focused SQL
+  regression test pins the real schema column and continues to reject unsafe
+  direct JSONB parameter casts. The failed transaction created no hidden-load
+  receipt and made no production database, public-file, canonical-manifest, or
+  deployment change.
+
+- Because the validator and this ledger are package-pinned inputs, the prior
+  `aec5476e19a3...` package and its preflight, backup authorization, and review
+  chain are superseded. A fresh clean commit, local validation, package seal,
+  preflight, and restore-verified backup are required before another production
+  attempt.

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -6807,3 +6807,33 @@ evidence against its verified top-level package.
   compatibility path that does not reference precinct-only tables, while both
   Minnesota precinct paths retain the exact publication gate. The production
   database was not mutated during this incident response.
+
+### 2026-08-09 - Minnesota post-repair release reseal
+
+- A clean `feature/mn-precinct-map-activation` worktree was created from merged
+  production commit `ccb8fa89e5816e80461cd07f40e388883f4b7eaa`. The 55
+  reviewed local-only Minnesota source/normalized/crosswalk artifacts and four
+  statewide delivery candidates were copied from the prior clean release
+  worktree only after byte-for-byte SHA-256 comparison with the primary local
+  copies found no difference. They remain untracked release inputs and are not
+  candidates for Git publication.
+
+- The strict loopback `crm_clone_dev` validator again proved 16,435 reporting
+  units, 49,305 certified candidate rows, 16,435 geometry features, 16,435
+  reviewed exact-ID crosswalks, 125 zero-vote units, and zero invalid
+  constraints. The focused Minnesota precinct suite, complete repository test
+  suite, TypeScript validation, and optimized production build passed.
+
+- The guarded local rehearsal passed for all four tracked elections while the
+  canonical manifests remained blocked. Hennepin County rendered and joined
+  405/405 precincts for 2012, 422/422 for 2016, 425/425 for 2020, and 396/396
+  for 2024. The browser check retained the official source terms and visible
+  OpenStreetMap attribution and reported no failed API response, browser error,
+  or framework overlay.
+
+- A provisional post-repair package/overlay/review chain was generated as
+  `d56a0bd04069...`, `e55e382a50a7...`, and `e8da7ac12601...`. This required
+  ledger entry is itself a package-pinned dependency, so that provisional chain
+  is intentionally superseded by the final reseal after this entry is
+  committed. No production database write, Blob upload, Vercel environment
+  change, canonical activation, deployment, or Git publication occurred.

--- a/scripts/lib/mn-precinct-gis-db.mjs
+++ b/scripts/lib/mn-precinct-gis-db.mjs
@@ -894,7 +894,7 @@ async function validateStoredProductionAudit(
   }
   const imports = await query(sql, [
     "select count(distinct ir.id)::int import_runs,count(rr.id)::int result_rows,",
-    " count(rr.id) filter (where ir.metadata->'productionReleaseAudit'=$4::text::jsonb)::int exact_audit_rows",
+    " count(rr.id) filter (where ir.summary->'productionReleaseAudit'=$4::text::jsonb)::int exact_audit_rows",
     "from import_runs ir",
     "join result_rows rr on rr.import_run_id=ir.id and rr.state_code=$1",
     "join contests c on c.id=rr.contest_id and c.election_id=$2::uuid",

--- a/tests/api/mn-precinct-local-rehearsal.test.mjs
+++ b/tests/api/mn-precinct-local-rehearsal.test.mjs
@@ -8,7 +8,6 @@ import {
   findMinnesotaPrecinctRehearsalManifest,
   listPrecinctGeometryManifestViewsWithMinnesotaRehearsal,
   MINNESOTA_PRECINCT_REHEARSAL_CANDIDATES,
-  readMinnesotaPrecinctRehearsalDelivery,
   resolveMinnesotaPrecinctRehearsal,
   verifyMinnesotaPrecinctRehearsalCandidateBytes,
 } from "../../src/lib/mn-precinct-rehearsal-server.ts";
@@ -49,11 +48,15 @@ test.beforeEach(restoreEnvironment);
 test("Minnesota rehearsal is absent unless the explicit local clone guard passes", () => {
   process.env.NODE_ENV = "test";
   assert.deepEqual(resolveMinnesotaPrecinctRehearsal(), { enabled: false });
+  const publicViews = listPrecinctGeometryManifestViewsWithMinnesotaRehearsal(
+    registry,
+    { state: "MN" },
+  );
+  assert.equal(publicViews.length, 4);
+  assert.equal(publicViews.every((view) => view.eligible), true);
   assert.equal(
-    listPrecinctGeometryManifestViewsWithMinnesotaRehearsal(registry, {
-      state: "MN",
-    }).length,
-    0,
+    publicViews.every((view) => !("localRehearsal" in view)),
+    true,
   );
 
   configureRehearsal();
@@ -84,44 +87,16 @@ test("Minnesota rehearsal is absent unless the explicit local clone guard passes
   assert.throws(resolveMinnesotaPrecinctRehearsal, /only permits localhost/);
 });
 
-test("the local manifest overlay preserves all canonical release blockers", () => {
+test("the local rehearsal refuses to override activated canonical manifests", () => {
   configureRehearsal();
   const before = JSON.stringify(registry);
-  const views = listPrecinctGeometryManifestViewsWithMinnesotaRehearsal(
-    registry,
-    { state: "MN" },
+  assert.throws(
+    () => listPrecinctGeometryManifestViewsWithMinnesotaRehearsal(
+      registry,
+      { state: "MN" },
+    ),
+    /no longer matches its reviewed blocked contract/,
   );
-
-  assert.equal(views.length, 4);
-  assert.deepEqual(
-    views.map((view) => view.election.year),
-    [2012, 2016, 2020, 2024],
-  );
-  for (const view of views) {
-    const candidate = MINNESOTA_PRECINCT_REHEARSAL_CANDIDATES.find(
-      (entry) => entry.manifestId === view.id,
-    );
-    assert.ok(candidate);
-    assert.equal(view.eligible, false);
-    assert.equal(view.delivery, null);
-    assert.equal(view.validation.status, "blocked");
-    assert.equal(view.validation.rowLevelRenderingSafe, false);
-    assert.deepEqual(view.publicEligibilityReasons, [
-      "validation status is not reviewed",
-      "row-level rendering is not safe",
-      "validation errors remain",
-      "no immutable delivery artifact is declared",
-    ]);
-    assert.equal(view.localRehearsal.active, true);
-    assert.equal(view.localRehearsal.mode, "local_only");
-    assert.equal(view.localRehearsal.publicEligible, false);
-    assert.equal(view.localRehearsal.delivery.sha256, candidate.sha256);
-    assert.equal(view.localRehearsal.delivery.byteCount, candidate.byteCount);
-    assert.equal(
-      view.localRehearsal.delivery.featureCount,
-      candidate.featureCount,
-    );
-  }
   assert.equal(JSON.stringify(registry), before);
   assert.equal(existsSync("public/data/geography/mn"), false);
 });
@@ -160,47 +135,33 @@ test("the API and UI use the marked rehearsal path without requesting blocked la
   );
 });
 
-test("all four pinned candidates can be read and county-filtered locally", {
-  timeout: 120_000,
-}, async () => {
+test("all four activated manifests reject the obsolete local rehearsal lookup", () => {
   configureRehearsal();
   for (const candidate of MINNESOTA_PRECINCT_REHEARSAL_CANDIDATES) {
-    const lookup = findMinnesotaPrecinctRehearsalManifest(
-      registry,
-      candidate.manifestId,
-    );
-    assert.ok(lookup);
-    const delivery = await readMinnesotaPrecinctRehearsalDelivery(
-      lookup,
-      "27053",
-    );
-    assert.equal(delivery.sourceByteCount, candidate.byteCount);
-    assert.equal(delivery.sourceSha256, candidate.sha256);
-    assert.ok(delivery.collection.features.length > 0);
-    assert.equal(
-      delivery.collection.features.every(
-        (feature) => feature.properties.parentGeoid === "27053",
+    assert.throws(
+      () => findMinnesotaPrecinctRehearsalManifest(
+        registry,
+        candidate.manifestId,
       ),
-      true,
+      /no longer matches its reviewed blocked contract/,
     );
-    assert.equal(delivery.collection.metadata.manifestId, candidate.manifestId);
-    assert.equal(delivery.collection.metadata.state, "MN");
   }
 });
 
-test("a wrong local candidate is rejected before it can be served", () => {
-  configureRehearsal();
+test("activated manifest bytes cannot be served through the local rehearsal path", () => {
   const candidate = MINNESOTA_PRECINCT_REHEARSAL_CANDIDATES[3];
-  const lookup = findMinnesotaPrecinctRehearsalManifest(
+  const publicView = listPrecinctGeometryManifestViewsWithMinnesotaRehearsal(
     registry,
-    candidate.manifestId,
-  );
-  assert.ok(lookup);
+    { state: "MN" },
+  )
+    .find((view) => view.id === candidate.manifestId);
+  assert.ok(publicView);
+  configureRehearsal();
   assert.throws(
     () => verifyMinnesotaPrecinctRehearsalCandidateBytes(
-      lookup,
+      { candidate, manifest: publicView },
       Buffer.from("not pinned"),
     ),
-    /byte count does not match its pin/,
+    /no longer matches its reviewed blocked contract/,
   );
 });

--- a/tests/api/mn-precinct-production-release.test.mjs
+++ b/tests/api/mn-precinct-production-release.test.mjs
@@ -68,11 +68,11 @@ test("Minnesota durable-audit SQL decodes serialized parameters as JSON objects"
   );
   assert.match(
     source,
-    /ir\.metadata->'productionReleaseAudit'=\$4::text::jsonb/,
+    /ir\.summary->'productionReleaseAudit'=\$4::text::jsonb/,
   );
   assert.doesNotMatch(
     source,
-    /(?:ir\.)?metadata->'productionReleaseAudit'=\$[34]::jsonb/,
+    /(?:ir\.)?(?:metadata|summary)->'productionReleaseAudit'=\$[34]::jsonb/,
   );
 });
 

--- a/tests/api/mn-precinct-release-candidate.test.mjs
+++ b/tests/api/mn-precinct-release-candidate.test.mjs
@@ -33,6 +33,17 @@ const EXPECTED_DELIVERIES = new Map([
   [2024, { byteCount: 27_550_483, sha256: "df94482464f9cd7065b2e6cf624eb6d19ab5717bb477ac57e798dd23066f9f06" }],
 ]);
 
+const canonicalRegistry = JSON.parse(
+  readFileSync("data/precinct-geometry-manifests.json", "utf8"),
+);
+const canonicalRegistryActivated = canonicalRegistry.manifests
+  .filter((manifest) => manifest.state === "MN")
+  .every((manifest) =>
+    manifest.validation?.status === "reviewed"
+    && manifest.validation?.rowLevelRenderingSafe === true
+    && manifest.delivery?.format === "parent_scoped_geojson"
+  );
+
 function canonicalPreimages() {
   return new Map(
     ["data/precinct-geometry-manifests.json", ...MANIFEST_PATHS]
@@ -41,9 +52,23 @@ function canonicalPreimages() {
 }
 
 const before = canonicalPreimages();
-const built = buildMinnesotaPrecinctReleaseCandidate();
+const built = canonicalRegistryActivated
+  ? null
+  : buildMinnesotaPrecinctReleaseCandidate();
 
-test("Minnesota release candidate freezes four exact deliveries and remains production no-go", () => {
+function preActivationTest(name, callback) {
+  test(name, (context) => {
+    if (canonicalRegistryActivated) {
+      context.skip(
+        "The canonical registry is already activated; the pre-activation package is immutable evidence.",
+      );
+      return;
+    }
+    return callback();
+  });
+}
+
+preActivationTest("Minnesota release candidate freezes four exact deliveries and remains production no-go", () => {
   const document = built.packageDocument;
   assert.equal(document.id, "mn-precinct-gis-four-election-v1");
   assert.equal(document.state, "MN");
@@ -140,7 +165,7 @@ test("Minnesota release candidate freezes four exact deliveries and remains prod
   assert.equal(document.localValidation.database.readOnlySession, true);
 });
 
-test("Minnesota local draft manifests pass the public contract without changing canonical files", () => {
+preActivationTest("Minnesota local draft manifests pass the public contract without changing canonical files", () => {
   assert.equal(built.draftManifests.length, 4);
   for (const draft of built.draftManifests) {
     const inspection = inspectPrecinctGeometryManifest(draft.manifest);
@@ -168,7 +193,7 @@ test("Minnesota local draft manifests pass the public contract without changing 
   }
 });
 
-test("Minnesota release package carries four indexes and 348 county assets", () => {
+preActivationTest("Minnesota release package carries four indexes and 348 county assets", () => {
   assert.equal(built.deliveryAssets.length, 352);
   assert.equal(
     built.deliveryAssets.filter((artifact) => artifact.path.endsWith("/index.json")).length,
@@ -184,7 +209,7 @@ test("Minnesota release package carries four indexes and 348 county assets", () 
   );
 });
 
-test("Minnesota release package serialization and dependency inventory are hash reviewable", () => {
+preActivationTest("Minnesota release package serialization and dependency inventory are hash reviewable", () => {
   assert.equal(
     built.packageBytes.equals(
       serializeMinnesotaReleaseDocument(built.packageDocument),
@@ -238,6 +263,17 @@ test("Minnesota release package serialization and dependency inventory are hash 
     assert.equal(group.every((item) => /^[a-f0-9]{64}$/.test(item.sha256)), true);
   }
   assert.ok(inventory.patchIsolationWarnings.length >= 4);
+});
+
+test("Minnesota activated registry cannot be resealed as a blocked release preimage", (context) => {
+  if (!canonicalRegistryActivated) {
+    context.skip("The canonical registry has not reached the public-activation lifecycle state.");
+    return;
+  }
+  assert.throws(
+    () => buildMinnesotaPrecinctReleaseCandidate(),
+    /registry manifest differs from its canonical file|canonical manifest is no longer fail-closed/,
+  );
 });
 
 test("Minnesota release artifact inspection rejects hash or byte tampering", () => {


### PR DESCRIPTION
## Scope

- Activate reviewed Minnesota precinct map manifests for the 2012, 2016, 2020, and 2024 presidential general elections.
- Update the four annual coverage inventories and canonical manifest registry from blocked to reviewed parent-scoped delivery.
- Fix the production durable-audit validator to read the established `import_runs.summary` JSONB column.
- Make local-rehearsal and release-candidate tests lifecycle-aware so an activated registry cannot be overridden or resealed as a blocked preimage.
- Retain OpenStreetMap as the precinct-map basemap and preserve visible LCC-GIS source terms and attribution.

## Official sources confirmed

- Certified Minnesota Secretary of State precinct result workbooks remain the sole vote authority for all four elections.
- Minnesota Legislative Coordinating Commission GIS election-vintage boundaries provide geometry and exact VTD identity.
- Preliminary LCC election attributes are excluded from public vote values; certified SOS rows are joined by reviewed exact VTD IDs.
- No raw GIS/source artifact is committed in this PR. The retained local artifacts remain hash-pinned release evidence.

## Guarded production preparation completed

- Release package: `d0804cf5031325fd1877a7a7fe232977e2fba62b74eb2f32c00a1cb276ff32cf`.
- Hidden-load receipt: `fe5fc5cede9dfa81f8829f20c38c7a7393171ab3914f6d92592b77199bad59fe` (`COMMITTED_HIDDEN_NOT_PUBLIC`).
- Loaded 16,435 precinct reporting units, 49,305 certified candidate rows, 16,435 geometry features, and 16,435 reviewed exact-ID crosswalks.
- All four geography versions remain blocked in the database with `publicDeliveryAuthorized=false`.
- A full production `public`-schema backup was restored and exactly verified across all 27 tables before the hidden load.
- Blob evidence: `83ff6a673fdb2bad577bb3e10f9bfd8a27689c64ffb92a879875fad88462e1b3`.
- Uploaded and re-downloaded/hash-verified 352 immutable objects (348 county GeoJSON files plus four indexes) at `https://ehnlruzhgkm5byoi.public.blob.vercel-storage.com`.
- `CRM_PRECINCT_GEOGRAPHY_ORIGIN` is configured for Preview only. Production is intentionally unchanged.

## Validation

- CivicResultMaps MCP doctor/inventory: healthy; no workflow drift.
- Strict loopback `crm_clone_dev` validation: 16,435 units/features/crosswalks, 49,305 rows, 125 zero-vote units, zero invalid constraints.
- `npm.cmd test`
- `npm.cmd run typecheck`
- `npm.cmd run build`
- `npm.cmd run test:precinct-geometry:mn` (24 files)
- `npm.cmd run validate:maps` (51-state geometry and joins; no failures)
- `npm.cmd run validate:provenance` (no missing source IDs/URLs)
- Focused Minnesota production-release/public-activation tests: 33/33 passed before activation generation.
- Post-load live fail-closed checks for Hennepin County: zero precinct rows and HTTP 404 geometry for 2012, 2016, 2020, and 2024.

## Website/API display path

- UI after final publication: Map tab -> Minnesota -> election year -> county -> Precinct detail.
- Manifest API: `/api/geography-manifests?state=MN`.
- Result API: `/api/results?state=MN&year=<year>&level=precinct&parentGeoid=<county GEOID>`.
- Geometry API: `/api/precinct-geography?manifestId=<manifest ID>&parentGeoid=<county GEOID>`.

## Remaining protected gates

- Do not merge until the PR Preview is READY on the exact activation commit and access protection is verified.
- The Preview must still return zero precinct result rows and 404 geometry because database publication status remains blocked.
- Before merging, configure the exact same Blob origin for Production and record the gate-capable rollback deployment.
- Merging to `main` auto-deploys production. After that exact deployment is READY/PROMOTED and still blocked, a separate receipt-bound `GO_PUBLIC` database transaction is the final public cutover.
- This PR does not itself change database publication status or perform that final cutover.

## Caveats and review

- 2016 and 2020 LCC election layers are geometry/identity evidence only; their preliminary election values are not displayed.
- Zero-vote precincts remain geographic and are retained.
- No new review subagent was spawned because the current coordination policy disallows unsolicited delegation. The previously reviewed guarded activation architecture remains intact, and the final diff passed the complete focused, national, and build validations listed above.
