### PR TITLE
Fix Minnesota publication JSONB comparison

### DIFF
--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -6893,3 +6893,28 @@ evidence against its verified top-level package.
   protected preview, is merged and deployed with the exact Blob origin, and a
   separately authorized database publication transaction completes the final
   cutover.
+
+### 2026-08-10 - Minnesota publication postcondition JSONB cast repair
+
+- Activation PR #215 merged and the exact activation tree was rebuilt in
+  Production with the reviewed Blob origin. Fresh protected-Preview,
+  Production, and prior gate-capable rollback-deployment checks all passed
+  while the database remained blocked.
+
+- The first guarded publication transaction revalidated the complete
+  Minnesota GIS plan and performed its status changes inside PostgreSQL, but
+  its final geography-version postcondition rejected the transaction and
+  rolled everything back. Live precinct results remained empty, geometry
+  remained 404, and no publication receipt was issued.
+
+- Forced-rollback diagnostics proved that status, authorization flags,
+  activation/package/Blob hashes, delivery origin, operation mode, and revision
+  all matched for four versions. Only the rollback target comparison failed:
+  the stored value was a JSON object, while the direct `$9::jsonb` parameter
+  comparison interpreted the serialized expectation as a JSON string.
+
+- Both publish and rollback postconditions now use the established
+  `$9::text::jsonb` boundary used elsewhere in this release tooling. Focused
+  regression assertions pin that exact cast for both operations. This repair
+  requires its own reviewed deployment and fresh deployment-bound public
+  authorization before the atomic database cutover is retried.

--- a/scripts/publish-mn-precinct-geography-status.mjs
+++ b/scripts/publish-mn-precinct-geography-status.mjs
@@ -489,11 +489,11 @@ async function verifyMinnesotaPublicationPostconditions(
     "  and gv.metadata->'publicActivation'->>'blobPublicationSha256'=$6",
     "  and gv.metadata->'publicActivation'->>'deliveryOrigin'=$7",
     "  and gv.metadata->'publicActivation'->>'authorizationSha256'=$8",
-    "  and gv.metadata->'publicActivation'->'rollbackTarget'=$9::jsonb",
+    "  and gv.metadata->'publicActivation'->'rollbackTarget'=$9::text::jsonb",
     "  and gv.metadata->'publicActivation'->>'mode'='publish')::int bound_activation,",
     context.mode === "publish"
       ? " count(*) filter (where not (gv.metadata->'publicActivation' ? 'rollback'))::int operation_bound,"
-      : " count(*) filter (where gv.metadata->'publicActivation'->'rollback'->>'rollbackId'=$10 and gv.metadata->'publicActivation'->'rollback'->>'activationCandidateSha256'=$4 and gv.metadata->'publicActivation'->'rollback'->>'blobPublicationSha256'=$6 and gv.metadata->'publicActivation'->'rollback'->>'authorizationSha256'=$11 and gv.metadata->'publicActivation'->'rollback'->>'publicationReceiptSha256'=$12 and gv.metadata->'publicActivation'->'rollback'->'rollbackTarget'=$9::jsonb and (gv.metadata->'publicActivation'->>'revision')::int=$13 and gv.metadata->'publicActivation'->>'changedAtUtc'=$14)::int operation_bound,",
+      : " count(*) filter (where gv.metadata->'publicActivation'->'rollback'->>'rollbackId'=$10 and gv.metadata->'publicActivation'->'rollback'->>'activationCandidateSha256'=$4 and gv.metadata->'publicActivation'->'rollback'->>'blobPublicationSha256'=$6 and gv.metadata->'publicActivation'->'rollback'->>'authorizationSha256'=$11 and gv.metadata->'publicActivation'->'rollback'->>'publicationReceiptSha256'=$12 and gv.metadata->'publicActivation'->'rollback'->'rollbackTarget'=$9::text::jsonb and (gv.metadata->'publicActivation'->>'revision')::int=$13 and gv.metadata->'publicActivation'->>'changedAtUtc'=$14)::int operation_bound,",
     context.mode === "publish"
       ? " min((gv.metadata->'publicActivation'->>'revision')::int)::int revision_min, max((gv.metadata->'publicActivation'->>'revision')::int)::int revision_max"
       : " min((gv.metadata->'publicActivation'->'rollback'->>'revision')::int)::int revision_min, max((gv.metadata->'publicActivation'->'rollback'->>'revision')::int)::int revision_max",

--- a/tests/api/mn-precinct-public-activation.test.mjs
+++ b/tests/api/mn-precinct-public-activation.test.mjs
@@ -1133,6 +1133,7 @@ test("Minnesota publication transaction atomically publishes exact versions and 
         },
       },
     }));
