### PR TITLE
Add guarded Nevada v2 production upgrade

### DIFF
--- a/docs/developer/nv-precinct-gis-runbook.md
+++ b/docs/developer/nv-precinct-gis-runbook.md
@@ -113,8 +113,11 @@ npm.cmd run precinct-gis:production-preflight:nv -- --package=$PKG --connect-rea
 
 Retain `$PREFLIGHT` and `$PREFLIGHT_SHA`. The preflight opens a read-only
 transaction, pins the host/port/database fingerprint, requires migration 0008,
-records whether migration 0009 is already present, and refuses any preexisting
-Nevada 2016/2020/2024 precinct release rows.
+and records whether migration 0009 is already present. The initial-load path
+refuses preexisting Nevada precinct rows. The reviewed v1-to-v2 correction path
+accepts only the exact year/count preimage recorded by the hash-pinned v1
+publication receipt; the write transaction independently verifies its published
+metadata, totals, features, crosswalks, and public activation before changing it.
 
 ### 2. Full backup and restore verification
 
@@ -142,6 +145,17 @@ Generate the immutable NO-GO template:
 npm.cmd run precinct-gis:production-release:nv -- --package=$PKG --package-sha256=$PKG_SHA --preflight-sha256=$PREFLIGHT_SHA --backup-manifest-sha256=$BACKUP_SHA --write-authorization-template
 ```
 
+For the reviewed Clark-result correction of the already-published v1 release,
+also set the exact predecessor evidence and include both arguments in this and
+every hidden-load/recovery command:
+
+```powershell
+$REPLACEMENT_RECEIPT='.etl/production-publication-receipts/NV/nv-publication-b13d531f79b0-nv-public-7002cd6-20260812T132755Z.json'
+$REPLACEMENT_SHA='7725db704181321f8dca9717b6902387bcecbd424975a1b29e0e8e0aea43fc4e'
+
+npm.cmd run precinct-gis:production-release:nv -- --package=$PKG --package-sha256=$PKG_SHA --preflight-sha256=$PREFLIGHT_SHA --backup-manifest-sha256=$BACKUP_SHA --replacement-publication-receipt=$REPLACEMENT_RECEIPT --replacement-publication-receipt-sha256=$REPLACEMENT_SHA --write-authorization-template
+```
+
 The completed record must change the decision to `GO_PRODUCTION`, identify the
 sole project owner in `approvedBy`, set an active authorization ID and expiry,
 and retain exactly these scopes:
@@ -149,6 +163,11 @@ and retain exactly these scopes:
 - `apply_migration_0009`
 - `load_nv_precinct_results_and_geometry_hidden`
 - `increment_public_data_revision`
+
+The v1-to-v2 correction instead uses `GO_PRODUCTION_UPGRADE` and has one
+additional exact scope:
+
+- `replace_reviewed_nv_precinct_release_v1_with_v2_hidden`
 
 Record its path and hash as `$AUTH` and `$AUTH_SHA`.
 
@@ -163,12 +182,29 @@ $env:CRM_NV_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256=$AUTH_SHA
 npm.cmd run precinct-gis:production-release:nv -- --package=$PKG --package-sha256=$PKG_SHA --preflight=$PREFLIGHT --preflight-sha256=$PREFLIGHT_SHA --backup-manifest=$BACKUP_MANIFEST --backup-manifest-sha256=$BACKUP_SHA --authorization=$AUTH --authorization-sha256=$AUTH_SHA --apply
 ```
 
+For the reviewed correction, also set and pass the predecessor receipt:
+
+```powershell
+$env:CRM_NV_PRECINCT_PRODUCTION_REPLACEMENT_RECEIPT_SHA256=$REPLACEMENT_SHA
+npm.cmd run precinct-gis:production-release:nv -- --package=$PKG --package-sha256=$PKG_SHA --preflight=$PREFLIGHT --preflight-sha256=$PREFLIGHT_SHA --backup-manifest=$BACKUP_MANIFEST --backup-manifest-sha256=$BACKUP_SHA --authorization=$AUTH --authorization-sha256=$AUTH_SHA --replacement-publication-receipt=$REPLACEMENT_RECEIPT --replacement-publication-receipt-sha256=$REPLACEMENT_SHA --apply
+```
+
 One PostgreSQL transaction upgrades the derivation-method constraint when
 needed, loads all three years, validates exact rows/features/crosswalks and
 durable audit metadata, and increments the public revision. Geography versions,
 result units, source documents, and import runs remain blocked with
 `publicDeliveryAuthorized=false`. The receipt decision is
 `COMMITTED_HIDDEN_NOT_PUBLIC`.
+
+The correction transaction is deliberately one-use and fail-closed. It accepts
+only the exact v1 receipt SHA embedded in the reviewed code, locks and validates
+all three published predecessor versions, candidate totals, zero-vote counts,
+5,230 reporting units/crosswalks, 15,690 result rows, 5,887 features, six source
+documents, three import runs, and their public-activation metadata. It then
+removes only those three reviewed v1 geometry versions (features and crosswalks
+cascade), upserts the sealed v2 rows, leaves all v2 publication flags blocked,
+validates the complete v2 contract, and increments the revision in the same
+transaction. A retry cannot match the v1 precondition.
 
 If the connection fails after the transaction body completes, do not rerun the
 write. Preserve the `.pending` marker and use the read-only recovery mode after
