### PR TITLE
Add guarded Iowa precinct rollback

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -64,6 +64,8 @@
 
 # Preserve every hash-pinned Iowa precinct source and reviewed artifact byte-for-byte.
 /data/precinct-geometry/IA/** -text whitespace=-trailing-space,-space-before-tab
+/data/precinct-geometry/IA/raw-shared/dspg-isu/DESCRIPTION text eol=crlf
+/data/precinct-geometry/IA/raw-shared/dspg-isu/LICENSE.md text eol=crlf
 /data/precinct-geometry/IA/**/*.pdf -diff
 /data/precinct-geometry/IA/**/*.zip -diff
 /data/precinct-geometry/IA/**/*.gz -diff

--- a/docs/developer/ia-precinct-gis-runbook.md
+++ b/docs/developer/ia-precinct-gis-runbook.md
@@ -198,15 +198,20 @@ hash. Preserve the Blob evidence path, SHA-256, and one credential-free HTTPS
 
 ## Deployment and atomic public cutover
 
-1. Set `CRM_PRECINCT_GEOGRAPHY_ORIGIN` to the exact Blob `deliveryOrigin` for
+1. Before changing Production, record the exact currently promoted,
+   gate-capable rollback deployment: deployment ID, credential-free HTTPS URL,
+   40-hex Git commit, resolved Git tree, and verification time. Confirm that
+   this deployment returns no Iowa precinct results and 404 for Iowa precinct
+   geometry while the database is blocked.
+2. Set `CRM_PRECINCT_GEOGRAPHY_ORIGIN` to the exact Blob `deliveryOrigin` for
    Preview only and create a fresh protected preview deployment of the static
    activation commit.
-2. Confirm its Git SHA and verify both Iowa endpoints remain closed while the
+3. Confirm its Git SHA and tree, and verify both Iowa endpoints remain closed while the
    database rows are blocked.
-3. Set the same origin for Production, merge the exact activation tree to
+4. Set the same origin for Production, merge the exact activation tree to
    `main`, and wait for its production deployment to be READY and PROMOTED.
-4. Again verify precinct results are empty and precinct geography returns 404.
-5. Build the database-publication plan from the exact hidden receipt and Blob
+5. Again verify precinct results are empty and precinct geography returns 404.
+6. Build the database-publication plan from the exact hidden receipt and Blob
    evidence:
 
 ```powershell
@@ -215,9 +220,11 @@ npm.cmd run precinct-gis:publication-status:ia -- --package=$PKG --package-sha25
 npm.cmd run precinct-gis:publication-status:ia -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_RECEIPT --blob-evidence-sha256=$BLOB_SHA --write-authorization-template
 ```
 
-Complete the publication authorization as `GO_PUBLIC`, pin the READY/PROMOTED
-production deployment and blocked-gate observations, and retain exactly these
-scopes:
+Complete the publication authorization as `GO_PUBLIC`. Pin the READY/PROMOTED
+production deployment's commit and resolved tree, the blocked-gate
+observations, and the previously recorded gate-capable rollback deployment's
+commit and resolved tree. The publication and rollback deployment IDs and
+trees must differ. Retain exactly these scopes:
 
 - `publish_ia_geography_versions`
 - `authorize_ia_precinct_results`
@@ -247,27 +254,65 @@ unavailable and issue #223 remains open.
 
 ## Rollback
 
-This implementation does **not** ship an executable, receipt-bound public
-rollback transaction. The full-schema backup is disaster-recovery evidence;
-it is not a substitute for a reviewed row-scoped rollback command. Therefore
-`GO_PUBLIC` is a hard stop until a separate change implements and tests all of
-the following:
+Preserve the exact successful publication receipt path and SHA-256. A rollback
+uses a new authorization; the original `GO_PUBLIC` record cannot authorize it.
+Generate the fail-closed template with the exact publication receipt:
 
-- one authorization bound to the exact successful Iowa publication receipt;
-- one atomic transaction that blocks the three geography versions and linked
-  reporting units together, preserving the original publication audit;
-- exact postconditions and read-only recovery for an ambiguous commit; and
-- a pinned gate-capable application deployment and fail-closed rollback order.
+```powershell
+npm.cmd run precinct-gis:publication-status:ia -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_RECEIPT --blob-evidence-sha256=$BLOB_SHA --plan-sha256=$PUBLICATION_PLAN_SHA --rollback --publication-receipt=$PUBLICATION_RECEIPT --publication-receipt-sha256=$PUBLICATION_RECEIPT_SHA --write-authorization-template
+```
 
-Before `GO_PUBLIC`, a failed preview, deployment, or Blob check simply stops the
-release while the database remains blocked. Do not improvise manual SQL, treat
-the full backup as an ordinary rollback, or claim that a public cutover is
-reversible with the tooling in this change.
+Complete it as `GO_ROLLBACK` with a unique rollback ID, an active window, the
+same pinned rollback target copied from the successful publication receipt,
+and both database-first/application-second acknowledgements. Retain exactly:
+
+- `block_ia_geography_versions`
+- `revoke_ia_precinct_results`
+- `increment_public_data_revision`
+
+Run the database reversal first while the activated, gate-capable application
+is still serving Production:
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production'
+$env:CRM_IA_PRECINCT_ROLLBACK_WRITES='I_ACKNOWLEDGE_DATABASE_FIRST_IOWA_PRECINCT_PUBLIC_ROLLBACK'
+$env:CRM_IA_PRECINCT_PUBLICATION_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_IA_PRECINCT_PUBLICATION_PLAN_SHA256=$PUBLICATION_PLAN_SHA
+$env:CRM_IA_PRECINCT_PUBLICATION_AUTHORIZATION_SHA256=$ROLLBACK_AUTH_SHA
+$env:CRM_IA_PRECINCT_PUBLICATION_RECEIPT_SHA256=$PUBLICATION_RECEIPT_SHA
+$env:CRM_IA_PRECINCT_ROLLBACK_ID='<rollback ID>'
+
+npm.cmd run precinct-gis:publication-status:ia -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_RECEIPT --blob-evidence-sha256=$BLOB_SHA --plan-sha256=$PUBLICATION_PLAN_SHA --rollback --publication-receipt=$PUBLICATION_RECEIPT --publication-receipt-sha256=$PUBLICATION_RECEIPT_SHA --authorization=$ROLLBACK_AUTH --authorization-sha256=$ROLLBACK_AUTH_SHA --apply
+```
+
+The transaction verifies the exact publication activation, authorization hash,
+receipt hash, revision, time, manifests, delivery origin, and rollback target;
+then it blocks all three geography versions and linked result units together,
+restores each original caveat, preserves the publication audit, records the
+rollback audit, and increments the public revision. Verify both endpoints are
+closed before restoring only the deployment pinned in the receipt. Hold other
+Production deployments until that restore and live verification finish.
+
+If the transaction body completed but commit acknowledgement or local receipt
+writing was ambiguous, do not rerun `--apply` or delete the `.pending` marker.
+Use the same command with `--recover-receipt` under these read-only guards:
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production-read-only'
+$env:CRM_IA_PRECINCT_PUBLICATION_RECEIPT_RECOVERY=$PUBLICATION_PLAN_SHA
+$env:CRM_IA_PRECINCT_PUBLICATION_AUTHORIZATION_SHA256=$ROLLBACK_AUTH_SHA
+$env:CRM_IA_PRECINCT_PUBLICATION_RECEIPT_SHA256=$PUBLICATION_RECEIPT_SHA
+```
+
+Recovery opens a read-only transaction, requires the exact durable rollback
+metadata and public revision, and writes only the immutable local receipt. The
+full-schema backup remains disaster-recovery evidence; it is not a substitute
+for this row-scoped rollback.
 
 ## Current authorization status
 
 This implementation and its local rehearsals authorize no production write,
 Blob upload, Vercel environment change, deployment, canonical activation, or
-public database transition. Hidden-load and publication tooling remain
-fail-closed; the missing executable public rollback is an additional required
-gate before any `GO_PUBLIC` authorization.
+public database transition. Hidden-load, publication, database-first rollback,
+and both receipt-recovery paths remain fail-closed until their exact separately
+reviewed authorization records are completed.

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -7269,10 +7269,19 @@ evidence against its verified top-level package.
   immutable package, canonical activation, production preflight, full backup
   and restore proof, sole-owner hidden load, Blob publication, database-gated
   deployment, atomic public cutover, and read-only receipt-recovery paths are
-  documented in `docs/developer/ia-precinct-gis-runbook.md`. That runbook also
-  records the remaining production stop condition accurately: this change does
-  not include an executable receipt-bound public rollback, so `GO_PUBLIC`
-  remains unauthorized until that path is implemented and reviewed.
+  documented in `docs/developer/ia-precinct-gis-runbook.md`.
+
+- The follow-up Iowa rollback contract binds a new `GO_ROLLBACK` authorization
+  to the exact successful publication receipt and reloads the original
+  hash-pinned `GO_PUBLIC` authorization. The original receipt's activation,
+  revision, time, delivery origin, authorization hash, and gate-capable rollback
+  deployment are checked again inside the locked transaction. The database is
+  blocked first across all three geography versions, crosswalks, reporting
+  units, source records, and import runs; original caveats and publication
+  provenance remain intact under a nested rollback audit. Only afterward may
+  the exact pinned application deployment be restored. An ambiguous commit has
+  a read-only, receipt-recovery path that preserves the pending marker on failed
+  reconciliation.
 
 - This work performs no production database mutation, Blob upload, Vercel
   setting or deployment change, canonical activation, or public eligibility

--- a/scripts/lib/ia-precinct-publication.mjs
+++ b/scripts/lib/ia-precinct-publication.mjs
@@ -14,6 +14,11 @@ export const IOWA_PUBLICATION_SCOPES = Object.freeze([
   "authorize_ia_precinct_results",
   "increment_public_data_revision",
 ]);