+    let versionPostconditionSql = null;
     const tx = {
       async unsafe(sql) {
         if (sql.includes("current_database()")) {
@@ -1156,6 +1157,7 @@ test("Minnesota publication transaction atomically publishes exact versions and 
           return [{ count: 4 }];
         }
         if (sql.includes("select count(*)::int versions")) {
+          versionPostconditionSql = sql;
           return [{
             versions: 4,
             expected_status: 4,
@@ -1224,6 +1226,10 @@ test("Minnesota publication transaction atomically publishes exact versions and 
       },
       productionMutationPerformed: true,
     });
+    assert.match(
+      versionPostconditionSql,
+      /rollbackTarget'=\$9::text::jsonb/,
+    );
   } finally {
     rmSync(item.root, { recursive: true, force: true });
   }
@@ -1270,6 +1276,7 @@ test("Minnesota rollback restores original caveats and rejects a substituted rol
       },
     }));
     const restoredCaveats = [];
+    let rollbackPostconditionSql = null;
     const tx = {
       async unsafe(sql, parameters = []) {
         if (sql.includes("current_database()")) {
@@ -1299,6 +1306,7 @@ test("Minnesota rollback restores original caveats and rejects a substituted rol
           return [{ revision: 30 }];
         }
         if (sql.includes("select count(*)::int versions")) {
+          rollbackPostconditionSql = sql;
           return [{
             versions: 4,
             expected_status: 4,
@@ -1390,6 +1398,10 @@ test("Minnesota rollback restores original caveats and rejects a substituted rol
     assert.equal(result.revision, 30);
     assert.equal(result.committedAtUtc, "2026-08-08T01:30:00.000Z");
     assert.deepEqual(restoredCaveats, Array(4).fill("Public delivery is not authorized."));
+    assert.match(
+      rollbackPostconditionSql,
+      /rollbackTarget'=\$9::text::jsonb/,
+    );
 
     await assert.rejects(
       () => applyMinnesotaGeographyPublicationTransaction(tx, {


### PR DESCRIPTION
## Scope

Fix the final Minnesota precinct publication-status postcondition for both publish and rollback operations.

## Root cause and safety evidence

The guarded production transaction correctly stored `publicActivation.rollbackTarget` as a JSON object, but the final SQL postcondition compared its serialized parameter using `$9::jsonb`. With the production PostgreSQL driver, that cast produced a JSON string, so all four otherwise-correct geography versions were rejected.

The failed transaction and every diagnostic transaction rolled back atomically. Live Minnesota precinct results remain empty, geometry remains `404`, and no publication receipt was issued.

Forced-rollback diagnostics proved that all four rows matched the expected status, authorization flags, activation/package/Blob hashes, delivery origin, operation mode, and revision; only the rollback-target comparison failed.

## Changes

- Cast the serialized rollback target through text before JSONB in the publish postcondition.
- Apply the same correction to the rollback postcondition.
- Pin both SQL forms with focused regression assertions.
- Record the production-safe incident and rollback evidence in the precinct GIS implementation ledger.

## Validation

- `node --experimental-strip-types --test tests/api/mn-precinct-public-activation.test.mjs` — 15/15 passed.
- `npm.cmd run typecheck` — passed.
- `npm.cmd run build` — passed.
- `git diff --check` — no content errors; Windows line-ending warnings only.
- Live fail-closed verification after rollback: zero Minnesota precinct result rows and `404` geometry.

## Website/API path

After this hotfix is merged and deployed, the existing guarded cutover will publish Minnesota precinct maps through `/api/results`, `/api/precinct-geography`, and the main election map for 2012, 2016, 2020, and 2024.

## Caveats and remaining step

This PR does not itself change production data. After merge, the deployment-bound sole-owner authorization must be refreshed and the guarded atomic publication transaction rerun.

## Review-subagent result

No subagent was used because the active runtime policy disallows unsolicited delegation. The change was instead verified against live forced-rollback diagnostics plus the focused regression suite and production build.