@@ -180,6 +216,12 @@ $env:CRM_NV_PRECINCT_HIDDEN_RECEIPT_RECOVERY=$PKG_SHA
 $env:CRM_NV_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256=$AUTH_SHA
 npm.cmd run precinct-gis:production-release:nv -- --package=$PKG --package-sha256=$PKG_SHA --preflight=$PREFLIGHT --preflight-sha256=$PREFLIGHT_SHA --backup-manifest=$BACKUP_MANIFEST --backup-manifest-sha256=$BACKUP_SHA --authorization=$AUTH --authorization-sha256=$AUTH_SHA --recover-receipt
 ```
+
+The correction recovery command must also retain
+`CRM_NV_PRECINCT_PRODUCTION_REPLACEMENT_RECEIPT_SHA256` and both
+`--replacement-publication-receipt*` arguments. Recovery opens a read-only
+transaction and requires the persisted v2 audit to contain the exact predecessor
+summary; it cannot perform another replacement.
 
 ### 5. Immutable Blob publication
 

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -7200,3 +7200,38 @@ evidence against its verified top-level package.
   `nv-precinct-gis-three-election-v2`; all production count guards and public
   activation inputs are resealed so the old blank-feature package cannot be
   replayed as this release.
+
+### 2026-08-12 - Nevada reviewed v1-to-v2 production replacement guard
+
+- The corrected v2 static registry can be deployed while the database still
+  contains published v1 rows; both geometry delivery and the corrected map stay
+  fail-closed because the registry and database release hashes do not match.
+  The normal hidden-load tool intentionally rejects that existing release, so a
+  separate reviewed replacement contract is required rather than bypassing the
+  replay guard or issuing manual SQL.
+
+- The replacement contract is pinned to the exact retained v1 public receipt
+  SHA-256 `7725db704181321f8dca9717b6902387bcecbd424975a1b29e0e8e0aea43fc4e`,
+  v1 package SHA-256
+  `0546735717fd46f501c23d931160fc45baf8f9b123f97faa5410bf684f951c9a`,
+  public plan, hidden receipt, Blob receipt, authorization, delivery origin,
+  activation ID/time/revision, and per-year predecessor counts and totals. The
+  authorization decision is `GO_PRODUCTION_UPGRADE` and carries the additional
+  `replace_reviewed_nv_precinct_release_v1_with_v2_hidden` scope plus an exact
+  environment receipt-hash acknowledgement.
+
+- Inside the locked transaction, the tool independently verifies the three
+  published v1 geography versions, public flags and activation metadata, 5,230
+  reporting units and crosswalks, 15,690 result rows, 5,887 features, candidate
+  totals, zero-vote units, six source documents, three import runs, and zero
+  invalid constraints. Only then does it remove the three v1 geometry versions,
+  upsert the sealed v2 contract, validate 5,288 units/crosswalks, 15,748 result
+  rows, and 5,796 features, leave every v2 public flag blocked, and increment the
+  public revision. The exact predecessor proof is persisted in the durable
+  release audit and hidden receipt; a replay cannot satisfy the v1 precondition.
+
+- The transaction was rehearsed against the fresh restore-verified production
+  backup in the fixed Docker clone. It upgraded the exact published v1 state to
+  blocked v2, rejected a second replacement attempt, validated all corrected
+  counts, and deliberately rolled back. The clone returned to the original
+  published v1 revision and three-version state.

--- a/scripts/apply-nv-precinct-release.mjs
+++ b/scripts/apply-nv-precinct-release.mjs
@@ -26,6 +26,7 @@ import {
   validateNevadaProductionAuthorization,
   validateNevadaProductionBackupEvidence,
   validateNevadaProductionPreflightEvidence,
+  validateNevadaReviewedReplacementPublicationReceipt,
 } from "./lib/nv-precinct-production-release.mjs";
 
 function parseArguments(args) {
@@ -44,6 +45,9 @@ function parseArguments(args) {
     authorizationPath: value("--authorization"),
     authorizationSha256: value("--authorization-sha256"),
     authorizationTemplatePath: value("--authorization-template"),
+    replacementPublicationReceiptPath: value("--replacement-publication-receipt"),
+    replacementPublicationReceiptSha256:
+      value("--replacement-publication-receipt-sha256"),
     receiptPath: value("--receipt"),
   };
   const known = new Set([
@@ -59,6 +63,8 @@ function parseArguments(args) {
     "--authorization",
     "--authorization-sha256",
     "--authorization-template",
+    "--replacement-publication-receipt",
+    "--replacement-publication-receipt-sha256",
     "--receipt",
   ]);
   for (const arg of args) {
@@ -71,6 +77,12 @@ function parseArguments(args) {
   if ([parsed.apply, parsed.recoverReceipt, parsed.writeAuthorizationTemplate]
     .filter(Boolean).length > 1) {
     throw new Error("Nevada production release modes are mutually exclusive");
+  }
+  if (Boolean(parsed.replacementPublicationReceiptPath)
+    !== Boolean(parsed.replacementPublicationReceiptSha256)) {
+    throw new Error(
+      "Nevada production replacement requires both the publication receipt path and SHA-256",
+    );
   }
   return parsed;
 }
@@ -202,8 +214,9 @@ function finishReceipt(reservation, value) {
   return { byteCount: bytes.length, sha256: sha256(bytes) };
 }
 
-function defaultTemplatePath(packageSha256) {
+function defaultTemplatePath(packageSha256, replacement = false) {
   return ".etl/production-authorizations/NV/nv-precinct-authorization-template-"
+    + (replacement ? "upgrade-" : "")
     + packageSha256.slice(0, 12)
     + ".json";
 }
@@ -285,36 +298,6 @@ export async function runNevadaProductionRelease(options = {}) {
       sha256: migration0009Declaration.sha256,
     },
   );
-  if (parsed.writeAuthorizationTemplate) {
-    const relativePath = parsed.authorizationTemplatePath
-      ?? defaultTemplatePath(packageArtifact.sha256);
-    const artifact = immutableJson(root, relativePath, buildNevadaProductionAuthorizationTemplate({
-      releaseCandidate,
-      preflightSha256: parsed.preflightSha256,
-      backupManifestSha256: parsed.backupManifestSha256,
-    }));
-    return {
-      mode: "write_authorization_template",
-      decision: "NO_GO_PRODUCTION",
-      releaseCandidate,
-      authorizationTemplate: artifact,
-      productionMutationPerformed: false,
-    };
-  }
-  if (!parsed.apply && !parsed.recoverReceipt) {
-    return {
-      mode: "plan",
-      decision: "NO_GO_PRODUCTION",
-      releaseCandidate,
-      productionMutationPerformed: false,
-      publicDeliveryAuthorized: false,
-      requiredEvidence: [
-        "fresh read-only production preflight",
-        "fresh full public-schema backup with exact restore verification",
-        "hash-pinned GO_PRODUCTION authorization",
-      ],
-    };
-  }
   const environment = options.environment ?? process.env;
   const clock = options.nowFactory ?? (() => options.now ?? new Date());
   const currentTime = () => {
@@ -325,6 +308,58 @@ export async function runNevadaProductionRelease(options = {}) {
     }
     return result;
   };
+  const replacementPublication = parsed.replacementPublicationReceiptPath
+    ? readEtlJson(
+      root,
+      parsed.replacementPublicationReceiptPath,
+      parsed.replacementPublicationReceiptSha256,
+      ".etl/production-publication-receipts/NV/",
+    )
+    : null;
+  const replacement = replacementPublication
+    ? validateNevadaReviewedReplacementPublicationReceipt(
+      replacementPublication.value,
+      {
+        publicationReceiptPath: replacementPublication.path,
+        publicationReceiptSha256: replacementPublication.sha256,
+        now: currentTime(),
+      },
+    )
+    : null;
+  if (parsed.writeAuthorizationTemplate) {
+    const relativePath = parsed.authorizationTemplatePath
+      ?? defaultTemplatePath(packageArtifact.sha256, Boolean(replacement));
+    const artifact = immutableJson(root, relativePath, buildNevadaProductionAuthorizationTemplate({
+      releaseCandidate,
+      preflightSha256: parsed.preflightSha256,
+      backupManifestSha256: parsed.backupManifestSha256,
+      replacement,
+    }));
+    return {
+      mode: "write_authorization_template",
+      decision: replacement ? "NO_GO_PRODUCTION_UPGRADE" : "NO_GO_PRODUCTION",
+      releaseCandidate,
+      authorizationTemplate: artifact,
+      productionMutationPerformed: false,
+    };
+  }
+  if (!parsed.apply && !parsed.recoverReceipt) {
+    return {
+      mode: "plan",
+      decision: replacement ? "NO_GO_PRODUCTION_UPGRADE" : "NO_GO_PRODUCTION",
+      releaseCandidate,
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      requiredEvidence: [
+        "fresh read-only production preflight",
+        "fresh full public-schema backup with exact restore verification",
+        "hash-pinned GO_PRODUCTION authorization",
+        ...(replacement
+          ? ["the exact reviewed v1 publication receipt and GO_PRODUCTION_UPGRADE scope"]
+          : []),
+      ],
+    };
+  }
   const databaseUrl = productionUrl(environment);
   const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
   const preflight = readEtlJson(
@@ -347,7 +382,7 @@ export async function runNevadaProductionRelease(options = {}) {
   const validateEvidenceAt = (now) => {
     const preflightSummary = validateNevadaProductionPreflightEvidence(
       preflight.value,
-      { releaseCandidate, endpointFingerprint, now },
+      { releaseCandidate, endpointFingerprint, now, replacement },
     );
     const backupSummary = validateNevadaProductionBackupEvidence(backup.value, {
       releaseCandidate,
@@ -362,6 +397,7 @@ export async function runNevadaProductionRelease(options = {}) {
         preflightSha256: preflight.sha256,
         backupManifestSha256: backup.sha256,
         now,
+        replacement,
       },
     );
     return { preflightSummary, backupSummary, authorizationSummary };
@@ -385,6 +421,9 @@ export async function runNevadaProductionRelease(options = {}) {
         !== packageArtifact.sha256
       || environment.CRM_NV_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256
         !== authorization.sha256
+      || (replacement
+        && environment.CRM_NV_PRECINCT_PRODUCTION_REPLACEMENT_RECEIPT_SHA256
+          !== replacement.publicationReceipt.sha256)
     ) {
       throw new Error("Nevada hidden receipt recovery is not explicitly read-only and hash-authorized");
     }
@@ -435,6 +474,7 @@ export async function runNevadaProductionRelease(options = {}) {
           authorizationId: evidence.authorizationSummary.authorizationId,
           endpointFingerprint,
           transaction: persistedAudit.transaction,
+          ...(replacement ? { replacementPublication: replacement } : {}),
         };
         if (JSON.stringify(persistedAudit) !== JSON.stringify(expectedAudit)) {
           throw new Error("Nevada hidden receipt recovery evidence does not match the durable database audit");
@@ -506,6 +546,7 @@ export async function runNevadaProductionRelease(options = {}) {
       canonicalManifestChanged: false,
       publicFileWritten: false,
       publicDeliveryAuthorized: false,
+      ...(replacement ? { replacement } : {}),
     };
     const receiptArtifact = finishReceipt(reservation, receiptDocument);
     return {
@@ -533,6 +574,13 @@ export async function runNevadaProductionRelease(options = {}) {
       !== authorization.sha256
   ) {
     throw new Error("Nevada production authorization environment acknowledgement drifted");
+  }
+  if (
+    replacement
+    && environment.CRM_NV_PRECINCT_PRODUCTION_REPLACEMENT_RECEIPT_SHA256
+      !== replacement.publicationReceipt.sha256
+  ) {
+    throw new Error("Nevada production replacement receipt acknowledgement drifted");
   }
   const reservation = reserveReceipt(
     root,
@@ -581,6 +629,7 @@ export async function runNevadaProductionRelease(options = {}) {
           executedAtUtc: transactionNow.toISOString(),
           publicRevision: expectedRevision,
         },
+        ...(replacement ? { replacementPublication: replacement } : {}),
       };
       const executionContext = {
         mode: "production_release",
@@ -644,6 +693,7 @@ export async function runNevadaProductionRelease(options = {}) {
     canonicalManifestChanged: false,
     publicFileWritten: false,
     publicDeliveryAuthorized: false,
+    ...(replacement ? { replacement } : {}),
   };
   const receiptArtifact = finishReceipt(reservation, receiptDocument);
   return {
@@ -653,6 +703,7 @@ export async function runNevadaProductionRelease(options = {}) {
     revision: committed.applied.revision,
     productionMutationPerformed: true,
     publicDeliveryAuthorized: false,
+    ...(replacement ? { replacement } : {}),
     receipt: { path: receiptPath, ...receiptArtifact },
   };
 }

--- a/scripts/lib/nv-precinct-gis-db.mjs
+++ b/scripts/lib/nv-precinct-gis-db.mjs
@@ -4,6 +4,10 @@ import {
   getLocalCloneDatabaseUrl,
 } from "../../src/db/database-driver.ts";
 import { reportingUnitCode } from "../../src/lib/precinct-geography.ts";
+import {
+  NEVADA_REVIEWED_V1_PUBLICATION,
+  validateNevadaProductionReplacementSummary,
+} from "./nv-precinct-production-release.mjs";
 
 const STATE = "NV";
 const SETUP_PARSER = "nevadaLocalPrecinctGisSetup";
@@ -24,6 +28,7 @@ const LOCAL_EXECUTION_CONTEXT = Object.freeze({
   },
   releaseCandidate: null,
   productionReleaseAudit: null,
+  productionReplacement: null,
 });
 
 const PRODUCTION_RELEASE_AUDIT_KEYS = Object.freeze([
@@ -91,7 +96,14 @@ function validatedProductionReleaseAudit(value) {
     executedAtUtc: value.transaction.executedAtUtc,
     publicRevision: Number(value.transaction.publicRevision),
   });
-  if (Object.keys(value).length !== PRODUCTION_RELEASE_AUDIT_KEYS.length) {
+  if (value.replacementPublication) {
+    output.replacementPublication = Object.freeze(
+      validateNevadaProductionReplacementSummary(value.replacementPublication),
+    );
+  }
+  const expectedKeyCount = PRODUCTION_RELEASE_AUDIT_KEYS.length
+    + (value.replacementPublication ? 1 : 0);
+  if (Object.keys(value).length !== expectedKeyCount) {
     throw new Error("Production Nevada execution release-audit metadata has extra fields");
   }
   return Object.freeze(output);
@@ -134,6 +146,12 @@ export function buildNevadaPrecinctExecutionContext(options = {}) {
     productionReleaseAudit: validatedProductionReleaseAudit(
       options.productionReleaseAudit,
     ),
+    productionReplacement:
+      options.productionReleaseAudit?.replacementPublication
+        ? validateNevadaProductionReplacementSummary(
+          options.productionReleaseAudit.replacementPublication,
+        )
+        : null,
   });
 }
 
@@ -185,6 +203,9 @@ function canonicalJson(value) {
   if (Array.isArray(value)) return value.map(canonicalJson);
   if (!value || typeof value !== "object") return value;
   return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonicalJson(value[key])]));
+}
+function semanticallyEqual(left, right) {
+  return JSON.stringify(canonicalJson(left)) === JSON.stringify(canonicalJson(right));
 }
 function query(client, lines, params = []) {
   return client.unsafe(Array.isArray(lines) ? lines.join("\n") : lines, params);
@@ -761,6 +782,188 @@ async function applyYear(tx, yearPlan, context) {
   };
 }
 
+export async function assertNevadaPublishedReplacementPrecondition(
+  tx,
+  replacementValue,
+) {
+  const replacement = validateNevadaProductionReplacementSummary(
+    replacementValue,
+  );
+  const reviewed = NEVADA_REVIEWED_V1_PUBLICATION;
+  const versions = await query(tx, [
+    "select e.id election_id,e.year,gv.status,gv.metadata,",
+    " (select count(*)::int from geography_features gf",
+    "  where gf.geometry_version_id=gv.id) features,",
+    " (select count(*)::int from reporting_unit_geometry_crosswalks x",
+    "  where x.geometry_version_id=gv.id) crosswalks,",
+    " (select count(*)::int from reporting_unit_geometry_crosswalks x",
+    "  join reporting_units ru on ru.id=x.reporting_unit_id",
+    "  where x.geometry_version_id=gv.id and ru.election_id=e.id",
+    "   and x.relationship_type='one_to_one'",
+    "   and x.match_method='exact_official_id'",
+    "   and x.review_status='reviewed' and x.confidence='high'",
+    "   and x.metadata->>'publicDeliveryAuthorized'='true'",
+    "   and x.metadata->'releaseCandidate'->>'publicDeliveryAuthorized'='true')",
+    "  exact_crosswalks,",
+    " (select count(*)::int from reporting_units ru",
+    "  where ru.state_code='NV' and ru.election_id=e.id",
+    "   and ru.reporting_grain='precinct') reporting_units,",
+    " (select count(*)::int from reporting_units ru",
+    "  where ru.state_code='NV' and ru.election_id=e.id",
+    "   and ru.reporting_grain='precinct'",
+    "   and ru.metadata->>'publicDeliveryAuthorized'='true'",
+    "   and ru.metadata->'releaseCandidate'->>'publicDeliveryAuthorized'='true')",
+    "  exact_reporting_units,",
+    " (select count(*)::int from result_rows rr",
+    "  join contests c on c.id=rr.contest_id",
+    "  join reporting_units ru on ru.id=rr.reporting_unit_id",
+    "  where rr.state_code='NV' and rr.level='precinct'",
+    "   and c.election_id=e.id and c.office='president'",
+    "   and ru.election_id=e.id and ru.reporting_grain='precinct') result_rows",
+    "from geography_versions gv join elections e on e.id=gv.election_id",
+    "where gv.state_code='NV' and gv.geography_type='precinct'",
+    " and e.office='president' and e.year=any($1::int[])",
+    "order by e.year for update of gv",
+  ], [reviewed.years.map((year) => year.year)]);
+  if (versions.length !== reviewed.years.length) {
+    throw new Error("Nevada reviewed v1 replacement has an incomplete geography-version set");
+  }
+  for (const [index, row] of versions.entries()) {
+    const expected = reviewed.years[index];
+    const metadata = row.metadata ?? {};
+    const activation = metadata.publicActivation ?? {};
+    if (
+      Number(row.year) !== expected.year
+      || row.status !== "published"
+      || metadata.manifestId !== expected.manifestId
+      || metadata.manifestSha256 !== expected.manifestSha256
+      || metadata.publicDeliveryAuthorized !== true
+      || !semanticallyEqual(metadata.releaseCandidate, {
+        id: replacement.releaseCandidate.id,
+        sha256: replacement.releaseCandidate.sha256,
+        publicDeliveryAuthorized: true,
+      })
+      || activation.activationId !== replacement.activationId
+      || activation.activationCandidateSha256 !== reviewed.publicationPlanSha256
+      || activation.releasePackageSha256 !== replacement.releaseCandidate.sha256
+      || activation.blobPublicationSha256 !== reviewed.blobPublicationSha256
+      || activation.deliveryOrigin !== reviewed.deliveryOrigin
+      || activation.authorizationSha256 !== reviewed.authorizationSha256
+      || activation.mode !== "publish"
+      || Number(activation.year) !== expected.year
+      || activation.manifestId !== expected.manifestId
+      || !/^[a-f0-9]{64}$/.test(activation.publicManifestSha256 ?? "")
+      || activation.changedAtUtc !== replacement.changedAtUtc
+      || Number(activation.revision) !== replacement.revision
+      || Number(row.reporting_units) !== expected.reportingUnits
+      || Number(row.exact_reporting_units) !== expected.reportingUnits
+      || Number(row.result_rows) !== expected.resultRows
+      || Number(row.features) !== expected.geometryFeatures
+      || Number(row.crosswalks) !== expected.reviewedExactCrosswalks
+      || Number(row.exact_crosswalks) !== expected.reviewedExactCrosswalks
+    ) {
+      throw new Error(
+        "Nevada " + expected.year + " reviewed v1 replacement precondition drifted",
+      );
+    }
+    const totals = await query(tx, [
+      "select candidate_name,sum(votes)::bigint votes from result_rows rr",
+      "join contests c on c.id=rr.contest_id",
+      "where rr.state_code='NV' and rr.level='precinct'",
+      " and c.election_id=$1::uuid and c.office='president'",
+      "group by candidate_name order by candidate_name",
+    ], [row.election_id]);
+    const actualTotals = Object.fromEntries(
+      totals.map((item) => [String(item.candidate_name), Number(item.votes)]),
+    );
+    const zero = await query(tx, [
+      "select count(*)::int count from (",
+      " select rr.reporting_unit_id from result_rows rr",
+      " join contests c on c.id=rr.contest_id",
+      " where rr.state_code='NV' and rr.level='precinct'",
+      "  and c.election_id=$1::uuid and c.office='president'",
+      " group by rr.reporting_unit_id having sum(rr.votes)=0) units",
+    ], [row.election_id]);
+    if (
+      !semanticallyEqual(actualTotals, expected.candidateTotals)
+      || Number(zero[0]?.count) !== expected.zeroVoteUnits
+    ) {
+      throw new Error(
+        "Nevada " + expected.year + " reviewed v1 result totals drifted",
+      );
+    }
+  }
+  const supporting = await query(tx, [
+    "select",
+    " (select count(*)::int from source_documents sd",
+    "  where sd.state_code='NV'",
+    "   and sd.metadata->'releaseCandidate'->>'sha256'=$1) source_documents,",
+    " (select count(*)::int from source_documents sd",
+    "  where sd.state_code='NV'",
+    "   and sd.metadata->'releaseCandidate'->>'sha256'=$1",
+    "   and sd.metadata->>'publicDeliveryAuthorized'='true'",
+    "   and sd.metadata->'releaseCandidate'->>'publicDeliveryAuthorized'='true')",
+    "  exact_source_documents,",
+    " (select count(*)::int from import_runs ir",
+    "  where ir.state_code='NV'",
+    "   and ir.summary->'releaseCandidate'->>'sha256'=$1) import_runs,",
+    " (select count(*)::int from import_runs ir",
+    "  where ir.state_code='NV'",
+    "   and ir.summary->'releaseCandidate'->>'sha256'=$1",
+    "   and ir.summary->>'publicDeliveryAuthorized'='true'",
+    "   and ir.summary->'releaseCandidate'->>'publicDeliveryAuthorized'='true')",
+    "  exact_import_runs,",
+    " (select count(*)::int from pg_constraint",
+    "  where connamespace='public'::regnamespace and not convalidated)",
+    "  invalid_constraints",
+  ], [replacement.releaseCandidate.sha256]);
+  const row = supporting[0] ?? {};
+  if (
+    Number(row.source_documents) !== reviewed.postconditions.sourceDocuments
+    || Number(row.exact_source_documents) !== reviewed.postconditions.sourceDocuments
+    || Number(row.import_runs) !== reviewed.postconditions.importRuns
+    || Number(row.exact_import_runs) !== reviewed.postconditions.importRuns
+    || Number(row.invalid_constraints) !== reviewed.postconditions.invalidConstraints
+  ) {
+    throw new Error("Nevada reviewed v1 supporting release metadata drifted");
+  }
+  return {
+    releaseCandidate: replacement.releaseCandidate,
+    publicationReceipt: replacement.publicationReceipt,
+    activationId: replacement.activationId,
+    revision: replacement.revision,
+    years: reviewed.years.map((year) => ({
+      year: year.year,
+      reportingUnits: year.reportingUnits,
+      resultRows: year.resultRows,
+      features: year.geometryFeatures,
+      crosswalks: year.reviewedExactCrosswalks,
+    })),
+  };
+}
+
+async function clearNevadaReviewedReplacementGeometry(tx, replacement) {
+  const reviewed = NEVADA_REVIEWED_V1_PUBLICATION;
+  const removed = await query(tx, [
+    "delete from geography_versions gv using elections e",
+    "where gv.election_id=e.id and gv.state_code='NV'",
+    " and gv.geography_type='precinct' and e.office='president'",
+    " and e.year=any($1::int[])",
+    " and gv.status='published'",
+    " and gv.metadata->'releaseCandidate'->>'id'=$2",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$3",
+    "returning gv.id",
+  ], [
+    reviewed.years.map((year) => year.year),
+    replacement.releaseCandidate.id,
+    replacement.releaseCandidate.sha256,
+  ]);
+  if (removed.length !== reviewed.years.length) {
+    throw new Error("Nevada reviewed v1 replacement geometry reset drifted");
+  }
+  return removed.length;
+}
+
 export async function applyNevadaPrecinctGisTransaction(
   tx,
   plan,
@@ -800,7 +1003,18 @@ export async function applyNevadaPrecinctGisTransaction(
       context.database.name + " lacks the complete migration 0008 precinct GIS schema",
     );
   }
-  if (context.mode === "production_release") {
+  let replacementPrecondition = null;
+  if (context.mode === "production_release" && context.productionReplacement) {
+    replacementPrecondition = await assertNevadaPublishedReplacementPrecondition(
+      tx,
+      context.productionReplacement,
+    );
+    replacementPrecondition.geometryVersionsRemoved =
+      await clearNevadaReviewedReplacementGeometry(
+        tx,
+        context.productionReplacement,
+      );
+  } else if (context.mode === "production_release") {
     const targetYears = plan.years.map((year) => year.year);
     const existing = await query(tx, [
       "select",
@@ -859,6 +1073,7 @@ export async function applyNevadaPrecinctGisTransaction(
     publicDeliveryAuthorized: false,
     releaseCandidate: context.releaseCandidate,
     productionReleaseAudit: context.productionReleaseAudit,
+    replacementPrecondition,
     revision: Number(revisions[0].revision),
     years,
   };

--- a/scripts/lib/nv-precinct-production-release.mjs
+++ b/scripts/lib/nv-precinct-production-release.mjs
@@ -5,6 +5,88 @@ export const NEVADA_PRODUCTION_RELEASE_SCOPES = Object.freeze([
   "load_nv_precinct_results_and_geometry_hidden",
   "increment_public_data_revision",
 ]);
+export const NEVADA_PRODUCTION_REPLACEMENT_SCOPE =
+  "replace_reviewed_nv_precinct_release_v1_with_v2_hidden";
+export const NEVADA_REVIEWED_V1_PUBLICATION = Object.freeze({
+  releaseCandidate: Object.freeze({
+    id: "nv-precinct-gis-three-election-v1",
+    path: ".etl/precinct-release-candidates/NV/nv-precinct-gis-three-election-v1-0546735717fd/release-candidate.json",
+    sha256: "0546735717fd46f501c23d931160fc45baf8f9b123f97faa5410bf684f951c9a",
+  }),
+  publicationReceiptSha256:
+    "7725db704181321f8dca9717b6902387bcecbd424975a1b29e0e8e0aea43fc4e",
+  publicationPlanSha256:
+    "b13d531f79b0912e4e474c004f3891361af4c4d30fac29403530e4dc81c1f9e3",
+  authorizationSha256:
+    "f4ce5a05decb42c13df0e776a78e3e4705bc12c026396374580456b14f4ae73e",
+  hiddenReceiptSha256:
+    "1b43d799687c64d3780f5d98e96c9a29b13f84d85e9d8bf06cf1d0fd305f20a4",
+  blobPublicationSha256:
+    "b98dfccb93c43944e5799ffeff9d6263d35c110129b158ecb1f9726d312af4d6",
+  deliveryOrigin: "https://ehnlruzhgkm5byoi.public.blob.vercel-storage.com",
+  years: Object.freeze([
+    Object.freeze({
+      year: 2016,
+      electionId: "2016-11-08-general",
+      manifestId: "nv-2016-11-08-general-precinct-geometry-candidate-v1",
+      manifestSha256:
+        "9cccfd6f2fc006c2f3e98e45b1835178383edf092639f6a5dfc0f016a8316999",
+      reportingUnits: 1_843,
+      resultRows: 5_529,
+      geometryFeatures: 2_067,
+      reviewedExactCrosswalks: 1_843,
+      zeroVoteUnits: 206,
+      candidateTotals: Object.freeze({
+        "Donald Trump": 510_920,
+        "Hillary Clinton": 537_405,
+        Other: 73_891,
+      }),
+    }),
+    Object.freeze({
+      year: 2020,
+      electionId: "2020-11-03-general",
+      manifestId: "nv-2020-11-03-general-precinct-geometry-candidate-v1",
+      manifestSha256:
+        "b343123b91646f991406775fc9bb02846455564d08265ecd2240a3db759ea4e4",
+      reportingUnits: 1_869,
+      resultRows: 5_607,
+      geometryFeatures: 2_094,
+      reviewedExactCrosswalks: 1_869,
+      zeroVoteUnits: 207,
+      candidateTotals: Object.freeze({
+        "Donald Trump": 669_458,
+        "Joe Biden": 703_213,
+        Other: 31_986,
+      }),
+    }),
+    Object.freeze({
+      year: 2024,
+      electionId: "2024-11-05-general",
+      manifestId: "nv-2024-11-05-general-precinct-geometry-candidate-v1",
+      manifestSha256:
+        "e543af3d6e31d2175c07d24f9de664692af22bb813bb9ddbd2c705c0186dff1b",
+      reportingUnits: 1_518,
+      resultRows: 4_554,
+      geometryFeatures: 1_726,
+      reviewedExactCrosswalks: 1_518,
+      zeroVoteUnits: 234,
+      candidateTotals: Object.freeze({
+        "Donald Trump": 750_923,
+        "Kamala Harris": 705_028,
+        Other: 28_431,
+      }),
+    }),
+  ]),
+  postconditions: Object.freeze({
+    geographyVersions: 3,
+    crosswalks: 5_230,
+    reportingUnits: 5_230,
+    sourceDocuments: 6,
+    importRuns: 3,
+    resultRows: 15_690,
+    invalidConstraints: 0,
+  }),
+});
 export const NEVADA_MAX_RELEASE_EVIDENCE_AGE_MS = 4 * 60 * 60 * 1000;
 
 export function sha256(bytes) {
@@ -33,11 +115,110 @@ function semanticallyEqual(left, right) {
   return JSON.stringify(semantic(left)) === JSON.stringify(semantic(right));
 }
 
+function validArtifact(value, prefix) {
+  return typeof value?.path === "string"
+    && value.path.startsWith(prefix)
+    && !value.path.includes("\\")
+    && !value.path.split("/").includes("..")
+    && /^[a-f0-9]{64}$/.test(value?.sha256 ?? "");
+}
+
+export function validateNevadaReviewedReplacementPublicationReceipt(
+  value,
+  context,
+) {
+  const reviewed = NEVADA_REVIEWED_V1_PUBLICATION;
+  if (
+    context?.publicationReceiptSha256 !== reviewed.publicationReceiptSha256
+    || !validArtifact(
+      { path: context?.publicationReceiptPath, sha256: context?.publicationReceiptSha256 },
+      ".etl/production-publication-receipts/NV/",
+    )
+    || value?.schemaVersion !== 1
+    || value?.state !== "NV"
+    || value?.decision !== "PUBLISHED"
+    || value?.productionMutationPerformed !== true
+    || value?.publicDeliveryAuthorized !== true
+    || !semanticallyEqual(value?.releaseCandidate, reviewed.releaseCandidate)
+    || value?.publicationPlan?.sha256 !== reviewed.publicationPlanSha256
+    || value?.authorization?.sha256 !== reviewed.authorizationSha256
+    || value?.hiddenLoad?.sha256 !== reviewed.hiddenReceiptSha256
+    || value?.blobPublication?.sha256 !== reviewed.blobPublicationSha256
+    || value?.blobPublication?.deliveryOrigin !== reviewed.deliveryOrigin
+    || !validArtifact(value?.authorization, ".etl/production-authorizations/NV/")
+    || !validArtifact(value?.hiddenLoad, ".etl/production-release-receipts/NV/")
+    || !validArtifact(value?.blobPublication, ".etl/precinct-blob-publications/NV/")
+    || typeof value?.activationId !== "string"
+    || !value.activationId.trim()
+    || !validIso(value?.changedAtUtc)
+    || Date.parse(value.changedAtUtc) > context.now.getTime()
+    || !Number.isInteger(Number(value?.revision))
+    || Number(value.revision) < 1
+    || !semanticallyEqual(value?.postconditions, reviewed.postconditions)
+    || value?.productionDeployment?.readyVerified !== true
+    || value?.productionDeployment?.promotedVerified !== true
+    || value?.productionDeployment?.blockedResultGateVerified !== true
+    || value?.productionDeployment?.blockedGeometryGateVerified !== true
+  ) {
+    throw new Error(
+      "Nevada reviewed v1 publication receipt is incomplete, altered, or incompatible",
+    );
+  }
+  return {
+    publicationReceipt: {
+      path: context.publicationReceiptPath,
+      sha256: context.publicationReceiptSha256,
+    },
+    releaseCandidate: { ...reviewed.releaseCandidate },
+    activationId: value.activationId.trim(),
+    changedAtUtc: value.changedAtUtc,
+    revision: Number(value.revision),
+  };
+}
+
+export function validateNevadaProductionReplacementSummary(value) {
+  const reviewed = NEVADA_REVIEWED_V1_PUBLICATION;
+  if (
+    !value
+    || !semanticallyEqual(value?.releaseCandidate, reviewed.releaseCandidate)
+    || value?.publicationReceipt?.sha256 !== reviewed.publicationReceiptSha256
+    || !validArtifact(
+      value?.publicationReceipt,
+      ".etl/production-publication-receipts/NV/",
+    )
+    || typeof value?.activationId !== "string"
+    || !value.activationId.trim()
+    || !validIso(value?.changedAtUtc)
+    || !Number.isInteger(Number(value?.revision))
+    || Number(value.revision) < 1
+    || Object.keys(value).sort().join(",")
+      !== "activationId,changedAtUtc,publicationReceipt,releaseCandidate,revision"
+  ) {
+    throw new Error("Nevada production replacement summary drifted");
+  }
+  return {
+    publicationReceipt: { ...value.publicationReceipt },
+    releaseCandidate: { ...value.releaseCandidate },
+    activationId: value.activationId.trim(),
+    changedAtUtc: value.changedAtUtc,
+    revision: Number(value.revision),
+  };
+}
+
+function expectedScopes(replacement) {
+  return replacement
+    ? [...NEVADA_PRODUCTION_RELEASE_SCOPES, NEVADA_PRODUCTION_REPLACEMENT_SCOPE]
+    : [...NEVADA_PRODUCTION_RELEASE_SCOPES];
+}
+
 export function buildNevadaProductionAuthorizationTemplate(context) {
+  const replacement = context.replacement
+    ? validateNevadaProductionReplacementSummary(context.replacement)
+    : null;
   return {
     schemaVersion: 1,
     state: "NV",
-    decision: "NO_GO_PRODUCTION",
+    decision: replacement ? "NO_GO_PRODUCTION_UPGRADE" : "NO_GO_PRODUCTION",
     authorizationId: null,
     releaseCandidate: {
       id: context.releaseCandidate.id,
@@ -47,12 +228,15 @@ export function buildNevadaProductionAuthorizationTemplate(context) {
       preflightSha256: context.preflightSha256 ?? null,
       backupManifestSha256: context.backupManifestSha256 ?? null,
     },
+    replacement,
     approvedBy: null,
     authorizedAtUtc: null,
     expiresAtUtc: null,
-    scopes: [...NEVADA_PRODUCTION_RELEASE_SCOPES],
+    scopes: expectedScopes(replacement),
     acknowledgement:
-      "This template is not authorization. GO_PRODUCTION authorizes only the hidden Nevada load and one public revision increment; public geometry and result visibility remain blocked.",
+      replacement
+        ? "This template is not authorization. GO_PRODUCTION_UPGRADE authorizes only the exact reviewed Nevada v1-to-v2 hidden replacement and one public revision increment; public geometry and result visibility remain blocked."
+        : "This template is not authorization. GO_PRODUCTION authorizes only the hidden Nevada load and one public revision increment; public geometry and result visibility remain blocked.",
   };
 }
 
@@ -60,6 +244,18 @@ export function validateNevadaProductionPreflightEvidence(report, context) {
   const targetYears = [2016, 2020, 2024];
   const precinctYearRows = report?.nevada?.precinctYearRows;
   const coreYearRows = report?.nevada?.coreYearRows;
+  const replacement = context.replacement
+    ? validateNevadaProductionReplacementSummary(context.replacement)
+    : null;
+  const expectedYearRows = replacement
+    ? NEVADA_REVIEWED_V1_PUBLICATION.years
+    : targetYears.map((year) => ({
+      year,
+      reportingUnits: 0,
+      resultRows: 0,
+      geometryFeatures: 0,
+      reviewedExactCrosswalks: 0,
+    }));
   if (
     report?.schemaVersion !== 1
     || report?.state !== "NV"
@@ -79,16 +275,19 @@ export function validateNevadaProductionPreflightEvidence(report, context) {
     || !Array.isArray(coreYearRows)
     || JSON.stringify(precinctYearRows.map((row) => Number(row.year)))
       !== JSON.stringify(targetYears)
-    || precinctYearRows.some((row) => [
-      row.reportingUnits,
-      row.linkedPrecinctResultRows,
-      row.geographyVersions,
-      row.geometryFeatures,
-      row.reviewedExactCrosswalks,
-    ].some((count) => Number(count) !== 0))
-    || coreYearRows.some((row) =>
-      targetYears.includes(Number(row.year))
-      && Number(row.precinctResultRows) !== 0)
+    || precinctYearRows.some((row, index) => {
+      const expected = expectedYearRows[index];
+      return Number(row.reportingUnits) !== expected.reportingUnits
+        || Number(row.linkedPrecinctResultRows) !== expected.resultRows
+        || Number(row.geographyVersions) !== (replacement ? 1 : 0)
+        || Number(row.geometryFeatures) !== expected.geometryFeatures
+        || Number(row.reviewedExactCrosswalks) !== expected.reviewedExactCrosswalks;
+    })
+    || coreYearRows.some((row) => {
+      const index = targetYears.indexOf(Number(row.year));
+      return index >= 0
+        && Number(row.precinctResultRows) !== expectedYearRows[index].resultRows;
+    })
   ) {
     throw new Error(
       "Nevada production preflight evidence is incompatible or already contains precinct release rows",
@@ -105,6 +304,7 @@ export function validateNevadaProductionPreflightEvidence(report, context) {
     databaseName: report.database.name.trim(),
     capturedAtUtc: report.capturedAtUtc,
     publicRevision: Number(report.publicRevision),
+    releaseMode: replacement ? "reviewed_v1_to_v2_replacement" : "initial_hidden_load",
   };
 }
 
@@ -178,10 +378,13 @@ export function validateNevadaProductionBackupEvidence(manifest, context) {
 }
 
 export function validateNevadaProductionAuthorization(value, context) {
+  const replacement = context.replacement
+    ? validateNevadaProductionReplacementSummary(context.replacement)
+    : null;
   if (
     value?.schemaVersion !== 1
     || value?.state !== "NV"
-    || value?.decision !== "GO_PRODUCTION"
+    || value?.decision !== (replacement ? "GO_PRODUCTION_UPGRADE" : "GO_PRODUCTION")
     || typeof value?.authorizationId !== "string"
     || !value.authorizationId.trim()
     || value?.releaseCandidate?.id !== context.releaseCandidate.id
@@ -191,8 +394,9 @@ export function validateNevadaProductionAuthorization(value, context) {
     || !validIso(value?.authorizedAtUtc)
     || !validIso(value?.expiresAtUtc)
     || !normalizeIdentity(value?.approvedBy)
+    || !semanticallyEqual(value?.replacement ?? null, replacement)
     || !Array.isArray(value?.scopes)
-    || !semanticallyEqual(value.scopes, NEVADA_PRODUCTION_RELEASE_SCOPES)
+    || !semanticallyEqual(value.scopes, expectedScopes(replacement))
   ) {
     throw new Error("Nevada production authorization is incomplete or incompatible");
   }
@@ -207,5 +411,6 @@ export function validateNevadaProductionAuthorization(value, context) {
     approvedBy: value.approvedBy.trim(),
     authorizedAtUtc: value.authorizedAtUtc,
     expiresAtUtc: value.expiresAtUtc,
+    replacement,
   };
 }

--- a/tests/api/nv-precinct-production-release.test.mjs
+++ b/tests/api/nv-precinct-production-release.test.mjs
@@ -2,11 +2,17 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
+  assertNevadaPublishedReplacementPrecondition,
+} from "../../scripts/lib/nv-precinct-gis-db.mjs";
+import {
   NEVADA_PRODUCTION_RELEASE_SCOPES,
+  NEVADA_PRODUCTION_REPLACEMENT_SCOPE,
+  NEVADA_REVIEWED_V1_PUBLICATION,
   buildNevadaProductionAuthorizationTemplate,
   validateNevadaProductionAuthorization,
   validateNevadaProductionBackupEvidence,
   validateNevadaProductionPreflightEvidence,
+  validateNevadaReviewedReplacementPublicationReceipt,
 } from "../../scripts/lib/nv-precinct-production-release.mjs";
 
 const releaseCandidate = {
@@ -79,6 +85,58 @@ function backup() {
       exactSourceRowCounts: true,
     },
   };
+}
+
+function reviewedV1PublicationReceipt() {
+  const reviewed = NEVADA_REVIEWED_V1_PUBLICATION;
+  return {
+    schemaVersion: 1,
+    state: "NV",
+    decision: "PUBLISHED",
+    activationId: "nv-public-7002cd6-20260812T132755Z",
+    releaseCandidate: { ...reviewed.releaseCandidate },
+    publicationPlan: {
+      id: "nv-precinct-database-publication-v1",
+      sha256: reviewed.publicationPlanSha256,
+    },
+    authorization: {
+      path: ".etl/production-authorizations/NV/nv-public-go.json",
+      sha256: reviewed.authorizationSha256,
+    },
+    hiddenLoad: {
+      path: ".etl/production-release-receipts/NV/nv-hidden.json",
+      sha256: reviewed.hiddenReceiptSha256,
+    },
+    blobPublication: {
+      path: ".etl/precinct-blob-publications/NV/nv-v1.json",
+      sha256: reviewed.blobPublicationSha256,
+      deliveryOrigin: reviewed.deliveryOrigin,
+    },
+    productionDeployment: {
+      readyVerified: true,
+      promotedVerified: true,
+      blockedResultGateVerified: true,
+      blockedGeometryGateVerified: true,
+    },
+    changedAtUtc: "2026-08-12T13:29:01.061Z",
+    revision: 9,
+    postconditions: { ...reviewed.postconditions },
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: true,
+  };
+}
+
+function replacementSummary() {
+  return validateNevadaReviewedReplacementPublicationReceipt(
+    reviewedV1PublicationReceipt(),
+    {
+      publicationReceiptPath:
+        ".etl/production-publication-receipts/NV/nv-v1.json",
+      publicationReceiptSha256:
+        NEVADA_REVIEWED_V1_PUBLICATION.publicationReceiptSha256,
+      now: new Date("2026-08-12T16:00:00.000Z"),
+    },
+  );
 }
 
 test("Nevada hidden release requires fresh exact preflight and restored backup", () => {
@@ -166,11 +224,179 @@ test("Nevada sole-owner authorization is hash-bound, scoped, and time-limited", 
   );
 });
 
+test("Nevada v2 replacement is bound to the exact reviewed v1 publication", () => {
+  const replacement = replacementSummary();
+  const reviewedYears = NEVADA_REVIEWED_V1_PUBLICATION.years;
+  const report = preflight();
+  report.nevada.precinctYearRows = reviewedYears.map((year) => ({
+    year: year.year,
+    reportingUnits: year.reportingUnits,
+    linkedPrecinctResultRows: year.resultRows,
+    geographyVersions: 1,
+    geometryFeatures: year.geometryFeatures,
+    reviewedExactCrosswalks: year.reviewedExactCrosswalks,
+  }));
+  report.nevada.coreYearRows = reviewedYears.map((year) => ({
+    year: year.year,
+    precinctResultRows: year.resultRows,
+  }));
+  const preflightSummary = validateNevadaProductionPreflightEvidence(report, {
+    releaseCandidate,
+    endpointFingerprint,
+    now,
+    replacement,
+  });
+  assert.equal(preflightSummary.releaseMode, "reviewed_v1_to_v2_replacement");
+  const driftedPreflight = structuredClone(report);
+  driftedPreflight.nevada.precinctYearRows[2].geometryFeatures -= 1;
+  assert.throws(
+    () => validateNevadaProductionPreflightEvidence(driftedPreflight, {
+      releaseCandidate,
+      endpointFingerprint,
+      now,
+      replacement,
+    }),
+    /incompatible or already contains/,
+  );
+
+  const template = buildNevadaProductionAuthorizationTemplate({
+    releaseCandidate,
+    preflightSha256: "4".repeat(64),
+    backupManifestSha256: "5".repeat(64),
+    replacement,
+  });
+  assert.equal(template.decision, "NO_GO_PRODUCTION_UPGRADE");
+  assert.equal(
+    template.scopes.at(-1),
+    NEVADA_PRODUCTION_REPLACEMENT_SCOPE,
+  );
+  const authorization = {
+    ...template,
+    decision: "GO_PRODUCTION_UPGRADE",
+    authorizationId: "nv-v2-replacement-camreyn",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-11T03:45:00.000Z",
+    expiresAtUtc: "2026-08-11T04:30:00.000Z",
+  };
+  const result = validateNevadaProductionAuthorization(authorization, {
+    releaseCandidate,
+    preflightSha256: "4".repeat(64),
+    backupManifestSha256: "5".repeat(64),
+    replacement,
+    now,
+  });
+  assert.equal(result.replacement.publicationReceipt.sha256,
+    NEVADA_REVIEWED_V1_PUBLICATION.publicationReceiptSha256);
+
+  const alteredReceipt = reviewedV1PublicationReceipt();
+  alteredReceipt.postconditions.reportingUnits += 1;
+  assert.throws(
+    () => validateNevadaReviewedReplacementPublicationReceipt(
+      alteredReceipt,
+      {
+        publicationReceiptPath:
+          ".etl/production-publication-receipts/NV/nv-v1.json",
+        publicationReceiptSha256:
+          NEVADA_REVIEWED_V1_PUBLICATION.publicationReceiptSha256,
+        now: new Date("2026-08-12T16:00:00.000Z"),
+      },
+    ),
+    /altered, or incompatible/,
+  );
+});
+
+test("Nevada v2 replacement transaction requires the exact published v1 rows", async () => {
+  const replacement = replacementSummary();
+  const reviewed = NEVADA_REVIEWED_V1_PUBLICATION;
+  const electionIds = Object.fromEntries(
+    reviewed.years.map((year) => [year.year, `election-${year.year}`]),
+  );
+  const buildVersions = () => reviewed.years.map((year) => ({
+    election_id: electionIds[year.year],
+    year: year.year,
+    status: "published",
+    metadata: {
+      manifestId: year.manifestId,
+      manifestSha256: year.manifestSha256,
+      publicDeliveryAuthorized: true,
+      releaseCandidate: {
+        id: replacement.releaseCandidate.id,
+        sha256: replacement.releaseCandidate.sha256,
+        publicDeliveryAuthorized: true,
+      },
+      publicActivation: {
+        activationId: replacement.activationId,
+        activationCandidateSha256: reviewed.publicationPlanSha256,
+        releasePackageSha256: replacement.releaseCandidate.sha256,
+        blobPublicationSha256: reviewed.blobPublicationSha256,
+        deliveryOrigin: reviewed.deliveryOrigin,
+        authorizationSha256: reviewed.authorizationSha256,
+        mode: "publish",
+        year: year.year,
+        manifestId: year.manifestId,
+        publicManifestSha256: "a".repeat(64),
+        changedAtUtc: replacement.changedAtUtc,
+        revision: replacement.revision,
+      },
+    },
+    features: year.geometryFeatures,
+    crosswalks: year.reviewedExactCrosswalks,
+    exact_crosswalks: year.reviewedExactCrosswalks,
+    reporting_units: year.reportingUnits,
+    exact_reporting_units: year.reportingUnits,
+    result_rows: year.resultRows,
+  }));
+  const fakeTransaction = (mutateVersions = (rows) => rows) => ({
+    async unsafe(sql, params) {
+      if (sql.includes("select e.id election_id,e.year")) {
+        return mutateVersions(buildVersions());
+      }
+      if (sql.includes("select candidate_name,sum(votes)")) {
+        const year = Number(String(params[0]).split("-").at(-1));
+        return Object.entries(
+          reviewed.years.find((item) => item.year === year).candidateTotals,
+        ).map(([candidate_name, votes]) => ({ candidate_name, votes }));
+      }
+      if (sql.includes("group by rr.reporting_unit_id having sum(rr.votes)=0")) {
+        const year = Number(String(params[0]).split("-").at(-1));
+        return [{
+          count: reviewed.years.find((item) => item.year === year).zeroVoteUnits,
+        }];
+      }
+      if (sql.includes("source_documents sd")) {
+        return [{
+          source_documents: reviewed.postconditions.sourceDocuments,
+          exact_source_documents: reviewed.postconditions.sourceDocuments,
+          import_runs: reviewed.postconditions.importRuns,
+          exact_import_runs: reviewed.postconditions.importRuns,
+          invalid_constraints: 0,
+        }];
+      }
+      throw new Error("Unexpected replacement precondition SQL: " + sql);
+    },
+  });
+  const result = await assertNevadaPublishedReplacementPrecondition(
+    fakeTransaction(),
+    replacement,
+  );
+  assert.equal(result.years[2].reportingUnits, 1_518);
+
+  await assert.rejects(
+    assertNevadaPublishedReplacementPrecondition(
+      fakeTransaction((rows) => rows.map((row) =>
+        row.year === 2024 ? { ...row, status: "blocked" } : row)),
+      replacement,
+    ),
+    /2024 reviewed v1 replacement precondition drifted/,
+  );
+});
+
 test("Nevada runner preserves public blocks and ambiguous-commit evidence", () => {
   const runner = readFileSync("scripts/apply-nv-precinct-release.mjs", "utf8");
   const database = readFileSync("scripts/lib/nv-precinct-gis-db.mjs", "utf8");
   assert.match(runner, /CRM_NV_PRECINCT_PRODUCTION_WRITES/);
   assert.match(runner, /CRM_NV_PRECINCT_PRODUCTION_AUTHORIZATION_SHA256/);
+  assert.match(runner, /CRM_NV_PRECINCT_PRODUCTION_REPLACEMENT_RECEIPT_SHA256/);
   assert.match(runner, /transactionBodyCompleted/);
   assert.match(runner, /ambiguous-commit recovery marker/);
   assert.match(runner, /--recover-receipt/);
@@ -183,4 +409,5 @@ test("Nevada runner preserves public blocks and ambiguous-commit evidence", () =
   assert.match(runner, /years: \[2016, 2020, 2024\]/);
   assert.match(database, /publicDeliveryAuthorized: false/);
   assert.match(database, /status='blocked'| 'blocked'/);
+  assert.match(database, /assertNevadaPublishedReplacementPrecondition/);
 });

--- a/tests/api/nv-precinct-production-upgrade-local-rehearsal.test.mjs
+++ b/tests/api/nv-precinct-production-upgrade-local-rehearsal.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import postgres from "postgres";
+import {
+  applyNevadaPrecinctGisTransaction,
+  validateNevadaPrecinctGisClient,
+} from "../../scripts/lib/nv-precinct-gis-db.mjs";
+import { buildNevadaPrecinctGisPlan } from "../../scripts/lib/nv-precinct-gis-plan.mjs";
+import {
+  NEVADA_REVIEWED_V1_PUBLICATION,
+  validateNevadaProductionReplacementSummary,
+} from "../../scripts/lib/nv-precinct-production-release.mjs";
+
+const DATABASE_URL =
+  "postgresql://crm_clone_admin:crm_clone_local_only@127.0.0.1:54329/crm_clone_dev";
+const V2_PACKAGE_SHA256 =
+  "aefa507b4e1a2577f9dfdc71b978a6e5201362d51e6111bcf3d7debf1df7aba1";
+
+function reviewedReplacement() {
+  const reviewed = NEVADA_REVIEWED_V1_PUBLICATION;
+  return validateNevadaProductionReplacementSummary({
+    publicationReceipt: {
+      path: ".etl/production-publication-receipts/NV/nv-publication-b13d531f79b0-nv-public-7002cd6-20260812T132755Z.json",
+      sha256: reviewed.publicationReceiptSha256,
+    },
+    releaseCandidate: { ...reviewed.releaseCandidate },
+    activationId: "nv-public-7002cd6-20260812T132755Z",
+    changedAtUtc: "2026-08-12T13:29:01.061Z",
+    revision: 9,
+  });
+}
+
+test("Nevada exact published v1 clone upgrades atomically to blocked v2", async () => {
+  const plan = await buildNevadaPrecinctGisPlan({ years: [2016, 2020, 2024] });
+  const replacement = reviewedReplacement();
+  const sql = postgres(DATABASE_URL, {
+    max: 1,
+    connection: { application_name: "crm-nv-v1-v2-upgrade-local-rehearsal" },
+  });
+  try {
+    const before = await sql.unsafe(
+      "select revision::int revision from public_data_revisions where scope='public'",
+    );
+    const beforeRevision = Number(before[0].revision);
+    await assert.rejects(
+      sql.begin(async (nv) => {
+        const releaseAudit = {
+          releasePackage: {
+            path: ".etl/precinct-release-candidates/NV/nv-precinct-gis-three-election-v2-aefa507b4e1a/release-candidate.json",
+            sha256: V2_PACKAGE_SHA256,
+          },
+          authorization: {
+            path: ".etl/production-authorizations/NV/nv-v2-upgrade-rehearsal.json",
+            sha256: "1".repeat(64),
+          },
+          preflight: {
+            path: ".etl/production-preflight-candidates/NV/nv-v2-upgrade-rehearsal.json",
+            sha256: "2".repeat(64),
+          },
+          backupManifest: {
+            sha256: "3".repeat(64),
+            dumpSha256: "4".repeat(64),
+          },
+          authorizationId: "nv-v2-upgrade-local-rehearsal",
+          endpointFingerprint: "5".repeat(64),
+          transaction: {
+            executedAtUtc: "2026-08-12T17:00:00.000Z",
+            publicRevision: beforeRevision + 1,
+          },
+          replacementPublication: replacement,
+        };
+        const executionContext = {
+          mode: "production_release",
+          releasePackageSha256: V2_PACKAGE_SHA256,
+          releaseCandidateId: "nv-precinct-gis-three-election-v2",
+          databaseName: "crm_clone_dev",
+          productionReleaseAudit: releaseAudit,
+        };
+        const applied = await applyNevadaPrecinctGisTransaction(nv, plan, {
+          executionContext,
+        });
+        assert.equal(applied.revision, beforeRevision + 1);
+        assert.equal(applied.replacementPrecondition.years[2].reportingUnits, 1_518);
+        assert.equal(applied.years[2].reportingUnits, 1_576);
+        assert.equal(applied.years[2].resultRows, 4_612);
+        assert.equal(applied.years[2].features, 1_635);
+        const validation = await validateNevadaPrecinctGisClient(nv, plan, {
+          executionContext,
+          readOnlySession: false,
+        });
+        assert.equal(
+          validation.years.reduce((sum, year) => sum + year.reportingUnits, 0),
+          5_288,
+        );
+        assert.equal(
+          validation.years.reduce((sum, year) => sum + year.resultRows, 0),
+          15_748,
+        );
+        assert.equal(
+          validation.years.reduce((sum, year) => sum + year.features, 0),
+          5_796,
+        );
+        assert.equal(
+          validation.years.reduce((sum, year) => sum + year.exactCrosswalks, 0),
+          5_288,
+        );
+        await assert.rejects(
+          applyNevadaPrecinctGisTransaction(nv, plan, { executionContext }),
+          /reviewed v1 replacement precondition drifted/,
+        );
+        throw new Error("ROLL_BACK_NEVADA_V1_V2_UPGRADE_REHEARSAL");
+      }),
+      /ROLL_BACK_NEVADA_V1_V2_UPGRADE_REHEARSAL/,
+    );
+    const after = await sql.unsafe([
+      "select revision::int revision,",
+      " (select count(*)::int from geography_versions gv",
+      "  where gv.state_code='NV' and gv.status='published') published",
+      "from public_data_revisions where scope='public'",
+    ].join("\n"));
+    assert.equal(Number(after[0].revision), beforeRevision);
+    assert.equal(Number(after[0].published), 3);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+});


### PR DESCRIPTION
## What changed

- adds a one-use, fail-closed Nevada v1 → corrected v2 production replacement mode
- binds the upgrade to the exact prior v1 publication receipt/package/activation evidence
- verifies all predecessor years, public flags, candidate totals, zero-vote counts, rows, features, crosswalks, source documents, and import runs inside the locked transaction
- replaces the three reviewed v1 geometry versions, loads sealed v2 data as blocked, persists the predecessor proof, and rejects replay
- documents the exact upgrade and read-only recovery procedure

## Why

PR #221 deployed the corrected v2 static manifest registry, while production PostgreSQL still contains the already-published v1 Nevada release. The normal hidden-load tool correctly refuses any existing release, leaving the geometry endpoint fail-closed. This hotfix adds the narrowly reviewed upgrade path needed to move production to v2 without manual SQL or a general overwrite bypass.

## Impact

After merge, operators can run a fresh preflight/backup, perform the exact v1 → blocked-v2 transaction, publish the 54 v2 Blob objects, and execute the existing atomic public cutover. The corrected release contains 5,288 reporting units, 15,748 result rows, 5,796 polygons, and 5,288 reviewed crosswalks. Nevada 2012 remains blocked under issue #220.

## Validation

- `node --experimental-strip-types --test` across 8 non-mutating Nevada release/Blob/activation/gate suites: 24/24 passed
- exact published-v1 Docker clone upgrade rehearsal: passed; all v2 counts validated, replay rejected, transaction deliberately rolled back
- `npm.cmd run typecheck`: passed
- `npm.cmd run build`: passed
- `git diff --check`: passed
