### PR TITLE
Fix Iowa publication crosswalk postcondition

### DIFF
--- a/scripts/publish-ia-precinct-geography-status.mjs
+++ b/scripts/publish-ia-precinct-geography-status.mjs
@@ -339,7 +339,7 @@ async function verifyPostconditions(
   const linked = await nv.unsafe([
     "select count(*)::int total,",
     " count(*) filter (where x.relationship_type='one_to_one'",
-    "  and x.match_method='exact_official_id' and x.review_status='reviewed'",
+    "  and x.match_method='official_crosswalk' and x.review_status='reviewed'",
     "  and x.confidence='high' and x.metadata->>'publicDeliveryAuthorized'=$2",
     "  and x.metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
     "from reporting_unit_geometry_crosswalks x",

--- a/tests/api/ia-precinct-publication.test.mjs
+++ b/tests/api/ia-precinct-publication.test.mjs
@@ -450,6 +450,7 @@ function rollbackClient(fixture) {
     }
     if (sql.includes("select e.year,gv.status")) return fixture.versions;
     if (sql.includes("from reporting_unit_geometry_crosswalks")) {
+      assert.match(sql, /x\.match_method='official_crosswalk'/);
       return [{ total: 4_994, exact: 4_994 }];
     }
     if (sql.includes("from reporting_units where")) {


### PR DESCRIPTION
## Scope
- Correct Iowa's final publication postcondition to verify the sealed `official_crosswalk` method actually stored for all 4,994 reviewed relationships.
- Add a regression assertion so the transaction fixture exercises that exact SQL contract.

## Production safety
- The initial production transaction failed inside its postcondition and rolled back atomically.
- Read-only production verification confirms all three geography versions remain `blocked`, no `publicActivation` metadata exists, and all 4,994 crosswalk flags remain false.
- This PR does not load data, publish the database, upload assets, or change canonical manifests.

## Validation
- `npm.cmd run test:precinct-geometry:ia` — passed, 15 files
- `npm.cmd run typecheck` — passed
- `git diff --check` — clean

## Display path
After this correction is deployed, the separately guarded publication transaction can authorize Iowa 2016, 2020, and 2024 precinct results and `/api/precinct-geography`. Iowa 2012 remains blocked.