### PR TITLE
Define Iowa canonical JSON validation

### DIFF
--- a/scripts/lib/ia-precinct-gis-db.mjs
+++ b/scripts/lib/ia-precinct-gis-db.mjs
@@ -181,6 +181,14 @@ function assertNoElectionValueProperties(value, context) {
   }
 }
 
+export function canonicalJson(value) {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonicalJson(value[key])]),
+  );
+}
+
 function query(client, lines, params = []) {
   return client.unsafe(Array.isArray(lines) ? lines.join("\n") : lines, params);
 }

--- a/tests/api/ia-precinct-gis-local.test.mjs
+++ b/tests/api/ia-precinct-gis-local.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   assertIowaGeometryVersionPrecondition,
+  canonicalJson,
 } from "../../scripts/lib/ia-precinct-gis-db.mjs";
 import {
   requiresPrecinctGeometryPublicationGate,
@@ -53,4 +54,16 @@ test("Iowa release precondition rejects duplicate or boundary-drifted versions",
     manifest_id: yearPlan.manifest.id,
     boundary_vintage: "drifted",
   }], yearPlan), /boundary-drifted geography versions/);
+});
+
+test("Iowa database validation compares nested JSON independent of key order", () => {
+  const left = {
+    z: [{ beta: 2, alpha: 1 }],
+    a: { delta: 4, gamma: 3 },
+  };
+  const right = {
+    a: { gamma: 3, delta: 4 },
+    z: [{ alpha: 1, beta: 2 }],
+  };
+  assert.deepEqual(canonicalJson(left), canonicalJson(right));
 });


### PR DESCRIPTION
## Scope

Fix the Iowa precinct GIS database validator before production release.

## Root cause

The merged Iowa loader called `canonicalJson(...)` while validating nested metadata, but the helper was never defined. The first strict local Docker rehearsal therefore stopped before any write with `ReferenceError: canonicalJson is not defined`.

## Changes

- Add the missing deterministic recursive JSON canonicalizer.
- Add a regression proving nested object key order does not affect validation.

## Verification

- `node --experimental-strip-types --test tests/api/ia-precinct-gis-local.test.mjs` — 4/4 passed.
- `npm.cmd run test:precinct-geometry:ia` — all 15 files passed.
- `npm.cmd run typecheck` — passed.
- Strict loopback Docker setup and validation passed for Iowa 2016, 2020, and 2024: 4,994 reporting units/features/crosswalks and 14,982 result rows, with zero invalid constraints.

No production database, Blob, Vercel environment, or canonical public manifest was changed.