+export const IOWA_PUBLIC_ROLLBACK_SCOPES = Object.freeze([
+  "block_ia_geography_versions",
+  "revoke_ia_precinct_results",
+  "increment_public_data_revision",
+]);
 
 const EXPECTED_TOTALS = Object.freeze({
   reportingUnits: 4_994,
@@ -430,6 +435,7 @@ export function buildIowaPublicationAuthorizationTemplate(plan, planSha256) {
       deploymentId: null,
       url: null,
       gitSha: null,
+      gitTreeSha: null,
       readyVerified: false,
       promotedVerified: false,
       blockedResultGateVerified: false,
@@ -437,6 +443,16 @@ export function buildIowaPublicationAuthorizationTemplate(plan, planSha256) {
       verifiedAtUtc: null,
       deliveryOrigin: plan.blobPublication.deliveryOrigin,
       staticRegistrySha256: plan.staticRegistry.sha256,
+    },
+    rollbackTarget: {
+      deploymentId: null,
+      url: null,
+      gitSha: null,
+      gitTreeSha: null,
+      verifiedAtUtc: null,
+      gateCapableVerified: false,
+      blockedResultGateVerified: false,
+      blockedGeometryGateVerified: false,
     },
     evidence: {
       hiddenLoad: { path: plan.hiddenLoad.path, sha256: plan.hiddenLoad.sha256 },
@@ -453,9 +469,17 @@ export function validateIowaPublicationAuthorization(value, context) {
   const authorizedAt = Date.parse(value?.authorizedAtUtc);
   const expiresAt = Date.parse(value?.expiresAtUtc);
   const deployedAt = Date.parse(value?.productionDeployment?.verifiedAtUtc);
+  const rollbackTargetAt = Date.parse(value?.rollbackTarget?.verifiedAtUtc);
+  const recovery = context.recovery === true;
   let deploymentUrl;
+  let rollbackTargetUrl;
   try {
     deploymentUrl = new URL(value?.productionDeployment?.url);
+  } catch {
+    // The common fail-closed check below reports an incompatible record.
+  }
+  try {
+    rollbackTargetUrl = new URL(value?.rollbackTarget?.url);
   } catch {
     // The common fail-closed check below reports an incompatible record.
   }
@@ -472,16 +496,13 @@ export function validateIowaPublicationAuthorization(value, context) {
     || value?.publicationPlan?.id !== context.plan.id
     || value?.publicationPlan?.sha256 !== context.planSha256
     || !semanticallyEqual(value?.scopes, IOWA_PUBLICATION_SCOPES)
-    || [authorizedAt, expiresAt, deployedAt].some(Number.isNaN)
-    || authorizedAt > now
+    || [authorizedAt, expiresAt, deployedAt, rollbackTargetAt].some(Number.isNaN)
     || expiresAt <= authorizedAt
-    || now > expiresAt
     || deployedAt > authorizedAt
-    || deployedAt > now
-    || now - deployedAt > 4 * 60 * 60 * 1000
     || typeof value?.productionDeployment?.deploymentId !== "string"
     || !value.productionDeployment.deploymentId.trim()
     || !/^[a-f0-9]{40}$/.test(value?.productionDeployment?.gitSha ?? "")
+    || !/^[a-f0-9]{40}$/.test(value?.productionDeployment?.gitTreeSha ?? "")
     || value?.productionDeployment?.readyVerified !== true
     || value?.productionDeployment?.promotedVerified !== true
     || value?.productionDeployment?.blockedResultGateVerified !== true
@@ -495,6 +516,31 @@ export function validateIowaPublicationAuthorization(value, context) {
     || deploymentUrl?.password
     || deploymentUrl?.search
     || deploymentUrl?.hash
+    || typeof value?.rollbackTarget?.deploymentId !== "string"
+    || !value.rollbackTarget.deploymentId.trim()
+    || value.rollbackTarget.deploymentId
+      === value.productionDeployment.deploymentId
+    || !/^[a-f0-9]{40}$/.test(value?.rollbackTarget?.gitSha ?? "")
+    || !/^[a-f0-9]{40}$/.test(value?.rollbackTarget?.gitTreeSha ?? "")
+    || value.rollbackTarget.gitTreeSha
+      === value.productionDeployment.gitTreeSha
+    || value?.rollbackTarget?.gateCapableVerified !== true
+    || value?.rollbackTarget?.blockedResultGateVerified !== true
+    || value?.rollbackTarget?.blockedGeometryGateVerified !== true
+    || rollbackTargetUrl?.protocol !== "https:"
+    || rollbackTargetUrl?.username
+    || rollbackTargetUrl?.password
+    || rollbackTargetUrl?.search
+    || rollbackTargetUrl?.hash
+    || rollbackTargetAt > authorizedAt
+    || (!recovery && (
+      authorizedAt > now
+      || now > expiresAt
+      || deployedAt > now
+      || now - deployedAt > 4 * 60 * 60 * 1000
+      || rollbackTargetAt > now
+      || now - rollbackTargetAt > 4 * 60 * 60 * 1000
+    ))
     || value?.evidence?.hiddenLoad?.path !== context.plan.hiddenLoad.path
     || value?.evidence?.hiddenLoad?.sha256 !== context.plan.hiddenLoad.sha256
     || value?.evidence?.blobPublication?.path
@@ -508,5 +554,100 @@ export function validateIowaPublicationAuthorization(value, context) {
     activationId: value.activationId.trim(),
     approvedBy: value.approvedBy.trim(),
     productionDeployment: value.productionDeployment,
+    rollbackTarget: value.rollbackTarget,
+  };
+}
+
+export function buildIowaPublicRollbackAuthorizationTemplate(
+  plan,
+  planSha256,
+  publicationReceipt,
+) {
+  return {
+    schemaVersion: 1,
+    state: "IA",
+    decision: "NO_GO_ROLLBACK",
+    rollbackId: null,
+    approvedBy: null,
+    authorizedAtUtc: null,
+    expiresAtUtc: null,
+    releaseCandidate: plan.releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    publication: {
+      activationId: publicationReceipt.activationId,
+      revision: publicationReceipt.revision,
+      changedAtUtc: publicationReceipt.changedAtUtc,
+    },
+    scopes: [...IOWA_PUBLIC_ROLLBACK_SCOPES],
+    rollbackWindow: {
+      startsAtUtc: null,
+      endsAtUtc: null,
+    },
+    applicationRollback: {
+      target: publicationReceipt.rollbackTarget,
+      databaseBlockFirstAcknowledged: false,
+      restoreAfterDatabaseRollbackAcknowledged: false,
+    },
+    evidence: {
+      publicationReceipt: {
+        path: publicationReceipt.path,
+        sha256: publicationReceipt.sha256,
+      },
+    },
+  };
+}
+
+export function validateIowaPublicRollbackAuthorization(value, context) {
+  const now = context.now ?? Date.now();
+  const authorizedAt = Date.parse(value?.authorizedAtUtc);
+  const expiresAt = Date.parse(value?.expiresAtUtc);
+  const startsAt = Date.parse(value?.rollbackWindow?.startsAtUtc);
+  const endsAt = Date.parse(value?.rollbackWindow?.endsAtUtc);
+  const receipt = context.publicationReceipt;
+  const recovery = context.recovery === true;
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "IA"
+    || value?.decision !== "GO_ROLLBACK"
+    || typeof value?.rollbackId !== "string"
+    || !value.rollbackId.trim()
+    || typeof value?.approvedBy !== "string"
+    || !value.approvedBy.trim()
+    || value?.releaseCandidate?.id !== context.plan.releaseCandidate.id
+    || value?.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
+    || value?.publicationPlan?.id !== context.plan.id
+    || value?.publicationPlan?.sha256 !== context.planSha256
+    || value?.publication?.activationId !== receipt.activationId
+    || Number(value?.publication?.revision) !== receipt.revision
+    || value?.publication?.changedAtUtc !== receipt.changedAtUtc
+    || !semanticallyEqual(value?.scopes, IOWA_PUBLIC_ROLLBACK_SCOPES)
+    || [authorizedAt, expiresAt, startsAt, endsAt].some(Number.isNaN)
+    || expiresAt <= authorizedAt
+    || startsAt > endsAt
+    || (!recovery && (
+      authorizedAt > now
+      || now > expiresAt
+      || startsAt > now
+      || now > endsAt
+    ))
+    || !semanticallyEqual(
+      value?.applicationRollback?.target,
+      receipt.rollbackTarget,
+    )
+    || value?.applicationRollback?.databaseBlockFirstAcknowledged !== true
+    || value?.applicationRollback?.restoreAfterDatabaseRollbackAcknowledged
+      !== true
+    || value?.evidence?.publicationReceipt?.path !== receipt.path
+    || value?.evidence?.publicationReceipt?.sha256 !== receipt.sha256
+  ) {
+    throw new Error("Iowa rollback authorization is absent, expired, or incompatible");
+  }
+  return {
+    activationId: value.rollbackId.trim(),
+    rollbackId: value.rollbackId.trim(),
+    publicationActivationId: receipt.activationId,
+    approvedBy: value.approvedBy.trim(),
+    rollbackWindow: value.rollbackWindow,
+    applicationRollback: value.applicationRollback,
   };
 }

--- a/scripts/lib/ia-precinct-release-readiness.mjs
+++ b/scripts/lib/ia-precinct-release-readiness.mjs
@@ -49,7 +49,7 @@ export async function buildIowaPrecinctReleaseReadiness(options = {}) {
       "Continue no-email archive and official-download discovery for the complete election-effective Iowa 2012 precinct boundary set; retain the tracked blocker until it is found and reviewed.",
       "Review the regenerated exact hash-pinned artifacts, license terms, and official-result reconciliation.",
       "Build immutable parent-scoped delivery packages for 2016, 2020, and 2024 while the unresolved 2012 vintage remains blocked.",
-      "Implement and review a receipt-bound atomic public rollback before any GO_PUBLIC authorization.",
+      "Review the receipt-bound database-first rollback and recovery contract before any GO_PUBLIC authorization.",
       "Use a separately reviewed guarded production release; this readiness report performs no publication or database write.",
     ],
   };

--- a/scripts/publish-ia-precinct-geography-status.mjs
+++ b/scripts/publish-ia-precinct-geography-status.mjs
@@ -17,11 +17,14 @@ import {
 import { buildIowaPrecinctGisPlan } from "./lib/ia-precinct-gis-plan.mjs";
 import { productionEndpointFingerprint } from "./lib/ia-precinct-production-preflight.mjs";
 import {
+  IOWA_PUBLIC_ROLLBACK_SCOPES,
+  buildIowaPublicRollbackAuthorizationTemplate,
   buildIowaPublicationAuthorizationTemplate,
   inspectIowaPublicationPlan,
   semanticallyEqual,
   serializeIowaPublicationDocument,
   sha256,
+  validateIowaPublicRollbackAuthorization,
   validateIowaPublicationAuthorization,
 } from "./lib/ia-precinct-publication.mjs";
 
@@ -38,11 +41,14 @@ function parseArguments(args) {
     planSha256: read("--plan-sha256"),
     authorizationPath: read("--authorization"),
     authorizationSha256: read("--authorization-sha256"),
+    publicationReceiptPath: read("--publication-receipt"),
+    publicationReceiptSha256: read("--publication-receipt-sha256"),
     outputPath: read("--output"),
     writePlan: args.includes("--write-plan"),
     writeAuthorizationTemplate: args.includes("--write-authorization-template"),
     apply: args.includes("--apply"),
     recoverReceipt: args.includes("--recover-receipt"),
+    rollback: args.includes("--rollback"),
   };
   const allowed = new Set([
     "--package",
@@ -54,6 +60,8 @@ function parseArguments(args) {
     "--plan-sha256",
     "--authorization",
     "--authorization-sha256",
+    "--publication-receipt",
+    "--publication-receipt-sha256",
     "--output",
   ]);
   for (const arg of args) {
@@ -63,6 +71,7 @@ function parseArguments(args) {
         "--write-authorization-template",
         "--apply",
         "--recover-receipt",
+        "--rollback",
       ].includes(arg)
       && ![...allowed].some((name) => arg.startsWith(name + "="))
     ) {
@@ -86,6 +95,12 @@ function parseArguments(args) {
     "blobEvidenceSha256",
   ]) {
     if (!parsed[field]) throw new Error("Iowa publication-status requires " + field);
+  }
+  if (
+    parsed.rollback
+    && (!parsed.publicationReceiptPath || !parsed.publicationReceiptSha256)
+  ) {
+    throw new Error("Iowa rollback requires the exact publication receipt and SHA-256");
   }
   return parsed;
 }
@@ -159,46 +174,120 @@ function productionUrl(environment = process.env) {
   return value;
 }
 
-function currentGitSha(root) {
-  const sha = execFileSync("git", ["rev-parse", "HEAD"], {
+function runGit(root, args, runner = execFileSync) {
+  return runner("git", args, {
     cwd: root,
     encoding: "utf8",
     windowsHide: true,
   }).trim();
-  if (!/^[a-f0-9]{40}$/.test(sha)) {
-    throw new Error("Iowa publication checkout HEAD is invalid");
-  }
-  const trackedStatus = execFileSync(
-    "git",
-    ["status", "--porcelain", "--untracked-files=no"],
-    { cwd: root, encoding: "utf8", windowsHide: true },
-  ).trim();
-  if (trackedStatus) {
-    throw new Error("Iowa publication checkout has tracked changes");
-  }
-  return sha;
 }
 
-function expectedActivationMetadata(context, manifest, previousCaveat, revision) {
+export function verifyIowaPublicationGitCandidate(
+  root,
+  publicAuthorization,
+  runner = execFileSync,
+) {
+  let head;
+  let headTree;
+  let productionTree;
+  let rollbackTree;
+  let trackedStatus;
+  try {
+    head = runGit(root, ["rev-parse", "HEAD"], runner);
+    headTree = runGit(root, ["rev-parse", "HEAD^{tree}"], runner);
+    productionTree = runGit(
+      root,
+      ["rev-parse", `${publicAuthorization.productionDeployment.gitSha}^{tree}`],
+      runner,
+    );
+    rollbackTree = runGit(
+      root,
+      ["rev-parse", `${publicAuthorization.rollbackTarget.gitSha}^{tree}`],
+      runner,
+    );
+    trackedStatus = runGit(
+      root,
+      ["status", "--porcelain", "--untracked-files=no"],
+      runner,
+    );
+  } catch {
+    throw new Error("Iowa publication Git evidence could not be resolved locally");
+  }
+  if (
+    head !== publicAuthorization.productionDeployment.gitSha
+    || headTree !== publicAuthorization.productionDeployment.gitTreeSha
+    || productionTree !== publicAuthorization.productionDeployment.gitTreeSha
+    || rollbackTree !== publicAuthorization.rollbackTarget.gitTreeSha
+    || trackedStatus
+  ) {
+    throw new Error("Iowa publication checkout or deployment Git evidence drifted");
+  }
   return {
+    gitSha: head,
+    gitTreeSha: headTree,
+    rollbackTarget: {
+      gitSha: publicAuthorization.rollbackTarget.gitSha,
+      gitTreeSha: rollbackTree,
+    },
+    trackedWorktreeClean: true,
+  };
+}
+
+function expectedActivationMetadata(
+  context,
+  manifest,
+  previousCaveat,
+  revision,
+  changedAtUtc = context.changedAtUtc,
+) {
+  const publication = context.publicationReceipt ?? {
     activationId: context.authorization.activationId,
+    authorizationSha256: context.authorizationSha256,
+    rollbackTarget: context.authorization.rollbackTarget,
+  };
+  return {
+    activationId: publication.activationId,
     activationCandidateSha256: context.planSha256,
     releasePackageSha256: context.plan.releaseCandidate.sha256,
     blobPublicationSha256: context.plan.blobPublication.sha256,
     deliveryOrigin: context.plan.blobPublication.deliveryOrigin,
-    authorizationSha256: context.authorizationSha256,
+    authorizationSha256: publication.authorizationSha256,
+    rollbackTarget: publication.rollbackTarget,
     mode: "publish",
     year: manifest.year,
     manifestId: manifest.manifestId,
     publicManifestSha256: manifest.publicManifestSha256,
     delivery: manifest.delivery,
     previousCaveat,
-    changedAtUtc: context.changedAtUtc,
+    changedAtUtc,
     revision,
   };
 }
 
-async function verifyPostconditions(nv, context, revision) {
+function expectedRollbackMetadata(context, revision) {
+  return {
+    rollbackId: context.authorization.rollbackId,
+    publicationActivationId: context.publicationReceipt.activationId,
+    activationCandidateSha256: context.planSha256,
+    releasePackageSha256: context.plan.releaseCandidate.sha256,
+    blobPublicationSha256: context.plan.blobPublication.sha256,
+    authorizationSha256: context.authorizationSha256,
+    publicationReceiptSha256: context.publicationReceipt.sha256,
+    rollbackTarget: context.authorization.applicationRollback.target,
+    changedAtUtc: context.changedAtUtc,
+    revision,
+    mode: "rollback",
+  };
+}
+
+async function verifyPostconditions(
+  nv,
+  context,
+  revision,
+  mode = context.mode ?? "publish",
+) {
+  const publicAuthorized = mode === "publish";
+  const wantedStatus = publicAuthorized ? "published" : "blocked";
   const versions = await nv.unsafe([
     "select e.year,gv.status,gv.caveat,gv.metadata",
     "from geography_versions gv join elections e on e.id=gv.election_id",
@@ -214,22 +303,35 @@ async function verifyPostconditions(nv, context, revision) {
     const previousCaveat = context.gisPlan.years[index].manifest.validation.errors
       .join(" ");
     const metadata = row.metadata ?? {};
+    const publicationRevision = context.publicationReceipt?.revision ?? revision;
+    const publicationChangedAt = context.publicationReceipt?.changedAtUtc
+      ?? context.changedAtUtc;
+    const originalActivation = expectedActivationMetadata(
+      context,
+      manifest,
+      previousCaveat,
+      publicationRevision,
+      publicationChangedAt,
+    );
+    const expectedActivation = publicAuthorized
+      ? originalActivation
+      : {
+        ...originalActivation,
+        rollback: expectedRollbackMetadata(context, revision),
+      };
+    const expectedCaveat = publicAuthorized
+      ? "Reviewed Iowa election-specific precinct geometry is publicly authorized under activation "
+        + originalActivation.activationId + "."
+      : previousCaveat;
     if (
       Number(row.year) !== manifest.year
-      || row.status !== "published"
+      || row.status !== wantedStatus
+      || String(row.caveat ?? "") !== expectedCaveat
       || metadata.manifestId !== manifest.manifestId
-      || metadata.publicDeliveryAuthorized !== true
-      || metadata.releaseCandidate?.publicDeliveryAuthorized !== true
+      || metadata.publicDeliveryAuthorized !== publicAuthorized
+      || metadata.releaseCandidate?.publicDeliveryAuthorized !== publicAuthorized
       || metadata.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
-      || !semanticallyEqual(
-        metadata.publicActivation,
-        expectedActivationMetadata(
-          context,
-          manifest,
-          previousCaveat,
-          revision,
-        ),
-      )
+      || !semanticallyEqual(metadata.publicActivation, expectedActivation)
     ) {
       throw new Error("Iowa " + manifest.year + " geography publication drifted");
     }
@@ -238,42 +340,42 @@ async function verifyPostconditions(nv, context, revision) {
     "select count(*)::int total,",
     " count(*) filter (where x.relationship_type='one_to_one'",
     "  and x.match_method='exact_official_id' and x.review_status='reviewed'",
-    "  and x.confidence='high' and x.metadata->>'publicDeliveryAuthorized'='true'",
-    "  and x.metadata->'releaseCandidate'->>'publicDeliveryAuthorized'='true')::int exact",
+    "  and x.confidence='high' and x.metadata->>'publicDeliveryAuthorized'=$2",
+    "  and x.metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
     "from reporting_unit_geometry_crosswalks x",
     "join geography_versions gv on gv.id=x.geometry_version_id",
     "where gv.state_code='IA' and gv.metadata->'releaseCandidate'->>'sha256'=$1",
-  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
   if (Number(linked[0]?.total) !== 4_994 || Number(linked[0]?.exact) !== 4_994) {
     throw new Error("Iowa publication crosswalk postcondition failed");
   }
   const units = await nv.unsafe([
     "select count(*)::int total, count(*) filter (where",
-    " metadata->>'publicDeliveryAuthorized'='true' and",
-    " metadata->'releaseCandidate'->>'publicDeliveryAuthorized'='true')::int exact",
+    " metadata->>'publicDeliveryAuthorized'=$2 and",
+    " metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
     "from reporting_units where state_code='IA' and reporting_grain='precinct'",
     " and metadata->'releaseCandidate'->>'sha256'=$1",
-  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
   if (Number(units[0]?.total) !== 4_994 || Number(units[0]?.exact) !== 4_994) {
     throw new Error("Iowa publication reporting-unit postcondition failed");
   }
   const sources = await nv.unsafe([
     "select count(*)::int total, count(*) filter (where",
-    " metadata->>'publicDeliveryAuthorized'='true' and",
-    " metadata->'releaseCandidate'->>'publicDeliveryAuthorized'='true')::int exact",
+    " metadata->>'publicDeliveryAuthorized'=$2 and",
+    " metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
     "from source_documents where state_code='IA'",
     " and metadata->'releaseCandidate'->>'sha256'=$1",
-  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
   if (Number(sources[0]?.total) !== 6 || Number(sources[0]?.exact) !== 6) {
     throw new Error("Iowa publication source-document postcondition failed");
   }
   const runs = await nv.unsafe([
     "select count(*)::int total, count(*) filter (where",
-    " summary->>'publicDeliveryAuthorized'='true' and",
-    " summary->'releaseCandidate'->>'publicDeliveryAuthorized'='true')::int exact",
+    " summary->>'publicDeliveryAuthorized'=$2 and",
+    " summary->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
     "from import_runs where state_code='IA'",
     " and summary->'releaseCandidate'->>'sha256'=$1",
-  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
   if (Number(runs[0]?.total) !== 3 || Number(runs[0]?.exact) !== 3) {
     throw new Error("Iowa publication import-run postcondition failed");
   }
@@ -292,7 +394,24 @@ async function verifyPostconditions(nv, context, revision) {
   if (Number(invalid[0]?.count) !== 0) {
     throw new Error("Iowa publication left invalid public constraints");
   }
+  const revisionRows = await nv.unsafe([
+    "select revision::int revision,reason from public_data_revisions",
+    "where scope='public'",
+  ].join("\n"));
+  const expectedReason = "Iowa precinct geometry " + mode + " "
+    + (publicAuthorized
+      ? context.authorization.activationId
+      : context.authorization.rollbackId);
+  if (
+    Number(revisionRows[0]?.revision) !== revision
+    || String(revisionRows[0]?.reason) !== expectedReason
+  ) {
+    throw new Error("Iowa publication revision postcondition failed");
+  }
   return {
+    mode,
+    status: wantedStatus,
+    publicDeliveryAuthorized: publicAuthorized,
     geographyVersions: 3,
     crosswalks: 4_994,
     reportingUnits: 4_994,
@@ -304,6 +423,24 @@ async function verifyPostconditions(nv, context, revision) {
 }
 
 export async function applyIowaGeographyPublicationTransaction(nv, context) {
+  const mode = context.mode ?? "publish";
+  if (!new Set(["publish", "rollback"]).has(mode)) {
+    throw new Error("Iowa publication transaction mode is invalid");
+  }
+  const publicAuthorized = mode === "publish";
+  if (mode === "rollback" && !context.publicationReceipt) {
+    throw new Error("Iowa rollback requires the exact publication receipt");
+  }
+  if (mode === "rollback" && (
+    context.authorization.publicationActivationId
+      !== context.publicationReceipt.activationId
+    || !semanticallyEqual(
+      context.authorization.applicationRollback?.target,
+      context.publicationReceipt.rollbackTarget,
+    )
+  )) {
+    throw new Error("Iowa rollback authorization drifted from the publication receipt");
+  }
   const identity = await nv.unsafe([
     "select current_database() database_name,",
     " current_setting('transaction_read_only') transaction_read_only",
@@ -322,13 +459,22 @@ export async function applyIowaGeographyPublicationTransaction(nv, context) {
   const revisions = await nv.unsafe(
     "select revision::int revision from public_data_revisions where scope='public' for update",
   );
-  if (revisions.length !== 1) throw new Error("Iowa public revision is missing");
-  const revision = Number(revisions[0].revision) + 1;
+  const currentRevision = Number(revisions[0]?.revision);
+  if (
+    revisions.length !== 1
+    || !Number.isInteger(currentRevision)
+    || currentRevision < 0
+  ) {
+    throw new Error("Iowa public revision is missing or invalid");
+  }
+  const revision = currentRevision + 1;
   const gisPlan = context.gisPlan;
-  await validateIowaPrecinctGisClient(nv, gisPlan, {
-    executionContext: context.executionContext,
-    readOnlySession: false,
-  });
+  if (mode === "publish") {
+    await (context.validateCurrentDatabase ?? validateIowaPrecinctGisClient)(nv, gisPlan, {
+      executionContext: context.executionContext,
+      readOnlySession: false,
+    });
+  }
   const versions = await nv.unsafe([
     "select gv.id,e.year,gv.status,gv.caveat,gv.metadata",
     "from geography_versions gv join elections e on e.id=gv.election_id",
@@ -337,44 +483,83 @@ export async function applyIowaGeographyPublicationTransaction(nv, context) {
     "order by e.year for update of gv",
   ].join("\n"), [context.plan.releaseCandidate.sha256]);
   if (versions.length !== 3) {
-    throw new Error("Iowa publication requires three blocked geography versions");
+    throw new Error("Iowa publication requires three exact geography versions");
   }
   for (const [index, version] of versions.entries()) {
     const manifest = context.plan.manifests[index];
     const expectedBlockedCaveat = gisPlan.years[index].manifest.validation.errors
       .join(" ");
-    if (
-      Number(version.year) !== manifest.year
-      || version.status !== "blocked"
+    const commonDrift = Number(version.year) !== manifest.year
       || version.metadata?.manifestId !== manifest.manifestId
+      || version.metadata?.releaseCandidate?.sha256
+        !== context.plan.releaseCandidate.sha256;
+    const originalActivation = mode === "rollback"
+      ? expectedActivationMetadata(
+        context,
+        manifest,
+        expectedBlockedCaveat,
+        context.publicationReceipt.revision,
+        context.publicationReceipt.changedAtUtc,
+      )
+      : null;
+    if (mode === "publish" && (
+      commonDrift
+      || version.status !== "blocked"
       || version.metadata?.manifestSha256 !== manifest.blockedManifestSha256
       || version.metadata?.publicDeliveryAuthorized !== false
       || version.metadata?.releaseCandidate?.publicDeliveryAuthorized !== false
-      || version.metadata?.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
       || String(version.caveat ?? "") !== expectedBlockedCaveat
       || Object.hasOwn(version.metadata ?? {}, "publicActivation")
-    ) {
+    )) {
       throw new Error("Iowa " + manifest.year + " publication precondition drifted");
     }
-    const activation = expectedActivationMetadata(
-      context,
-      manifest,
-      expectedBlockedCaveat,
-      revision,
-    );
+    if (mode === "rollback" && (
+      commonDrift
+      || version.status !== "published"
+      || String(version.caveat ?? "")
+        !== "Reviewed Iowa election-specific precinct geometry is publicly authorized under activation "
+          + context.publicationReceipt.activationId + "."
+      || version.metadata?.publicDeliveryAuthorized !== true
+      || version.metadata?.releaseCandidate?.publicDeliveryAuthorized !== true
+      || !semanticallyEqual(version.metadata?.publicActivation, originalActivation)
+    )) {
+      throw new Error(
+        "Iowa " + manifest.year
+          + " rollback does not match the publication being reversed",
+      );
+    }
+    const activation = mode === "publish"
+      ? expectedActivationMetadata(
+        context,
+        manifest,
+        expectedBlockedCaveat,
+        revision,
+      )
+      : {
+        ...originalActivation,
+        rollback: expectedRollbackMetadata(context, revision),
+      };
+    const wantedStatus = publicAuthorized ? "published" : "blocked";
+    const wantedCaveat = publicAuthorized
+      ? "Reviewed Iowa election-specific precinct geometry is publicly authorized under activation "
+        + context.authorization.activationId + "."
+      : originalActivation.previousCaveat;
+    const currentStatus = publicAuthorized ? "blocked" : "published";
     const updated = await nv.unsafe([
-      "update geography_versions set status='published',",
-      " caveat=$2,",
-      " metadata=jsonb_set(jsonb_set(metadata,",
-      "  '{publicDeliveryAuthorized}','true'::jsonb,true),",
-      "  '{releaseCandidate,publicDeliveryAuthorized}','true'::jsonb,true)",
-      "  || jsonb_build_object('publicActivation',$3::text::jsonb),",
-      " updated_at=now() where id=$1::uuid and status='blocked' returning id",
+      "update geography_versions set status=$2,",
+      " caveat=$3,",
+      " metadata=jsonb_set(jsonb_set(jsonb_set(metadata,",
+      "  '{publicDeliveryAuthorized}',$4::text::jsonb,true),",
+      "  '{releaseCandidate,publicDeliveryAuthorized}',$4::text::jsonb,true),",
+      "  '{publicActivation}',$5::text::jsonb,true),",
+      " updated_at=now() where id=$1::uuid and status=$6 returning id",
     ].join("\n"), [
       version.id,
-      "Reviewed Iowa election-specific precinct geometry is publicly authorized under activation "
-        + context.authorization.activationId + ".",
+      wantedStatus,
+      wantedCaveat,
+      JSON.stringify(publicAuthorized),
       JSON.stringify(activation),
+      currentStatus,
     ]);
     if (updated.length !== 1) {
       throw new Error("Iowa " + manifest.year + " publication update lost its lock");
@@ -382,40 +567,40 @@ export async function applyIowaGeographyPublicationTransaction(nv, context) {
   }
   const crosswalks = await nv.unsafe([
     "update reporting_unit_geometry_crosswalks x set metadata=",
-    " jsonb_set(jsonb_set(x.metadata,'{publicDeliveryAuthorized}','true'::jsonb,true),",
-    " '{releaseCandidate,publicDeliveryAuthorized}','true'::jsonb,true)",
+    " jsonb_set(jsonb_set(x.metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
     "from geography_versions gv where gv.id=x.geometry_version_id",
     " and gv.state_code='IA' and gv.metadata->'releaseCandidate'->>'sha256'=$1",
     "returning x.id",
-  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
   if (crosswalks.length !== 4_994) {
     throw new Error("Iowa publication crosswalk update count drifted");
   }
   const units = await nv.unsafe([
     "update reporting_units set metadata=",
-    " jsonb_set(jsonb_set(metadata,'{publicDeliveryAuthorized}','true'::jsonb,true),",
-    " '{releaseCandidate,publicDeliveryAuthorized}','true'::jsonb,true)",
+    " jsonb_set(jsonb_set(metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
     "where state_code='IA' and reporting_grain='precinct'",
     " and metadata->'releaseCandidate'->>'sha256'=$1 returning id",
-  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
   if (units.length !== 4_994) {
     throw new Error("Iowa publication reporting-unit update count drifted");
   }
   const sources = await nv.unsafe([
     "update source_documents set metadata=",
-    " jsonb_set(jsonb_set(metadata,'{publicDeliveryAuthorized}','true'::jsonb,true),",
-    " '{releaseCandidate,publicDeliveryAuthorized}','true'::jsonb,true)",
+    " jsonb_set(jsonb_set(metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
     "where state_code='IA' and metadata->'releaseCandidate'->>'sha256'=$1 returning id",
-  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
   if (sources.length !== 6) {
     throw new Error("Iowa publication source-document update count drifted");
   }
   const runs = await nv.unsafe([
     "update import_runs set summary=",
-    " jsonb_set(jsonb_set(summary,'{publicDeliveryAuthorized}','true'::jsonb,true),",
-    " '{releaseCandidate,publicDeliveryAuthorized}','true'::jsonb,true)",
+    " jsonb_set(jsonb_set(summary,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
     "where state_code='IA' and summary->'releaseCandidate'->>'sha256'=$1 returning id",
-  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
   if (runs.length !== 3) {
     throw new Error("Iowa publication import-run update count drifted");
   }
@@ -423,17 +608,22 @@ export async function applyIowaGeographyPublicationTransaction(nv, context) {
     "update public_data_revisions set revision=revision+1,updated_at=now(),reason=$1",
     "where scope='public' returning revision::int revision,updated_at",
   ].join("\n"), [
-    "Iowa precinct geometry publish " + context.authorization.activationId,
+    "Iowa precinct geometry " + mode + " "
+      + (publicAuthorized
+        ? context.authorization.activationId
+        : context.authorization.rollbackId),
   ]);
   if (Number(revisionRows[0]?.revision) !== revision) {
     throw new Error("Iowa publication revision increment drifted");
   }
-  const postconditions = await verifyPostconditions(nv, context, revision);
+  const postconditions = await verifyPostconditions(nv, context, revision, mode);
   return {
-    result: "PUBLISHED",
+    result: publicAuthorized ? "PUBLISHED" : "ROLLED_BACK",
+    mode,
     revision,
     changedAtUtc: context.changedAtUtc,
     postconditions,
+    publicDeliveryAuthorized: publicAuthorized,
   };
 }
 
@@ -442,14 +632,97 @@ function defaultPlanPath(planSha256) {
     + planSha256.slice(0, 12) + ".json";
 }
 
-function defaultAuthorizationPath(planSha256) {
-  return ".etl/production-authorizations/IA/ia-publication-authorization-template-"
+function defaultAuthorizationPath(planSha256, mode = "publish") {
+  return ".etl/production-authorizations/IA/ia-" + mode + "-authorization-template-"
     + planSha256.slice(0, 12) + ".json";
 }
 
-function defaultReceiptPath(planSha256, activationId) {
+export function inspectIowaPublicationReceipt(root, options, built) {
+  const artifact = safeJson(
+    root,
+    options.publicationReceiptPath,
+    options.publicationReceiptSha256,
+    ".etl/production-publication-receipts/IA",
+  );
+  const value = artifact.value;
+  const publicAuthorizationArtifact = safeJson(
+    root,
+    value?.authorization?.path,
+    value?.authorization?.sha256,
+    ".etl/production-authorizations/IA",
+  );
+  const publicAuthorization = validateIowaPublicationAuthorization(
+    publicAuthorizationArtifact.value,
+    {
+      plan: built.plan,
+      planSha256: built.sha256,
+      now: options.now ?? Date.now(),
+      recovery: true,
+    },
+  );
+  const changedAt = Date.parse(value?.changedAtUtc);
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "IA"
+    || value?.mode !== "publish"
+    || value?.decision !== "PUBLISHED"
+    || value?.activationId !== publicAuthorization.activationId
+    || value?.approvedBy !== publicAuthorization.approvedBy
+    || !semanticallyEqual(value?.releaseCandidate, built.plan.releaseCandidate)
+    || value?.publicationPlan?.id !== built.plan.id
+    || value?.publicationPlan?.sha256 !== built.sha256
+    || value?.authorization?.path !== publicAuthorizationArtifact.path
+    || value?.authorization?.sha256 !== publicAuthorizationArtifact.sha256
+    || value?.hiddenLoad?.path !== built.plan.hiddenLoad.path
+    || value?.hiddenLoad?.sha256 !== built.plan.hiddenLoad.sha256
+    || value?.blobPublication?.path !== built.plan.blobPublication.path
+    || value?.blobPublication?.sha256 !== built.plan.blobPublication.sha256
+    || value?.blobPublication?.deliveryOrigin
+      !== built.plan.blobPublication.deliveryOrigin
+    || !semanticallyEqual(
+      value?.productionDeployment,
+      publicAuthorization.productionDeployment,
+    )
+    || !semanticallyEqual(value?.rollbackTarget, publicAuthorization.rollbackTarget)
+    || Number.isNaN(changedAt)
+    || changedAt > (options.now ?? Date.now())
+    || Date.parse(publicAuthorization.rollbackTarget.verifiedAtUtc) > changedAt
+    || !Number.isInteger(Number(value?.revision))
+    || Number(value.revision) < 1
+    || value?.postconditions?.mode !== "publish"
+    || value?.postconditions?.status !== "published"
+    || value?.postconditions?.publicDeliveryAuthorized !== true
+    || value?.postconditions?.geographyVersions !== 3
+    || value?.postconditions?.crosswalks !== 4_994
+    || value?.postconditions?.reportingUnits !== 4_994
+    || value?.postconditions?.sourceDocuments !== 6
+    || value?.postconditions?.importRuns !== 3
+    || value?.postconditions?.resultRows !== 14_982
+    || value?.postconditions?.invalidConstraints !== 0
+    || value?.productionMutationPerformed !== true
+    || value?.publicDeliveryAuthorized !== true
+  ) {
+    throw new Error("Iowa publication receipt is incomplete or incompatible");
+  }
+  return {
+    artifact,
+    publicAuthorization,
+    summary: {
+      path: artifact.path,
+      sha256: artifact.sha256,
+      activationId: value.activationId,
+      authorizationSha256: publicAuthorizationArtifact.sha256,
+      revision: Number(value.revision),
+      changedAtUtc: value.changedAtUtc,
+      rollbackTarget: value.rollbackTarget,
+      productionDeployment: value.productionDeployment,
+    },
+  };
+}
+
+function defaultReceiptPath(planSha256, activationId, mode = "publish") {
   const safeId = activationId.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 80);
-  return ".etl/production-publication-receipts/IA/ia-publication-"
+  return ".etl/production-publication-receipts/IA/ia-" + mode + "-"
     + planSha256.slice(0, 12) + "-" + safeId + ".json";
 }
 
@@ -458,6 +731,8 @@ function reserveReceipt(
   relativePath,
   planSha256,
   authorizationSha256,
+  mode,
+  publicationReceiptSha256 = null,
   options = {},
 ) {
   const absolute = path.resolve(root, ...relativePath.split("/"));
@@ -472,8 +747,10 @@ function reserveReceipt(
     schemaVersion: 1,
     state: "IA",
     purpose: "ambiguous-commit recovery marker",
+    mode,
     planSha256,
     authorizationSha256,
+    publicationReceiptSha256,
   };
   const pendingBytes = serializeIowaPublicationDocument(pendingDocument);
   if (existsSync(pending)) {
@@ -483,7 +760,7 @@ function reserveReceipt(
     ) {
       return { absolute, pending, pendingBytes, disposition: "reused" };
     }
-    throw new Error("A Iowa publication recovery marker already exists; reconcile it before retrying");
+    throw new Error("An Iowa publication recovery marker already exists; reconcile it before retrying");
   }
   writeFileSync(pending, pendingBytes, { flag: "wx", mode: 0o600 });
   return { absolute, pending, pendingBytes, disposition: "created" };
@@ -510,11 +787,31 @@ function finishPublicationReceipt(reservation, receipt) {
 export async function runIowaGeographyPublication(options = {}) {
   const root = path.resolve(options.root ?? process.cwd());
   const parsed = options.packagePath ? options : parseArguments(process.argv.slice(2));
+  const mode = parsed.rollback ? "rollback" : "publish";
+  const environment = options.environment ?? process.env;
+  const clock = options.nowFactory ?? (() => options.now ?? new Date());
+  const currentTime = () => {
+    const value = clock();
+    const result = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    if (Number.isNaN(result.getTime())) {
+      throw new Error("Iowa publication clock returned an invalid time");
+    }
+    return result;
+  };
   const built = inspectIowaPublicationPlan({ ...parsed, root });
   if (parsed.planSha256 && parsed.planSha256 !== built.sha256) {
     throw new Error("Iowa publication plan SHA-256 drifted");
   }
+  const publicationReceipt = mode === "rollback"
+    ? inspectIowaPublicationReceipt(root, {
+      ...parsed,
+      now: currentTime().getTime(),
+    }, built)
+    : null;
   if (parsed.writePlan) {
+    if (mode === "rollback") {
+      throw new Error("Iowa rollback reuses the exact hash-pinned publication plan");
+    }
     const artifact = immutableJson(
       root,
       parsed.outputPath ?? defaultPlanPath(built.sha256),
@@ -529,15 +826,23 @@ export async function runIowaGeographyPublication(options = {}) {
     };
   }
   if (parsed.writeAuthorizationTemplate) {
+    const template = mode === "rollback"
+      ? buildIowaPublicRollbackAuthorizationTemplate(
+        built.plan,
+        built.sha256,
+        publicationReceipt.summary,
+      )
+      : buildIowaPublicationAuthorizationTemplate(built.plan, built.sha256);
     const artifact = immutableJson(
       root,
-      parsed.outputPath ?? defaultAuthorizationPath(built.sha256),
-      buildIowaPublicationAuthorizationTemplate(built.plan, built.sha256),
+      parsed.outputPath ?? defaultAuthorizationPath(built.sha256, mode),
+      template,
       ".etl/production-authorizations/IA",
     );
     return {
       mode: "write_authorization_template",
-      decision: "NO_GO_PUBLIC",
+      operation: mode,
+      decision: mode === "rollback" ? "NO_GO_ROLLBACK" : "NO_GO_PUBLIC",
       publicationPlanSha256: built.sha256,
       authorizationTemplate: artifact,
       productionMutationPerformed: false,
@@ -546,8 +851,14 @@ export async function runIowaGeographyPublication(options = {}) {
   if (!parsed.apply && !parsed.recoverReceipt) {
     return {
       mode: "plan",
-      decision: built.plan.decision,
+      operation: mode,
+      decision: mode === "rollback"
+        ? "GO_ROLLBACK_AUTHORIZATION_REQUIRED"
+        : built.plan.decision,
       publicationPlanSha256: built.sha256,
+      requiredScopes: mode === "rollback"
+        ? [...IOWA_PUBLIC_ROLLBACK_SCOPES]
+        : undefined,
       productionMutationPerformed: false,
       expectedTotals: built.plan.expectedTotals,
     };
@@ -558,20 +869,20 @@ export async function runIowaGeographyPublication(options = {}) {
     parsed.authorizationSha256,
     ".etl/production-authorizations/IA",
   );
-  const environment = options.environment ?? process.env;
-  const clock = options.nowFactory ?? (() => options.now ?? new Date());
-  const currentTime = () => {
-    const value = clock();
-    const result = value instanceof Date ? new Date(value.getTime()) : new Date(value);
-    if (Number.isNaN(result.getTime())) {
-      throw new Error("Iowa publication clock returned an invalid time");
-    }
-    return result;
-  };
-  const validateAuthorizationAt = (now) => validateIowaPublicationAuthorization(
-    authorizationArtifact.value,
-    { plan: built.plan, planSha256: built.sha256, now: now.getTime() },
-  );
+  const validateAuthorizationAt = (now, recovery = false) => mode === "rollback"
+    ? validateIowaPublicRollbackAuthorization(authorizationArtifact.value, {
+      plan: built.plan,
+      planSha256: built.sha256,
+      publicationReceipt: publicationReceipt.summary,
+      now: now.getTime(),
+      recovery,
+    })
+    : validateIowaPublicationAuthorization(authorizationArtifact.value, {
+      plan: built.plan,
+      planSha256: built.sha256,
+      now: now.getTime(),
+      recovery,
+    });
   const databaseUrl = productionUrl(environment);
   const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
   if (endpointFingerprint !== built.plan.hiddenLoad.endpointFingerprint) {
@@ -589,46 +900,63 @@ export async function runIowaGeographyPublication(options = {}) {
     productionReleaseAudit: built.plan.hiddenLoad.productionReleaseAudit,
   };
   buildIowaPrecinctExecutionContext(executionContext);
-  const rawActivationId = typeof authorizationArtifact.value?.activationId === "string"
-    ? authorizationArtifact.value.activationId.trim()
+  const rawOperationId = mode === "rollback"
+    ? authorizationArtifact.value?.rollbackId
+    : authorizationArtifact.value?.activationId;
+  const operationId = typeof rawOperationId === "string"
+    ? rawOperationId.trim()
     : "";
   const receiptPath = parsed.outputPath ?? defaultReceiptPath(
     built.sha256,
-    rawActivationId || "invalid-activation",
+    operationId || "invalid-authorization",
+    mode,
   );
+  const publicAuthorization = mode === "publish"
+    ? null
+    : publicationReceipt.publicAuthorization;
 
-  const receiptDocument = (authorization, committed, recovery = null) => ({
-    schemaVersion: 1,
-    state: "IA",
-    decision: "PUBLISHED",
-    activationId: authorization.activationId,
-    approvedBy: authorization.approvedBy,
-    releaseCandidate: built.plan.releaseCandidate,
-    publicationPlan: {
-      id: built.plan.id,
-      sha256: built.sha256,
-    },
-    authorization: {
-      path: authorizationArtifact.path,
-      sha256: authorizationArtifact.sha256,
-    },
-    hiddenLoad: {
-      path: built.plan.hiddenLoad.path,
-      sha256: built.plan.hiddenLoad.sha256,
-    },
-    blobPublication: {
-      path: built.plan.blobPublication.path,
-      sha256: built.plan.blobPublication.sha256,
-      deliveryOrigin: built.plan.blobPublication.deliveryOrigin,
-    },
-    productionDeployment: authorization.productionDeployment,
-    changedAtUtc: committed.changedAtUtc,
-    revision: committed.revision,
-    postconditions: committed.postconditions,
-    ...(recovery ? { recovery } : {}),
-    productionMutationPerformed: true,
-    publicDeliveryAuthorized: true,
-  });
+  const receiptDocument = (authorization, committed, recovery = null) => {
+    const originalPublicAuthorization = mode === "publish"
+      ? authorization
+      : publicAuthorization;
+    return {
+      schemaVersion: 1,
+      state: "IA",
+      mode,
+      decision: mode === "publish" ? "PUBLISHED" : "ROLLED_BACK",
+      activationId: mode === "publish"
+        ? authorization.activationId
+        : publicationReceipt.summary.activationId,
+      ...(mode === "rollback" ? { rollbackId: authorization.rollbackId } : {}),
+      approvedBy: authorization.approvedBy,
+      releaseCandidate: built.plan.releaseCandidate,
+      publicationPlan: { id: built.plan.id, sha256: built.sha256 },
+      authorization: {
+        path: authorizationArtifact.path,
+        sha256: authorizationArtifact.sha256,
+      },
+      hiddenLoad: {
+        path: built.plan.hiddenLoad.path,
+        sha256: built.plan.hiddenLoad.sha256,
+      },
+      blobPublication: {
+        path: built.plan.blobPublication.path,
+        sha256: built.plan.blobPublication.sha256,
+        deliveryOrigin: built.plan.blobPublication.deliveryOrigin,
+      },
+      productionDeployment: originalPublicAuthorization.productionDeployment,
+      rollbackTarget: originalPublicAuthorization.rollbackTarget,
+      ...(mode === "rollback"
+        ? { publicationReceipt: publicationReceipt.summary }
+        : {}),
+      changedAtUtc: committed.changedAtUtc,
+      revision: committed.revision,
+      postconditions: committed.postconditions,
+      ...(recovery ? { recovery } : {}),
+      productionMutationPerformed: true,
+      publicDeliveryAuthorized: mode === "publish",
+    };
+  };
 
   if (parsed.recoverReceipt) {
     if (
@@ -636,14 +964,21 @@ export async function runIowaGeographyPublication(options = {}) {
       || environment.CRM_IA_PRECINCT_PUBLICATION_RECEIPT_RECOVERY !== built.sha256
       || environment.CRM_IA_PRECINCT_PUBLICATION_AUTHORIZATION_SHA256
         !== authorizationArtifact.sha256
+      || (mode === "rollback"
+        && environment.CRM_IA_PRECINCT_PUBLICATION_RECEIPT_SHA256
+          !== publicationReceipt.summary.sha256)
     ) {
-      throw new Error("Iowa publication receipt recovery is not explicitly read-only and hash-authorized");
+      throw new Error(
+        "Iowa publication receipt recovery is not explicitly read-only and hash-authorized",
+      );
     }
     const reservation = reserveReceipt(
       root,
       receiptPath,
       built.sha256,
       authorizationArtifact.sha256,
+      mode,
+      publicationReceipt?.summary.sha256 ?? null,
       { allowExisting: true },
     );
     let sql;
@@ -678,7 +1013,7 @@ export async function runIowaGeographyPublication(options = {}) {
           throw new Error("Iowa publication receipt recovery database identity drifted");
         }
         const versions = await nv.unsafe([
-          "select e.year,gv.metadata from geography_versions gv",
+          "select e.year,gv.status,gv.caveat,gv.metadata from geography_versions gv",
           "join elections e on e.id=gv.election_id",
           "where gv.state_code='IA' and gv.geography_type='precinct'",
           " and gv.metadata->'releaseCandidate'->>'sha256'=$1 order by e.year",
@@ -686,9 +1021,11 @@ export async function runIowaGeographyPublication(options = {}) {
         if (versions.length !== 3) {
           throw new Error("Iowa publication receipt recovery found an incomplete version set");
         }
-        const firstActivation = versions[0]?.metadata?.publicActivation;
-        const changedAtUtc = firstActivation?.changedAtUtc;
-        const revision = Number(firstActivation?.revision);
+        const operationAudit = mode === "publish"
+          ? versions[0]?.metadata?.publicActivation
+          : versions[0]?.metadata?.publicActivation?.rollback;
+        const changedAtUtc = operationAudit?.changedAtUtc;
+        const revision = Number(operationAudit?.revision);
         const recoveryNow = currentTime();
         if (
           typeof changedAtUtc !== "string"
@@ -697,33 +1034,29 @@ export async function runIowaGeographyPublication(options = {}) {
           || !Number.isInteger(revision)
           || revision < 1
         ) {
-          throw new Error("Iowa publication receipt recovery activation metadata is incomplete");
+          throw new Error("Iowa publication receipt recovery audit is incomplete");
         }
-        const authorization = validateAuthorizationAt(new Date(changedAtUtc));
-        if (currentGitSha(root) !== authorization.productionDeployment.gitSha) {
-          throw new Error("Iowa publication recovery checkout does not match the verified deployment");
-        }
+        const authorization = validateAuthorizationAt(
+          new Date(changedAtUtc),
+          true,
+        );
         const context = {
+          mode,
           plan: built.plan,
           planSha256: built.sha256,
           authorization,
           authorizationSha256: authorizationArtifact.sha256,
+          publicationReceipt: publicationReceipt?.summary ?? null,
           changedAtUtc,
           gisPlan,
           executionContext,
         };
-        const postconditions = await verifyPostconditions(nv, context, revision);
-        const revisionRows = await nv.unsafe([
-          "select revision::int revision,reason from public_data_revisions",
-          "where scope='public'",
-        ].join("\n"));
-        if (
-          Number(revisionRows[0]?.revision) !== revision
-          || String(revisionRows[0]?.reason)
-            !== "Iowa precinct geometry publish " + authorization.activationId
-        ) {
-          throw new Error("Iowa publication receipt recovery public revision drifted");
-        }
+        const postconditions = await verifyPostconditions(
+          nv,
+          context,
+          revision,
+          mode,
+        );
         return { authorization, changedAtUtc, revision, postconditions };
       });
     } catch (error) {
@@ -741,11 +1074,14 @@ export async function runIowaGeographyPublication(options = {}) {
     const receiptBytes = finishPublicationReceipt(reservation, receipt);
     return {
       mode: "recover_receipt",
-      decision: "RECOVERED_PUBLICATION_RECEIPT",
+      operation: mode,
+      decision: mode === "publish"
+        ? "RECOVERED_PUBLICATION_RECEIPT"
+        : "RECOVERED_ROLLBACK_RECEIPT",
       activationId: recovered.authorization.activationId,
       revision: recovered.revision,
       productionMutationPerformed: false,
-      publicDeliveryAuthorized: true,
+      publicDeliveryAuthorized: mode === "publish",
       receipt: {
         path: receiptPath,
         sha256: sha256(receiptBytes),
@@ -756,28 +1092,38 @@ export async function runIowaGeographyPublication(options = {}) {
 
   const initialNow = currentTime();
   const authorization = validateAuthorizationAt(initialNow);
+  const writeAuthorized = mode === "publish"
+    ? environment.CRM_IA_PRECINCT_PUBLICATION_WRITES
+        === "I_ACKNOWLEDGE_ATOMIC_IOWA_PRECINCT_PUBLIC_CUTOVER"
+      && environment.CRM_IA_PRECINCT_PUBLICATION_ACTIVATION_ID
+        === authorization.activationId
+    : environment.CRM_IA_PRECINCT_ROLLBACK_WRITES
+        === "I_ACKNOWLEDGE_DATABASE_FIRST_IOWA_PRECINCT_PUBLIC_ROLLBACK"
+      && environment.CRM_IA_PRECINCT_ROLLBACK_ID === authorization.rollbackId
+      && environment.CRM_IA_PRECINCT_PUBLICATION_RECEIPT_SHA256
+        === publicationReceipt.summary.sha256;
   if (
     environment.CRM_DATABASE_ENVIRONMENT !== "production"
-    || environment.CRM_IA_PRECINCT_PUBLICATION_WRITES
-      !== "I_ACKNOWLEDGE_ATOMIC_IOWA_PRECINCT_PUBLIC_CUTOVER"
+    || !writeAuthorized
     || environment.CRM_IA_PRECINCT_PUBLICATION_PACKAGE_SHA256
       !== built.plan.releaseCandidate.sha256
     || environment.CRM_IA_PRECINCT_PUBLICATION_PLAN_SHA256 !== built.sha256
     || environment.CRM_IA_PRECINCT_PUBLICATION_AUTHORIZATION_SHA256
       !== authorizationArtifact.sha256
-    || environment.CRM_IA_PRECINCT_PUBLICATION_ACTIVATION_ID
-      !== authorization.activationId
   ) {
-    throw new Error("Iowa public cutover is not explicitly hash-authorized");
+    throw new Error("Iowa public " + mode + " is not explicitly hash-authorized");
   }
-  if (currentGitSha(root) !== authorization.productionDeployment.gitSha) {
-    throw new Error("Iowa publication checkout does not match the verified deployment");
-  }
+  const activePublicAuthorization = mode === "publish"
+    ? authorization
+    : publicAuthorization;
+  verifyIowaPublicationGitCandidate(root, activePublicAuthorization, options.gitRunner);
   const reservation = reserveReceipt(
     root,
     receiptPath,
     built.sha256,
     authorizationArtifact.sha256,
+    mode,
+    publicationReceipt?.summary.sha256 ?? null,
   );
   let sql;
   try {
@@ -797,17 +1143,21 @@ export async function runIowaGeographyPublication(options = {}) {
     committed = await sql.begin(async (nv) => {
       const transactionNow = currentTime();
       const finalAuthorization = validateAuthorizationAt(transactionNow);
-      if (
-        finalAuthorization.activationId !== authorization.activationId
-        || currentGitSha(root) !== finalAuthorization.productionDeployment.gitSha
-      ) {
-        throw new Error("Iowa publication authorization or checkout drifted before the transaction");
+      if (finalAuthorization.activationId !== authorization.activationId) {
+        throw new Error("Iowa publication authorization drifted before the transaction");
       }
+      verifyIowaPublicationGitCandidate(
+        root,
+        activePublicAuthorization,
+        options.gitRunner,
+      );
       const result = await applyIowaGeographyPublicationTransaction(nv, {
+        mode,
         plan: built.plan,
         planSha256: built.sha256,
         authorization: finalAuthorization,
         authorizationSha256: authorizationArtifact.sha256,
+        publicationReceipt: publicationReceipt?.summary ?? null,
         changedAtUtc: transactionNow.toISOString(),
         gisPlan,
         executionContext,
@@ -827,11 +1177,12 @@ export async function runIowaGeographyPublication(options = {}) {
   const receiptBytes = finishPublicationReceipt(reservation, receipt);
   return {
     mode: "apply",
-    decision: "PUBLISHED",
+    operation: mode,
+    decision: mode === "publish" ? "PUBLISHED" : "ROLLED_BACK",
     activationId: authorization.activationId,
     revision: committed.revision,
     productionMutationPerformed: true,
-    publicDeliveryAuthorized: true,
+    publicDeliveryAuthorized: mode === "publish",
     receipt: {
       path: receiptPath,
       sha256: sha256(receiptBytes),

--- a/tests/api/ia-precinct-publication.test.mjs
+++ b/tests/api/ia-precinct-publication.test.mjs
@@ -1,20 +1,57 @@
 import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
-import { inspectIowaPrecinctBlobPublicationPlan } from "../../scripts/lib/ia-precinct-blob-publication.mjs";
-import { validateIowaBlobPublicationEvidence } from "../../scripts/lib/ia-precinct-publication.mjs";
-import { buildIowaTestReleaseFixture } from "./ia-precinct-release-fixture.mjs";
-
-const { prepared } = await buildIowaTestReleaseFixture({ write: true });
-const blobPlan = inspectIowaPrecinctBlobPublicationPlan({
-  packagePath: prepared.releaseCandidate.path,
-  packageSha256: prepared.releaseCandidate.sha256,
-});
+import {
+  IOWA_PUBLICATION_SCOPES,
+  IOWA_PUBLIC_ROLLBACK_SCOPES,
+  buildIowaPublicRollbackAuthorizationTemplate,
+  buildIowaPublicationAuthorizationTemplate,
+  serializeIowaPublicationDocument,
+  sha256,
+  validateIowaBlobPublicationEvidence,
+  validateIowaPublicRollbackAuthorization,
+  validateIowaPublicationAuthorization,
+} from "../../scripts/lib/ia-precinct-publication.mjs";
+import {
+  applyIowaGeographyPublicationTransaction,
+  inspectIowaPublicationReceipt,
+  verifyIowaPublicationGitCandidate,
+} from "../../scripts/publish-ia-precinct-geography-status.mjs";
 const deliveryOrigin = "https://example.public.blob.vercel-storage.com";
+const blobReleaseCandidate = {
+  id: "ia-precinct-gis-three-election-v1",
+  path: ".etl/precinct-release-candidates/IA/example/release-candidate.json",
+  sha256: "d".repeat(64),
+};
+const blobArtifacts = Array.from({ length: 300 }, (_, index) => {
+  const year = [2016, 2020, 2024][Math.min(2, Math.floor(index / 100))];
+  const kind = index % 100 === 99 ? "index" : "parent";
+  return {
+    kind,
+    year,
+    packageRelativePath: `delivery-assets/${year}/file-${index}.json`,
+    publicUrl: `/data/geography/ia/${year}/file-${index}.json`,
+    pathname: `data/geography/ia/${year}/file-${index}.json`,
+    byteCount: 100 + index,
+    sha256: index.toString(16).padStart(64, "0"),
+  };
+});
+const blobPlan = {
+  releaseCandidate: blobReleaseCandidate,
+  artifacts: blobArtifacts,
+};
 const evidence = {
   schemaVersion: 1,
   state: "IA",
   purpose: "ia-precinct-parent-scoped-immutable-geometry-publication",
-  releaseCandidate: blobPlan.releaseCandidate,
+  releaseCandidate: blobReleaseCandidate,
   authorizationId: "ia-blob-publication-1",
   publishedAtUtc: "2026-08-13T00:00:00.000Z",
   deliveryOrigin,
@@ -27,6 +64,74 @@ const evidence = {
     disposition: "created",
   })),
 };
+
+const releaseCandidate = {
+  id: "ia-precinct-gis-three-election-v1",
+  path: ".etl/precinct-release-candidates/IA/example/release-candidate.json",
+  sha256: "1".repeat(64),
+};
+const planSha256 = "2".repeat(64);
+const rollbackTarget = {
+  deploymentId: "dpl_iowa_previous",
+  url: "https://previous.civicresultmaps.org",
+  gitSha: "3".repeat(40),
+  gitTreeSha: "4".repeat(40),
+  verifiedAtUtc: "2026-08-13T00:30:00.000Z",
+  gateCapableVerified: true,
+  blockedResultGateVerified: true,
+  blockedGeometryGateVerified: true,
+};
+const authorizationPlan = {
+  id: "ia-precinct-database-publication-v1",
+  releaseCandidate,
+  hiddenLoad: { path: "hidden.json", sha256: "5".repeat(64) },
+  blobPublication: {
+    path: "blob.json",
+    sha256: "6".repeat(64),
+    deliveryOrigin,
+  },
+  staticRegistry: { sha256: "7".repeat(64) },
+};
+
+function publicAuthorization() {
+  const value = buildIowaPublicationAuthorizationTemplate(
+    authorizationPlan,
+    planSha256,
+  );
+  Object.assign(value, {
+    decision: "GO_PUBLIC",
+    activationId: "ia-public-camreyn",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T00:50:00.000Z",
+    expiresAtUtc: "2026-08-13T02:00:00.000Z",
+  });
+  Object.assign(value.productionDeployment, {
+    deploymentId: "dpl_iowa_public",
+    url: "https://civicresultmaps.org",
+    gitSha: "8".repeat(40),
+    gitTreeSha: "9".repeat(40),
+    readyVerified: true,
+    promotedVerified: true,
+    blockedResultGateVerified: true,
+    blockedGeometryGateVerified: true,
+    verifiedAtUtc: "2026-08-13T00:45:00.000Z",
+  });
+  Object.assign(value.rollbackTarget, rollbackTarget);
+  return value;
+}
+
+function publicationSummary() {
+  return {
+    path: ".etl/production-publication-receipts/IA/ia-publish.json",
+    sha256: "a".repeat(64),
+    activationId: "ia-public-camreyn",
+    authorizationSha256: "b".repeat(64),
+    revision: 41,
+    changedAtUtc: "2026-08-13T01:00:00.000Z",
+    rollbackTarget,
+    productionDeployment: publicAuthorization().productionDeployment,
+  };
+}
 
 test("Iowa Blob evidence requires all 300 immutable artifacts", () => {
   const result = validateIowaBlobPublicationEvidence(
@@ -41,4 +146,450 @@ test("Iowa Blob evidence requires all 300 immutable artifacts", () => {
     () => validateIowaBlobPublicationEvidence(incomplete, blobPlan),
     /incomplete or incompatible/,
   );
+});
+
+test("Iowa public authorization pins production and rollback deployment trees", () => {
+  const value = publicAuthorization();
+  const checked = validateIowaPublicationAuthorization(value, {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  assert.equal(checked.approvedBy, "Camreyn");
+  assert.deepEqual(value.scopes, IOWA_PUBLICATION_SCOPES);
+  assert.deepEqual(checked.rollbackTarget, rollbackTarget);
+
+  const sameTree = structuredClone(value);
+  sameTree.rollbackTarget.gitTreeSha = value.productionDeployment.gitTreeSha;
+  assert.throws(
+    () => validateIowaPublicationAuthorization(sameTree, {
+      plan: authorizationPlan,
+      planSha256,
+      now: Date.parse("2026-08-13T01:01:00.000Z"),
+    }),
+    /incompatible/,
+  );
+});
+
+test("Iowa rollback authorization is bound to the exact publication receipt", () => {
+  const receipt = publicationSummary();
+  const value = buildIowaPublicRollbackAuthorizationTemplate(
+    authorizationPlan,
+    planSha256,
+    receipt,
+  );
+  Object.assign(value, {
+    decision: "GO_ROLLBACK",
+    rollbackId: "ia-rollback-camreyn",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T01:10:00.000Z",
+    expiresAtUtc: "2026-08-13T02:00:00.000Z",
+  });
+  Object.assign(value.rollbackWindow, {
+    startsAtUtc: "2026-08-13T01:10:00.000Z",
+    endsAtUtc: "2026-08-13T01:50:00.000Z",
+  });
+  value.applicationRollback.databaseBlockFirstAcknowledged = true;
+  value.applicationRollback.restoreAfterDatabaseRollbackAcknowledged = true;
+  const checked = validateIowaPublicRollbackAuthorization(value, {
+    plan: authorizationPlan,
+    planSha256,
+    publicationReceipt: receipt,
+    now: Date.parse("2026-08-13T01:20:00.000Z"),
+  });
+  assert.equal(checked.rollbackId, "ia-rollback-camreyn");
+  assert.deepEqual(value.scopes, IOWA_PUBLIC_ROLLBACK_SCOPES);
+
+  const substituted = structuredClone(value);
+  substituted.applicationRollback.target.deploymentId = "dpl_substituted";
+  assert.throws(
+    () => validateIowaPublicRollbackAuthorization(substituted, {
+      plan: authorizationPlan,
+      planSha256,
+      publicationReceipt: receipt,
+      now: Date.parse("2026-08-13T01:20:00.000Z"),
+    }),
+    /incompatible/,
+  );
+});
+
+test("Iowa publication receipt reloads its exact original public authorization", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "crm-ia-publication-"));
+  const authorizationPath =
+    ".etl/production-authorizations/IA/ia-public-authorization.json";
+  const receiptPath =
+    ".etl/production-publication-receipts/IA/ia-publish-receipt.json";
+  const authorization = publicAuthorization();
+  const authorizationBytes = serializeIowaPublicationDocument(authorization);
+  const authorizationSha256 = sha256(authorizationBytes);
+  const plan = {
+    ...authorizationPlan,
+    hiddenLoad: authorizationPlan.hiddenLoad,
+    blobPublication: authorizationPlan.blobPublication,
+  };
+  const receipt = {
+    schemaVersion: 1,
+    state: "IA",
+    mode: "publish",
+    decision: "PUBLISHED",
+    activationId: authorization.activationId,
+    approvedBy: authorization.approvedBy,
+    releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    authorization: { path: authorizationPath, sha256: authorizationSha256 },
+    hiddenLoad: plan.hiddenLoad,
+    blobPublication: {
+      ...plan.blobPublication,
+      deliveryOrigin,
+    },
+    productionDeployment: authorization.productionDeployment,
+    rollbackTarget,
+    changedAtUtc: "2026-08-13T01:00:00.000Z",
+    revision: 41,
+    postconditions: {
+      mode: "publish",
+      status: "published",
+      publicDeliveryAuthorized: true,
+      geographyVersions: 3,
+      crosswalks: 4_994,
+      reportingUnits: 4_994,
+      sourceDocuments: 6,
+      importRuns: 3,
+      resultRows: 14_982,
+      invalidConstraints: 0,
+    },
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: true,
+  };
+  for (const [relative, bytes] of [
+    [authorizationPath, authorizationBytes],
+    [receiptPath, serializeIowaPublicationDocument(receipt)],
+  ]) {
+    const absolute = path.resolve(root, ...relative.split("/"));
+    mkdirSync(path.dirname(absolute), { recursive: true });
+    writeFileSync(absolute, bytes);
+  }
+  const receiptBytes = readFileSync(path.resolve(root, ...receiptPath.split("/")));
+  const inspected = inspectIowaPublicationReceipt(root, {
+    publicationReceiptPath: receiptPath,
+    publicationReceiptSha256: sha256(receiptBytes),
+    now: Date.parse("2026-08-13T01:10:00.000Z"),
+  }, { plan, sha256: planSha256 });
+  assert.equal(inspected.summary.activationId, authorization.activationId);
+
+  const substituted = structuredClone(receipt);
+  substituted.rollbackTarget.deploymentId = "dpl_substituted";
+  const substitutedPath =
+    ".etl/production-publication-receipts/IA/ia-substituted-receipt.json";
+  const substitutedBytes = serializeIowaPublicationDocument(substituted);
+  writeFileSync(
+    path.resolve(root, ...substitutedPath.split("/")),
+    substitutedBytes,
+  );
+  assert.throws(
+    () => inspectIowaPublicationReceipt(root, {
+      publicationReceiptPath: substitutedPath,
+      publicationReceiptSha256: sha256(substitutedBytes),
+      now: Date.parse("2026-08-13T01:10:00.000Z"),
+    }, { plan, sha256: planSha256 }),
+    /incomplete or incompatible/,
+  );
+});
+
+test("Iowa Git verifier resolves both the live and rollback deployment trees", () => {
+  const authorization = validateIowaPublicationAuthorization(publicAuthorization(), {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  const outputs = new Map([
+    ["rev-parse HEAD", authorization.productionDeployment.gitSha],
+    ["rev-parse HEAD^{tree}", authorization.productionDeployment.gitTreeSha],
+    [
+      `rev-parse ${authorization.productionDeployment.gitSha}^{tree}`,
+      authorization.productionDeployment.gitTreeSha,
+    ],
+    [
+      `rev-parse ${authorization.rollbackTarget.gitSha}^{tree}`,
+      authorization.rollbackTarget.gitTreeSha,
+    ],
+    ["status --porcelain --untracked-files=no", ""],
+  ]);
+  const runner = (_command, args) => outputs.get(args.join(" ")) + "\n";
+  assert.equal(
+    verifyIowaPublicationGitCandidate(process.cwd(), authorization, runner)
+      .trackedWorktreeClean,
+    true,
+  );
+  outputs.set(
+    `rev-parse ${authorization.rollbackTarget.gitSha}^{tree}`,
+    "f".repeat(40),
+  );
+  assert.throws(
+    () => verifyIowaPublicationGitCandidate(process.cwd(), authorization, runner),
+    /drifted/,
+  );
+});
+
+function rollbackTransactionFixture() {
+  const manifests = [2016, 2020, 2024].map((year, index) => ({
+    year,
+    manifestId: `ia-${year}-manifest`,
+    publicManifestSha256: String(index + 3).repeat(64).slice(0, 64),
+    blockedManifestSha256: String(index + 6).repeat(64).slice(0, 64),
+    delivery: {
+      format: "parent_scoped_geojson",
+      featureCount: [1680, 1661, 1653][index],
+      parentCount: 99,
+      indexPath: `/data/geography/ia/${year}/index.json`,
+    },
+  }));
+  const plan = {
+    id: authorizationPlan.id,
+    releaseCandidate,
+    hiddenLoad: { databaseName: "neondb" },
+    blobPublication: {
+      sha256: "6".repeat(64),
+      deliveryOrigin,
+    },
+    manifests,
+  };
+  const publicationReceipt = publicationSummary();
+  const gisPlan = {
+    years: manifests.map((manifest) => ({
+      manifest: { validation: { errors: [`blocked ${manifest.year}`] } },
+    })),
+  };
+  const versions = manifests.map((manifest, index) => {
+    const previousCaveat = gisPlan.years[index].manifest.validation.errors.join(" ");
+    return {
+      id: `00000000-0000-0000-0000-00000000${index + 1}`,
+      year: manifest.year,
+      status: "published",
+      caveat: "Reviewed Iowa election-specific precinct geometry is publicly authorized under activation "
+        + publicationReceipt.activationId + ".",
+      metadata: {
+        manifestId: manifest.manifestId,
+        publicDeliveryAuthorized: true,
+        releaseCandidate: {
+          sha256: releaseCandidate.sha256,
+          publicDeliveryAuthorized: true,
+        },
+        publicActivation: {
+          activationId: publicationReceipt.activationId,
+          activationCandidateSha256: planSha256,
+          releasePackageSha256: releaseCandidate.sha256,
+          blobPublicationSha256: plan.blobPublication.sha256,
+          deliveryOrigin,
+          authorizationSha256: publicationReceipt.authorizationSha256,
+          rollbackTarget,
+          mode: "publish",
+          year: manifest.year,
+          manifestId: manifest.manifestId,
+          publicManifestSha256: manifest.publicManifestSha256,
+          delivery: manifest.delivery,
+          previousCaveat,
+          changedAtUtc: publicationReceipt.changedAtUtc,
+          revision: publicationReceipt.revision,
+        },
+      },
+    };
+  });
+  const authorization = {
+    activationId: "ia-rollback-camreyn",
+    rollbackId: "ia-rollback-camreyn",
+    publicationActivationId: publicationReceipt.activationId,
+    approvedBy: "Camreyn",
+    applicationRollback: { target: rollbackTarget },
+  };
+  return { plan, publicationReceipt, gisPlan, versions, authorization };
+}
+
+function rollbackClient(fixture) {
+  let revision = 41;
+  let reason = "Iowa precinct geometry publish ia-public-camreyn";
+  let versionUpdateCount = 0;
+  const unsafe = async (statement, parameters = []) => {
+    const sql = String(statement);
+    if (sql.includes("current_database()")) {
+      return [{ database_name: "neondb", transaction_read_only: "off" }];
+    }
+    if (sql.includes("set_config") || sql.includes("pg_advisory_xact_lock")) {
+      return [];
+    }
+    if (sql.includes("for update") && sql.includes("public_data_revisions")) {
+      return [{ revision }];
+    }
+    if (sql.includes("for update of gv")) return fixture.versions;
+    if (sql.startsWith("update geography_versions")) {
+      const row = fixture.versions.find((item) => item.id === parameters[0]);
+      row.status = parameters[1];
+      row.caveat = parameters[2];
+      row.metadata.publicDeliveryAuthorized = JSON.parse(parameters[3]);
+      row.metadata.releaseCandidate.publicDeliveryAuthorized = JSON.parse(parameters[3]);
+      row.metadata.publicActivation = JSON.parse(parameters[4]);
+      versionUpdateCount += 1;
+      return [{ id: row.id }];
+    }
+    if (sql.startsWith("update reporting_unit_geometry_crosswalks")) {
+      return Array.from({ length: 4_994 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update reporting_units")) {
+      return Array.from({ length: 4_994 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update source_documents")) {
+      return Array.from({ length: 6 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update import_runs")) {
+      return Array.from({ length: 3 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update public_data_revisions")) {
+      revision += 1;
+      reason = parameters[0];
+      return [{ revision }];
+    }
+    if (sql.includes("select e.year,gv.status")) return fixture.versions;
+    if (sql.includes("from reporting_unit_geometry_crosswalks")) {
+      return [{ total: 4_994, exact: 4_994 }];
+    }
+    if (sql.includes("from reporting_units where")) {
+      return [{ total: 4_994, exact: 4_994 }];
+    }
+    if (sql.includes("from source_documents where")) {
+      return [{ total: 6, exact: 6 }];
+    }
+    if (sql.includes("from import_runs where")) {
+      return [{ total: 3, exact: 3 }];
+    }
+    if (sql.includes("from result_rows rr")) return [{ total: 14_982 }];
+    if (sql.includes("from pg_constraint")) return [{ count: 0 }];
+    if (sql.includes("from public_data_revisions")) return [{ revision, reason }];
+    throw new Error("Unexpected Iowa publication SQL: " + sql);
+  };
+  return { unsafe, get versionUpdateCount() { return versionUpdateCount; } };
+}
+
+test("Iowa rollback atomically blocks database delivery and preserves publish audit", async () => {
+  const fixture = rollbackTransactionFixture();
+  const client = rollbackClient(fixture);
+  const result = await applyIowaGeographyPublicationTransaction(client, {
+    mode: "rollback",
+    plan: fixture.plan,
+    planSha256,
+    authorization: fixture.authorization,
+    authorizationSha256: "c".repeat(64),
+    publicationReceipt: fixture.publicationReceipt,
+    changedAtUtc: "2026-08-13T01:30:00.000Z",
+    gisPlan: fixture.gisPlan,
+  });
+  assert.equal(result.result, "ROLLED_BACK");
+  assert.equal(result.publicDeliveryAuthorized, false);
+  assert.equal(client.versionUpdateCount, 3);
+  for (const [index, version] of fixture.versions.entries()) {
+    assert.equal(version.status, "blocked");
+    assert.equal(version.caveat, `blocked ${[2016, 2020, 2024][index]}`);
+    assert.equal(version.metadata.publicDeliveryAuthorized, false);
+    assert.equal(version.metadata.publicActivation.activationId, "ia-public-camreyn");
+    assert.equal(
+      version.metadata.publicActivation.rollback.rollbackId,
+      "ia-rollback-camreyn",
+    );
+    assert.equal(
+      version.metadata.publicActivation.rollback.publicationReceiptSha256,
+      fixture.publicationReceipt.sha256,
+    );
+  }
+});
+
+test("Iowa publication atomically records the pinned rollback target", async () => {
+  const fixture = rollbackTransactionFixture();
+  for (const [index, version] of fixture.versions.entries()) {
+    version.status = "blocked";
+    version.caveat = `blocked ${version.year}`;
+    version.metadata = {
+      manifestId: fixture.plan.manifests[index].manifestId,
+      manifestSha256: fixture.plan.manifests[index].blockedManifestSha256,
+      publicDeliveryAuthorized: false,
+      releaseCandidate: {
+        sha256: releaseCandidate.sha256,
+        publicDeliveryAuthorized: false,
+      },
+    };
+  }
+  const authorization = validateIowaPublicationAuthorization(publicAuthorization(), {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  const client = rollbackClient(fixture);
+  const result = await applyIowaGeographyPublicationTransaction(client, {
+    mode: "publish",
+    plan: fixture.plan,
+    planSha256,
+    authorization,
+    authorizationSha256: "b".repeat(64),
+    changedAtUtc: "2026-08-13T01:02:00.000Z",
+    gisPlan: fixture.gisPlan,
+    executionContext: {},
+    validateCurrentDatabase: async () => ({ validated: true }),
+  });
+  assert.equal(result.result, "PUBLISHED");
+  assert.equal(result.publicDeliveryAuthorized, true);
+  assert.equal(client.versionUpdateCount, 3);
+  for (const version of fixture.versions) {
+    assert.equal(version.status, "published");
+    assert.equal(version.metadata.publicDeliveryAuthorized, true);
+    assert.equal(
+      version.metadata.publicActivation.activationId,
+      authorization.activationId,
+    );
+    assert.deepEqual(
+      version.metadata.publicActivation.rollbackTarget,
+      rollbackTarget,
+    );
+    assert.equal(
+      Object.hasOwn(version.metadata.publicActivation, "rollback"),
+      false,
+    );
+  }
+});
+
+test("Iowa rollback transaction rejects a substituted live rollback target", async () => {
+  const fixture = rollbackTransactionFixture();
+  fixture.authorization.applicationRollback.target = {
+    ...rollbackTarget,
+    deploymentId: "dpl_substituted",
+  };
+  const client = rollbackClient(fixture);
+  await assert.rejects(
+    () => applyIowaGeographyPublicationTransaction(client, {
+      mode: "rollback",
+      plan: fixture.plan,
+      planSha256,
+      authorization: fixture.authorization,
+      authorizationSha256: "c".repeat(64),
+      publicationReceipt: fixture.publicationReceipt,
+      changedAtUtc: "2026-08-13T01:30:00.000Z",
+      gisPlan: fixture.gisPlan,
+    }),
+    /drifted from the publication receipt/,
+  );
+  assert.equal(client.versionUpdateCount, 0);
+});
+
+test("Iowa publication runner contains database-first rollback and read-only recovery guards", () => {
+  const source = readFileSync(
+    "scripts/publish-ia-precinct-geography-status.mjs",
+    "utf8",
+  );
+  assert.match(source, /--rollback/);
+  assert.match(source, /--publication-receipt-sha256/);
+  assert.match(
+    source,
+    /I_ACKNOWLEDGE_DATABASE_FIRST_IOWA_PRECINCT_PUBLIC_ROLLBACK/,
+  );
+  assert.match(source, /sql\.begin\("read only"/);
+  assert.match(source, /publicationReceiptSha256/);
+  assert.match(source, /transactionBodyCompleted/);
+  assert.match(source, /disposition === "created"/);
 });


### PR DESCRIPTION
## What changed

- adds a separately authorized, publication-receipt-bound Iowa public rollback
- blocks the three released Iowa geography versions, linked results, crosswalks, source documents, and import runs in one database transaction
- preserves the original publication audit and caveats while recording a nested rollback audit
- adds read-only recovery for an ambiguous rollback commit or local receipt failure
- pins and locally resolves both the active production deployment tree and the gate-capable rollback deployment tree
- fixes the clean-checkout CRLF contract for two hash-pinned Iowa source-license artifacts
- updates the Iowa runbook, readiness report, and precinct GIS implementation ledger

## Why

PR #224 intentionally left `GO_PUBLIC` blocked because Iowa had no executable row-scoped rollback. The release also exposed a clean-checkout mismatch: two retained source files were sealed from CRLF bytes but lacked an explicit cross-platform checkout rule. This PR closes both release gates without authorizing or performing any production mutation.

## Safety contract

- a new `GO_ROLLBACK` record must match the exact successful publication receipt and its SHA-256
- the receipt is revalidated against the original hash-pinned `GO_PUBLIC` authorization
- a substituted rollback target fails before database access and again inside the transaction
- rollback closes the database gates first; only the pinned gate-capable application deployment may be restored afterward
- ambiguous commits retain an immutable pending marker and can only be reconciled in a read-only transaction

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run test:precinct-geometry:ia` (15 files passed)
- `node --experimental-strip-types --test tests/api/ia-precinct-publication.test.mjs` (9 tests passed)
- `npm.cmd run build`
- `git diff --check`

No production database, Blob, Vercel environment, deployment, or public-status mutation was performed.
