### PR TITLE
Add guarded Maine local reporting GIS release

### DIFF
--- a/docs/developer/me-local-reporting-gis-runbook.md
+++ b/docs/developer/me-local-reporting-gis-runbook.md
@@ -102,17 +102,205 @@ that secondary election fields are absent from normalized geometry, verifies
 the retained 2012 MGGG/GeoLibrary provenance chain, and checks the 2012
 exclusions and 2024 temporal bracket.
 
-## Current public-release gate
+## Guarded three-election release
 
-All four manifests deliberately have `delivery: null` and
-`validation.status: blocked`. They are not added to the canonical public
-manifest registry by this collection change. No production database, Blob,
-Vercel environment, deployment, or public alias is mutated.
+The release candidate is limited to 2016, 2020, and 2024. It contains 1,542
+reporting units, 4,626 candidate-result rows, 1,542 polygons, 1,542 reviewed
+relationships, 48 county-scoped GeoJSON files, and three indexes. The 2020
+package preserves its one official zero-vote unit. The tooling rejects 2012
+rather than silently dropping its five unmatched rows or weakening its source
+and license gates. Resolving 2012 remains tracked in
+[GitHub issue #230](https://github.com/Camreyn/civicresultmaps/issues/230).
 
-The next reviewed change may build guarded database, immutable county-scoped
-delivery, publication, activation, and rollback tooling for 2016, 2020, and
-2024. It must extend the application contract to preserve
-`local_reporting_unit` labels end to end; hard-coded `precinct` labels or SQL
-filters must not silently admit Maine data. The 2012 package remains outside
-that release until its explicit geometry, vintage, and derivative-permission
-blockers are resolved.
+The application, database, manifests, immutable delivery, and user-facing
+labels all retain `local_reporting_unit`. Maine is now part of the guarded
+publication contract, but only at that exact grain. A hidden Maine row cannot
+be surfaced by the results API, and a static manifest cannot be served by the
+geography API, until the same exact database release is published.
+
+### Local database validation and package sealing
+
+Use only the fixed loopback Docker clone:
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='local'
+$env:CRM_DATABASE_STRICT='true'
+$env:CRM_DATABASE_LOCAL_WRITES='true'
+$env:DATABASE_URL='postgresql://crm_clone_admin:crm_clone_local_only@127.0.0.1:54329/crm_clone_dev'
+
+npm.cmd run local-gis:plan:me -- --years=2016,2020,2024
+npm.cmd run local-gis:setup:me:local -- --years=2016,2020,2024
+npm.cmd run local-gis:validate:me:local -- --years=2016,2020,2024 --report=.etl/local-db/me-public-local-gis-validation.json
+
+Remove-Item Env:CRM_DATABASE_ENVIRONMENT,Env:CRM_DATABASE_STRICT,Env:CRM_DATABASE_LOCAL_WRITES,Env:DATABASE_URL
+
+npm.cmd run local-gis:release-candidate:me
+npm.cmd run local-gis:release-candidate:me:write
+```
+
+Record the content-addressed package path and full SHA-256 as `$PKG` and
+`$PKG_SHA`. Generation changes no production database, Blob object, canonical
+manifest, Vercel setting, or public eligibility state.
+
+### Static activation candidate
+
+Static activation is a separate reviewed Git change:
+
+```powershell
+npm.cmd run local-gis:public-activation:me -- --package=$PKG --package-sha256=$PKG_SHA
+npm.cmd run local-gis:public-activation:me -- --package=$PKG --package-sha256=$PKG_SHA --write
+```
+
+The writer changes exactly four tracked files: the canonical registry and the
+2016, 2020, and 2024 coverage inventories. It preflights all four outputs,
+stages them before replacement, and restores prior bytes on failure. It never
+adds the 2012 manifest. Do not merge that activation change until the hidden
+load, immutable Blob publication, delivery origin, and production deployment
+sequence below are ready. Merging `main` automatically deploys Production on
+this project.
+
+### Production evidence and hidden load
+
+Use a clean checkout of the exact reviewed commit. Supply exactly one explicit
+unpooled URL in `POSTGRES_URL_NON_POOLING` or
+`POSTGRES_DATABASE_URL_UNPOOLED`; none of these commands loads `.env.local`.
+
+Run the read-only preflight before the backup:
+
+```powershell
+npm.cmd run local-gis:production-preflight:me -- --package=$PKG
+
+$env:CRM_DATABASE_ENVIRONMENT='production-read-only'
+$env:CRM_ME_LOCAL_GEOGRAPHY_PRODUCTION_PREFLIGHT_ACK=$PKG_SHA
+$env:POSTGRES_URL_NON_POOLING='<explicit unpooled production URL>'
+npm.cmd run local-gis:production-preflight:me -- --package=$PKG --connect-read-only
+```
+
+Retain the preflight path, SHA-256, database identity, and 64-hex endpoint
+fingerprint. The initial-load path rejects preexisting Maine local-release
+rows. Create and restore-verify the full public-schema backup strictly after
+that preflight:
+
+```powershell
+npm.cmd run local-gis:production-backup:me -- -ReleasePackagePath $PKG -ReleasePackageSha256 $PKG_SHA
+
+$env:CRM_ME_LOCAL_GEOGRAPHY_BACKUP_ACK='CREATE_FULL_PUBLIC_SCHEMA_ROLLBACK_BACKUP'
+$env:CRM_ME_LOCAL_GEOGRAPHY_BACKUP_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_ME_LOCAL_GEOGRAPHY_BACKUP_ENDPOINT_FINGERPRINT='<preflight endpoint fingerprint>'
+npm.cmd run local-gis:production-backup:me -- -ReleasePackagePath $PKG -ReleasePackageSha256 $PKG_SHA -Execute
+```
+
+Retain the backup manifest and SHA-256. It must prove an exact PostgreSQL 17
+restore, matching table and row sets, read-only default, and zero invalid
+constraints. Both preflight and backup evidence must still be fresh when the
+hidden-load transaction begins.
+
+Generate an immutable NO-GO authorization template:
+
+```powershell
+npm.cmd run local-gis:production-release:me -- --package=$PKG --package-sha256=$PKG_SHA --preflight-sha256=$PREFLIGHT_SHA --backup-manifest-sha256=$BACKUP_SHA --write-authorization-template
+```
+
+A completed `GO_PRODUCTION` record identifies the owner, uses a unique active
+authorization ID, pins both evidence hashes, and retains exactly these scopes:
+
+- `apply_migration_0009`
+- `load_me_local_reporting_results_and_geometry_hidden`
+- `increment_public_data_revision`
+
+Record its path and SHA-256 as `$AUTH` and `$AUTH_SHA`, then run the coupled
+migration and hidden load:
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production'
+$env:CRM_ME_LOCAL_GEOGRAPHY_PRODUCTION_WRITES=$PKG_SHA
+$env:CRM_ME_LOCAL_GEOGRAPHY_PRODUCTION_AUTHORIZATION_ID='<authorization ID>'
+$env:CRM_ME_LOCAL_GEOGRAPHY_PRODUCTION_AUTHORIZATION_SHA256=$AUTH_SHA
+
+npm.cmd run local-gis:production-release:me -- --package=$PKG --package-sha256=$PKG_SHA --preflight=$PREFLIGHT --preflight-sha256=$PREFLIGHT_SHA --backup-manifest=$BACKUP_MANIFEST --backup-manifest-sha256=$BACKUP_SHA --authorization=$AUTH --authorization-sha256=$AUTH_SHA --apply
+```
+
+One transaction applies migration 0009 if needed, loads and validates all
+three elections, stores the exact audit evidence, and increments the public
+revision. Every geography version and reporting unit remains blocked with
+`publicDeliveryAuthorized=false`. Preserve the immutable
+`COMMITTED_HIDDEN_NOT_PUBLIC` receipt. If commit acknowledgement or receipt
+writing is ambiguous, preserve the `.pending` marker and use the command's
+hash-authorized `--recover-receipt` mode under
+`CRM_DATABASE_ENVIRONMENT=production-read-only`; never rerun the write.
+
+### Immutable Blob delivery
+
+Plan first, then authorize exactly 51 content-addressed objects:
+
+```powershell
+npm.cmd run local-gis:delivery-publish:me -- --package=$PKG --package-sha256=$PKG_SHA
+
+$env:CRM_ME_LOCAL_GEOGRAPHY_PUBLIC_FILE_WRITES='I_ACKNOWLEDGE_PUBLIC_IMMUTABLE_GEOMETRY_UPLOAD'
+$env:CRM_ME_LOCAL_GEOGRAPHY_PUBLIC_FILE_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_ME_LOCAL_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID='<owner authorization ID>'
+npm.cmd run local-gis:delivery-publish:me -- --package=$PKG --package-sha256=$PKG_SHA --write
+```
+
+The publisher writes all 48 county objects before the three indexes, refuses
+overwrites and random suffixes, redownloads every public object, and verifies
+its hash. Preserve the Blob evidence path, SHA-256, and its single
+credential-free HTTPS `deliveryOrigin`.
+
+### Deployment and atomic public cutover
+
+1. Record the exact currently promoted, gate-capable rollback deployment and
+   verify both Maine APIs are closed while the database is blocked.
+2. Configure the exact Blob origin for Preview, deploy the static activation
+   tree to a protected Preview, and verify its commit/tree and closed gates.
+3. Configure the same origin for Production, merge the exact activation tree
+   to `main`, await READY/PROMOTED, and verify both gates are still closed.
+4. Build the publication plan and NO-GO authorization template from the exact
+   hidden receipt and Blob evidence:
+
+```powershell
+npm.cmd run local-gis:publication-status:me -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_RECEIPT --blob-evidence-sha256=$BLOB_SHA --write-plan
+
+npm.cmd run local-gis:publication-status:me -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_RECEIPT --blob-evidence-sha256=$BLOB_SHA --write-authorization-template
+```
+
+The completed `GO_PUBLIC` record pins the exact READY/PROMOTED activation
+deployment, its Git tree, the closed-gate observations, and the previously
+recorded rollback deployment. It retains exactly these scopes:
+
+- `publish_me_local_geography_versions`
+- `authorize_me_local_results`
+- `increment_public_data_revision`
+
+The final database transaction is the public cutover:
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production'
+$env:CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_WRITES='I_ACKNOWLEDGE_ATOMIC_MAINE_LOCAL_PUBLIC_CUTOVER'
+$env:CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_PLAN_SHA256=$PUBLICATION_PLAN_SHA
+$env:CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_AUTHORIZATION_SHA256=$PUBLIC_AUTH_SHA
+$env:CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_ACTIVATION_ID='<activation ID>'
+
+npm.cmd run local-gis:publication-status:me -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_RECEIPT --blob-evidence-sha256=$BLOB_SHA --plan-sha256=$PUBLICATION_PLAN_SHA --authorization=$PUBLIC_AUTH --authorization-sha256=$PUBLIC_AUTH_SHA --apply
+```
+
+That transaction publishes the exact three geography versions, authorizes
+only their linked local result units, checks all postconditions, and increments
+the public revision. Then verify 2016, 2020, and 2024 through both APIs and the
+live map. Confirm that 2012 remains unavailable.
+
+### Rollback and current authorization status
+
+Rollback requires a new `GO_ROLLBACK` authorization bound to the exact
+successful publication receipt. It blocks the database first while the
+gate-capable application remains live, verifies both public endpoints are
+closed, and only then restores the deployment pinned in that receipt. The
+publication tool also provides read-only receipt recovery for an ambiguous
+commit; it does not permit replaying the write.
+
+This implementation and its local validation authorize no production write,
+Blob upload, Vercel environment change, deployment, canonical activation, or
+public database transition. All three candidate years remain blocked until the
+complete sequence is separately reviewed and executed. Maine 2012 remains
+outside the release.

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -7350,3 +7350,42 @@ evidence against its verified top-level package.
   candidate, these are directional review inputs rather than evidence of fraud
   or misconduct. Production was neither promoted nor queried for indicator
   counts in this collection task.
+
+### 2026-08-13 - Maine guarded three-election local release tooling
+
+- The application publication contract now maps Maine specifically to
+  `local_reporting_unit`. Existing IA, MN, NV, and TX releases remain pinned to
+  `precinct`. Manifest lookup, exact database publication checks, parent-scoped
+  result queries, delivery joins, and map copy all preserve the selected grain.
+  A Minnesota-only local rehearsal cannot bypass Maine's publication gate.
+
+- New deterministic Maine plan, local setup, read-only validation, release
+  candidate, production preflight, full backup/restore proof, hidden-load,
+  immutable Blob publication, static activation, database publication,
+  database-first rollback, and read-only receipt-recovery tools cover only
+  2016, 2020, and 2024. The loaders use Maine SOS values exclusively and reject
+  2012 at plan construction.
+
+- The exact three-election plan contains 1,542 reporting units, 4,626
+  candidate rows, 1,542 polygons, and 1,542 reviewed relationships across all
+  16 counties per year. It produces 48 parent-scoped GeoJSON files followed by
+  three hash-pinned indexes. The one official 2020 zero-vote unit is retained.
+
+- The fixed loopback `crm_clone_dev` load and an independent read-only
+  validation passed with exact per-year feature, result, relationship, and vote
+  totals, zero invalid constraints, all versions blocked, and all public
+  authorization flags false. The resulting immutable local candidate is
+  `me-local-reporting-gis-three-election-v1`; its package SHA-256 is
+  `9c92f333130825f3e573de75d927878ecc2cb782550642cda4b3f763d4f3e4f6`.
+  A dry static-activation plan produced exactly the registry plus three
+  coverage-ledger outputs and did not write them.
+
+- Maine 2012 remains separately fail-closed and tracked in issue #230. Its five
+  unmatched source rows/eight votes, election-vintage uncertainty, and
+  unresolved derivative redistribution permission are not waived by the
+  three-election tooling.
+
+- This implementation performs no production database mutation, public Blob
+  upload, Vercel environment or deployment change, canonical registry change,
+  or public eligibility transition. The guarded operational sequence is in
+  `docs/developer/me-local-reporting-gis-runbook.md`.

--- a/package.json
+++ b/package.json
@@ -313,7 +313,19 @@
     "precinct-gis:replay:me:2020": "node --experimental-strip-types scripts/collect-me-local-reporting-geometry.mjs --year=2020 --retrieved-at=2026-08-13T14:00:00Z",
     "precinct-gis:collect:me:2024": "node --experimental-strip-types scripts/collect-me-local-reporting-geometry.mjs --year=2024 --retrieved-at=2026-08-13T14:00:00Z",
     "precinct-gis:replay:me:2024": "node --experimental-strip-types scripts/collect-me-local-reporting-geometry.mjs --year=2024 --retrieved-at=2026-08-13T14:00:00Z",
-    "test:precinct-geometry:me": "node --experimental-strip-types --test tests/api/me-local-reporting-geometry.test.mjs"
+    "local-gis:plan:me": "node --experimental-strip-types scripts/setup-me-local-gis-local.mjs",
+    "local-gis:setup:me:local": "node --experimental-strip-types scripts/setup-me-local-gis-local.mjs --apply",
+    "local-gis:validate:me:local": "node --experimental-strip-types scripts/validate-me-local-gis-local.mjs",
+    "local-gis:release-candidate:me": "node --max-old-space-size=4096 --experimental-strip-types scripts/prepare-me-local-release-candidate.mjs",
+    "local-gis:release-candidate:me:write": "node --max-old-space-size=4096 --experimental-strip-types scripts/prepare-me-local-release-candidate.mjs --write",
+    "local-gis:delivery-publish:me": "node --experimental-strip-types scripts/publish-me-local-delivery-assets.mjs",
+    "local-gis:production-preflight:me": "node --experimental-strip-types scripts/report-me-local-production-preflight.mjs",
+    "local-gis:production-backup:me": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/backup-me-local-production.ps1",
+    "local-gis:production-release:me": "node --max-old-space-size=4096 --experimental-strip-types scripts/apply-me-local-release.mjs",
+    "local-gis:public-activation:me": "node --experimental-strip-types scripts/prepare-me-local-public-activation.mjs",
+    "local-gis:publication-status:me": "node --max-old-space-size=4096 --experimental-strip-types scripts/publish-me-local-geography-status.mjs",
+    "test:precinct-geometry:me": "node --experimental-strip-types --test tests/api/me-local-reporting-geometry.test.mjs",
+    "test:local-gis:me": "node --experimental-strip-types --test tests/api/me-local-reporting-geometry.test.mjs tests/api/me-local-gis-plan.test.mjs tests/api/me-local-gis-local.test.mjs tests/api/me-local-release-candidate.test.mjs tests/api/me-local-blob-publication.test.mjs tests/api/me-local-production-release.test.mjs tests/api/me-local-public-activation.test.mjs tests/api/me-local-publication-gate.test.mjs tests/api/me-local-publication.test.mjs"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.5.18",

--- a/scripts/apply-me-local-release.mjs
+++ b/scripts/apply-me-local-release.mjs
@@ -1,0 +1,668 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import postgres from "postgres";
+import {
+  applyMaineLocalGisTransaction,
+  readMainePersistedProductionReleaseAudit,
+  validateMaineLocalGisClient,
+} from "./lib/me-local-gis-db.mjs";
+import { buildMaineLocalGisPlan } from "./lib/me-local-gis-plan.mjs";
+import { inspectReleaseArtifact } from "./lib/me-local-release-candidate.mjs";
+import {
+  assertMaineReleaseCandidateDocument,
+  productionEndpointFingerprint,
+} from "./lib/me-local-production-preflight.mjs";
+import {
+  buildMaineProductionAuthorizationTemplate,
+  sha256,
+  validateMaineProductionAuthorization,
+  validateMaineProductionBackupEvidence,
+  validateMaineProductionPreflightEvidence,
+} from "./lib/me-local-production-release.mjs";
+
+function parseArguments(args) {
+  const value = (name) => args.find((arg) => arg.startsWith(name + "="))
+    ?.slice(name.length + 1);
+  const parsed = {
+    apply: args.includes("--apply"),
+    recoverReceipt: args.includes("--recover-receipt"),
+    writeAuthorizationTemplate: args.includes("--write-authorization-template"),
+    packagePath: value("--package"),
+    packageSha256: value("--package-sha256"),
+    preflightPath: value("--preflight"),
+    preflightSha256: value("--preflight-sha256"),
+    backupManifestPath: value("--backup-manifest"),
+    backupManifestSha256: value("--backup-manifest-sha256"),
+    authorizationPath: value("--authorization"),
+    authorizationSha256: value("--authorization-sha256"),
+    authorizationTemplatePath: value("--authorization-template"),
+    receiptPath: value("--receipt"),
+  };
+  const known = new Set([
+    "--apply",
+    "--recover-receipt",
+    "--write-authorization-template",
+    "--package",
+    "--package-sha256",
+    "--preflight",
+    "--preflight-sha256",
+    "--backup-manifest",
+    "--backup-manifest-sha256",
+    "--authorization",
+    "--authorization-sha256",
+    "--authorization-template",
+    "--receipt",
+  ]);
+  for (const arg of args) {
+    const key = arg.split("=")[0];
+    if (!known.has(key)) throw new Error("Unknown Maine production-release option: " + arg);
+  }
+  if (!parsed.packagePath || !parsed.packageSha256) {
+    throw new Error("Maine production release requires --package and --package-sha256");
+  }
+  if ([parsed.apply, parsed.recoverReceipt, parsed.writeAuthorizationTemplate]
+    .filter(Boolean).length > 1) {
+    throw new Error("Maine production release modes are mutually exclusive");
+  }
+  return parsed;
+}
+
+function safeEtlPath(root, relativePath, requiredPrefix) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith(requiredPrefix)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+  ) {
+    throw new Error("Unsafe Maine release evidence path: " + relativePath);
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...requiredPrefix.replace(/\/$/, "").split("/"));
+  if (!absolute.startsWith(allowed + path.sep)) {
+    throw new Error("Maine release evidence escapes its .etl root");
+  }
+  return absolute;
+}
+
+function readEtlJson(root, relativePath, expectedSha256, prefix) {
+  if (!/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")) {
+    throw new Error("Maine release evidence requires an exact SHA-256");
+  }
+  const absolute = safeEtlPath(root, relativePath, prefix);
+  const bytes = readFileSync(absolute);
+  if (sha256(bytes) !== expectedSha256) {
+    throw new Error("Maine release evidence SHA-256 drifted: " + relativePath);
+  }
+  return { path: relativePath, absolute, bytes, sha256: expectedSha256, value: JSON.parse(bytes) };
+}
+
+function readBackupManifest(relativeOrAbsolutePath, expectedSha256, root) {
+  if (!/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")) {
+    throw new Error("Maine backup manifest requires an exact SHA-256");
+  }
+  const absolute = path.isAbsolute(relativeOrAbsolutePath)
+    ? path.resolve(relativeOrAbsolutePath)
+    : path.resolve(root, relativeOrAbsolutePath);
+  const bytes = readFileSync(absolute);
+  if (sha256(bytes) !== expectedSha256) {
+    throw new Error("Maine backup manifest SHA-256 drifted");
+  }
+  return { absolute, bytes, sha256: expectedSha256, value: JSON.parse(bytes) };
+}
+
+function productionUrl(environment = process.env) {
+  const first = environment.POSTGRES_URL_NON_POOLING?.trim() || "";
+  const second = environment.POSTGRES_DATABASE_URL_UNPOOLED?.trim() || "";
+  if (!first && !second) {
+    throw new Error("Maine production release requires an explicit unpooled PostgreSQL URL");
+  }
+  if (first && second && first !== second) {
+    throw new Error("Maine production release found conflicting unpooled PostgreSQL URLs");
+  }
+  return first || second;
+}
+
+function immutableJson(root, relativePath, value) {
+  const absolute = safeEtlPath(root, relativePath, path.posix.dirname(relativePath) + "/");
+  const bytes = Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+  if (existsSync(absolute)) {
+    if (!readFileSync(absolute).equals(bytes)) {
+      throw new Error("Refusing to overwrite different Maine release evidence");
+    }
+    return { path: relativePath, byteCount: bytes.length, sha256: sha256(bytes), disposition: "verified_existing" };
+  }
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, bytes, { flag: "wx" });
+  return { path: relativePath, byteCount: bytes.length, sha256: sha256(bytes), disposition: "created" };
+}
+
+function reserveReceipt(
+  root,
+  relativePath,
+  packageSha256,
+  authorizationSha256,
+  options = {},
+) {
+  const absolute = safeEtlPath(
+    root,
+    relativePath,
+    ".etl/production-release-receipts/ME/",
+  );
+  if (existsSync(absolute)) throw new Error("Maine production receipt already exists");
+  const pending = absolute + ".pending";
+  const pendingBytes = Buffer.from(JSON.stringify({
+    schemaVersion: 1,
+    state: "ME",
+    packageSha256,
+    authorizationSha256,
+    purpose: "ambiguous-commit recovery marker",
+  }, null, 2) + "\n");
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  if (existsSync(pending)) {
+    if (
+      options.allowExisting === true
+      && readFileSync(pending).equals(pendingBytes)
+    ) {
+      return {
+        absolute,
+        pending,
+        pendingBytes,
+        disposition: "reused",
+      };
+    }
+    throw new Error("A Maine release recovery marker already exists; reconcile it before retrying");
+  }
+  writeFileSync(pending, pendingBytes, { flag: "wx" });
+  return { absolute, pending, pendingBytes, disposition: "created" };
+}
+
+function finishReceipt(reservation, value) {
+  const bytes = Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+  const temporary = reservation.absolute + ".write-" + sha256(bytes).slice(0, 12) + ".tmp";
+  if (existsSync(temporary)) {
+    if (!readFileSync(temporary).equals(bytes)) {
+      throw new Error("Maine hidden receipt temporary file drifted");
+    }
+  } else {
+    writeFileSync(temporary, bytes, { flag: "wx" });
+  }
+  renameSync(temporary, reservation.absolute);
+  if (readFileSync(reservation.pending).equals(reservation.pendingBytes)) {
+    unlinkSync(reservation.pending);
+  }
+  return { byteCount: bytes.length, sha256: sha256(bytes) };
+}
+
+function defaultTemplatePath(packageSha256) {
+  return ".etl/production-authorizations/ME/me-local-authorization-template-"
+    + packageSha256.slice(0, 12)
+    + ".json";
+}
+
+function defaultReceiptPath(packageSha256, authorizationId) {
+  const safeId = authorizationId.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 80);
+  return ".etl/production-release-receipts/ME/me-local-hidden-load-"
+    + packageSha256.slice(0, 12)
+    + "-"
+    + safeId
+    + ".json";
+}
+
+async function ensureMaineDerivationConstraint(tx, migrationArtifact) {
+  const inspect = async () => tx.unsafe([
+    "select pg_get_constraintdef(oid) definition from pg_constraint",
+    "where connamespace='public'::regnamespace",
+    " and conname='geography_versions_derivation_method_check'",
+  ].join("\n"));
+  const beforeRows = await inspect();
+  if (beforeRows.length !== 1) {
+    throw new Error("Maine derivation-method constraint is missing or ambiguous");
+  }
+  const beforeDefinition = String(beforeRows[0].definition ?? "");
+  const complete = beforeDefinition.includes("secondary_reconstruction")
+    && beforeDefinition.includes("hybrid_reconstruction");
+  if (complete) {
+    return { before: "complete", after: "complete", statementsApplied: 0 };
+  }
+  if (
+    !beforeDefinition.includes("official_export")
+    || !beforeDefinition.includes("official_service")
+    || !beforeDefinition.includes("digitized_map")
+    || !beforeDefinition.includes("official_crosswalk")
+  ) {
+    throw new Error("Maine derivation-method constraint preimage drifted");
+  }
+  const statements = migrationArtifact.bytes.toString("utf8")
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+  if (statements.length !== 2) {
+    throw new Error("Maine migration 0009 statement set drifted");
+  }
+  for (const statement of statements) await tx.unsafe(statement);
+  const afterRows = await inspect();
+  const afterDefinition = String(afterRows[0]?.definition ?? "");
+  if (
+    afterRows.length !== 1
+    || !afterDefinition.includes("secondary_reconstruction")
+    || !afterDefinition.includes("hybrid_reconstruction")
+  ) {
+    throw new Error("Maine migration 0009 did not establish the required constraint");
+  }
+  return { before: "absent", after: "complete", statementsApplied: 2 };
+}
+
+export async function runMaineProductionRelease(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const parsed = options.packagePath ? options : parseArguments(process.argv.slice(2));
+  const packageArtifact = inspectReleaseArtifact(root, parsed.packagePath, {
+    allowedRoots: [".etl/precinct-release-candidates/ME/"],
+    sha256: parsed.packageSha256,
+  });
+  const packageDocument = JSON.parse(packageArtifact.bytes.toString("utf8"));
+  const releaseCandidate = assertMaineReleaseCandidateDocument(
+    packageDocument,
+    packageArtifact.sha256,
+  );
+  const migration0009Declaration = releaseCandidate.migrations.find(
+    (migration) => migration.path === "drizzle/0009_public_wolfpack.sql",
+  );
+  const migration0009Artifact = inspectReleaseArtifact(
+    root,
+    migration0009Declaration.path,
+    {
+      allowedRoots: ["drizzle/"],
+      byteCount: migration0009Declaration.byteCount,
+      sha256: migration0009Declaration.sha256,
+    },
+  );
+  const environment = options.environment ?? process.env;
+  const clock = options.nowFactory ?? (() => options.now ?? new Date());
+  const currentTime = () => {
+    const value = clock();
+    const result = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    if (Number.isNaN(result.getTime())) {
+      throw new Error("Maine production release clock returned an invalid time");
+    }
+    return result;
+  };
+  if (parsed.writeAuthorizationTemplate) {
+    const relativePath = parsed.authorizationTemplatePath
+      ?? defaultTemplatePath(packageArtifact.sha256);
+    const artifact = immutableJson(root, relativePath, buildMaineProductionAuthorizationTemplate({
+      releaseCandidate,
+      preflightSha256: parsed.preflightSha256,
+      backupManifestSha256: parsed.backupManifestSha256,
+    }));
+    return {
+      mode: "write_authorization_template",
+      decision: "NO_GO_PRODUCTION",
+      releaseCandidate,
+      authorizationTemplate: artifact,
+      productionMutationPerformed: false,
+    };
+  }
+  if (!parsed.apply && !parsed.recoverReceipt) {
+    return {
+      mode: "plan",
+      decision: "NO_GO_PRODUCTION",
+      releaseCandidate,
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      requiredEvidence: [
+        "fresh read-only production preflight",
+        "fresh full public-schema backup with exact restore verification",
+        "hash-pinned GO_PRODUCTION authorization",
+      ],
+    };
+  }
+  const databaseUrl = productionUrl(environment);
+  const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
+  const preflight = readEtlJson(
+    root,
+    parsed.preflightPath,
+    parsed.preflightSha256,
+    ".etl/production-preflight-candidates/ME/",
+  );
+  const backup = readBackupManifest(
+    parsed.backupManifestPath,
+    parsed.backupManifestSha256,
+    root,
+  );
+  const authorization = readEtlJson(
+    root,
+    parsed.authorizationPath,
+    parsed.authorizationSha256,
+    ".etl/production-authorizations/ME/",
+  );
+  const validateEvidenceAt = (now) => {
+    const preflightSummary = validateMaineProductionPreflightEvidence(
+      preflight.value,
+      { releaseCandidate, endpointFingerprint, now },
+    );
+    const backupSummary = validateMaineProductionBackupEvidence(backup.value, {
+      releaseCandidate,
+      endpointFingerprint,
+      preflightCapturedAtUtc: preflightSummary.capturedAtUtc,
+      now,
+    });
+    const authorizationSummary = validateMaineProductionAuthorization(
+      authorization.value,
+      {
+        releaseCandidate,
+        preflightSha256: preflight.sha256,
+        backupManifestSha256: backup.sha256,
+        now,
+      },
+    );
+    return { preflightSummary, backupSummary, authorizationSummary };
+  };
+  const rawAuthorizationId = typeof authorization.value?.authorizationId === "string"
+    ? authorization.value.authorizationId.trim()
+    : "";
+  const receiptPath = parsed.receiptPath ?? defaultReceiptPath(
+    packageArtifact.sha256,
+    rawAuthorizationId || "invalid-authorization",
+  );
+  const plan = await buildMaineLocalGisPlan({
+    root,
+    years: [2016, 2020, 2024],
+  });
+
+  if (parsed.recoverReceipt) {
+    if (
+      environment.CRM_DATABASE_ENVIRONMENT !== "production-read-only"
+      || environment.CRM_ME_LOCAL_GEOGRAPHY_HIDDEN_RECEIPT_RECOVERY
+        !== packageArtifact.sha256
+      || environment.CRM_ME_LOCAL_GEOGRAPHY_PRODUCTION_AUTHORIZATION_SHA256
+        !== authorization.sha256
+    ) {
+      throw new Error("Maine hidden receipt recovery is not explicitly read-only and hash-authorized");
+    }
+    const reservation = reserveReceipt(
+      root,
+      receiptPath,
+      packageArtifact.sha256,
+      authorization.sha256,
+      { allowExisting: true },
+    );
+    let sql;
+    try {
+      sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+        max: 1,
+        connect_timeout: 10,
+        idle_timeout: 20,
+        connection: {
+          application_name: "civicresultmaps-me-local-hidden-receipt-recovery",
+          default_transaction_read_only: true,
+        },
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    }
+    let recovered;
+    try {
+      recovered = await sql.begin("read only", async (nv) => {
+        const persistedAudit = await readMainePersistedProductionReleaseAudit(
+          nv,
+          { id: releaseCandidate.id, sha256: packageArtifact.sha256 },
+        );
+        const committedAt = new Date(persistedAudit.transaction.executedAtUtc);
+        if (committedAt.getTime() > currentTime().getTime()) {
+          throw new Error("Maine hidden receipt recovery found a future commit timestamp");
+        }
+        const evidence = validateEvidenceAt(committedAt);
+        const expectedAudit = {
+          releasePackage: { path: parsed.packagePath, sha256: packageArtifact.sha256 },
+          authorization: { path: parsed.authorizationPath, sha256: authorization.sha256 },
+          preflight: { path: parsed.preflightPath, sha256: preflight.sha256 },
+          backupManifest: {
+            sha256: backup.sha256,
+            dumpSha256: evidence.backupSummary.dumpSha256,
+          },
+          authorizationId: evidence.authorizationSummary.authorizationId,
+          endpointFingerprint,
+          transaction: persistedAudit.transaction,
+        };
+        if (JSON.stringify(persistedAudit) !== JSON.stringify(expectedAudit)) {
+          throw new Error("Maine hidden receipt recovery evidence does not match the durable database audit");
+        }
+        const executionContext = {
+          mode: "production_release",
+          releasePackageSha256: packageArtifact.sha256,
+          releaseCandidateId: releaseCandidate.id,
+          databaseName: evidence.preflightSummary.databaseName,
+          productionReleaseAudit: persistedAudit,
+        };
+        const validation = await validateMaineLocalGisClient(nv, plan, {
+          executionContext,
+          readOnlySession: true,
+        });
+        if (Number(validation.revision) !== persistedAudit.transaction.publicRevision) {
+          throw new Error("Maine hidden receipt recovery public revision drifted");
+        }
+        return { persistedAudit, evidence, validation, executionContext };
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+    const recoveredTransaction = {
+      database: recovered.validation.database,
+      executionMode: "production_release",
+      productionMutationPerformed: true,
+      publicDeliveryAuthorized: false,
+      releaseCandidate: recovered.validation.releaseCandidate,
+      productionReleaseAudit: recovered.persistedAudit,
+      revision: recovered.persistedAudit.transaction.publicRevision,
+      years: recovered.validation.years,
+      disposition: "recovered_existing",
+    };
+    const receiptDocument = {
+      schemaVersion: 1,
+      state: "ME",
+      decision: "COMMITTED_HIDDEN_NOT_PUBLIC",
+      releaseCandidate: {
+        id: releaseCandidate.id,
+        path: parsed.packagePath,
+        sha256: packageArtifact.sha256,
+      },
+      committedAtUtc: recovered.persistedAudit.transaction.executedAtUtc,
+      endpointFingerprint,
+      authorization: {
+        id: recovered.evidence.authorizationSummary.authorizationId,
+        path: authorization.path,
+        sha256: authorization.sha256,
+        approvedBy: recovered.evidence.authorizationSummary.approvedBy,
+      },
+      preflight: { path: preflight.path, sha256: preflight.sha256 },
+      backup: {
+        manifestSha256: backup.sha256,
+        dumpSha256: recovered.evidence.backupSummary.dumpSha256,
+      },
+      transaction: recoveredTransaction,
+      validation: recovered.validation,
+      recovery: {
+        recoveredAtUtc: currentTime().toISOString(),
+        productionMutationPerformed: false,
+      },
+      productionMutationPerformed: true,
+      canonicalManifestChanged: false,
+      publicFileWritten: false,
+      publicDeliveryAuthorized: false,
+    };
+    const receiptArtifact = finishReceipt(reservation, receiptDocument);
+    return {
+      mode: "recover_receipt",
+      decision: "RECOVERED_HIDDEN_RECEIPT",
+      releaseCandidate: receiptDocument.releaseCandidate,
+      revision: recoveredTransaction.revision,
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      receipt: { path: receiptPath, ...receiptArtifact },
+    };
+  }
+
+  const initialEvidence = validateEvidenceAt(currentTime());
+  if (
+    environment.CRM_DATABASE_ENVIRONMENT !== "production"
+    || environment.CRM_ME_LOCAL_GEOGRAPHY_PRODUCTION_WRITES !== packageArtifact.sha256
+  ) {
+    throw new Error("Maine production writes are not explicitly package-authorized");
+  }
+  if (
+    environment.CRM_ME_LOCAL_GEOGRAPHY_PRODUCTION_AUTHORIZATION_ID
+      !== initialEvidence.authorizationSummary.authorizationId
+    || environment.CRM_ME_LOCAL_GEOGRAPHY_PRODUCTION_AUTHORIZATION_SHA256
+      !== authorization.sha256
+  ) {
+    throw new Error("Maine production authorization environment acknowledgement drifted");
+  }
+  const reservation = reserveReceipt(
+    root,
+    receiptPath,
+    packageArtifact.sha256,
+    authorization.sha256,
+  );
+  let sql;
+  try {
+    sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+      max: 1,
+      connect_timeout: 10,
+      idle_timeout: 20,
+      connection: { application_name: "civicresultmaps-me-local-production-release" },
+    });
+  } catch (error) {
+    if (existsSync(reservation.pending)) unlinkSync(reservation.pending);
+    throw error;
+  }
+  let transactionBodyCompleted = false;
+  let committed;
+  try {
+    committed = await sql.begin(async (nv) => {
+      const transactionNow = currentTime();
+      const finalEvidence = validateEvidenceAt(transactionNow);
+      const migration0009 = await ensureMaineDerivationConstraint(
+        nv,
+        migration0009Artifact,
+      );
+      const revisions = await nv.unsafe(
+        "select revision::int revision from public_data_revisions where scope='public' for update",
+      );
+      if (revisions.length !== 1) throw new Error("Maine production public revision is missing");
+      const expectedRevision = Number(revisions[0].revision) + 1;
+      const releaseAudit = {
+        releasePackage: { path: parsed.packagePath, sha256: packageArtifact.sha256 },
+        authorization: { path: parsed.authorizationPath, sha256: authorization.sha256 },
+        preflight: { path: parsed.preflightPath, sha256: preflight.sha256 },
+        backupManifest: {
+          sha256: backup.sha256,
+          dumpSha256: finalEvidence.backupSummary.dumpSha256,
+        },
+        authorizationId: finalEvidence.authorizationSummary.authorizationId,
+        endpointFingerprint,
+        transaction: {
+          executedAtUtc: transactionNow.toISOString(),
+          publicRevision: expectedRevision,
+        },
+      };
+      const executionContext = {
+        mode: "production_release",
+        releasePackageSha256: packageArtifact.sha256,
+        releaseCandidateId: releaseCandidate.id,
+        databaseName: finalEvidence.preflightSummary.databaseName,
+        productionReleaseAudit: releaseAudit,
+      };
+      const applied = await applyMaineLocalGisTransaction(nv, plan, {
+        executionContext,
+      });
+      if (applied.revision !== expectedRevision) {
+        throw new Error("Maine production public revision increment drifted");
+      }
+      const validation = await validateMaineLocalGisClient(nv, plan, {
+        executionContext,
+        readOnlySession: false,
+      });
+      transactionBodyCompleted = true;
+      return {
+        applied: { ...applied, migration0009 },
+        validation,
+        releaseAudit,
+      };
+    });
+  } catch (error) {
+    // A post-COMMIT connection failure is ambiguous. Keep the pending marker
+    // once the transaction body completed so a retry cannot double-apply.
+    if (!transactionBodyCompleted && existsSync(reservation.pending)) {
+      unlinkSync(reservation.pending);
+    }
+    throw error;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+  const receiptDocument = {
+    schemaVersion: 1,
+    state: "ME",
+    decision: "COMMITTED_HIDDEN_NOT_PUBLIC",
+    releaseCandidate: {
+      id: releaseCandidate.id,
+      path: parsed.packagePath,
+      sha256: packageArtifact.sha256,
+    },
+    committedAtUtc: committed.releaseAudit.transaction.executedAtUtc,
+    endpointFingerprint,
+    authorization: {
+      id: initialEvidence.authorizationSummary.authorizationId,
+      path: authorization.path,
+      sha256: authorization.sha256,
+      approvedBy: initialEvidence.authorizationSummary.approvedBy,
+    },
+    preflight: { path: preflight.path, sha256: preflight.sha256 },
+    backup: {
+      manifestSha256: backup.sha256,
+      dumpSha256: initialEvidence.backupSummary.dumpSha256,
+    },
+    transaction: committed.applied,
+    validation: committed.validation,
+    productionMutationPerformed: true,
+    canonicalManifestChanged: false,
+    publicFileWritten: false,
+    publicDeliveryAuthorized: false,
+  };
+  const receiptArtifact = finishReceipt(reservation, receiptDocument);
+  return {
+    mode: "apply",
+    decision: receiptDocument.decision,
+    releaseCandidate: receiptDocument.releaseCandidate,
+    revision: committed.applied.revision,
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: false,
+    receipt: { path: receiptPath, ...receiptArtifact },
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runMaineProductionRelease().then(
+    (result) => console.log(JSON.stringify(result, null, 2)),
+    (error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/backup-me-local-production.ps1
+++ b/scripts/backup-me-local-production.ps1
@@ -1,0 +1,393 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ReleasePackagePath,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[a-f0-9]{64}$')]
+  [string]$ReleasePackageSha256,
+
+  [switch]$Execute
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$CloneContainer = 'crm-db-clone-postgres'
+$CloneHost = '127.0.0.1'
+$ClonePort = 54329
+$CloneAdminDatabase = 'crm_clone_admin'
+$CloneUser = 'crm_clone_admin'
+$VerifyDatabase = 'crm_me_local_restore_verify'
+$BackupRoot = 'C:\tmp\crm-db-clone\me-local-release-backups'
+$ContainerBackupRoot = '/backups/me-local-release-backups'
+$ExpectedLegacyEndpointFingerprint = 'bf2bf2213814'
+
+function Fail([string]$Message) {
+  throw "Maine production backup aborted: $Message"
+}
+
+function Get-Sha256([byte[]]$Bytes) {
+  $algorithm = [Security.Cryptography.SHA256]::Create()
+  try {
+    return ([BitConverter]::ToString($algorithm.ComputeHash($Bytes)) -replace '-', '').ToLowerInvariant()
+  }
+  finally {
+    $algorithm.Dispose()
+  }
+}
+
+function Assert-ReleasePackage {
+  $candidateRoot = [IO.Path]::GetFullPath((Join-Path $RepoRoot '.etl\precinct-release-candidates\ME'))
+  $candidatePath = [IO.Path]::GetFullPath((Join-Path $RepoRoot $ReleasePackagePath))
+  if (
+    -not $candidatePath.StartsWith($candidateRoot + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase) -or
+    [IO.Path]::GetFileName($candidatePath) -ne 'release-candidate.json' -or
+    -not (Test-Path -LiteralPath $candidatePath -PathType Leaf)
+  ) {
+    Fail 'The release package must be an existing release-candidate.json under .etl/precinct-release-candidates/ME.'
+  }
+  $bytes = [IO.File]::ReadAllBytes($candidatePath)
+  if ((Get-Sha256 $bytes) -ne $ReleasePackageSha256) {
+    Fail 'The release package SHA-256 does not match the exact acknowledgement.'
+  }
+  $document = [Text.Encoding]::UTF8.GetString($bytes) | ConvertFrom-Json
+  if (
+    $document.schemaVersion -ne 1 -or
+    $document.id -ne 'me-local-reporting-gis-three-election-v1' -or
+    $document.state -ne 'ME' -or
+    $document.decision -ne 'NO_GO_PRODUCTION' -or
+    $document.safety.productionMutationPerformed -ne $false -or
+    $document.safety.canonicalManifestChanged -ne $false -or
+    $document.totals.elections -ne 3
+  ) {
+    Fail 'The release package contract is incompatible.'
+  }
+  return [ordered]@{
+    id = $document.id
+    path = $ReleasePackagePath.Replace('\', '/')
+    sha256 = $ReleasePackageSha256
+  }
+}
+
+function Require-Command([string]$Name) {
+  $command = Get-Command $Name -ErrorAction SilentlyContinue
+  if (-not $command) {
+    Fail "Required command '$Name' was not found on PATH."
+  }
+  return $command.Source
+}
+
+function Get-RequiredSourceUrl {
+  $first = [Environment]::GetEnvironmentVariable('POSTGRES_URL_NON_POOLING')
+  $second = [Environment]::GetEnvironmentVariable('POSTGRES_DATABASE_URL_UNPOOLED')
+  if ([string]::IsNullOrWhiteSpace($first) -and [string]::IsNullOrWhiteSpace($second)) {
+    Fail 'Set POSTGRES_URL_NON_POOLING or POSTGRES_DATABASE_URL_UNPOOLED in this process environment.'
+  }
+  if (
+    -not [string]::IsNullOrWhiteSpace($first) -and
+    -not [string]::IsNullOrWhiteSpace($second) -and
+    $first -ne $second
+  ) {
+    Fail 'The two allowed production URL variables disagree.'
+  }
+  if (-not [string]::IsNullOrWhiteSpace($first)) { return $first }
+  return $second
+}
+
+function Assert-RemoteSource([string]$Url) {
+  try { $uri = [Uri]$Url } catch { Fail 'The production URL is not a valid PostgreSQL URI.' }
+  if (
+    $uri.Scheme -notin @('postgres', 'postgresql') -or
+    [string]::IsNullOrWhiteSpace($uri.Host) -or
+    $uri.Host.ToLowerInvariant() -in @('localhost', '127.0.0.1', '::1', $CloneHost) -or
+    $uri.Port -eq $ClonePort
+  ) {
+    Fail 'The production URL is not an allowed remote PostgreSQL endpoint.'
+  }
+}
+
+function Get-EndpointFingerprint([string]$Url) {
+  $uri = [Uri]$Url
+  $database = [Uri]::UnescapeDataString($uri.AbsolutePath.TrimStart('/'))
+  $port = if ($uri.IsDefaultPort) { '5432' } else { [string]$uri.Port }
+  $identity = @($uri.Host.ToLowerInvariant(), $port, $database) -join "`n"
+  return Get-Sha256 ([Text.Encoding]::UTF8.GetBytes($identity))
+}
+
+function Get-LegacyEndpointFingerprint([string]$Url) {
+  $uri = [Uri]$Url
+  $bytes = [Text.Encoding]::UTF8.GetBytes($uri.Host.ToLowerInvariant() + $uri.AbsolutePath)
+  return (Get-Sha256 $bytes).Substring(0, 12)
+}
+
+function Get-RemoteExecEnv([string]$Url) {
+  $uri = [Uri]$Url
+  $userinfo = [Uri]::UnescapeDataString($uri.UserInfo)
+  $separator = $userinfo.IndexOf(':')
+  if ($separator -lt 1) { Fail 'The production URL must include a username and password.' }
+  $database = [Uri]::UnescapeDataString($uri.AbsolutePath.TrimStart('/'))
+  if ([string]::IsNullOrWhiteSpace($database)) { Fail 'The production URL must include a database name.' }
+  $port = if ($uri.IsDefaultPort) { '5432' } else { [string]$uri.Port }
+  return @(
+    '--env', "PGHOST=$($uri.Host)",
+    '--env', "PGPORT=$port",
+    '--env', "PGDATABASE=$database",
+    '--env', "PGUSER=$($userinfo.Substring(0, $separator))",
+    '--env', "PGPASSWORD=$($userinfo.Substring($separator + 1))",
+    '--env', 'PGSSLMODE=require',
+    '--env', 'PGCHANNELBINDING=require',
+    '--env', 'PGOPTIONS=-c default_transaction_read_only=on'
+  )
+}
+
+function Assert-CloneContainer {
+  $container = @((& $script:Docker inspect $CloneContainer) | ConvertFrom-Json)
+  if ($LASTEXITCODE -ne 0 -or $container.Count -ne 1) { Fail 'Docker inspection failed.' }
+  $container = $container[0]
+  if (
+    $container.Name -ne "/$CloneContainer" -or
+    $container.Config.Labels.'com.civicresultmaps.purpose' -ne 'isolated-production-clone' -or
+    $container.State.Health.Status -ne 'healthy'
+  ) {
+    Fail 'The running clone container identity, purpose, or health is invalid.'
+  }
+  $bindings = @($container.NetworkSettings.Ports.'5432/tcp')
+  if (
+    $bindings.Count -ne 1 -or
+    $bindings[0].HostIp -ne $CloneHost -or
+    $bindings[0].HostPort -ne "$ClonePort"
+  ) {
+    Fail 'The clone container is not restricted to the reserved loopback port.'
+  }
+  $mounts = @($container.Mounts | Where-Object {
+    $_.Type -eq 'bind' -and $_.Destination -eq '/backups' -and $_.RW -eq $true
+  })
+  if ($mounts.Count -ne 1) { Fail 'The clone container does not have the required backup bind mount.' }
+}
+
+function Assert-ContainerTools {
+  $versions = @(
+    (& $script:Docker exec --user postgres $CloneContainer psql --version)
+    (& $script:Docker exec --user postgres $CloneContainer pg_dump --version)
+    (& $script:Docker exec --user postgres $CloneContainer pg_restore --version)
+  )
+  $majors = @($versions | ForEach-Object {
+    if ($_ -match '(\d+)(?:\.\d+)?') { [int]$Matches[1] }
+  })
+  if ($LASTEXITCODE -ne 0 -or $majors.Count -ne 3 -or @($majors | Where-Object { $_ -ne 17 }).Count) {
+    Fail 'The clone container must provide PostgreSQL 17 psql, pg_dump, and pg_restore.'
+  }
+}
+
+function Invoke-RemoteRows([string]$Sql, [string]$Description) {
+  $rows = & $script:Docker exec --user postgres @script:RemoteExecEnv $CloneContainer psql --no-psqlrc --set ON_ERROR_STOP=1 --tuples-only --no-align --quiet --command $Sql
+  if ($LASTEXITCODE -ne 0) { Fail "$Description failed." }
+  return @($rows)
+}
+
+function Invoke-LocalRows([string]$Database, [string]$Sql, [string]$Description) {
+  $rows = & $script:Docker exec --user postgres $CloneContainer psql --no-psqlrc --set ON_ERROR_STOP=1 --tuples-only --no-align --quiet --username $CloneUser --dbname $Database --command $Sql
+  if ($LASTEXITCODE -ne 0) { Fail "$Description failed." }
+  return @($rows)
+}
+
+function Invoke-LocalAdmin([string]$Sql, [string]$Description) {
+  $null = Invoke-LocalRows $CloneAdminDatabase $Sql $Description
+}
+
+function Get-TableCounts([string[]]$Tables, [scriptblock]$Runner) {
+  $counts = [ordered]@{}
+  foreach ($table in $Tables) {
+    if ($table -notmatch '^[a-z0-9_]+$') { Fail 'A public table name is unsafe.' }
+    $sql = "SELECT count(*) FROM public.`"$table`";"
+    $value = @(& $Runner $sql)
+    if ($value.Count -ne 1 -or $value[0].Trim() -notmatch '^\d+$') {
+      Fail "Could not obtain an exact row count for public.$table."
+    }
+    $counts[$table] = [int64]$value[0].Trim()
+  }
+  return $counts
+}
+
+function Assert-EqualCounts($Source, $Restored) {
+  if ($Source.Count -ne $Restored.Count) { Fail 'Restored public table count differs from production.' }
+  foreach ($key in $Source.Keys) {
+    if (-not $Restored.Contains($key) -or [int64]$Restored[$key] -ne [int64]$Source[$key]) {
+      Fail "Restored row count differs for public.$key."
+    }
+  }
+}
+
+function Restrict-BackupAccess([string[]]$Paths) {
+  $icacls = Get-Command icacls -ErrorAction SilentlyContinue
+  if (-not $icacls -or $env:OS -ne 'Windows_NT') {
+    Fail 'Restrictive Windows ACL tooling is unavailable.'
+  }
+  $user = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+  foreach ($target in $Paths) {
+    $isDirectory = Test-Path -LiteralPath $target -PathType Container
+    $userGrant = if ($isDirectory) { "$user`:(OI)(CI)F" } else { "$user`:F" }
+    $systemGrant = if ($isDirectory) { 'SYSTEM:(OI)(CI)F' } else { 'SYSTEM:F' }
+    & $icacls.Source $target '/inheritance:r' '/grant:r' $userGrant '/grant:r' $systemGrant | Out-Null
+    if ($LASTEXITCODE -ne 0) { Fail "Could not restrict ACLs on $target." }
+  }
+}
+
+$releaseCandidate = Assert-ReleasePackage
+if (-not $Execute) {
+  [ordered]@{
+    mode = 'plan'
+    decision = 'NO_BACKUP_CREATED'
+    releaseCandidate = $releaseCandidate
+    sourceEndpointFingerprint = 'computed_during_execution'
+    sourceEndpointLegacyApprovalFingerprint = $ExpectedLegacyEndpointFingerprint
+    includedSchemas = @('public')
+    excludedTableDataPatterns = @()
+    restoreVerificationRequired = $true
+    remoteMutationPerformed = $false
+    outputDirectory = $BackupRoot
+    acknowledgementRequired = @(
+      'CRM_ME_LOCAL_GEOGRAPHY_BACKUP_ACK=CREATE_FULL_PUBLIC_SCHEMA_ROLLBACK_BACKUP',
+      'CRM_ME_LOCAL_GEOGRAPHY_BACKUP_ENDPOINT_FINGERPRINT=<fresh 64-hex preflight endpoint fingerprint>'
+    )
+  } | ConvertTo-Json -Depth 6
+  exit 0
+}
+
+if (
+  [Environment]::GetEnvironmentVariable('CRM_ME_LOCAL_GEOGRAPHY_BACKUP_ACK') -ne 'CREATE_FULL_PUBLIC_SCHEMA_ROLLBACK_BACKUP' -or
+  [Environment]::GetEnvironmentVariable('CRM_ME_LOCAL_GEOGRAPHY_BACKUP_PACKAGE_SHA256') -ne $ReleasePackageSha256
+) {
+  Fail 'Execution requires the exact backup acknowledgement and release package SHA-256.'
+}
+
+$sourceUrl = Get-RequiredSourceUrl
+Assert-RemoteSource $sourceUrl
+if ((Get-LegacyEndpointFingerprint $sourceUrl) -ne $ExpectedLegacyEndpointFingerprint) {
+  Fail 'The production endpoint fingerprint is not approved.'
+}
+$sourceEndpointFingerprint = Get-EndpointFingerprint $sourceUrl
+if (
+  $sourceEndpointFingerprint -notmatch '^[a-f0-9]{64}$' -or
+  [Environment]::GetEnvironmentVariable('CRM_ME_LOCAL_GEOGRAPHY_BACKUP_ENDPOINT_FINGERPRINT') -ne $sourceEndpointFingerprint
+) {
+  Fail 'Execution requires the exact fresh 64-hex preflight endpoint fingerprint acknowledgement.'
+}
+$script:Docker = Require-Command docker
+$script:RemoteExecEnv = @(Get-RemoteExecEnv $sourceUrl)
+Assert-CloneContainer
+Assert-ContainerTools
+
+$identity = ((Invoke-RemoteRows "SELECT current_setting('server_version_num') || '|' || pg_database_size(current_database()) || '|' || current_setting('transaction_read_only') || '|' || (SELECT string_agg(lanname, ',' ORDER BY lanname) FROM pg_language WHERE lanispl);" 'Production identity preflight') -join '').Trim().Split('|')
+if (
+  $identity.Count -ne 4 -or
+  $identity[0] -notmatch '^\d{5,6}$' -or
+  [int](([int]$identity[0]) / 10000) -ne 17 -or
+  $identity[2] -ne 'on' -or
+  $identity[3] -ne 'plpgsql'
+) {
+  Fail 'The production identity or read-only session contract is incompatible.'
+}
+
+$sourceTables = @(Invoke-RemoteRows "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;" 'Production public table inventory')
+if (
+  $sourceTables.Count -lt 27 -or
+  @($sourceTables | Where-Object { $_ -notmatch '^[a-z0-9_]+$' }).Count -ne 0
+) {
+  Fail 'The production public table inventory is incomplete or unsafe.'
+}
+$sourceCounts = Get-TableCounts $sourceTables { param($sql) Invoke-RemoteRows $sql 'Production public table count' }
+$sourceInvalidConstraints = [int](((Invoke-RemoteRows "SELECT count(*) FROM pg_constraint WHERE connamespace='public'::regnamespace AND NOT convalidated;" 'Production constraint check') -join '').Trim())
+if ($sourceInvalidConstraints -ne 0) { Fail 'Production has invalid public constraints.' }
+
+New-Item -ItemType Directory -Force -Path $BackupRoot | Out-Null
+Restrict-BackupAccess @($BackupRoot)
+$stamp = [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssZ')
+$dumpFile = "me-local-full-public-$stamp.dump"
+$dumpPath = Join-Path $BackupRoot $dumpFile
+$containerDumpPath = "$ContainerBackupRoot/$dumpFile"
+$manifestPath = Join-Path $BackupRoot "me-local-full-public-$stamp.manifest.json"
+$createdAtUtc = [DateTime]::UtcNow.ToString('o')
+
+& $script:Docker exec --user postgres @script:RemoteExecEnv $CloneContainer pg_dump --format=custom --schema=public --file=$containerDumpPath
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $dumpPath -PathType Leaf)) {
+  Fail 'The full public-schema pg_dump failed.'
+}
+Restrict-BackupAccess @($dumpPath)
+
+$list = @(& $script:Docker exec --user postgres $CloneContainer pg_restore --list $containerDumpPath)
+if ($LASTEXITCODE -ne 0) { Fail 'Could not inspect the full dump archive.' }
+$tableDataEntries = @($list | ForEach-Object {
+  if ($_ -match ' TABLE DATA public ([^ ]+) ') { $Matches[1] }
+} | Sort-Object -Unique)
+if (@(Compare-Object $sourceTables $tableDataEntries).Count -ne 0) {
+  Fail 'The dump archive does not contain TABLE DATA entries for every public table.'
+}
+
+Invoke-LocalAdmin "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$VerifyDatabase' AND pid <> pg_backend_pid();" 'Terminate prior verification clients'
+Invoke-LocalAdmin "DROP DATABASE IF EXISTS `"$VerifyDatabase`";" 'Drop prior verification database'
+Invoke-LocalAdmin "CREATE DATABASE `"$VerifyDatabase`" OWNER `"$CloneUser`";" 'Create verification database'
+$null = Invoke-LocalRows $VerifyDatabase 'DROP SCHEMA public CASCADE;' 'Prepare verification database'
+& $script:Docker exec --user postgres $CloneContainer pg_restore --exit-on-error --no-owner --no-privileges --username=$CloneUser --dbname=$VerifyDatabase $containerDumpPath
+if ($LASTEXITCODE -ne 0) { Fail 'Restoring the full backup into the isolated verification database failed.' }
+
+$restoredTables = @(Invoke-LocalRows $VerifyDatabase "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;" 'Restored public table inventory')
+if (@(Compare-Object $sourceTables $restoredTables).Count -ne 0) {
+  Fail 'The restored public table set differs from production.'
+}
+$restoredCounts = Get-TableCounts $restoredTables { param($sql) Invoke-LocalRows $VerifyDatabase $sql 'Restored public table count' }
+Assert-EqualCounts $sourceCounts $restoredCounts
+$restoredInvalidConstraints = [int](((Invoke-LocalRows $VerifyDatabase "SELECT count(*) FROM pg_constraint WHERE connamespace='public'::regnamespace AND NOT convalidated;" 'Restored constraint check') -join '').Trim())
+if ($restoredInvalidConstraints -ne 0) { Fail 'The restored backup has invalid public constraints.' }
+Invoke-LocalAdmin "ALTER DATABASE `"$VerifyDatabase`" SET default_transaction_read_only=on;" 'Lock verification database read-only by default'
+
+$manifest = [ordered]@{
+  manifestVersion = 3
+  backupPurpose = 'me-local-production-release-rollback'
+  createdAtUtc = $createdAtUtc
+  releaseCandidate = $releaseCandidate
+  dumpFile = $dumpFile
+  dumpSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $dumpPath).Hash.ToLowerInvariant()
+  dumpFormat = 'custom'
+  includedSchemas = @('public')
+  excludedTableDataPatterns = @()
+  sourceEndpointFingerprint = $sourceEndpointFingerprint
+  sourceEndpointLegacyApprovalFingerprint = $ExpectedLegacyEndpointFingerprint
+  sourceServerVersionNum = [int]$identity[0]
+  sourceDatabaseBytes = [int64]$identity[1]
+  sourcePublicTableCount = $sourceTables.Count
+  sourcePublicTableRowCounts = $sourceCounts
+  sourceInvalidConstraints = $sourceInvalidConstraints
+  pgClientMajor = 17
+  remoteMutationPerformed = $false
+  restoreVerification = [ordered]@{
+    verified = $true
+    verifiedAtUtc = [DateTime]::UtcNow.ToString('o')
+    database = $VerifyDatabase
+    defaultTransactionReadOnly = $true
+    publicTableCount = $restoredTables.Count
+    publicTableRowCounts = $restoredCounts
+    invalidConstraints = $restoredInvalidConstraints
+    tableDataEntryCount = $tableDataEntries.Count
+    exactSourceTableSet = $true
+    exactSourceRowCounts = $true
+  }
+}
+$json = $manifest | ConvertTo-Json -Depth 8
+[IO.File]::WriteAllText($manifestPath, $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+Restrict-BackupAccess @($manifestPath)
+
+[ordered]@{
+  mode = 'execute'
+  decision = 'BACKUP_AND_RESTORE_VERIFIED'
+  releaseCandidate = $releaseCandidate
+  dumpFile = $dumpPath
+  dumpSha256 = $manifest.dumpSha256
+  manifest = $manifestPath
+  sourcePublicTableCount = $sourceTables.Count
+  restoredPublicTableCount = $restoredTables.Count
+  restoreVerified = $true
+  remoteMutationPerformed = $false
+} | ConvertTo-Json -Depth 6

--- a/scripts/lib/me-local-blob-publication.mjs
+++ b/scripts/lib/me-local-blob-publication.mjs
@@ -1,0 +1,216 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function safeReleasePackage(root, relativePath) {
+  if (
+    typeof relativePath !== "string"
+    || !/^\.etl\/precinct-release-candidates\/ME\/[^/]+\/release-candidate\.json$/.test(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+  ) {
+    throw new Error("Maine Blob publication package path is unsafe");
+  }
+  const resolvedRoot = path.resolve(root);
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  if (!absolutePath.startsWith(resolvedRoot + path.sep)) {
+    throw new Error("Maine Blob publication package escapes the repository");
+  }
+  return absolutePath;
+}
+
+function safePackageAsset(releaseRoot, relativePath) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith("delivery-assets/")
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+  ) {
+    throw new Error("Maine Blob publication asset path is unsafe");
+  }
+  const absolutePath = path.resolve(releaseRoot, ...relativePath.split("/"));
+  if (!absolutePath.startsWith(path.resolve(releaseRoot) + path.sep)) {
+    throw new Error("Maine Blob publication asset escapes the package");
+  }
+  return absolutePath;
+}
+
+function publicPathname(publicUrl) {
+  if (
+    typeof publicUrl !== "string"
+    || !publicUrl.startsWith("/data/geography/me/")
+    || publicUrl.includes("\\")
+    || publicUrl.includes("?")
+    || publicUrl.includes("#")
+  ) {
+    throw new Error("Maine Blob publication URL is not a safe geography path");
+  }
+  const segments = publicUrl.split("/").filter(Boolean);
+  if (segments.some((segment) => {
+    try {
+      const decoded = decodeURIComponent(segment);
+      return decoded === "."
+        || decoded === ".."
+        || decoded.includes("/")
+        || decoded.includes("\\");
+    } catch {
+      return true;
+    }
+  })) {
+    throw new Error("Maine Blob publication URL has an unsafe segment");
+  }
+  return publicUrl.slice(1);
+}
+
+function inspectAsset(releaseRoot, declaration, kind, year) {
+  const absolutePath = safePackageAsset(
+    releaseRoot,
+    declaration.packageRelativePath,
+  );
+  if (!existsSync(absolutePath)) {
+    throw new Error(
+      "Maine " + year + " " + kind + " asset is missing",
+    );
+  }
+  const bytes = readFileSync(absolutePath);
+  const digest = sha256(bytes);
+  if (
+    bytes.length !== declaration.byteCount
+    || digest !== declaration.sha256
+  ) {
+    throw new Error(
+      "Maine " + year + " " + kind + " asset hash or byte count drifted",
+    );
+  }
+  return {
+    kind,
+    year,
+    packageRelativePath: declaration.packageRelativePath,
+    publicUrl: declaration.publicUrl,
+    pathname: publicPathname(declaration.publicUrl),
+    byteCount: bytes.length,
+    sha256: digest,
+    absolutePath,
+  };
+}
+
+export function inspectMaineLocalBlobPublicationPlan(options) {
+  const root = path.resolve(options.root ?? process.cwd());
+  if (!/^[a-f0-9]{64}$/.test(options.packageSha256 ?? "")) {
+    throw new Error("Maine Blob publication requires the exact package SHA-256");
+  }
+  const packageAbsolutePath = safeReleasePackage(root, options.packagePath);
+  if (!existsSync(packageAbsolutePath)) {
+    throw new Error("Maine Blob publication package is missing");
+  }
+  const packageBytes = readFileSync(packageAbsolutePath);
+  if (sha256(packageBytes) !== options.packageSha256) {
+    throw new Error("Maine Blob publication package SHA-256 does not match");
+  }
+  const document = JSON.parse(packageBytes.toString("utf8"));
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "me-local-reporting-gis-three-election-v1"
+    || document?.state !== "ME"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.safety?.publicFileWritten !== false
+    || document?.safety?.canonicalManifestChanged !== false
+    || document?.safety?.publicEligibilityChanged !== false
+    || document?.totals?.elections !== 3
+    || !Array.isArray(document.years)
+    || document.years.length !== 3
+  ) {
+    throw new Error("Maine Blob publication package contract is incompatible");
+  }
+  const releaseRoot = path.dirname(packageAbsolutePath);
+  const artifacts = [];
+  for (const year of document.years) {
+    const delivery = year.parentScopedDelivery;
+    if (
+      ![2016, 2020, 2024].includes(year.year)
+      || delivery?.format !== "parent_scoped_geojson"
+      || delivery?.publicationPerformed !== false
+      || delivery?.electionValuesInDelivery !== false
+      || delivery?.parentCount !== 16
+      || delivery?.featureCount !== year.reviewedGeometry?.featureCount
+      || !Array.isArray(delivery?.parentArtifacts)
+      || delivery.parentArtifacts.length !== 16
+      || year.proposedPublicDelivery?.format !== "parent_scoped_geojson"
+      || year.proposedPublicDelivery?.sha256 !== delivery.index?.sha256
+      || year.proposedPublicDelivery?.byteCount !== delivery.index?.byteCount
+      || year.proposedPublicDelivery?.url !== delivery.index?.publicUrl
+    ) {
+      throw new Error(
+        "Maine " + year.year + " parent-scoped publication contract drifted",
+      );
+    }
+    for (const parent of delivery.parentArtifacts) {
+      if (!/^23\d{3}$/.test(parent.parentGeoid ?? "")) {
+        throw new Error(
+          "Maine " + year.year + " publication has an invalid parent GEOID",
+        );
+      }
+      artifacts.push(inspectAsset(releaseRoot, parent, "parent", year.year));
+    }
+    artifacts.push(inspectAsset(
+      releaseRoot,
+      delivery.index,
+      "index",
+      year.year,
+    ));
+  }
+  const pathnames = new Set(artifacts.map((artifact) => artifact.pathname));
+  if (artifacts.length !== 51 || pathnames.size !== artifacts.length) {
+    throw new Error("Maine Blob publication asset set is incomplete or duplicated");
+  }
+  artifacts.sort((left, right) => {
+    if (left.kind !== right.kind) return left.kind === "parent" ? -1 : 1;
+    return left.pathname.localeCompare(right.pathname);
+  });
+  return {
+    schemaVersion: 1,
+    state: "ME",
+    releaseCandidate: {
+      id: document.id,
+      path: options.packagePath,
+      sha256: options.packageSha256,
+    },
+    decision: "NO_GO_PUBLICATION",
+    assetCount: artifacts.length,
+    indexCount: artifacts.filter((artifact) => artifact.kind === "index").length,
+    parentArtifactCount: artifacts.filter((artifact) => artifact.kind === "parent").length,
+    totalByteCount: artifacts.reduce((sum, artifact) => sum + artifact.byteCount, 0),
+    uploadOrder: "all parent artifacts before indexes",
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+    artifacts,
+  };
+}
+
+export function validateMaineBlobPublicationAuthorization(
+  plan,
+  environment = process.env,
+) {
+  if (
+    environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLIC_FILE_WRITES
+      !== "I_ACKNOWLEDGE_PUBLIC_IMMUTABLE_GEOMETRY_UPLOAD"
+    || environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLIC_FILE_PACKAGE_SHA256
+      !== plan.releaseCandidate.sha256
+    || typeof environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID
+      !== "string"
+    || !environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID.trim()
+  ) {
+    throw new Error(
+      "Maine public immutable geometry upload is not explicitly authorized",
+    );
+  }
+  return {
+    authorizationId:
+      environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID.trim(),
+  };
+}

--- a/scripts/lib/me-local-gis-db.mjs
+++ b/scripts/lib/me-local-gis-db.mjs
@@ -1,0 +1,1417 @@
+import postgres from "postgres";
+import {
+  getDatabaseDriver,
+  getLocalCloneDatabaseUrl,
+} from "../../src/db/database-driver.ts";
+import { reportingUnitCode } from "../../src/lib/precinct-geography.ts";
+
+const STATE = "ME";
+const SETUP_PARSER = "maineLocalReportingGisSetup";
+const APPLICATION_NAME = "civicresultmaps-local-me-local-gis";
+
+const LOCAL_EXECUTION_CONTEXT = Object.freeze({
+  mode: "local",
+  importParser: SETUP_PARSER,
+  importScope: "local-only",
+  resultParser: "scripts/setup-me-local-gis-local.mjs",
+  reviewedBy: "repository-reviewed",
+  revisionReason: "Local-only Maine reviewed local reporting unit GIS setup",
+  database: {
+    environment: "local",
+    host: "loopback",
+    port: 54329,
+    name: "crm_clone_dev",
+  },
+  releaseCandidate: null,
+  productionReleaseAudit: null,
+});
+
+const PRODUCTION_RELEASE_AUDIT_KEYS = Object.freeze([
+  "releasePackage",
+  "authorization",
+  "preflight",
+  "backupManifest",
+  "authorizationId",
+  "endpointFingerprint",
+  "transaction",
+]);
+
+const PRODUCTION_RELEASE_AUDIT_ARTIFACT_KEYS = Object.freeze([
+  "releasePackage",
+  "authorization",
+  "preflight",
+]);
+
+function validatedProductionReleaseAudit(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Production Maine execution requires durable release-audit metadata");
+  }
+  const output = {};
+  for (const key of PRODUCTION_RELEASE_AUDIT_ARTIFACT_KEYS) {
+    const item = value[key];
+    if (
+      typeof item?.path !== "string"
+      || !item.path.startsWith(".etl/")
+      || item.path.includes("\\")
+      || item.path.split("/").includes("..")
+      || !/^[a-f0-9]{64}$/.test(item?.sha256 ?? "")
+    ) {
+      throw new Error("Production Maine execution release-audit metadata is invalid: " + key);
+    }
+    output[key] = Object.freeze({
+      path: item.path,
+      sha256: item.sha256,
+    });
+  }
+  if (
+    !value.backupManifest
+    || Object.keys(value.backupManifest).sort().join(",") !== "dumpSha256,sha256"
+    || !/^[a-f0-9]{64}$/.test(value.backupManifest.sha256 ?? "")
+    || !/^[a-f0-9]{64}$/.test(value.backupManifest.dumpSha256 ?? "")
+    || typeof value.authorizationId !== "string"
+    || !value.authorizationId.trim()
+    || !/^[a-f0-9]{64}$/.test(value.endpointFingerprint ?? "")
+    || !value.transaction
+    || Object.keys(value.transaction).sort().join(",")
+      !== "executedAtUtc,publicRevision"
+    || typeof value.transaction.executedAtUtc !== "string"
+    || Number.isNaN(Date.parse(value.transaction.executedAtUtc))
+    || !Number.isInteger(Number(value.transaction.publicRevision))
+    || Number(value.transaction.publicRevision) < 1
+  ) {
+    throw new Error("Production Maine execution release-audit metadata is invalid");
+  }
+  output.backupManifest = Object.freeze({
+    sha256: value.backupManifest.sha256,
+    dumpSha256: value.backupManifest.dumpSha256,
+  });
+  output.authorizationId = value.authorizationId.trim();
+  output.endpointFingerprint = value.endpointFingerprint;
+  output.transaction = Object.freeze({
+    executedAtUtc: value.transaction.executedAtUtc,
+    publicRevision: Number(value.transaction.publicRevision),
+  });
+  if (Object.keys(value).length !== PRODUCTION_RELEASE_AUDIT_KEYS.length) {
+    throw new Error("Production Maine execution release-audit metadata has extra fields");
+  }
+  return Object.freeze(output);
+}
+
+export function buildMaineLocalExecutionContext(options = {}) {
+  if (!options.mode || options.mode === "local") return LOCAL_EXECUTION_CONTEXT;
+  if (options.mode !== "production_release") {
+    throw new Error("Unknown Maine local reporting unit execution mode");
+  }
+  if (!/^[a-f0-9]{64}$/.test(options.releasePackageSha256 ?? "")) {
+    throw new Error("Production Maine execution requires a release-package SHA-256");
+  }
+  if (!/^me-local-reporting-gis-three-election-v\d+$/.test(options.releaseCandidateId ?? "")) {
+    throw new Error("Production Maine execution requires the reviewed release-candidate ID");
+  }
+  if (typeof options.databaseName !== "string" || !options.databaseName.trim()) {
+    throw new Error("Production Maine execution requires the preflight database name");
+  }
+  return Object.freeze({
+    mode: "production_release",
+    importParser: "maineLocalGisProductionRelease",
+    importScope: "production-release-hidden-load",
+    resultParser: "scripts/apply-me-local-release.mjs",
+    reviewedBy: "repository-reviewed-release",
+    revisionReason:
+      "Maine three-election local reporting unit GIS hidden load "
+      + options.releasePackageSha256,
+    database: {
+      environment: "production",
+      host: "remote",
+      port: null,
+      name: options.databaseName,
+    },
+    releaseCandidate: Object.freeze({
+      id: options.releaseCandidateId,
+      sha256: options.releasePackageSha256,
+      publicDeliveryAuthorized: false,
+    }),
+    productionReleaseAudit: validatedProductionReleaseAudit(
+      options.productionReleaseAudit,
+    ),
+  });
+}
+
+export function assertMaineGeometryVersionPrecondition(versions, yearPlan) {
+  if (
+    !Array.isArray(versions)
+    || versions.length > 1
+    || versions.some((row) =>
+      row.manifest_id !== yearPlan.manifest.id
+      || row.boundary_vintage !== yearPlan.manifest.geography.boundaryVintage
+    )
+  ) {
+    throw new Error(
+      "Maine "
+      + yearPlan.year
+      + " has multiple, foreign, or boundary-drifted geography versions",
+    );
+  }
+}
+
+function executionMetadata(context) {
+  return context.releaseCandidate
+    ? {
+      releaseCandidate: context.releaseCandidate,
+      productionReleaseAudit: context.productionReleaseAudit,
+    }
+    : {};
+}
+
+const FORBIDDEN_ELECTION_PROPERTY =
+  /^(?:USPRS|USSEN|VOTES?|TOTALVOTES?|TOTVOTING|REG7AM|EDR|CANDIDATE|PARTY)/i;
+
+function assertNoElectionValueProperties(value, context) {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertNoElectionValueProperties(item, context + "[" + index + "]"));
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_ELECTION_PROPERTY.test(key)) {
+      throw new Error(context + " contains election-value property " + key);
+    }
+    assertNoElectionValueProperties(child, context + "." + key);
+  }
+}
+
+export function canonicalJson(value) {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonicalJson(value[key])]),
+  );
+}
+
+function query(client, lines, params = []) {
+  return client.unsafe(Array.isArray(lines) ? lines.join("\n") : lines, params);
+}
+
+function chunks(rows, size = 400) {
+  const output = [];
+  for (let index = 0; index < rows.length; index += size) {
+    output.push(rows.slice(index, index + size));
+  }
+  return output;
+}
+
+async function sourceDocument(tx, document) {
+  const rows = await query(tx, [
+    "insert into source_documents (",
+    " slug, state_code, election_year, category, title, source_url, authority,",
+    " local_artifact, parser, timestamp_basis, confidence, status, metadata",
+    ") values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::text::jsonb)",
+    "on conflict (slug) do update set",
+    " election_year=excluded.election_year, category=excluded.category,",
+    " title=excluded.title, source_url=excluded.source_url,",
+    " authority=excluded.authority, local_artifact=excluded.local_artifact,",
+    " parser=excluded.parser, timestamp_basis=excluded.timestamp_basis,",
+    " confidence=excluded.confidence, status=excluded.status,",
+    " metadata=excluded.metadata",
+    "where source_documents.state_code=excluded.state_code",
+    "returning id",
+  ], [
+    document.slug,
+    STATE,
+    document.year,
+    document.category,
+    document.title,
+    document.sourceUrl,
+    document.authority,
+    document.localArtifact,
+    document.parser,
+    document.timestampBasis,
+    document.confidence,
+    document.status,
+    JSON.stringify(document.metadata),
+  ]);
+  if (rows.length !== 1) {
+    throw new Error("Source-document slug belongs to another state: " + document.slug);
+  }
+  return String(rows[0].id);
+}
+
+async function electionAndContest(tx, yearPlan) {
+  const existing = await query(tx, [
+    "select id,election_date from elections",
+    "where year=$1 and office='president'",
+  ], [yearPlan.year]);
+  if (existing.length && String(existing[0].election_date) !== yearPlan.electionDate) {
+    throw new Error(
+      "Existing " + yearPlan.year + " presidential date is "
+      + existing[0].election_date + ", expected " + yearPlan.electionDate,
+    );
+  }
+  const elections = await query(tx, [
+    "insert into elections (year,office,election_date,label)",
+    "values ($1,'president',$2,$3)",
+    "on conflict (year,office) do update set label=excluded.label",
+    "returning id",
+  ], [yearPlan.year, yearPlan.electionDate, yearPlan.year + " General Election"]);
+  const electionId = String(elections[0].id);
+  const contests = await query(tx, [
+    "insert into contests (election_id,state_code,office,title)",
+    "values ($1::uuid,$2,'president',$3)",
+    "on conflict (election_id,state_code,office) do update set title=excluded.title",
+    "returning id",
+  ], [electionId, STATE, "Maine " + yearPlan.year + " President"]);
+  return { electionId, contestId: String(contests[0].id) };
+}
+
+async function candidates(tx, contestId, yearPlan) {
+  const records = [];
+  const seen = new Set();
+  for (const row of yearPlan.resultRows) {
+    const key = row.candidateName + "|" + row.party;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    records.push({
+      name: row.candidateName,
+      party: row.party,
+      order: records.length + 1,
+    });
+  }
+  for (const record of records) {
+    await query(tx, [
+      "insert into candidates (contest_id,name,party,ballot_order)",
+      "values ($1::uuid,$2,$3,$4)",
+      "on conflict (contest_id,name,party) do update set ballot_order=excluded.ballot_order",
+    ], [contestId, record.name, record.party, record.order]);
+  }
+}
+
+async function importRun(tx, yearPlan, resultSourceDocumentId, context) {
+  const found = await query(tx, [
+    "select id from import_runs",
+    "where state_code=$1 and election_year=$2 and parser=$3",
+    " and source_document_id=$4::uuid",
+    "order by started_at,id limit 1",
+  ], [STATE, yearPlan.year, context.importParser, resultSourceDocumentId]);
+  const summary = JSON.stringify({
+    scope: context.importScope,
+    electionId: yearPlan.electionId,
+    reportingUnits: yearPlan.reportingUnits.length,
+    resultRows: yearPlan.resultRows.length,
+    geometryDisposition: yearPlan.geometry.disposition,
+    geometryFeatures: yearPlan.geometry.features.length,
+    crosswalks: yearPlan.geometry.crosswalks.length,
+    publicDeliveryAuthorized: false,
+    ...executionMetadata(context),
+  });
+  if (found.length) {
+    await query(tx, [
+      "update import_runs set status='promoted',finished_at=now(),",
+      " summary=$2::text::jsonb where id=$1::uuid",
+    ], [found[0].id, summary]);
+    return String(found[0].id);
+  }
+  const inserted = await query(tx, [
+    "insert into import_runs (state_code,election_year,parser,source_document_id,",
+    " status,started_at,finished_at,summary)",
+    "values ($1,$2,$3,$4::uuid,'promoted',now(),now(),$5::text::jsonb)",
+    "returning id",
+  ], [STATE, yearPlan.year, context.importParser, resultSourceDocumentId, summary]);
+  return String(inserted[0].id);
+}
+
+async function reportingUnits(
+  tx,
+  yearPlan,
+  electionId,
+  resultSourceDocumentId,
+  context,
+) {
+  for (const batch of chunks(yearPlan.reportingUnits)) {
+    const records = batch.map((unit) => ({
+      reporting_grain: unit.reportingGrain,
+      parent_geoid: unit.parentGeoid,
+      source_unit_id: unit.sourceUnitId,
+      source_display_name: unit.sourceDisplayName,
+      is_geographic: unit.isGeographic,
+      metadata: {
+        electionEventId: yearPlan.electionId,
+        reportingUnitCode: unit.code,
+        setupTool: context.resultParser,
+        resultStatus: unit.resultStatus,
+        ...(unit.resultStatus === "candidate_detail_suppressed"
+          ? {
+            reportedRegistration: unit.reportedRegistration,
+            reportedTurnout: unit.reportedTurnout,
+            reportedTotalVotes: unit.reportedTotalVotes,
+          }
+          : {}),
+        ...executionMetadata(context),
+      },
+    }));
+    await query(tx, [
+      "insert into reporting_units (state_code,election_id,reporting_grain,",
+      " parent_geoid,source_unit_id,source_display_name,is_geographic,",
+      " source_document_id,metadata)",
+      "select $1,$2::uuid,incoming.reporting_grain,incoming.parent_geoid,",
+      " incoming.source_unit_id,incoming.source_display_name,incoming.is_geographic,",
+      " $3::uuid,incoming.metadata",
+      "from jsonb_to_recordset($4::text::jsonb) incoming (",
+      " reporting_grain text,parent_geoid text,source_unit_id text,",
+      " source_display_name text,is_geographic boolean,metadata jsonb)",
+      "on conflict on constraint reporting_units_state_election_grain_parent_source_unique",
+      "do update set source_display_name=excluded.source_display_name,",
+      " is_geographic=excluded.is_geographic,",
+      " source_document_id=excluded.source_document_id,metadata=excluded.metadata,",
+      " updated_at=now()",
+    ], [STATE, electionId, resultSourceDocumentId, JSON.stringify(records)]);
+  }
+  const stored = await query(tx, [
+    "select id,reporting_grain,parent_geoid,source_unit_id",
+    "from reporting_units",
+    "where state_code=$1 and election_id=$2::uuid and reporting_grain='local_reporting_unit'",
+  ], [STATE, electionId]);
+  if (stored.length !== yearPlan.reportingUnits.length) {
+    throw new Error("Maine " + yearPlan.year + " reporting-unit count drifted");
+  }
+  const ids = new Map();
+  for (const row of stored) {
+    const code = reportingUnitCode({
+      state: STATE,
+      electionId: yearPlan.electionId,
+      reportingGrain: String(row.reporting_grain),
+      parentGeoid: row.parent_geoid ? String(row.parent_geoid) : null,
+      sourceUnitId: String(row.source_unit_id),
+    });
+    ids.set(code, String(row.id));
+  }
+  for (const unit of yearPlan.reportingUnits) {
+    if (!ids.has(unit.code)) throw new Error("Missing local reporting unit " + unit.code);
+  }
+  return ids;
+}
+
+async function results(tx, yearPlan, contestId, importRunId, sourceDocumentId, unitIds) {
+  for (const batch of chunks(yearPlan.resultRows)) {
+    const records = batch.map((row) => ({
+      jurisdiction_code: row.jurisdictionCode,
+      jurisdiction_name: row.jurisdictionName,
+      candidate_name: row.candidateName,
+      party: row.party,
+      votes: row.votes,
+      reporting_unit_id: unitIds.get(row.jurisdictionCode),
+    }));
+    if (records.some((row) => !row.reporting_unit_id)) {
+      throw new Error("Maine " + yearPlan.year + " result lacks reporting unit");
+    }
+    await query(tx, [
+      "insert into result_rows (import_run_id,contest_id,state_code,",
+      " jurisdiction_code,jurisdiction_name,jurisdiction_tag,level,",
+      " candidate_name,party,votes,reporting_unit_id,source_document_id)",
+      "select $1::uuid,$2::uuid,$3,incoming.jurisdiction_code,",
+      " incoming.jurisdiction_name,null,'local_reporting_unit',incoming.candidate_name,",
+      " incoming.party,incoming.votes,incoming.reporting_unit_id,$4::uuid",
+      "from jsonb_to_recordset($5::text::jsonb) incoming (",
+      " jurisdiction_code text,jurisdiction_name text,candidate_name text,",
+      " party text,votes integer,reporting_unit_id uuid)",
+      "on conflict (contest_id,level,jurisdiction_code,candidate_name,party)",
+      "do update set jurisdiction_name=excluded.jurisdiction_name,",
+      " state_code=excluded.state_code,jurisdiction_tag=excluded.jurisdiction_tag,",
+      " level=excluded.level,votes=excluded.votes,",
+      " reporting_unit_id=excluded.reporting_unit_id,",
+      " source_document_id=excluded.source_document_id,",
+      " import_run_id=excluded.import_run_id",
+    ], [importRunId, contestId, STATE, sourceDocumentId, JSON.stringify(records)]);
+  }
+  const stored = await query(tx, [
+    "select jurisdiction_code,jurisdiction_name,candidate_name,party,votes,",
+    " reporting_unit_id from result_rows",
+    "where contest_id=$1::uuid and state_code=$2 and level='local_reporting_unit'",
+    " and jurisdiction_code like $3",
+  ], [contestId, STATE, "reporting:" + STATE + ":" + yearPlan.electionId + ":%"]);
+  if (stored.length !== yearPlan.resultRows.length) {
+    throw new Error("Maine " + yearPlan.year + " local-result count drifted");
+  }
+  const expected = new Map(yearPlan.resultRows.map((row) => [
+    [row.jurisdictionCode, row.candidateName, row.party].join("|"),
+    row,
+  ]));
+  for (const row of stored) {
+    const key = [row.jurisdiction_code, row.candidate_name, row.party].join("|");
+    const wanted = expected.get(key);
+    if (
+      !wanted
+      || Number(row.votes) !== wanted.votes
+      || String(row.jurisdiction_name) !== wanted.jurisdictionName
+      || String(row.reporting_unit_id) !== unitIds.get(wanted.jurisdictionCode)
+    ) {
+      throw new Error("Maine " + yearPlan.year + " result drift at " + key);
+    }
+  }
+}
+
+async function clearLocalReplayRows(tx, yearPlan, electionId, contestId, context) {
+  if (context.mode !== "local") return;
+  await query(tx, [
+    "delete from reporting_unit_geometry_crosswalks crosswalk",
+    "using geography_versions version",
+    "where crosswalk.geometry_version_id=version.id",
+    " and version.state_code=$1 and version.election_id=$2::uuid",
+    " and version.geography_type='local_reporting_unit'",
+  ], [STATE, electionId]);
+  // A reviewed local replay may legitimately replace an earlier blocked
+  // boundary snapshot. Never delete a release-attributed or published version;
+  // either condition survives this cleanup and the normal precondition below
+  // rejects the replay.
+  await query(tx, [
+    "delete from geography_versions",
+    "where state_code=$1 and election_id=$2::uuid",
+    " and geography_type='local_reporting_unit' and status='blocked'",
+    " and metadata->'releaseCandidate' is null",
+  ], [STATE, electionId]);
+  await query(tx, [
+    "delete from result_rows",
+    "where contest_id=$1::uuid and state_code=$2 and level='local_reporting_unit'",
+    " and jurisdiction_code like $3",
+  ], [contestId, STATE, `reporting:${STATE}:${yearPlan.electionId}:%`]);
+  await query(tx, [
+    "delete from reporting_units",
+    "where state_code=$1 and election_id=$2::uuid and reporting_grain='local_reporting_unit'",
+    " and metadata->>'setupTool'=$3",
+  ], [STATE, electionId, context.resultParser]);
+}
+
+async function geometry(
+  tx,
+  yearPlan,
+  electionId,
+  sourceDocumentId,
+  unitIds,
+  context,
+) {
+  if (yearPlan.geometry.disposition === "blocked") {
+    const existing = await query(tx, [
+      "select count(*)::int count from geography_versions",
+      "where state_code=$1 and election_id=$2::uuid and geography_type='local_reporting_unit'",
+    ], [STATE, electionId]);
+    if (Number(existing[0].count) !== 0) {
+      throw new Error("Blocked Maine " + yearPlan.year + " already has geometry");
+    }
+    return { geographyVersions: 0, features: 0, crosswalks: 0 };
+  }
+
+  const versions = await query(tx, [
+    "select id,boundary_vintage,metadata->>'manifestId' manifest_id from geography_versions",
+    "where state_code=$1 and election_id=$2::uuid and geography_type='local_reporting_unit'",
+  ], [STATE, electionId]);
+  assertMaineGeometryVersionPrecondition(versions, yearPlan);
+
+  const upserted = await query(tx, [
+    "insert into geography_versions (state_code,election_id,geography_type,",
+    " boundary_vintage,vintage_status,source_document_id,source_layer,",
+    " source_crs,served_crs,derivation_method,status,caveat,metadata,updated_at)",
+    "values ($1,$2::uuid,'local_reporting_unit',$3,$4,$5::uuid,$6,$7,$8,$9,",
+    " 'blocked',$10,$11::text::jsonb,now())",
+    "on conflict (state_code,election_id,geography_type,boundary_vintage)",
+    "do update set vintage_status=excluded.vintage_status,",
+    " source_document_id=excluded.source_document_id,source_layer=excluded.source_layer,",
+    " source_crs=excluded.source_crs,served_crs=excluded.served_crs,",
+    " derivation_method=excluded.derivation_method,status='blocked',",
+    " caveat=excluded.caveat,metadata=excluded.metadata,updated_at=now()",
+    "returning id",
+  ], [
+    STATE,
+    electionId,
+    yearPlan.manifest.geography.boundaryVintage,
+    yearPlan.manifest.geography.vintageStatus,
+    sourceDocumentId,
+    yearPlan.manifest.id,
+    yearPlan.manifest.normalization.sourceCrs,
+    yearPlan.manifest.normalization.servedCrs,
+    yearPlan.manifest.geography.derivationMethod,
+    yearPlan.manifest.validation.errors.join(" "),
+    JSON.stringify({
+      manifestId: yearPlan.manifest.id,
+      manifestPath: yearPlan.manifestPath,
+      manifestSha256: yearPlan.manifestSha256,
+      manifestByteCount: yearPlan.manifestByteCount,
+      source: {
+        artifact: yearPlan.manifest.source.artifact,
+        sha256: yearPlan.manifest.source.sha256,
+        byteCount: yearPlan.artifactByteCounts.source,
+      },
+      normalization: {
+        artifact: yearPlan.manifest.normalization.artifact,
+        sha256: yearPlan.manifest.normalization.sha256,
+        byteCount: yearPlan.artifactByteCounts.normalization,
+        featureCount: yearPlan.geometry.features.length,
+      },
+      crosswalk: {
+        artifact: yearPlan.manifest.crosswalk.artifact,
+        sha256: yearPlan.manifest.crosswalk.sha256,
+        byteCount: yearPlan.artifactByteCounts.crosswalk,
+        reviewedRelationships: yearPlan.geometry.crosswalks.length,
+        reviewedNoDataFeatures:
+          yearPlan.manifest.crosswalk.reviewedNoDataFeatures,
+      },
+      licenseOrTerms: yearPlan.manifest.source.licenseOrTerms,
+      publicDeliveryAuthorized: false,
+      ...executionMetadata(context),
+    }),
+  ]);
+  const versionId = String(upserted[0].id);
+
+  for (const batch of chunks(yearPlan.geometry.features, 250)) {
+    const records = batch.map((feature) => ({
+      source_feature_id: feature.sourceFeatureId,
+      parent_geoid: feature.parentGeoid,
+      name: feature.name,
+      geometry_key: feature.geometryKey,
+      is_geographic: feature.isGeographic,
+      properties: feature.properties,
+    }));
+    await query(tx, [
+      "insert into geography_features (geometry_version_id,source_feature_id,",
+      " parent_geoid,name,geometry_key,is_geographic,properties)",
+      "select $1::uuid,incoming.source_feature_id,incoming.parent_geoid,",
+      " incoming.name,incoming.geometry_key,incoming.is_geographic,incoming.properties",
+      "from jsonb_to_recordset($2::text::jsonb) incoming (",
+      " source_feature_id text,parent_geoid text,name text,geometry_key text,",
+      " is_geographic boolean,properties jsonb)",
+      "on conflict (geometry_version_id,source_feature_id) do update set",
+      " parent_geoid=excluded.parent_geoid,name=excluded.name,",
+      " geometry_key=excluded.geometry_key,is_geographic=excluded.is_geographic,",
+      " properties=excluded.properties",
+    ], [versionId, JSON.stringify(records)]);
+  }
+  await query(tx, [
+    "delete from geography_features feature",
+    "where feature.geometry_version_id=$1::uuid and not exists (",
+    " select 1 from jsonb_array_elements_text($2::text::jsonb) ids(value)",
+    " where ids.value=feature.source_feature_id)",
+  ], [
+    versionId,
+    JSON.stringify(yearPlan.geometry.features.map((row) => row.sourceFeatureId)),
+  ]);
+  const storedFeatures = await query(tx, [
+    "select id,source_feature_id from geography_features",
+    "where geometry_version_id=$1::uuid",
+  ], [versionId]);
+  if (storedFeatures.length !== yearPlan.geometry.features.length) {
+    throw new Error("Maine " + yearPlan.year + " geography-feature count drifted");
+  }
+  const featureIds = new Map(
+    storedFeatures.map((row) => [String(row.source_feature_id), String(row.id)]),
+  );
+
+  await query(tx, [
+    "delete from reporting_unit_geometry_crosswalks",
+    "where geometry_version_id=$1::uuid",
+  ], [versionId]);
+  for (const batch of chunks(yearPlan.geometry.crosswalks)) {
+    const records = batch.map((row) => ({
+      reporting_unit_id: unitIds.get(row.reportingUnitCode),
+      geography_feature_id: featureIds.get(row.sourceFeatureId),
+      relationship_type: row.relationshipType,
+      match_method: row.matchMethod,
+      review_status: row.reviewStatus,
+      confidence: row.confidence,
+      note: row.note,
+      metadata: {
+        manifestId: yearPlan.manifest.id,
+        resultUnitCode: row.reportingUnitCode,
+        sourceFeatureId: row.sourceFeatureId,
+        publicDeliveryAuthorized: false,
+        ...executionMetadata(context),
+      },
+    }));
+    if (records.some((row) => !row.reporting_unit_id || !row.geography_feature_id)) {
+      throw new Error("Maine " + yearPlan.year + " cannot resolve crosswalk UUIDs");
+    }
+    await query(tx, [
+      "insert into reporting_unit_geometry_crosswalks (reporting_unit_id,",
+      " geometry_version_id,geography_feature_id,relationship_type,match_method,",
+      " review_status,confidence,source_document_id,reviewed_by,note,metadata)",
+      "select incoming.reporting_unit_id,$1::uuid,incoming.geography_feature_id,",
+      " incoming.relationship_type,incoming.match_method,incoming.review_status,",
+      " incoming.confidence,$2::uuid,$3,incoming.note,",
+      " incoming.metadata",
+      "from jsonb_to_recordset($4::text::jsonb) incoming (",
+      " reporting_unit_id uuid,geography_feature_id uuid,relationship_type text,",
+      " match_method text,review_status text,confidence text,note text,metadata jsonb)",
+    ], [versionId, sourceDocumentId, context.reviewedBy, JSON.stringify(records)]);
+  }
+  const counts = await query(tx, [
+    "select count(*)::int total,",
+    " count(*) filter (where review_status='reviewed')::int reviewed",
+    "from reporting_unit_geometry_crosswalks",
+    "where geometry_version_id=$1::uuid",
+  ], [versionId]);
+  const expected = yearPlan.geometry.crosswalks.length;
+  if (["total", "reviewed"]
+    .some((key) => Number(counts[0][key]) !== expected)) {
+    throw new Error("Maine " + yearPlan.year + " crosswalk count drifted");
+  }
+  return { geographyVersions: 1, features: storedFeatures.length, crosswalks: expected };
+}
+
+async function applyYear(tx, yearPlan, context) {
+  const ids = await electionAndContest(tx, yearPlan);
+  await clearLocalReplayRows(
+    tx,
+    yearPlan,
+    ids.electionId,
+    ids.contestId,
+    context,
+  );
+  await candidates(tx, ids.contestId, yearPlan);
+
+  const resultSourceId = await sourceDocument(tx, {
+    slug: yearPlan.resultSource.slug,
+    year: yearPlan.year,
+    category: "Reviewed source-specific presidential local reporting results",
+    title: "Maine " + yearPlan.year + " presidential local reporting results",
+    sourceUrl: yearPlan.resultSource.url,
+    authority: yearPlan.resultSource.authority,
+    localArtifact: yearPlan.resultSource.artifact,
+    parser: context.resultParser,
+    timestampBasis: yearPlan.resultSource.timestampBasis,
+    confidence: "The plan retains each Maine source's official, reconstructed, and temporal caveats; these local reporting rows never replace certified county/state totals.",
+    status: "loaded",
+    metadata: {
+      sourceId: yearPlan.resultSource.id,
+      sha256: yearPlan.resultSource.sha256,
+      byteCount: yearPlan.resultSource.byteCount,
+      electionEventId: yearPlan.electionId,
+      reportingUnits: yearPlan.reportingUnits.length,
+      zeroVoteUnits: yearPlan.zeroVoteUnits,
+      totals: yearPlan.totals,
+      supplementalArtifacts: yearPlan.resultSource.supplementalArtifacts ?? [],
+      publicDeliveryAuthorized: false,
+      ...executionMetadata(context),
+    },
+  });
+  const geometrySourceId = await sourceDocument(tx, {
+    slug: yearPlan.geometrySourceSlug,
+    year: yearPlan.year,
+    category: yearPlan.geometry.disposition === "blocked"
+      ? "Local reporting geometry availability evidence"
+      : "Reviewed election-applicable statewide local reporting boundaries",
+    title: "Maine " + yearPlan.year + " local reporting geometry package",
+    sourceUrl: yearPlan.manifest.source.url,
+    authority: yearPlan.manifest.source.authority,
+    localArtifact: yearPlan.manifest.source.artifact,
+    parser: yearPlan.manifest.normalization.script,
+    timestampBasis: yearPlan.manifest.geography.boundaryVintage,
+    confidence: yearPlan.geometry.disposition === "blocked"
+      ? "Retained official evidence; geometry remains fail-closed."
+      : "Reviewed election-specific local reporting package with the exact source-local crosswalk and retained provenance caveats.",
+    status: yearPlan.geometry.disposition === "blocked" ? "needs_data" : "loaded",
+    metadata: {
+      manifestId: yearPlan.manifest.id,
+      manifestPath: yearPlan.manifestPath,
+      manifestSha256: yearPlan.manifestSha256,
+      manifestByteCount: yearPlan.manifestByteCount,
+      source: {
+        artifact: yearPlan.manifest.source.artifact,
+        sha256: yearPlan.manifest.source.sha256,
+        byteCount: yearPlan.artifactByteCounts.source,
+      },
+      normalization: {
+        artifact: yearPlan.manifest.normalization.artifact,
+        sha256: yearPlan.manifest.normalization.sha256,
+        byteCount: yearPlan.artifactByteCounts.normalization,
+      },
+      crosswalk: {
+        artifact: yearPlan.manifest.crosswalk.artifact,
+        sha256: yearPlan.manifest.crosswalk.sha256,
+        byteCount: yearPlan.artifactByteCounts.crosswalk,
+      },
+      geometryDisposition: yearPlan.geometry.disposition,
+      blockCode: yearPlan.geometry.blockCode,
+      licenseOrTerms: yearPlan.manifest.source.licenseOrTerms,
+      publicDeliveryAuthorized: false,
+      ...executionMetadata(context),
+    },
+  });
+
+  const runId = await importRun(tx, yearPlan, resultSourceId, context);
+  const unitIds = await reportingUnits(
+    tx,
+    yearPlan,
+    ids.electionId,
+    resultSourceId,
+    context,
+  );
+  await results(tx, yearPlan, ids.contestId, runId, resultSourceId, unitIds);
+  const geometryCounts = await geometry(
+    tx,
+    yearPlan,
+    ids.electionId,
+    geometrySourceId,
+    unitIds,
+    context,
+  );
+  return {
+    year: yearPlan.year,
+    electionId: yearPlan.electionId,
+    reportingUnits: unitIds.size,
+    resultRows: yearPlan.resultRows.length,
+    zeroVoteUnits: yearPlan.zeroVoteUnits,
+    totals: yearPlan.totals,
+    geometryDisposition: yearPlan.geometry.disposition,
+    ...geometryCounts,
+  };
+}
+
+export async function applyMaineLocalGisTransaction(
+  tx,
+  plan,
+  options = {},
+) {
+  const context = buildMaineLocalExecutionContext(
+    options.executionContext,
+  );
+  const identity = await query(tx, [
+    "select current_database() database_name,",
+    " current_setting('transaction_read_only') transaction_read_only",
+  ]);
+  if (
+    identity.length !== 1
+    || String(identity[0].transaction_read_only) !== "off"
+    || String(identity[0].database_name) !== context.database.name
+  ) {
+    throw new Error(
+      "Maine local reporting unit release transaction database identity or write mode drifted",
+    );
+  }
+
+  await query(tx, "select set_config('lock_timeout','30s',true)");
+  await query(
+    tx,
+    "select pg_advisory_xact_lock(hashtextextended('crm-me-local-gis-release-v1',0))",
+  );
+  const tables = await query(tx, [
+    "select count(*)::int count from unnest(array[",
+    " 'elections','contests','candidates','source_documents','import_runs',",
+    " 'result_rows','reporting_units','geography_versions','geography_features',",
+    " 'reporting_unit_geometry_crosswalks']) required(name)",
+    "where to_regclass('public.'||required.name) is not null",
+  ]);
+  if (Number(tables[0].count) !== 10) {
+    throw new Error(
+      context.database.name + " lacks the complete migration 0008 local geography schema",
+    );
+  }
+  if (context.mode === "production_release") {
+    const targetYears = plan.years.map((year) => year.year);
+    const existing = await query(tx, [
+      "select",
+      " (select count(*)::int from reporting_units ru",
+      "  join elections e on e.id=ru.election_id",
+      "  where ru.state_code='ME' and ru.reporting_grain='local_reporting_unit'",
+      "   and e.office='president' and e.year=any($1::int[])) reporting_units,",
+      " (select count(*)::int from result_rows rr",
+      "  join contests c on c.id=rr.contest_id",
+      "  join elections e on e.id=c.election_id",
+      "  where rr.state_code='ME' and rr.level='local_reporting_unit'",
+      "   and e.office='president' and e.year=any($1::int[])) result_rows,",
+      " (select count(*)::int from geography_versions gv",
+      "  join elections e on e.id=gv.election_id",
+      "  where gv.state_code='ME' and gv.geography_type='local_reporting_unit'",
+      "   and e.office='president' and e.year=any($1::int[])) geography_versions",
+    ], [targetYears]);
+    const counts = existing[0] ?? {};
+    if (
+      Number(counts.reporting_units) !== 0
+      || Number(counts.result_rows) !== 0
+      || Number(counts.geography_versions) !== 0
+    ) {
+      throw new Error(
+        "Maine production hidden load refuses existing local reporting release rows; "
+        + "use read-only receipt recovery or a separately reviewed rollback path",
+      );
+    }
+  }
+  await query(tx, [
+    "insert into states (code,name,authority) values ($1,$2,$3)",
+    "on conflict (code) do update set name=excluded.name,authority=excluded.authority",
+  ], [STATE, plan.stateName, plan.authority]);
+
+  const years = [];
+  for (const yearPlan of plan.years) {
+    years.push(await applyYear(tx, yearPlan, context));
+    if (
+      process.env.NODE_ENV === "test"
+      && options.testOnlyFailAfterYear === yearPlan.year
+    ) {
+      throw new Error("Intentional Maine GIS rollback after " + yearPlan.year);
+    }
+  }
+  const revisions = await query(tx, [
+    "insert into public_data_revisions (scope,revision,updated_at,reason)",
+    "values ('public',1,now(),$1)",
+    "on conflict (scope) do update set",
+    " revision=public_data_revisions.revision+1,updated_at=now(),reason=excluded.reason",
+    "returning revision::int revision",
+  ], [context.revisionReason]);
+  return {
+    database: context.database,
+    executionMode: context.mode,
+    productionMutationPerformed: context.mode === "production_release",
+    publicDeliveryAuthorized: false,
+    releaseCandidate: context.releaseCandidate,
+    productionReleaseAudit: context.productionReleaseAudit,
+    revision: Number(revisions[0].revision),
+    years,
+  };
+}
+
+export async function applyMaineLocalGisPlan(plan, options = {}) {
+  if (getDatabaseDriver() !== "postgres") {
+    throw new Error("Maine local GIS setup requires CRM_DATABASE_DRIVER=postgres");
+  }
+  const databaseUrl = getLocalCloneDatabaseUrl({ requireWriteOptIn: true });
+  const sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+    max: 1,
+    connect_timeout: 10,
+    idle_timeout: 20,
+    connection: { application_name: APPLICATION_NAME },
+  });
+  try {
+    return await sql.begin((tx) => applyMaineLocalGisTransaction(
+      tx,
+      plan,
+      {
+        executionContext: { mode: "local" },
+        testOnlyFailAfterYear: options.testOnlyFailAfterYear,
+      },
+    ));
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+async function validateSourceDocumentRecords(sql, yearPlan, context) {
+  const rows = await query(sql, [
+    "select slug,election_year,category,title,source_url,authority,local_artifact,",
+    " parser,timestamp_basis,status,metadata",
+    "from source_documents where state_code=$1 and slug in ($2,$3)",
+  ], [STATE, yearPlan.resultSource.slug, yearPlan.geometrySourceSlug]);
+  if (rows.length !== 2) {
+    throw new Error("Maine " + yearPlan.year + " source-document count drifted");
+  }
+  const bySlug = new Map(rows.map((row) => [String(row.slug), row]));
+  const result = bySlug.get(yearPlan.resultSource.slug);
+  const geometry = bySlug.get(yearPlan.geometrySourceSlug);
+  const resultMetadata = result?.metadata ?? {};
+  const geometryMetadata = geometry?.metadata ?? {};
+  if (
+    !result
+    || Number(result.election_year) !== yearPlan.year
+    || String(result.source_url) !== yearPlan.resultSource.url
+    || String(result.authority) !== yearPlan.resultSource.authority
+    || String(result.local_artifact) !== yearPlan.resultSource.artifact
+    || String(result.parser) !== context.resultParser
+    || String(result.timestamp_basis) !== yearPlan.resultSource.timestampBasis
+    || String(result.status) !== "loaded"
+    || resultMetadata.sha256 !== yearPlan.resultSource.sha256
+    || Number(resultMetadata.byteCount) !== yearPlan.resultSource.byteCount
+    || resultMetadata.electionEventId !== yearPlan.electionId
+    || resultMetadata.publicDeliveryAuthorized !== false
+    || JSON.stringify(canonicalJson(resultMetadata.supplementalArtifacts ?? []))
+      !== JSON.stringify(canonicalJson(yearPlan.resultSource.supplementalArtifacts ?? []))
+    || JSON.stringify(canonicalJson(resultMetadata.releaseCandidate ?? null))
+      !== JSON.stringify(canonicalJson(context.releaseCandidate))
+    || JSON.stringify(canonicalJson(resultMetadata.productionReleaseAudit ?? null))
+      !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
+  ) {
+    throw new Error("Maine " + yearPlan.year + " result provenance drifted");
+  }
+  const geometryStatus = yearPlan.geometry.disposition === "blocked" ? "needs_data" : "loaded";
+  if (
+    !geometry
+    || Number(geometry.election_year) !== yearPlan.year
+    || String(geometry.source_url) !== yearPlan.manifest.source.url
+    || String(geometry.authority) !== yearPlan.manifest.source.authority
+    || String(geometry.local_artifact) !== yearPlan.manifest.source.artifact
+    || String(geometry.parser) !== yearPlan.manifest.normalization.script
+    || String(geometry.timestamp_basis) !== yearPlan.manifest.geography.boundaryVintage
+    || String(geometry.status) !== geometryStatus
+    || geometryMetadata.manifestId !== yearPlan.manifest.id
+    || geometryMetadata.manifestPath !== yearPlan.manifestPath
+    || geometryMetadata.manifestSha256 !== yearPlan.manifestSha256
+    || Number(geometryMetadata.manifestByteCount) !== yearPlan.manifestByteCount
+    || geometryMetadata.source?.artifact !== yearPlan.manifest.source.artifact
+    || geometryMetadata.source?.sha256 !== yearPlan.manifest.source.sha256
+    || Number(geometryMetadata.source?.byteCount) !== yearPlan.artifactByteCounts.source
+    || geometryMetadata.normalization?.artifact !== yearPlan.manifest.normalization.artifact
+    || geometryMetadata.normalization?.sha256 !== yearPlan.manifest.normalization.sha256
+    || Number(geometryMetadata.normalization?.byteCount)
+      !== yearPlan.artifactByteCounts.normalization
+    || geometryMetadata.crosswalk?.artifact !== yearPlan.manifest.crosswalk.artifact
+    || geometryMetadata.crosswalk?.sha256 !== yearPlan.manifest.crosswalk.sha256
+    || Number(geometryMetadata.crosswalk?.byteCount) !== yearPlan.artifactByteCounts.crosswalk
+    || geometryMetadata.licenseOrTerms !== yearPlan.manifest.source.licenseOrTerms
+    || geometryMetadata.blockCode !== yearPlan.geometry.blockCode
+    || geometryMetadata.geometryDisposition !== yearPlan.geometry.disposition
+    || geometryMetadata.publicDeliveryAuthorized !== false
+    || JSON.stringify(canonicalJson(geometryMetadata.releaseCandidate ?? null))
+      !== JSON.stringify(canonicalJson(context.releaseCandidate))
+    || JSON.stringify(canonicalJson(geometryMetadata.productionReleaseAudit ?? null))
+      !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
+  ) {
+    throw new Error("Maine " + yearPlan.year + " geometry provenance drifted");
+  }
+  return {
+    resultSourceSlug: yearPlan.resultSource.slug,
+    geometrySourceSlug: yearPlan.geometrySourceSlug,
+  };
+}
+
+async function validateStoredProductionAudit(
+  sql,
+  yearPlan,
+  electionId,
+  context,
+) {
+  if (!context.releaseCandidate) return;
+  const audit = JSON.stringify(context.productionReleaseAudit);
+  // `audit` is serialized JSON text. Preserve the intermediate text cast so
+  // Postgres.js does not encode the parameter as a JSON string scalar.
+  const units = await query(sql, [
+    "select count(*)::int total,",
+    " count(*) filter (where metadata->'productionReleaseAudit'=$3::text::jsonb)::int exact_audit",
+    "from reporting_units where state_code=$1 and election_id=$2::uuid",
+    " and reporting_grain='local_reporting_unit'",
+  ], [STATE, electionId, audit]);
+  if (
+    Number(units[0]?.total) !== yearPlan.reportingUnits.length
+    || Number(units[0]?.exact_audit) !== yearPlan.reportingUnits.length
+  ) {
+    throw new Error("Maine " + yearPlan.year + " reporting-unit release audit drifted");
+  }
+  const imports = await query(sql, [
+    "select count(distinct ir.id)::int import_runs,count(rr.id)::int result_rows,",
+    " count(rr.id) filter (where ir.summary->'productionReleaseAudit'=$4::text::jsonb)::int exact_audit_rows",
+    "from import_runs ir",
+    "join result_rows rr on rr.import_run_id=ir.id and rr.state_code=$1",
+    "join contests c on c.id=rr.contest_id and c.election_id=$2::uuid",
+    "where ir.state_code=$1 and ir.election_year=$3 and ir.parser=$5",
+    " and rr.level='local_reporting_unit'",
+  ], [STATE, electionId, yearPlan.year, audit, context.importParser]);
+  if (
+    Number(imports[0]?.import_runs) !== 1
+    || Number(imports[0]?.result_rows) !== yearPlan.resultRows.length
+    || Number(imports[0]?.exact_audit_rows) !== yearPlan.resultRows.length
+  ) {
+    throw new Error("Maine " + yearPlan.year + " import-run release audit drifted");
+  }
+}
+
+async function validateStoredGeometryRecords(sql, yearPlan, electionId, context) {
+  if (yearPlan.geometry.disposition === "blocked") {
+    return { exactFeatures: 0, exactCrosswalks: 0 };
+  }
+  const versions = await query(sql, [
+    "select metadata from geography_versions",
+    "where state_code=$1 and election_id=$2::uuid and geography_type='local_reporting_unit'",
+  ], [STATE, electionId]);
+  const expectedVersionMetadata = {
+    manifestId: yearPlan.manifest.id,
+    manifestPath: yearPlan.manifestPath,
+    manifestSha256: yearPlan.manifestSha256,
+    manifestByteCount: yearPlan.manifestByteCount,
+    source: {
+      artifact: yearPlan.manifest.source.artifact,
+      sha256: yearPlan.manifest.source.sha256,
+      byteCount: yearPlan.artifactByteCounts.source,
+    },
+    normalization: {
+      artifact: yearPlan.manifest.normalization.artifact,
+      sha256: yearPlan.manifest.normalization.sha256,
+      byteCount: yearPlan.artifactByteCounts.normalization,
+      featureCount: yearPlan.geometry.features.length,
+    },
+    crosswalk: {
+      artifact: yearPlan.manifest.crosswalk.artifact,
+      sha256: yearPlan.manifest.crosswalk.sha256,
+      byteCount: yearPlan.artifactByteCounts.crosswalk,
+      reviewedRelationships: yearPlan.geometry.crosswalks.length,
+      reviewedNoDataFeatures:
+        yearPlan.manifest.crosswalk.reviewedNoDataFeatures,
+    },
+    licenseOrTerms: yearPlan.manifest.source.licenseOrTerms,
+    publicDeliveryAuthorized: false,
+    ...executionMetadata(context),
+  };
+  if (
+    versions.length !== 1
+    || JSON.stringify(canonicalJson(versions[0].metadata))
+      !== JSON.stringify(canonicalJson(expectedVersionMetadata))
+  ) {
+    throw new Error("Maine " + yearPlan.year + " geography-version provenance drifted");
+  }
+  const features = await query(sql, [
+    "select gf.source_feature_id,gf.parent_geoid,gf.name,gf.geometry_key,",
+    " gf.is_geographic,gf.properties",
+    "from geography_features gf",
+    "join geography_versions gv on gv.id=gf.geometry_version_id",
+    "where gv.state_code=$1 and gv.election_id=$2::uuid",
+    " and gv.geography_type='local_reporting_unit' and gv.metadata->>'manifestId'=$3",
+    "order by gf.source_feature_id",
+  ], [STATE, electionId, yearPlan.manifest.id]);
+  const expectedFeatures = new Map(
+    yearPlan.geometry.features.map((feature) => [feature.sourceFeatureId, feature]),
+  );
+  if (features.length !== expectedFeatures.size) {
+    throw new Error("Maine " + yearPlan.year + " exact feature count drifted");
+  }
+  const seenFeatures = new Set();
+  for (const row of features) {
+    const sourceFeatureId = String(row.source_feature_id);
+    const expected = expectedFeatures.get(sourceFeatureId);
+    assertNoElectionValueProperties(
+      row.properties,
+      "Maine " + yearPlan.year + " stored feature " + sourceFeatureId,
+    );
+    if (
+      !expected
+      || seenFeatures.has(sourceFeatureId)
+      || String(row.parent_geoid) !== expected.parentGeoid
+      || String(row.name) !== expected.name
+      || String(row.geometry_key) !== expected.geometryKey
+      || row.is_geographic !== expected.isGeographic
+      || JSON.stringify(canonicalJson(row.properties))
+        !== JSON.stringify(canonicalJson(expected.properties))
+    ) {
+      throw new Error("Maine " + yearPlan.year + " stored feature drifted at " + sourceFeatureId);
+    }
+    seenFeatures.add(sourceFeatureId);
+  }
+
+  const crosswalks = await query(sql, [
+    "select ru.reporting_grain,ru.parent_geoid,ru.source_unit_id,",
+    " gf.source_feature_id,x.relationship_type,x.match_method,x.review_status,",
+    " x.confidence,x.reviewed_by,x.note,x.metadata",
+    "from reporting_unit_geometry_crosswalks x",
+    "join geography_versions gv on gv.id=x.geometry_version_id",
+    "join reporting_units ru on ru.id=x.reporting_unit_id",
+    "join geography_features gf on gf.id=x.geography_feature_id",
+    "join source_documents sd on sd.id=x.source_document_id",
+    "where gv.state_code=$1 and gv.election_id=$2::uuid",
+    " and ru.state_code=$1 and ru.election_id=$2::uuid",
+    " and gv.metadata->>'manifestId'=$3 and sd.slug=$4",
+    "order by ru.parent_geoid,ru.source_unit_id",
+  ], [STATE, electionId, yearPlan.manifest.id, yearPlan.geometrySourceSlug]);
+  const expectedCrosswalks = new Map(yearPlan.geometry.crosswalks.map((crosswalk) => [
+    `${crosswalk.reportingUnitCode}|${crosswalk.sourceFeatureId}`,
+    crosswalk,
+  ]));
+  if (crosswalks.length !== expectedCrosswalks.size) {
+    throw new Error("Maine " + yearPlan.year + " exact crosswalk count drifted");
+  }
+  const seenCrosswalks = new Set();
+  for (const row of crosswalks) {
+    const reportingCode = reportingUnitCode({
+      state: STATE,
+      electionId: yearPlan.electionId,
+      reportingGrain: String(row.reporting_grain),
+      parentGeoid: row.parent_geoid ? String(row.parent_geoid) : null,
+      sourceUnitId: String(row.source_unit_id),
+    });
+    const crosswalkKey = `${reportingCode}|${row.source_feature_id}`;
+    const expected = expectedCrosswalks.get(crosswalkKey);
+    const metadata = row.metadata ?? {};
+    if (
+      !expected
+      || seenCrosswalks.has(crosswalkKey)
+      || String(row.source_feature_id) !== expected.sourceFeatureId
+      || String(row.relationship_type) !== expected.relationshipType
+      || String(row.match_method) !== expected.matchMethod
+      || String(row.review_status) !== expected.reviewStatus
+      || String(row.confidence) !== expected.confidence
+      || String(row.reviewed_by) !== context.reviewedBy
+      || String(row.note ?? "") !== expected.note
+      || metadata.manifestId !== yearPlan.manifest.id
+      || metadata.resultUnitCode !== reportingCode
+      || metadata.sourceFeatureId !== expected.sourceFeatureId
+      || metadata.publicDeliveryAuthorized !== false
+      || JSON.stringify(canonicalJson(metadata.releaseCandidate ?? null))
+        !== JSON.stringify(canonicalJson(context.releaseCandidate))
+      || JSON.stringify(canonicalJson(metadata.productionReleaseAudit ?? null))
+        !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
+    ) {
+      throw new Error("Maine " + yearPlan.year + " stored crosswalk drifted at " + reportingCode);
+    }
+    seenCrosswalks.add(crosswalkKey);
+  }
+  return { exactFeatures: features.length, exactCrosswalks: crosswalks.length };
+}
+
+export async function readMainePersistedProductionReleaseAudit(
+  sql,
+  releaseCandidate,
+) {
+  if (
+    typeof releaseCandidate?.id !== "string"
+    || !/^[a-f0-9]{64}$/.test(releaseCandidate?.sha256 ?? "")
+  ) {
+    throw new Error("Maine hidden receipt recovery requires an exact release candidate");
+  }
+  const rows = await query(sql, [
+    "select e.year,gv.status,gv.metadata",
+    "from geography_versions gv",
+    "join elections e on e.id=gv.election_id",
+    "where gv.state_code='ME' and gv.geography_type='local_reporting_unit'",
+    " and gv.metadata->'releaseCandidate'->>'id'=$1",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$2",
+    "order by e.year",
+  ], [releaseCandidate.id, releaseCandidate.sha256]);
+  const expectedYears = [2016, 2020, 2024];
+  if (
+    rows.length !== expectedYears.length
+    || rows.some((row, index) => Number(row.year) !== expectedYears[index])
+  ) {
+    throw new Error("Maine hidden receipt recovery found an incomplete year set");
+  }
+  const firstAudit = rows[0]?.metadata?.productionReleaseAudit;
+  const audit = validatedProductionReleaseAudit(firstAudit);
+  for (const row of rows) {
+    if (
+      String(row.status) !== "blocked"
+      || row.metadata?.publicDeliveryAuthorized !== false
+      || JSON.stringify(canonicalJson(row.metadata?.releaseCandidate ?? null))
+        !== JSON.stringify(canonicalJson({
+          id: releaseCandidate.id,
+          sha256: releaseCandidate.sha256,
+          publicDeliveryAuthorized: false,
+        }))
+      || JSON.stringify(canonicalJson(row.metadata?.productionReleaseAudit ?? null))
+        !== JSON.stringify(canonicalJson(audit))
+    ) {
+      throw new Error("Maine hidden receipt recovery audit drifted across years");
+    }
+  }
+  return audit;
+}
+
+export async function validateMaineLocalGisClient(
+  sql,
+  plan,
+  options = {},
+) {
+    const context = buildMaineLocalExecutionContext(
+      options.executionContext,
+    );
+    const output = [];
+    for (const yearPlan of plan.years) {
+      const rows = await query(sql, [
+        "select e.id election_id,",
+        " (select count(*)::int from reporting_units ru",
+        "  where ru.state_code=$1 and ru.election_id=e.id",
+        "   and ru.reporting_grain='local_reporting_unit') reporting_units,",
+        " (select count(*)::int from result_rows rr join contests c on c.id=rr.contest_id",
+        "  where rr.state_code=$1 and c.election_id=e.id and c.office='president'",
+        "   and rr.level='local_reporting_unit' and rr.jurisdiction_code like $3) result_rows,",
+        " (select count(*)::int from result_rows rr",
+        "  join contests c on c.id=rr.contest_id",
+        "  join reporting_units ru on ru.id=rr.reporting_unit_id",
+        "  where rr.state_code=$1 and c.election_id=e.id and c.office='president'",
+        "   and rr.level='local_reporting_unit' and rr.jurisdiction_code like $3",
+        "   and ru.state_code=$1 and ru.election_id=e.id and ru.reporting_grain='local_reporting_unit')",
+        "  same_year_result_rows,",
+        " (select count(*)::int from geography_versions gv",
+        "  where gv.state_code=$1 and gv.election_id=e.id",
+        "   and gv.geography_type='local_reporting_unit') geography_versions,",
+        " (select count(*)::int from geography_versions gv",
+        "  where gv.state_code=$1 and gv.election_id=e.id",
+        "   and gv.geography_type='local_reporting_unit' and gv.status='blocked'",
+        "   and gv.metadata->>'manifestId'=$4::text and gv.metadata->>'manifestSha256'=$5::text",
+        "   and gv.metadata->>'publicDeliveryAuthorized'='false')",
+        "  safe_geography_versions,",
+        " (select count(*)::int from geography_features gf",
+        "  join geography_versions gv on gv.id=gf.geometry_version_id",
+        "  where gv.state_code=$1 and gv.election_id=e.id",
+        "   and gv.geography_type='local_reporting_unit') features,",
+        " (select count(*)::int from reporting_unit_geometry_crosswalks x",
+        "  join geography_versions gv on gv.id=x.geometry_version_id",
+        "  join reporting_units ru on ru.id=x.reporting_unit_id",
+        "  where gv.state_code=$1 and gv.election_id=e.id and ru.election_id=e.id",
+        "   and x.review_status='reviewed') crosswalks",
+        "from elections e where e.year=$2 and e.office='president'",
+      ], [
+        STATE,
+        yearPlan.year,
+        "reporting:" + STATE + ":" + yearPlan.electionId + ":%",
+        yearPlan.manifest.id,
+        yearPlan.manifestSha256,
+      ]);
+      if (rows.length !== 1) throw new Error("Missing " + yearPlan.year + " election");
+      const row = rows[0];
+      const expectedGeometry = yearPlan.geometry.disposition === "blocked"
+        ? { versions: 0, features: 0, crosswalks: 0 }
+        : {
+          versions: 1,
+          features: yearPlan.geometry.features.length,
+          crosswalks: yearPlan.geometry.crosswalks.length,
+        };
+      if (
+        Number(row.reporting_units) !== yearPlan.reportingUnits.length
+        || Number(row.result_rows) !== yearPlan.resultRows.length
+        || Number(row.geography_versions) !== expectedGeometry.versions
+        || Number(row.features) !== expectedGeometry.features
+        || Number(row.same_year_result_rows) !== yearPlan.resultRows.length
+        || Number(row.crosswalks) !== expectedGeometry.crosswalks
+        || Number(row.safe_geography_versions) !== expectedGeometry.versions
+      ) {
+        throw new Error("Maine " + yearPlan.year + " database counts drifted: " + JSON.stringify({
+          actual: row,
+          expected: {
+            reportingUnits: yearPlan.reportingUnits.length,
+            resultRows: yearPlan.resultRows.length,
+            sameYearResultRows: yearPlan.resultRows.length,
+            geographyVersions: expectedGeometry.versions,
+            features: expectedGeometry.features,
+            crosswalks: expectedGeometry.crosswalks,
+            safeGeographyVersions: expectedGeometry.versions,
+          },
+        }));
+      }
+      const provenance = await validateSourceDocumentRecords(
+        sql,
+        yearPlan,
+        context,
+      );
+      await validateStoredProductionAudit(
+        sql,
+        yearPlan,
+        row.election_id,
+        context,
+      );
+      const exactGeometry = await validateStoredGeometryRecords(
+        sql,
+        yearPlan,
+        row.election_id,
+        context,
+      );
+
+      const totals = await query(sql, [
+        "select candidate_name,sum(votes)::bigint votes from result_rows rr",
+        "join contests c on c.id=rr.contest_id",
+        "where rr.state_code=$1 and c.election_id=$2::uuid and rr.level='local_reporting_unit'",
+        " and rr.jurisdiction_code like $3",
+        "group by candidate_name order by candidate_name",
+      ], [
+        STATE,
+        row.election_id,
+        "reporting:" + STATE + ":" + yearPlan.electionId + ":%",
+      ]);
+      const actualTotals = Object.fromEntries(
+        totals.map((item) => [String(item.candidate_name), Number(item.votes)]),
+      );
+      const democraticName = yearPlan.resultRows.find((row) => row.party === "DEM")?.candidateName;
+      const republicanName = yearPlan.resultRows.find((row) => row.party === "REP")?.candidateName;
+      if (!democraticName || !republicanName) {
+        throw new Error("Maine " + yearPlan.year + " major-party candidate grouping drifted");
+      }
+      const expectedTotals = {
+        [democraticName]: yearPlan.totals.Democratic,
+        [republicanName]: yearPlan.totals.Republican,
+        Other: yearPlan.totals.Other,
+        ...(yearPlan.totals.Suppressed > 0
+          ? { "Candidate detail suppressed by official source": yearPlan.totals.Suppressed }
+          : {}),
+      };
+      for (const [name, votes] of Object.entries(expectedTotals)) {
+        if (actualTotals[name] !== votes) {
+          throw new Error("Maine " + yearPlan.year + " " + name + " total drifted");
+        }
+      }
+      if (Object.keys(actualTotals).length !== Object.keys(expectedTotals).length) {
+        throw new Error("Maine " + yearPlan.year + " candidate grouping drifted");
+      }
+      const zero = await query(sql, [
+        "select count(*)::int count from (",
+        " select rr.reporting_unit_id from result_rows rr",
+        " join contests c on c.id=rr.contest_id",
+        " where rr.state_code=$1 and c.election_id=$2::uuid and rr.level='local_reporting_unit'",
+        "  and rr.jurisdiction_code like $3",
+        " group by rr.reporting_unit_id having sum(rr.votes)=0) units",
+      ], [
+        STATE,
+        row.election_id,
+        "reporting:" + STATE + ":" + yearPlan.electionId + ":%",
+      ]);
+      if (Number(zero[0].count) !== yearPlan.zeroVoteUnits) {
+        throw new Error("Maine " + yearPlan.year + " zero-vote count drifted");
+      }
+      output.push({
+        year: yearPlan.year,
+        electionId: yearPlan.electionId,
+        reportingUnits: Number(row.reporting_units),
+        resultRows: Number(row.result_rows),
+        sameYearResultRows: Number(row.same_year_result_rows),
+        candidateTotals: actualTotals,
+        totalVotes: Object.values(actualTotals).reduce((sum, value) => sum + value, 0),
+        zeroVoteUnits: Number(zero[0].count),
+        resultSourceSlug: provenance.resultSourceSlug,
+        geometrySourceSlug: provenance.geometrySourceSlug,
+        geometryDisposition: yearPlan.geometry.disposition,
+        geographyVersions: Number(row.geography_versions),
+        features: Number(row.features),
+        safeBlockedGeographyVersions: Number(row.safe_geography_versions),
+        reviewedCrosswalks: Number(row.crosswalks),
+        exactFeatures: exactGeometry.exactFeatures,
+        exactCrosswalks: exactGeometry.exactCrosswalks,
+      });
+    }
+    const invalid = await query(sql, [
+      "select count(*)::int count from pg_constraint",
+      "where connamespace='public'::regnamespace and not convalidated",
+    ]);
+    if (Number(invalid[0].count) !== 0) {
+      throw new Error("Maine local reporting unit database has unvalidated public constraints");
+    }
+    const revision = await query(sql, [
+      "select revision::int revision from public_data_revisions where scope='public'",
+    ]);
+    return {
+      database: {
+        ...context.database,
+        readOnlySession: options.readOnlySession ?? context.mode === "local",
+      },
+      executionMode: context.mode,
+      productionMutationPerformed: context.mode === "production_release",
+      publicDeliveryAuthorized: false,
+      releaseCandidate: context.releaseCandidate,
+      productionReleaseAudit: context.productionReleaseAudit,
+      invalidConstraints: 0,
+      revision: revision.length ? Number(revision[0].revision) : null,
+      years: output,
+    };
+}
+
+export async function validateMaineLocalGisDatabase(plan, options = {}) {
+  if (getDatabaseDriver() !== "postgres") {
+    throw new Error("Maine local GIS validation requires CRM_DATABASE_DRIVER=postgres");
+  }
+  const databaseUrl = getLocalCloneDatabaseUrl();
+  const sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+    max: 1,
+    connect_timeout: 10,
+    idle_timeout: 20,
+    connection: {
+      application_name: APPLICATION_NAME + "-validator",
+      default_transaction_read_only: true,
+    },
+  });
+  try {
+    return await validateMaineLocalGisClient(sql, plan, {
+      executionContext: { mode: "local" },
+      readOnlySession: true,
+    });
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}

--- a/scripts/lib/me-local-gis-plan.mjs
+++ b/scripts/lib/me-local-gis-plan.mjs
@@ -1,0 +1,501 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+import {
+  inspectPrecinctGeometryManifest,
+  reportingUnitCode,
+} from "../../src/lib/precinct-geography.ts";
+import { validateManifestArtifacts } from "./precinct-geometry-validation.mjs";
+
+const STATE = "ME";
+const GEOGRAPHY_LEVEL = "local_reporting_unit";
+const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+export const MAINE_LOCAL_GIS_YEAR_SPECS = Object.freeze([
+  {
+    year: 2016,
+    electionId: "2016-11-08-general",
+    electionDate: "2016-11-08",
+    manifestSha256: "585320793abfa81b524f6ab440b5f265f7ecdda503e6068688ce9aa05bdae2eb",
+    manifestByteCount: 4_122,
+    geometryByteCount: 2_465_979,
+    resultsSha256: "eee124e13eaa5ddc337a71d8f8ac764107d046bb2b56c0902525ea3ce8d82a50",
+    resultsByteCount: 21_370,
+    crosswalkByteCount: 446_258,
+    expectedUnits: 532,
+    expectedFeatures: 532,
+    expectedCrosswalkRecords: 532,
+    expectedNoDataFeatures: 0,
+    expectedTotalVotes: 743_941,
+    democratic: { name: "Hillary Clinton", party: "DEM" },
+    republican: { name: "Donald Trump", party: "REP" },
+    resultSource: {
+      id: "me-2016-president-local-results",
+      slug: "me-2016-sos-president-local-results",
+      url: "https://www.maine.gov/sos/sites/maine.gov.sos/files/content/assets/president.xlsx",
+      artifact: "data/precinct-geometry/ME/2016-11-08-general/normalized/me-2016-president-local-results.json.gz",
+      sha256: "eee124e13eaa5ddc337a71d8f8ac764107d046bb2b56c0902525ea3ce8d82a50",
+      byteCount: 21_370,
+      timestampBasis: "Official Maine Secretary of State presidential municipal and local reporting rows, reconciled without allocating town totals across wards.",
+      authority: "Maine Secretary of State",
+    },
+  },
+  {
+    year: 2020,
+    electionId: "2020-11-03-general",
+    electionDate: "2020-11-03",
+    manifestSha256: "6469acce5cabbcb69f7acde57686ca1186291add736963428879afb1c790936d",
+    manifestByteCount: 4_132,
+    geometryByteCount: 2_426_827,
+    resultsSha256: "e11aaee805b1bc3abc3dd8d8512cd67e9f114bd953b16b837d62c97355e09212",
+    resultsByteCount: 19_412,
+    crosswalkByteCount: 433_882,
+    expectedUnits: 516,
+    expectedFeatures: 516,
+    expectedCrosswalkRecords: 516,
+    expectedNoDataFeatures: 0,
+    expectedTotalVotes: 813_742,
+    democratic: { name: "Joe Biden", party: "DEM" },
+    republican: { name: "Donald Trump", party: "REP" },
+    resultSource: {
+      id: "me-2020-president-local-results",
+      slug: "me-2020-sos-president-local-results",
+      url: "https://www.maine.gov/sos/sites/maine.gov.sos/files/content/assets/presandvisecnty1120.xlsx",
+      artifact: "data/precinct-geometry/ME/2020-11-03-general/normalized/me-2020-president-local-results.json.gz",
+      sha256: "e11aaee805b1bc3abc3dd8d8512cd67e9f114bd953b16b837d62c97355e09212",
+      byteCount: 19_412,
+      timestampBasis: "Official Maine Secretary of State presidential municipal and local reporting rows, reconciled without allocating town totals across wards.",
+      authority: "Maine Secretary of State",
+    },
+  },
+  {
+    year: 2024,
+    electionId: "2024-11-05-general",
+    electionDate: "2024-11-05",
+    manifestSha256: "065b5bdabb91a72490c7c26788c8d75762e7f14548a3f7ca86b38f79800aa001",
+    manifestByteCount: 5_436,
+    geometryByteCount: 5_407_353,
+    resultsSha256: "d60930ed8f1b44cd906f05b52c3378453fc63dfa5eb4ccdd9827d47606fcb10a",
+    resultsByteCount: 19_127,
+    crosswalkByteCount: 416_577,
+    expectedUnits: 494,
+    expectedFeatures: 494,
+    expectedCrosswalkRecords: 494,
+    expectedNoDataFeatures: 0,
+    expectedTotalVotes: 824_806,
+    democratic: { name: "Kamala Harris", party: "DEM" },
+    republican: { name: "Donald Trump", party: "REP" },
+    resultSource: {
+      id: "me-2024-president-local-results",
+      slug: "me-2024-sos-president-local-results",
+      url: "https://www.maine.gov/sos/sites/maine.gov.sos/files/inline-files/President%20and%20Vice%20President%20FINAL-Corrected%2020241205.xlsx",
+      artifact: "data/precinct-geometry/ME/2024-11-05-general/normalized/me-2024-president-local-results.json.gz",
+      sha256: "d60930ed8f1b44cd906f05b52c3378453fc63dfa5eb4ccdd9827d47606fcb10a",
+      byteCount: 19_127,
+      timestampBasis: "Official corrected Maine Secretary of State presidential municipal and local reporting rows; reviewed combined units use exact sums of named official rows.",
+      authority: "Maine Secretary of State",
+    },
+  },
+].map((spec) => Object.freeze({
+  ...spec,
+  manifestPath: `data/precinct-geometry/ME/${spec.electionId}/manifest.json`,
+  resultsPath: `data/precinct-geometry/ME/${spec.electionId}/normalized/me-${spec.year}-president-local-results.json.gz`,
+  geometrySourceSlug: `me-${spec.year}-local-reporting-geometry`,
+})));
+
+function insideRoot(root, relativePath) {
+  if (
+    typeof relativePath !== "string"
+    || path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+  ) {
+    throw new Error(`Unsafe Maine artifact path: ${relativePath}`);
+  }
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, ...relativePath.split("/"));
+  if (
+    resolved !== resolvedRoot
+    && !resolved.startsWith(resolvedRoot + path.sep)
+  ) {
+    throw new Error(`Maine artifact escapes root: ${relativePath}`);
+  }
+  return resolved;
+}
+
+function verified(root, relativePath, expectedSha, expectedBytes, label) {
+  const target = insideRoot(root, relativePath);
+  if (!existsSync(target)) {
+    throw new Error(`${label} is missing: ${relativePath}`);
+  }
+  const bytes = readFileSync(target);
+  if (bytes.length !== expectedBytes || sha256(bytes) !== expectedSha) {
+    throw new Error(`${label} bytes or SHA-256 drifted`);
+  }
+  return bytes;
+}
+
+function forbiddenProperties(value, context) {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => forbiddenProperties(entry, `${context}[${index}]`));
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (/^(?:VOTES?|TOTALVOTES?|CANDIDATE|PARTY|G\d{2}PRE)/i.test(key)) {
+      throw new Error(`${context} contains election-value property ${key}`);
+    }
+    forbiddenProperties(child, `${context}.${key}`);
+  }
+}
+
+function buildResultPlan(spec, document) {
+  if (
+    document.schemaVersion !== 1
+    || document.state !== STATE
+    || document.electionId !== spec.electionId
+    || document.reportingGrain !== GEOGRAPHY_LEVEL
+    || document.rows?.length !== spec.expectedUnits
+    || document.colorableUnitCount !== spec.expectedUnits
+  ) {
+    throw new Error(`Maine ${spec.year} normalized result contract drifted`);
+  }
+  const reportingUnits = [];
+  const resultRows = [];
+  const codes = new Set();
+  const totals = { Democratic: 0, Republican: 0, Other: 0, Total: 0 };
+  let zeroVoteUnits = 0;
+  for (const row of document.rows) {
+    const code = reportingUnitCode({
+      state: STATE,
+      electionId: spec.electionId,
+      reportingGrain: GEOGRAPHY_LEVEL,
+      parentGeoid: row.parentGeoid,
+      sourceUnitId: row.sourceUnitId,
+    });
+    if (
+      code !== row.resultUnitCode
+      || codes.has(code)
+      || !/^23\d{3}$/.test(row.parentGeoid)
+    ) {
+      throw new Error(`Maine ${spec.year} normalized result identity drifted`);
+    }
+    codes.add(code);
+    const total = Number(row.total);
+    const democratic = Number(row.democratic);
+    const republican = Number(row.republican);
+    const other = Number(row.other);
+    if (
+      ![democratic, republican, other, total].every(Number.isSafeInteger)
+      || [democratic, republican, other].some((value) => value < 0)
+      || total !== democratic + republican + other
+    ) {
+      throw new Error(`Maine ${spec.year} normalized result total drifted for ${code}`);
+    }
+    if (total === 0) zeroVoteUnits += 1;
+    reportingUnits.push({
+      code,
+      sourceUnitId: row.sourceUnitId,
+      sourceDisplayName: row.sourceDisplayName,
+      parentGeoid: row.parentGeoid,
+      reportingGrain: GEOGRAPHY_LEVEL,
+      isGeographic: true,
+      resultStatus: "candidate_detail_complete",
+    });
+    resultRows.push(
+      {
+        jurisdictionCode: code,
+        jurisdictionName: row.sourceDisplayName,
+        candidateName: spec.democratic.name,
+        party: spec.democratic.party,
+        votes: democratic,
+      },
+      {
+        jurisdictionCode: code,
+        jurisdictionName: row.sourceDisplayName,
+        candidateName: spec.republican.name,
+        party: spec.republican.party,
+        votes: republican,
+      },
+      {
+        jurisdictionCode: code,
+        jurisdictionName: row.sourceDisplayName,
+        candidateName: "Other",
+        party: "OTHER",
+        votes: other,
+      },
+    );
+    totals.Democratic += democratic;
+    totals.Republican += republican;
+    totals.Other += other;
+    totals.Total += total;
+  }
+  if (totals.Total !== spec.expectedTotalVotes) {
+    throw new Error(`Maine ${spec.year} official total drifted`);
+  }
+  return {
+    reportingUnits,
+    resultRows,
+    totals,
+    zeroVoteUnits,
+    candidateDetailSuppressedUnits: 0,
+    source: spec.resultSource,
+  };
+}
+
+function buildGeometryPlan(root, spec, manifest, results) {
+  const inspection = validateManifestArtifacts(manifest, {
+    root,
+    skipDelivery: true,
+  });
+  if (inspection.errors.length) {
+    throw new Error(
+      `Maine ${spec.year} artifact validation failed: ${inspection.errors.join("; ")}`,
+    );
+  }
+  if (
+    manifest.geography.level !== GEOGRAPHY_LEVEL
+    || manifest.crosswalk.status !== "reviewed"
+    || manifest.crosswalk.resultUnits !== spec.expectedUnits
+    || manifest.crosswalk.matchedResultUnits !== spec.expectedUnits
+    || manifest.crosswalk.unmatchedResultUnits !== 0
+    || manifest.crosswalk.nonGeographicResultUnits !== 0
+    || manifest.crosswalk.reviewedRelationshipRecords
+      !== spec.expectedCrosswalkRecords
+    || manifest.crosswalk.reviewedNoDataFeatures
+      !== spec.expectedNoDataFeatures
+    || manifest.delivery !== null
+  ) {
+    throw new Error(`Maine ${spec.year} reviewed local geometry contract drifted`);
+  }
+  const geometryBytes = verified(
+    root,
+    manifest.normalization.artifact,
+    manifest.normalization.sha256,
+    spec.geometryByteCount,
+    `Maine ${spec.year} geometry`,
+  );
+  const normalized = JSON.parse(gunzipSync(geometryBytes).toString("utf8"));
+  const features = [];
+  const featureByKey = new Map();
+  for (const feature of normalized.features ?? []) {
+    const parent = String(feature.properties?.CRM_PARENT_GEOID ?? "");
+    const id = String(feature.properties?.CRM_FEATURE_ID ?? "");
+    const sourceFeatureId = `${parent}|${id}`;
+    forbiddenProperties(feature.properties, `Maine ${spec.year} feature ${sourceFeatureId}`);
+    if (
+      !/^23\d{3}$/.test(parent)
+      || !id
+      || !["Polygon", "MultiPolygon"].includes(feature.geometry?.type)
+      || featureByKey.has(sourceFeatureId)
+    ) {
+      throw new Error(`Maine ${spec.year} normalized feature identity drifted`);
+    }
+    const record = {
+      sourceFeatureId,
+      parentGeoid: parent,
+      name: String(feature.properties.SOURCE_NAME ?? id),
+      geometryKey: sourceFeatureId,
+      isGeographic: true,
+      properties: feature.properties,
+    };
+    features.push(record);
+    featureByKey.set(sourceFeatureId, record);
+  }
+  if (features.length !== spec.expectedFeatures) {
+    throw new Error(`Maine ${spec.year} normalized feature count drifted`);
+  }
+  const crosswalkBytes = verified(
+    root,
+    manifest.crosswalk.artifact,
+    manifest.crosswalk.sha256,
+    spec.crosswalkByteCount,
+    `Maine ${spec.year} crosswalk`,
+  );
+  const crosswalk = JSON.parse(crosswalkBytes.toString("utf8"));
+  if (
+    crosswalk.state !== STATE
+    || crosswalk.electionId !== spec.electionId
+    || crosswalk.geographyLevel !== GEOGRAPHY_LEVEL
+  ) {
+    throw new Error(`Maine ${spec.year} crosswalk envelope drifted`);
+  }
+  const unitsByCode = new Map(
+    results.reportingUnits.map((unit) => [unit.code, unit]),
+  );
+  const seenUnits = new Set();
+  const crosswalks = [];
+  for (const [index, row] of (crosswalk.rows ?? []).entries()) {
+    const unit = unitsByCode.get(row.resultUnitCode);
+    if (
+      !unit
+      || row.sourceUnitId !== unit.sourceUnitId
+      || row.parentGeoid !== unit.parentGeoid
+      || row.reportingGrain !== GEOGRAPHY_LEVEL
+      || seenUnits.has(row.resultUnitCode)
+      || !Array.isArray(row.relationships)
+      || row.relationships.length !== 1
+    ) {
+      throw new Error(`Maine ${spec.year} crosswalk identity drift at row ${index}`);
+    }
+    seenUnits.add(row.resultUnitCode);
+    const relationship = row.relationships[0];
+    forbiddenProperties(relationship, `Maine ${spec.year} crosswalk row ${index}`);
+    if (
+      relationship.relationshipType !== "one_to_one"
+      || relationship.reviewStatus !== "reviewed"
+      || relationship.confidence !== "high"
+      || !["exact_official_id", "official_crosswalk"].includes(
+        relationship.matchMethod,
+      )
+      || !featureByKey.has(relationship.sourceFeatureId)
+    ) {
+      throw new Error(`Maine ${spec.year} crosswalk relationship drift at row ${index}`);
+    }
+    crosswalks.push({
+      reportingUnitCode: row.resultUnitCode,
+      sourceFeatureId: relationship.sourceFeatureId,
+      relationshipType: relationship.relationshipType,
+      matchMethod: relationship.matchMethod,
+      reviewStatus: relationship.reviewStatus,
+      confidence: relationship.confidence,
+      note: String(relationship.note ?? ""),
+    });
+  }
+  if (
+    seenUnits.size !== spec.expectedUnits
+    || crosswalks.length !== spec.expectedCrosswalkRecords
+  ) {
+    throw new Error(`Maine ${spec.year} crosswalk counts drifted`);
+  }
+  return {
+    disposition: "loadable_reviewed",
+    sourceGatePassed: true,
+    publicReleaseEligible: false,
+    blockCode: null,
+    reasons: [...manifest.validation.errors],
+    features,
+    crosswalks,
+    artifactWarnings: inspection.warnings,
+  };
+}
+
+async function loadYear(root, spec) {
+  const manifestBytes = verified(
+    root,
+    spec.manifestPath,
+    spec.manifestSha256,
+    spec.manifestByteCount,
+    `Maine ${spec.year} manifest`,
+  );
+  const manifest = JSON.parse(manifestBytes.toString("utf8"));
+  const contract = inspectPrecinctGeometryManifest(manifest);
+  if (
+    contract.errors.length
+    || manifest.state !== STATE
+    || manifest.election.id !== spec.electionId
+    || manifest.election.date !== spec.electionDate
+    || manifest.geography.level !== GEOGRAPHY_LEVEL
+  ) {
+    throw new Error(
+      `Maine ${spec.year} manifest contract drifted: ${contract.errors.join("; ")}`,
+    );
+  }
+  const resultBytes = verified(
+    root,
+    spec.resultsPath,
+    spec.resultsSha256,
+    spec.resultsByteCount,
+    `Maine ${spec.year} normalized results`,
+  );
+  const results = buildResultPlan(
+    spec,
+    JSON.parse(gunzipSync(resultBytes).toString("utf8")),
+  );
+  return {
+    year: spec.year,
+    electionId: spec.electionId,
+    electionDate: spec.electionDate,
+    manifestPath: spec.manifestPath,
+    manifestSha256: spec.manifestSha256,
+    manifestByteCount: spec.manifestByteCount,
+    artifactByteCounts: {
+      source: manifest.source.byteCount,
+      normalization: spec.geometryByteCount,
+      crosswalk: spec.crosswalkByteCount,
+    },
+    manifest,
+    resultSource: results.source,
+    reportingUnits: results.reportingUnits,
+    resultRows: results.resultRows,
+    totals: results.totals,
+    zeroVoteUnits: results.zeroVoteUnits,
+    candidateDetailSuppressedUnits:
+      results.candidateDetailSuppressedUnits,
+    sourceRows: results.reportingUnits.length,
+    geometry: buildGeometryPlan(root, spec, manifest, results),
+    geometrySourceSlug: spec.geometrySourceSlug,
+  };
+}
+
+export async function buildMaineLocalGisPlan(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const selected = options.years
+    ? new Set(options.years.map(Number))
+    : new Set(MAINE_LOCAL_GIS_YEAR_SPECS.map((spec) => spec.year));
+  for (const selectedYear of selected) {
+    if (!MAINE_LOCAL_GIS_YEAR_SPECS.some((spec) => spec.year === selectedYear)) {
+      throw new Error(
+        "Supported Maine local GIS years are 2016, 2020, and 2024; 2012 remains blocked and cannot be loaded",
+      );
+    }
+  }
+  const years = [];
+  for (const spec of MAINE_LOCAL_GIS_YEAR_SPECS.filter(
+    (entry) => selected.has(entry.year),
+  )) {
+    years.push(await loadYear(root, spec));
+  }
+  if (!years.length) {
+    throw new Error("Select at least one Maine local GIS year");
+  }
+  return {
+    schemaVersion: 1,
+    state: STATE,
+    stateName: "Maine",
+    authority: "Maine Secretary of State and retained reviewed geometry sources",
+    scope: "local-only presidential general-election local reporting unit GIS setup",
+    geographyLevel: GEOGRAPHY_LEVEL,
+    years,
+  };
+}
+
+export function summarizeMaineLocalGisPlan(plan) {
+  return {
+    schemaVersion: plan.schemaVersion,
+    state: plan.state,
+    scope: plan.scope,
+    geographyLevel: plan.geographyLevel,
+    years: plan.years.map((year) => ({
+      year: year.year,
+      electionId: year.electionId,
+      manifestId: year.manifest.id,
+      manifestSha256: year.manifestSha256,
+      reportingUnits: year.reportingUnits.length,
+      resultRows: year.resultRows.length,
+      zeroVoteUnits: year.zeroVoteUnits,
+      candidateDetailSuppressedUnits: year.candidateDetailSuppressedUnits,
+      totals: year.totals,
+      geometryDisposition: year.geometry.disposition,
+      geometryFeatures: year.geometry.features.length,
+      reviewedCrosswalks: year.geometry.crosswalks.length,
+      reviewedNoDataFeatures: year.manifest.crosswalk.reviewedNoDataFeatures,
+      sourceGatePassed: year.geometry.sourceGatePassed,
+      publicReleaseEligible: year.geometry.publicReleaseEligible,
+      publicDeliveryAuthorized: false,
+      blockers: year.geometry.reasons,
+      caveats: year.manifest.caveats,
+    })),
+  };
+}

--- a/scripts/lib/me-local-production-preflight.mjs
+++ b/scripts/lib/me-local-production-preflight.mjs
@@ -1,0 +1,353 @@
+import { createHash } from "node:crypto";
+
+const LOOPBACK_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "[::1]",
+]);
+
+const PRECINCT_TABLES = Object.freeze([
+  "geography_features",
+  "geography_versions",
+  "reporting_unit_geometry_crosswalks",
+  "reporting_units",
+]);
+
+const REPORTING_UNIT_COLUMNS = Object.freeze([
+  ["result_rows", "reporting_unit_id"],
+  ["review_rows", "reporting_unit_id"],
+  ["turnout_rows", "reporting_unit_id"],
+]);
+
+function query(client, lines, params = []) {
+  return client.unsafe(Array.isArray(lines) ? lines.join("\n") : lines, params);
+}
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function productionEndpointFingerprint(databaseUrl) {
+  let parsed;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    throw new Error("Maine production preflight requires a valid PostgreSQL URL");
+  }
+  if (!/^postgres(?:ql)?:$/.test(parsed.protocol)) {
+    throw new Error("Maine production preflight requires a PostgreSQL URL");
+  }
+  if (LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase())) {
+    throw new Error("Maine production preflight refuses a loopback database URL");
+  }
+  const databaseName = decodeURIComponent(parsed.pathname).replace(/^\//, "");
+  if (!databaseName) {
+    throw new Error("Maine production preflight requires a database name");
+  }
+  return createHash("sha256")
+    .update([
+      parsed.hostname.toLowerCase(),
+      parsed.port || "5432",
+      databaseName,
+    ].join("\n"))
+    .digest("hex");
+}
+
+export function assertMaineReleaseCandidateDocument(
+  document,
+  packageSha256,
+) {
+  if (!/^[a-f0-9]{64}$/.test(packageSha256 ?? "")) {
+    throw new Error("Maine release package SHA-256 is invalid");
+  }
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "me-local-reporting-gis-three-election-v1"
+    || document?.state !== "ME"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.safety?.explicitProductionAuthorizationRequired !== true
+    || document?.safety?.productionMutationPerformed !== false
+    || document?.safety?.publicFileWritten !== false
+    || document?.safety?.canonicalManifestChanged !== false
+    || document?.safety?.canonicalRegistryChanged !== false
+  ) {
+    throw new Error("Maine release candidate does not match the guarded contract");
+  }
+  const expectedTotals = {
+    elections: 3,
+    reportingUnits: 1_542,
+    candidateResultRows: 4_626,
+    zeroVoteUnits: 1,
+    geometryFeatures: 1_542,
+    reviewedExactCrosswalks: 1_542,
+  };
+  for (const [key, value] of Object.entries(expectedTotals)) {
+    if (Number(document?.totals?.[key]) !== value) {
+      throw new Error("Maine release candidate total drifted: " + key);
+    }
+  }
+  const migrations = document?.databaseActivationContract?.migrations;
+  const expectedMigrationPaths = [
+    "drizzle/0008_typical_thunderbolts.sql",
+    "drizzle/0009_public_wolfpack.sql",
+  ];
+  if (
+    !Array.isArray(migrations)
+    || migrations.length !== expectedMigrationPaths.length
+    || migrations.some((migration, index) =>
+      migration?.path !== expectedMigrationPaths[index]
+      || !Number.isSafeInteger(migration?.byteCount)
+      || migration.byteCount <= 0
+      || !/^[a-f0-9]{64}$/.test(migration?.sha256 ?? ""))
+  ) {
+    throw new Error("Maine release candidate migration pins are invalid");
+  }
+  const years = (document.years ?? []).map((year) => Number(year.year));
+  if (JSON.stringify(years) !== JSON.stringify([2016, 2020, 2024])) {
+    throw new Error("Maine release candidate year set drifted");
+  }
+  return {
+    id: document.id,
+    sha256: packageSha256,
+    migrations,
+    totals: expectedTotals,
+    canonicalManifestPreimages: document.years.map((year) => ({
+      year: year.year,
+      path: year.canonicalManifest.path,
+      byteCount: year.canonicalManifest.byteCount,
+      sha256: year.canonicalManifest.sha256,
+      validationStatus: year.canonicalManifest.validationStatus,
+      rowLevelRenderingSafe: year.canonicalManifest.rowLevelRenderingSafe,
+      delivery: year.canonicalManifest.delivery,
+    })),
+  };
+}
+
+function migrationState(tableRows, columnRows) {
+  const tables = new Set(tableRows.map((row) => String(row.table_name)));
+  const columns = new Set(
+    columnRows.map((row) => `${row.table_name}.${row.column_name}`),
+  );
+  const presentTables = PRECINCT_TABLES.filter((name) => tables.has(name));
+  const presentColumns = REPORTING_UNIT_COLUMNS.filter(([table, column]) =>
+    columns.has(`${table}.${column}`));
+  const absent = presentTables.length === 0 && presentColumns.length === 0;
+  const complete = presentTables.length === PRECINCT_TABLES.length
+    && presentColumns.length === REPORTING_UNIT_COLUMNS.length;
+  return {
+    status: absent ? "absent" : complete ? "complete" : "partial_blocked",
+    expectedTables: [...PRECINCT_TABLES],
+    presentTables,
+    expectedReportingUnitColumns: REPORTING_UNIT_COLUMNS.map(
+      ([table, column]) => `${table}.${column}`,
+    ),
+    presentReportingUnitColumns: presentColumns.map(
+      ([table, column]) => `${table}.${column}`,
+    ),
+  };
+}
+
+function derivationConstraintState(rows, schemaStatus) {
+  if (schemaStatus === "absent") {
+    return { status: "absent", definition: null };
+  }
+  if (rows.length !== 1) {
+    return { status: "partial_blocked", definition: null };
+  }
+  const definition = String(rows[0].definition ?? "");
+  return {
+    status: definition.includes("secondary_reconstruction")
+        && definition.includes("hybrid_reconstruction")
+      ? "complete"
+      : "absent",
+    definition,
+  };
+}
+
+export function buildMaineProductionPreflightReport(snapshot, context) {
+  if (String(snapshot.identity?.transaction_read_only) !== "on") {
+    throw new Error("Maine production preflight did not use a read-only transaction");
+  }
+  const schema = migrationState(snapshot.precinctTables, snapshot.precinctColumns);
+  if (schema.status === "partial_blocked") {
+    throw new Error("Maine production schema is partially migrated; release is blocked");
+  }
+  const invalidConstraints = Number(snapshot.invalidConstraints ?? NaN);
+  if (!Number.isInteger(invalidConstraints)) {
+    throw new Error("Maine production preflight constraint count is invalid");
+  }
+  const migration0009 = derivationConstraintState(
+    snapshot.derivationConstraint,
+    schema.status,
+  );
+  if (migration0009.status === "partial_blocked") {
+    throw new Error("Maine production derivation-method constraint is ambiguous");
+  }
+  const report = {
+    schemaVersion: 1,
+    state: "ME",
+    scope: "read-only Maine local reporting unit GIS production preflight",
+    capturedAtUtc: context.capturedAtUtc,
+    releaseCandidate: context.releaseCandidate,
+    endpointFingerprint: context.endpointFingerprint,
+    database: {
+      name: String(snapshot.identity.database_name),
+      serverVersionNum: String(snapshot.identity.server_version_num),
+      databaseBytes: String(snapshot.identity.database_bytes),
+      transactionReadOnly: true,
+    },
+    productionMutationPerformed: false,
+    canonicalManifestChanged: false,
+    publicFileWritten: false,
+    publicTableCount: snapshot.publicTables.length,
+    publicTables: snapshot.publicTables.map((row) => String(row.table_name)),
+    migration0008: schema,
+    migration0009,
+    invalidConstraints,
+    publicRevision: snapshot.revision.length
+      ? Number(snapshot.revision[0].revision)
+      : null,
+    maine: {
+      coreYearRows: snapshot.coreYears.map((row) => ({
+        year: Number(row.year),
+        electionDate: String(row.election_date),
+        resultRows: Number(row.result_rows),
+        localResultRows: Number(row.local_result_rows),
+        countyResultRows: Number(row.county_result_rows),
+      })),
+      localYearRows: snapshot.localYears.map((row) => ({
+        year: Number(row.year),
+        reportingUnits: Number(row.reporting_units),
+        linkedLocalResultRows: Number(row.linked_local_result_rows),
+        geographyVersions: Number(row.geography_versions),
+        geometryFeatures: Number(row.geometry_features),
+        reviewedExactCrosswalks: Number(row.reviewed_exact_crosswalks),
+      })),
+      sourceDocuments: snapshot.sourceDocuments.map((row) => ({
+        slug: String(row.slug),
+        electionYear: Number(row.election_year),
+        status: String(row.status),
+        localArtifact: String(row.local_artifact ?? ""),
+      })),
+    },
+    canonicalManifestPreimages:
+      context.releaseCandidate.canonicalManifestPreimages,
+    stopConditions: [
+      "migration0008.status is partial_blocked",
+      "migration0009.status is partial_blocked",
+      "any invalid public constraint exists",
+      "the endpoint fingerprint or database name differs from authorization",
+      "any Maine year or row set differs before the write transaction",
+      "any canonical manifest preimage differs from the release package",
+    ],
+  };
+  return report;
+}
+
+export async function collectMaineProductionPreflight(sql, context) {
+  const identityRows = await query(sql, [
+    "select current_database() database_name,",
+    " current_setting('server_version_num') server_version_num,",
+    " current_setting('transaction_read_only') transaction_read_only,",
+    " pg_database_size(current_database())::text database_bytes",
+  ]);
+  if (identityRows.length !== 1) {
+    throw new Error("Maine production preflight database identity is missing");
+  }
+  const publicTables = await query(sql, [
+    "select tablename table_name from pg_catalog.pg_tables",
+    "where schemaname='public' order by tablename",
+  ]);
+  const precinctTables = await query(sql, [
+    "select table_name from information_schema.tables",
+    "where table_schema='public' and table_name = any($1::text[])",
+    "order by table_name",
+  ], [[...PRECINCT_TABLES]]);
+  const precinctColumns = await query(sql, [
+    "select table_name,column_name from information_schema.columns",
+    "where table_schema='public' and (table_name,column_name) in (",
+    " ('result_rows','reporting_unit_id'),",
+    " ('review_rows','reporting_unit_id'),",
+    " ('turnout_rows','reporting_unit_id'))",
+    "order by table_name,column_name",
+  ]);
+  const invalid = await query(sql, [
+    "select count(*)::int count from pg_constraint",
+    "where connamespace='public'::regnamespace and not convalidated",
+  ]);
+  const revision = await query(sql, [
+    "select revision::int revision from public_data_revisions where scope='public'",
+  ]);
+  const derivationConstraint = await query(sql, [
+    "select pg_get_constraintdef(oid) definition from pg_constraint",
+    "where connamespace='public'::regnamespace",
+    " and conname='geography_versions_derivation_method_check'",
+  ]);
+  const coreYears = await query(sql, [
+    "select e.year,e.election_date,",
+    " count(rr.id)::int result_rows,",
+    " count(rr.id) filter (where rr.level='local_reporting_unit')::int local_result_rows,",
+    " count(rr.id) filter (where rr.level='county')::int county_result_rows",
+    "from elections e",
+    "left join contests c on c.election_id=e.id and c.state_code='ME'",
+    "left join result_rows rr on rr.contest_id=c.id and rr.state_code='ME'",
+    "where e.office='president' and (c.id is not null or e.year in (2016,2020,2024))",
+    "group by e.year,e.election_date order by e.year",
+  ]);
+  const sourceDocuments = await query(sql, [
+    "select slug,election_year,status,local_artifact from source_documents",
+    "where state_code='ME' order by election_year,slug",
+  ]);
+
+  const state = migrationState(precinctTables, precinctColumns);
+  let localYears = [];
+  if (state.status === "complete") {
+    localYears = await query(sql, [
+      "select e.year,",
+      " (select count(*)::int from reporting_units ru",
+      "  where ru.state_code='ME' and ru.election_id=e.id",
+      "   and ru.reporting_grain='local_reporting_unit') reporting_units,",
+      " (select count(*)::int from result_rows rr",
+      "  join contests c on c.id=rr.contest_id",
+      "  where rr.state_code='ME' and c.election_id=e.id",
+      "   and rr.level='local_reporting_unit' and rr.reporting_unit_id is not null)",
+      "  linked_local_result_rows,",
+      " (select count(*)::int from geography_versions gv",
+      "  where gv.state_code='ME' and gv.election_id=e.id",
+      "   and gv.geography_type='local_reporting_unit') geography_versions,",
+      " (select count(*)::int from geography_features gf",
+      "  join geography_versions gv on gv.id=gf.geometry_version_id",
+      "  where gv.state_code='ME' and gv.election_id=e.id",
+      "   and gv.geography_type='local_reporting_unit') geometry_features,",
+      " (select count(*)::int from reporting_unit_geometry_crosswalks x",
+      "  join geography_versions gv on gv.id=x.geometry_version_id",
+      "  join reporting_units ru on ru.id=x.reporting_unit_id",
+      "  where gv.state_code='ME' and gv.election_id=e.id",
+      "   and ru.election_id=e.id and x.relationship_type='one_to_one'",
+      "   and x.match_method in ('exact_official_id','official_crosswalk')",
+      "   and x.review_status='reviewed' and x.confidence='high')",
+      "  reviewed_exact_crosswalks",
+      "from elections e where e.office='president'",
+      " and e.year in (2016,2020,2024) order by e.year",
+    ]);
+  }
+
+  return buildMaineProductionPreflightReport({
+    identity: identityRows[0],
+    publicTables,
+    precinctTables,
+    precinctColumns,
+    derivationConstraint,
+    invalidConstraints: invalid[0]?.count,
+    revision,
+    coreYears,
+    localYears,
+    sourceDocuments,
+  }, context);
+}
+
+export const maineLocalSchemaContract = Object.freeze({
+  tables: PRECINCT_TABLES,
+  reportingUnitColumns: REPORTING_UNIT_COLUMNS,
+});

--- a/scripts/lib/me-local-production-release.mjs
+++ b/scripts/lib/me-local-production-release.mjs
@@ -1,0 +1,235 @@
+import { createHash } from "node:crypto";
+
+export const MAINE_PRODUCTION_RELEASE_SCOPES = Object.freeze([
+  "apply_migration_0009",
+  "load_me_local_reporting_results_and_geometry_hidden",
+  "increment_public_data_revision",
+]);
+export const MAINE_MAX_RELEASE_EVIDENCE_AGE_MS = 4 * 60 * 60 * 1000;
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function validIso(value) {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function normalizeIdentity(value) {
+  return typeof value === "string"
+    ? value.trim().normalize("NFKC").replace(/\s+/gu, " ").toLocaleLowerCase("en-US")
+    : "";
+}
+
+function semantic(value) {
+  if (Array.isArray(value)) return value.map(semantic);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, semantic(value[key])]),
+  );
+}
+
+function semanticallyEqual(left, right) {
+  return JSON.stringify(semantic(left)) === JSON.stringify(semantic(right));
+}
+
+function validArtifact(value, prefix) {
+  return typeof value?.path === "string"
+    && value.path.startsWith(prefix)
+    && !value.path.includes("\\")
+    && !value.path.split("/").includes("..")
+    && /^[a-f0-9]{64}$/.test(value?.sha256 ?? "");
+}
+
+function expectedScopes() {
+  return [...MAINE_PRODUCTION_RELEASE_SCOPES];
+}
+
+export function buildMaineProductionAuthorizationTemplate(context) {
+  return {
+    schemaVersion: 1,
+    state: "ME",
+    decision: "NO_GO_PRODUCTION",
+    authorizationId: null,
+    releaseCandidate: {
+      id: context.releaseCandidate.id,
+      sha256: context.releaseCandidate.sha256,
+    },
+    evidence: {
+      preflightSha256: context.preflightSha256 ?? null,
+      backupManifestSha256: context.backupManifestSha256 ?? null,
+    },
+    approvedBy: null,
+    authorizedAtUtc: null,
+    expiresAtUtc: null,
+    scopes: expectedScopes(),
+    acknowledgement:
+      "This template is not authorization. GO_PRODUCTION authorizes only migration 0009, the hidden Maine load, and one public revision increment; public geometry and result visibility remain blocked.",
+  };
+}
+
+export function validateMaineProductionPreflightEvidence(report, context) {
+  const targetYears = [2016, 2020, 2024];
+  const localYearRows = report?.maine?.localYearRows;
+  const coreYearRows = report?.maine?.coreYearRows;
+  const expectedYearRows = targetYears.map((year) => ({
+      year,
+      reportingUnits: 0,
+      resultRows: 0,
+      geometryFeatures: 0,
+      reviewedExactCrosswalks: 0,
+    }));
+  if (
+    report?.schemaVersion !== 1
+    || report?.state !== "ME"
+    || report?.productionMutationPerformed !== false
+    || report?.database?.transactionReadOnly !== true
+    || report?.invalidConstraints !== 0
+    || report?.migration0008?.status !== "complete"
+    || !["absent", "complete"].includes(report?.migration0009?.status)
+    || report?.releaseCandidate?.id !== context.releaseCandidate.id
+    || report?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || report?.endpointFingerprint !== context.endpointFingerprint
+    || !/^[a-f0-9]{64}$/.test(report?.endpointFingerprint ?? "")
+    || !Number.isInteger(Number(report?.publicRevision))
+    || Number(report.publicRevision) < 1
+    || !validIso(report?.capturedAtUtc)
+    || !Array.isArray(localYearRows)
+    || !Array.isArray(coreYearRows)
+    || JSON.stringify(localYearRows.map((row) => Number(row.year)))
+      !== JSON.stringify(targetYears)
+    || localYearRows.some((row, index) => {
+      const expected = expectedYearRows[index];
+      return Number(row.reportingUnits) !== expected.reportingUnits
+        || Number(row.linkedLocalResultRows) !== expected.resultRows
+        || Number(row.geographyVersions) !== 0
+        || Number(row.geometryFeatures) !== expected.geometryFeatures
+        || Number(row.reviewedExactCrosswalks) !== expected.reviewedExactCrosswalks;
+    })
+    || coreYearRows.some((row) => {
+      const index = targetYears.indexOf(Number(row.year));
+      return index >= 0
+        && Number(row.localResultRows) !== expectedYearRows[index].resultRows;
+    })
+  ) {
+    throw new Error(
+      "Maine production preflight evidence is incompatible or already contains local reporting release rows",
+    );
+  }
+  const age = context.now.getTime() - Date.parse(report.capturedAtUtc);
+  if (age < 0 || age > MAINE_MAX_RELEASE_EVIDENCE_AGE_MS) {
+    throw new Error("Maine production preflight is outside the four-hour release window");
+  }
+  if (typeof report.database.name !== "string" || !report.database.name.trim()) {
+    throw new Error("Maine production preflight database name is missing");
+  }
+  return {
+    databaseName: report.database.name.trim(),
+    capturedAtUtc: report.capturedAtUtc,
+    publicRevision: Number(report.publicRevision),
+    releaseMode: "initial_hidden_load",
+  };
+}
+
+export function validateMaineProductionBackupEvidence(manifest, context) {
+  const restore = manifest?.restoreVerification;
+  if (
+    !Number.isInteger(manifest?.manifestVersion)
+    || manifest.manifestVersion < 3
+    || manifest?.backupPurpose !== "me-local-production-release-rollback"
+    || manifest?.releaseCandidate?.id !== context.releaseCandidate.id
+    || manifest?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || manifest?.sourceEndpointFingerprint !== context.endpointFingerprint
+    || !/^[a-f0-9]{64}$/.test(manifest?.dumpSha256 ?? "")
+    || manifest?.dumpFormat !== "custom"
+    || Number(manifest?.pgClientMajor) !== 17
+    || Math.trunc(Number(manifest?.sourceServerVersionNum) / 10_000) !== 17
+    || JSON.stringify(manifest?.includedSchemas) !== JSON.stringify(["public"])
+    || !Array.isArray(manifest?.excludedTableDataPatterns)
+    || manifest.excludedTableDataPatterns.length !== 0
+    || manifest?.remoteMutationPerformed !== false
+    || Number(manifest?.sourceInvalidConstraints) !== 0
+    || restore?.verified !== true
+    || restore?.defaultTransactionReadOnly !== true
+    || restore?.exactSourceTableSet !== true
+    || restore?.exactSourceRowCounts !== true
+    || Number(restore?.invalidConstraints) !== 0
+    || !validIso(manifest?.createdAtUtc)
+    || !validIso(restore?.verifiedAtUtc)
+  ) {
+    throw new Error("Maine production backup evidence is incomplete or incompatible");
+  }
+  const created = Date.parse(manifest.createdAtUtc);
+  const restored = Date.parse(restore.verifiedAtUtc);
+  const preflight = Date.parse(context.preflightCapturedAtUtc);
+  const now = context.now.getTime();
+  if (
+    Number.isNaN(preflight)
+    || created <= preflight
+    || restored < created
+    || now - created < 0
+    || now - created > MAINE_MAX_RELEASE_EVIDENCE_AGE_MS
+    || now - restored < 0
+    || now - restored > MAINE_MAX_RELEASE_EVIDENCE_AGE_MS
+  ) {
+    throw new Error("Maine backup must follow the fresh preflight and restore within four hours");
+  }
+  const sourceCounts = manifest.sourcePublicTableRowCounts;
+  const restoredCounts = restore.publicTableRowCounts;
+  const sourceTableCount = Number(manifest.sourcePublicTableCount);
+  if (
+    !sourceCounts
+    || !restoredCounts
+    || typeof sourceCounts !== "object"
+    || typeof restoredCounts !== "object"
+    || Array.isArray(sourceCounts)
+    || Array.isArray(restoredCounts)
+    || sourceTableCount !== Number(restore.publicTableCount)
+    || sourceTableCount !== Number(restore.tableDataEntryCount)
+    || Object.keys(sourceCounts).length !== sourceTableCount
+    || Object.keys(restoredCounts).length !== sourceTableCount
+    || !semanticallyEqual(sourceCounts, restoredCounts)
+  ) {
+    throw new Error("Maine production backup exact table or row-count proof drifted");
+  }
+  return {
+    dumpSha256: manifest.dumpSha256,
+    createdAtUtc: manifest.createdAtUtc,
+    restoredAtUtc: restore.verifiedAtUtc,
+    sourcePublicTableCount: sourceTableCount,
+  };
+}
+
+export function validateMaineProductionAuthorization(value, context) {
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "ME"
+    || value?.decision !== "GO_PRODUCTION"
+    || typeof value?.authorizationId !== "string"
+    || !value.authorizationId.trim()
+    || value?.releaseCandidate?.id !== context.releaseCandidate.id
+    || value?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || value?.evidence?.preflightSha256 !== context.preflightSha256
+    || value?.evidence?.backupManifestSha256 !== context.backupManifestSha256
+    || !validIso(value?.authorizedAtUtc)
+    || !validIso(value?.expiresAtUtc)
+    || !normalizeIdentity(value?.approvedBy)
+    || value?.replacement !== undefined
+    || !Array.isArray(value?.scopes)
+    || !semanticallyEqual(value.scopes, expectedScopes())
+  ) {
+    throw new Error("Maine production authorization is incomplete or incompatible");
+  }
+  const authorized = Date.parse(value.authorizedAtUtc);
+  const expires = Date.parse(value.expiresAtUtc);
+  const now = context.now.getTime();
+  if (authorized > now || expires <= now || expires <= authorized) {
+    throw new Error("Maine production authorization is not active");
+  }
+  return {
+    authorizationId: value.authorizationId.trim(),
+    approvedBy: value.approvedBy.trim(),
+    authorizedAtUtc: value.authorizedAtUtc,
+    expiresAtUtc: value.expiresAtUtc,
+  };
+}

--- a/scripts/lib/me-local-public-activation.mjs
+++ b/scripts/lib/me-local-public-activation.mjs
@@ -1,0 +1,457 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { inspectReleaseArtifact } from "./me-local-release-candidate.mjs";
+import {
+  inspectPrecinctGeometryManifest,
+  inspectPrecinctGeometryRegistry,
+} from "../../src/lib/precinct-geography.ts";
+
+export const MAINE_PUBLIC_ACTIVATION_ROOT =
+  ".etl/precinct-public-activations/ME";
+export const MAINE_PUBLIC_ACTIVATION_YEARS = Object.freeze([
+  2016,
+  2020,
+  2024,
+]);
+
+const REGISTRY_PATH = "data/precinct-geometry-manifests.json";
+const COVERAGE_PATHS = Object.freeze([
+  [2016, "data/precinct-geometry-coverage-inventory-2016.json"],
+  [2020, "data/precinct-geometry-coverage-inventory-2020.json"],
+  [2024, "data/precinct-geometry-coverage-inventory.json"],
+]);
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function serializeMainePublicActivationDocument(value) {
+  return Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonical(value[key])]),
+  );
+}
+
+function semanticallyEqual(left, right) {
+  return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+}
+
+function readRepositoryJson(root, relativePath) {
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  if (!existsSync(absolutePath)) {
+    throw new Error("Maine public activation target is missing: " + relativePath);
+  }
+  const bytes = readFileSync(absolutePath);
+  return {
+    path: relativePath,
+    absolutePath,
+    bytes,
+    byteCount: bytes.length,
+    sha256: sha256(bytes),
+    value: JSON.parse(bytes.toString("utf8")),
+  };
+}
+
+function loadReleasePackage(options) {
+  if (!/^[a-f0-9]{64}$/.test(options.packageSha256 ?? "")) {
+    throw new Error("Maine public activation requires the exact package SHA-256");
+  }
+  const artifact = inspectReleaseArtifact(options.root, options.packagePath, {
+    allowedRoots: [".etl/precinct-release-candidates/ME/"],
+    sha256: options.packageSha256,
+  });
+  const document = JSON.parse(artifact.bytes.toString("utf8"));
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "me-local-reporting-gis-three-election-v1"
+    || document?.state !== "ME"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.safety?.canonicalManifestChanged !== false
+    || document?.safety?.publicEligibilityChanged !== false
+    || document?.totals?.elections !== 3
+    || !Array.isArray(document?.years)
+    || !semanticallyEqual(
+      document.years.map((year) => Number(year.year)),
+      MAINE_PUBLIC_ACTIVATION_YEARS,
+    )
+    || Number.isNaN(Date.parse(document?.preparedFromLocalValidationAt))
+  ) {
+    throw new Error("Maine public-activation package contract is incompatible");
+  }
+  return {
+    artifact,
+    document,
+    packageRoot: path.dirname(path.resolve(
+      options.root,
+      ...artifact.path.split("/"),
+    )),
+    identity: {
+      id: document.id,
+      path: options.packagePath,
+      sha256: artifact.sha256,
+    },
+  };
+}
+
+function loadDraftManifests(root, loaded) {
+  return loaded.document.years.map((year) => {
+    const draft = inspectReleaseArtifact(
+      loaded.packageRoot,
+      year.draftManifest.path,
+      {
+        allowedRoots: ["draft-manifests/"],
+        byteCount: year.draftManifest.byteCount,
+        sha256: year.draftManifest.sha256,
+      },
+    );
+    const manifest = JSON.parse(draft.bytes.toString("utf8"));
+    const inspection = inspectPrecinctGeometryManifest(manifest);
+    if (
+      inspection.errors.length
+      || inspection.publicEligibilityReasons.length
+      || manifest.state !== "ME"
+      || manifest.election?.year !== year.year
+      || manifest.id !== year.manifestId
+      || manifest.geography?.level !== "local_reporting_unit"
+      || manifest.delivery?.format !== "parent_scoped_geojson"
+      || manifest.delivery?.url !== year.proposedPublicDelivery?.url
+      || manifest.delivery?.sha256 !== year.proposedPublicDelivery?.sha256
+      || manifest.delivery?.byteCount !== year.proposedPublicDelivery?.byteCount
+      || manifest.delivery?.featureCount !== year.reviewedGeometry?.featureCount
+      || manifest.delivery?.parentCount !== 16
+    ) {
+      throw new Error("Maine " + year.year + " draft manifest is not public-eligible");
+    }
+    const preimage = inspectReleaseArtifact(root, year.canonicalManifest.path, {
+      allowedRoots: ["data/precinct-geometry/ME/"],
+      byteCount: year.canonicalManifest.byteCount,
+      sha256: year.canonicalManifest.sha256,
+    });
+    const preimageManifest = JSON.parse(preimage.bytes.toString("utf8"));
+    if (
+      preimageManifest.id !== manifest.id
+      || preimageManifest.validation?.status !== "blocked"
+      || preimageManifest.validation?.rowLevelRenderingSafe !== true
+      || preimageManifest.delivery !== null
+    ) {
+      throw new Error("Maine " + year.year + " canonical source preimage is not blocked");
+    }
+    return {
+      year: year.year,
+      manifestId: manifest.id,
+      preimage: {
+        path: year.canonicalManifest.path,
+        byteCount: preimage.byteCount,
+        sha256: preimage.sha256,
+      },
+      draft: {
+        path: path.posix.join(
+          path.posix.dirname(loaded.identity.path),
+          year.draftManifest.path,
+        ),
+        byteCount: draft.byteCount,
+        sha256: draft.sha256,
+        manifest,
+      },
+    };
+  });
+}
+
+function updateRegistry(root, manifests, activatedAtUtc) {
+  const current = readRepositoryJson(root, REGISTRY_PATH);
+  if (
+    current.value?.schemaVersion !== 1
+    || !Array.isArray(current.value?.manifests)
+  ) {
+    throw new Error("Maine canonical manifest registry is invalid");
+  }
+  const existing = current.value.manifests.filter((row) => row?.state === "ME");
+  const drafts = manifests.map((item) => item.draft.manifest);
+  let disposition;
+  let nextRows;
+  if (existing.length === 0) {
+    disposition = "activate";
+    nextRows = [...current.value.manifests, ...drafts];
+  } else if (
+    existing.length === drafts.length
+    && drafts.every((draft) => existing.some((row) => semanticallyEqual(row, draft)))
+  ) {
+    disposition = "verified_existing";
+    nextRows = current.value.manifests;
+  } else {
+    throw new Error("Maine canonical registry is partially activated or drifted");
+  }
+  const value = {
+    ...current.value,
+    updatedAt: disposition === "activate" ? activatedAtUtc : current.value.updatedAt,
+    manifests: nextRows,
+  };
+  const inspection = inspectPrecinctGeometryRegistry(
+    value,
+    Math.max(Date.now(), Date.parse(activatedAtUtc) + 1),
+  );
+  if (inspection.errors.length) {
+    throw new Error(
+      "Maine activated registry is invalid: " + inspection.errors.join("; "),
+    );
+  }
+  const eligible = inspection.manifests.filter((item, index) =>
+    value.manifests[index]?.state === "ME"
+    && item.publicEligibilityReasons.length === 0);
+  if (eligible.length !== 3) {
+    throw new Error("Maine activated registry does not contain three eligible manifests");
+  }
+  return { current, value, disposition };
+}
+
+function recomputeCoverageSummary(value) {
+  const states = value.states ?? [];
+  const count = (field, choices) => Object.fromEntries(
+    choices.map((choice) => [
+      choice,
+      states.filter((row) => (row[field] ?? "undecided") === choice).length,
+    ]),
+  );
+  return {
+    totalJurisdictions: states.length,
+    programStatus: count("programStatus", ["not_started", "in_progress", "reviewed"]),
+    disposition: count("disposition", [
+      "undecided",
+      "mapped",
+      "partial",
+      "official_geometry_unavailable",
+      "blocked",
+    ]),
+    publicEligibleJurisdictions: states.filter((row) =>
+      (row.geometry?.publicEligibleManifestCount ?? 0) > 0).length,
+  };
+}
+
+function maineCoverageRow(manifest, activatedAtUtc) {
+  return {
+    state: "ME",
+    stateName: "Maine",
+    electionId: manifest.election.id,
+    programStatus: "reviewed",
+    wave: 8,
+    disposition: "mapped",
+    checkedAt: activatedAtUtc,
+    sourceTiers: ["official_export", "official_service"].includes(
+      manifest.geography.derivationMethod,
+    )
+      ? ["tier_1_official_export_database"]
+      : ["tier_1_official_export_database", "tier_3_secondary_geometry"],
+    resultReportingGrains: ["local_reporting_unit"],
+    generalOfficialSourceLeads: [
+      manifest.source.url,
+      "https://sos.maine.gov/mainens/election-results-statistics",
+    ],
+    geometry: {
+      manifestIds: [manifest.id],
+      officialSourceLeads: [manifest.source.url],
+      retainedArtifacts: [
+        manifest.source.artifact,
+        manifest.normalization.artifact,
+        manifest.crosswalk.artifact,
+      ],
+      levels: [manifest.geography.level],
+      vintageStatuses: [manifest.geography.vintageStatus],
+      featureCount: manifest.normalization.featureCount,
+      publicEligibleManifestCount: 1,
+    },
+    crosswalk: {
+      resultUnits: manifest.crosswalk.resultUnits,
+      colorableResultUnits: manifest.crosswalk.colorableResultUnits,
+      matchedResultUnits: manifest.crosswalk.matchedResultUnits,
+      unmatchedResultUnits: manifest.crosswalk.unmatchedResultUnits,
+      nonGeographicResultUnits: manifest.crosswalk.nonGeographicResultUnits,
+      sourceAliasResultUnits: manifest.crosswalk.sourceAliasResultUnits,
+    },
+    blockers: [],
+    nextAction:
+      "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
+    notes: [
+      ["official_export", "official_service"].includes(
+          manifest.geography.derivationMethod,
+        )
+        ? "An official Maine local-boundary source supplies the reviewed presentation geometry."
+        : manifest.election.year === 2020
+          ? "VEST election-specific geometry is explicitly attributed and used only with official Maine Secretary of State local result rows and retained CC BY 4.0 evidence."
+          : "The New York Times election-specific official-boundary compilation and reviewed Maine GeoLibrary gap geometry are used only with official Maine Secretary of State result rows under retained terms.",
+      manifest.election.year === 2016
+        ? "The attributed election-specific geometry is joined to official Maine Secretary of State local results through the retained reviewed crosswalk."
+        : "The attributed election-specific geometry is joined to official Maine Secretary of State local results through exact retained identities; election values are excluded from geometry delivery.",
+      manifest.election.year === 2024
+        ? "The 2024 geometry is distributed under the retained New York Times C-UDA 1.0 Non-Commercial terms; the public map and provenance must preserve attribution, non-commercial use, and downstream terms."
+        : "Geometry redistribution terms and exact source provenance are retained with the release artifacts.",
+      "The 2012 election remains separately blocked because five official result rows and eight votes are not mapped, election-date vintage is unconfirmed, and derivative redistribution permission remains unresolved.",
+    ],
+  };
+}
+
+function updateCoverage(root, manifest, relativePath, activatedAtUtc) {
+  const current = readRepositoryJson(root, relativePath);
+  if (!Array.isArray(current.value?.states)) {
+    throw new Error("Maine coverage inventory is invalid: " + relativePath);
+  }
+  const existing = current.value.states.filter((row) => row?.state === "ME");
+  let disposition;
+  let states;
+  if (existing.length === 0) {
+    const expectedRow = maineCoverageRow(manifest, activatedAtUtc);
+    disposition = "activate";
+    states = [...current.value.states, expectedRow];
+  } else if (existing.length === 1) {
+    const row = existing[0];
+    const currentEligible = Number(
+      row.geometry?.publicEligibleManifestCount,
+    );
+    if (
+      row.electionId !== manifest.election.id
+      || row.programStatus !== "reviewed"
+      || row.disposition !== "mapped"
+      || !Array.isArray(row.geometry?.manifestIds)
+      || row.geometry.manifestIds.length !== 1
+      || row.geometry.manifestIds[0] !== manifest.id
+      || row.geometry.featureCount !== manifest.normalization.featureCount
+      || !semanticallyEqual(
+        row.geometry.levels,
+        [manifest.geography.level],
+      )
+      || ![0, 1].includes(currentEligible)
+      || row.crosswalk?.resultUnits !== manifest.crosswalk.resultUnits
+      || row.crosswalk?.matchedResultUnits
+        !== manifest.crosswalk.matchedResultUnits
+      || row.crosswalk?.unmatchedResultUnits
+        !== manifest.crosswalk.unmatchedResultUnits
+    ) {
+      throw new Error(relativePath + " contains a drifted Maine row");
+    }
+    const expectedRow = {
+      ...row,
+      checkedAt: currentEligible === 1 ? row.checkedAt : activatedAtUtc,
+      geometry: {
+        ...row.geometry,
+        publicEligibleManifestCount: 1,
+      },
+      blockers: [],
+      nextAction:
+        "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
+    };
+    if (currentEligible === 1) {
+      if (!semanticallyEqual(row, expectedRow)) {
+        throw new Error(relativePath + " contains a partial Maine activation");
+      }
+      disposition = "verified_existing";
+      states = current.value.states;
+    } else {
+      disposition = "activate";
+      states = current.value.states.map((candidate) =>
+        candidate?.state === "ME" ? expectedRow : candidate);
+    }
+  } else {
+    throw new Error(relativePath + " contains a partial or drifted Maine row");
+  }
+  const value = {
+    ...current.value,
+    updatedAt: disposition === "activate" ? activatedAtUtc : current.value.updatedAt,
+    states,
+  };
+  value.summary = recomputeCoverageSummary(value);
+  return { current, value, disposition };
+}
+
+function outputFile(relativePath, built) {
+  const bytes = serializeMainePublicActivationDocument(built.value);
+  return {
+    path: relativePath,
+    absolutePath: built.current.absolutePath,
+    preimage: {
+      byteCount: built.current.byteCount,
+      sha256: built.current.sha256,
+    },
+    byteCount: bytes.length,
+    sha256: sha256(bytes),
+    disposition: built.disposition,
+    bytes,
+  };
+}
+
+export function inspectMainePublicActivationPlan(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const loaded = loadReleasePackage({ ...options, root });
+  const manifests = loadDraftManifests(root, loaded);
+  const activatedAtUtc = loaded.document.preparedFromLocalValidationAt;
+  const outputs = [outputFile(
+    REGISTRY_PATH,
+    updateRegistry(root, manifests, activatedAtUtc),
+  )];
+  for (const [year, relativePath] of COVERAGE_PATHS) {
+    const manifest = manifests.find((item) => item.year === year)?.draft.manifest;
+    if (!manifest) throw new Error("Maine activation is missing year " + year);
+    outputs.push(outputFile(
+      relativePath,
+      updateCoverage(root, manifest, relativePath, activatedAtUtc),
+    ));
+  }
+  const plan = {
+    schemaVersion: 1,
+    id: "me-local-public-activation-three-election-v1",
+    state: "ME",
+    decision: "DEPLOY_GUARDED_STATIC_MANIFESTS_DATABASE_REMAINS_BLOCKED",
+    releaseCandidate: loaded.identity,
+    activatedAtUtc,
+    manifests: manifests.map((item) => ({
+      year: item.year,
+      manifestId: item.manifestId,
+      canonicalSourcePreimage: item.preimage,
+      draftManifest: {
+        path: item.draft.path,
+        byteCount: item.draft.byteCount,
+        sha256: item.draft.sha256,
+        publicManifestSha256: sha256(
+          serializeMainePublicActivationDocument(item.draft.manifest),
+        ),
+        delivery: item.draft.manifest.delivery,
+      },
+    })),
+    trackedOutputs: outputs.map(({
+      bytes: _bytes,
+      absolutePath: _absolutePath,
+      ...file
+    }) => file),
+    safety: {
+      productionContacted: false,
+      productionMutationPerformed: false,
+      publicFileWritten: false,
+      databasePublicationStatusChanged: false,
+      publicEndpointsRemainDatabaseGated: true,
+      gitPublicationPerformed: false,
+    },
+  };
+  const bytes = serializeMainePublicActivationDocument(plan);
+  const digest = sha256(bytes);
+  return {
+    root,
+    packageDocument: loaded.document,
+    plan,
+    bytes,
+    sha256: digest,
+    outputPath: path.posix.join(
+      MAINE_PUBLIC_ACTIVATION_ROOT,
+      loaded.identity.sha256.slice(0, 12) + "-" + digest.slice(0, 12),
+      "activation-candidate.json",
+    ),
+    outputs,
+  };
+}

--- a/scripts/lib/me-local-publication.mjs
+++ b/scripts/lib/me-local-publication.mjs
@@ -1,0 +1,653 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { inspectMaineLocalBlobPublicationPlan } from "./me-local-blob-publication.mjs";
+import { inspectReleaseArtifact } from "./me-local-release-candidate.mjs";
+import {
+  inspectPrecinctGeometryManifest,
+  inspectPrecinctGeometryRegistry,
+} from "../../src/lib/precinct-geography.ts";
+
+export const MAINE_PUBLICATION_YEARS = Object.freeze([2016, 2020, 2024]);
+export const MAINE_PUBLICATION_SCOPES = Object.freeze([
+  "publish_me_local_geography_versions",
+  "authorize_me_local_results",
+  "increment_public_data_revision",
+]);
+export const MAINE_PUBLIC_ROLLBACK_SCOPES = Object.freeze([
+  "block_me_local_geography_versions",
+  "revoke_me_local_results",
+  "increment_public_data_revision",
+]);
+
+const EXPECTED_TOTALS = Object.freeze({
+  reportingUnits: 1_542,
+  candidateResultRows: 4_626,
+  geometryFeatures: 1_542,
+  reviewedExactCrosswalks: 1_542,
+  zeroVoteUnits: 1,
+  sourceDocuments: 6,
+  importRuns: 3,
+});
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function serializeMainePublicationDocument(value) {
+  return Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonical(value[key])]),
+  );
+}
+
+export function semanticallyEqual(left, right) {
+  return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+}
+
+function safeEvidence(root, relativePath, allowedRoot, expectedSha256) {
+  if (
+    typeof relativePath !== "string"
+    || path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !relativePath.startsWith(allowedRoot + "/")
+    || !relativePath.endsWith(".json")
+    || !/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")
+  ) {
+    throw new Error("Maine publication evidence path is unsafe");
+  }
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...allowedRoot.split("/"));
+  if (!absolutePath.startsWith(allowed + path.sep) || !existsSync(absolutePath)) {
+    throw new Error("Maine publication evidence is missing");
+  }
+  const bytes = readFileSync(absolutePath);
+  const digest = sha256(bytes);
+  if (digest !== expectedSha256) {
+    throw new Error("Maine publication evidence SHA-256 drifted");
+  }
+  return {
+    path: relativePath,
+    absolutePath,
+    bytes,
+    sha256: digest,
+    value: JSON.parse(bytes.toString("utf8")),
+  };
+}
+
+function credentialFreeHttpsOrigin(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error("Maine publication delivery origin is invalid");
+  }
+  if (
+    parsed.protocol !== "https:"
+    || parsed.username
+    || parsed.password
+    || parsed.search
+    || parsed.hash
+    || parsed.pathname !== "/"
+    || parsed.origin !== value
+  ) {
+    throw new Error("Maine publication origin must be credential-free HTTPS");
+  }
+  return parsed.origin;
+}
+
+function loadPackage(root, packagePath, packageSha256) {
+  if (!/^[a-f0-9]{64}$/.test(packageSha256 ?? "")) {
+    throw new Error("Maine publication requires the exact package SHA-256");
+  }
+  const artifact = inspectReleaseArtifact(root, packagePath, {
+    allowedRoots: [".etl/precinct-release-candidates/ME/"],
+    sha256: packageSha256,
+  });
+  const document = JSON.parse(artifact.bytes.toString("utf8"));
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "me-local-reporting-gis-three-election-v1"
+    || document?.state !== "ME"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.totals?.reportingUnits !== EXPECTED_TOTALS.reportingUnits
+    || document?.totals?.candidateResultRows !== EXPECTED_TOTALS.candidateResultRows
+    || document?.totals?.geometryFeatures !== EXPECTED_TOTALS.geometryFeatures
+    || document?.totals?.reviewedExactCrosswalks
+      !== EXPECTED_TOTALS.reviewedExactCrosswalks
+    || document?.totals?.zeroVoteUnits !== EXPECTED_TOTALS.zeroVoteUnits
+    || !Array.isArray(document?.years)
+    || !semanticallyEqual(
+      document.years.map((year) => Number(year.year)),
+      MAINE_PUBLICATION_YEARS,
+    )
+  ) {
+    throw new Error("Maine publication release package is incompatible");
+  }
+  return {
+    artifact,
+    document,
+    root: path.dirname(path.resolve(root, ...artifact.path.split("/"))),
+    identity: { id: document.id, path: packagePath, sha256: artifact.sha256 },
+  };
+}
+
+function publicManifests(root, loaded) {
+  const registryPath = "data/precinct-geometry-manifests.json";
+  const registryBytes = readFileSync(path.resolve(root, registryPath));
+  const registry = JSON.parse(registryBytes.toString("utf8"));
+  const inspection = inspectPrecinctGeometryRegistry(registry);
+  if (inspection.errors.length) {
+    throw new Error("Maine publication registry is invalid: " + inspection.errors.join("; "));
+  }
+  const rows = registry.manifests.filter((manifest) => manifest?.state === "ME");
+  if (rows.length !== 3) {
+    throw new Error("Maine publication registry does not contain three manifests");
+  }
+  return loaded.document.years.map((year) => {
+    const draftArtifact = inspectReleaseArtifact(loaded.root, year.draftManifest.path, {
+      allowedRoots: ["draft-manifests/"],
+      byteCount: year.draftManifest.byteCount,
+      sha256: year.draftManifest.sha256,
+    });
+    const draft = JSON.parse(draftArtifact.bytes.toString("utf8"));
+    const manifest = rows.find((row) => row.id === year.manifestId);
+    const manifestInspection = inspectPrecinctGeometryManifest(manifest);
+    if (
+      !manifest
+      || !semanticallyEqual(manifest, draft)
+      || manifestInspection.errors.length
+      || manifestInspection.publicEligibilityReasons.length
+      || manifest.election?.year !== year.year
+      || manifest.delivery?.format !== "parent_scoped_geojson"
+      || manifest.delivery?.featureCount !== year.reviewedGeometry.featureCount
+      || manifest.delivery?.parentCount !== 16
+    ) {
+      throw new Error("Maine " + year.year + " public manifest drifted from the package");
+    }
+    return {
+      year: year.year,
+      electionId: year.electionId,
+      manifestId: manifest.id,
+      publicManifestSha256: sha256(serializeMainePublicationDocument(manifest)),
+      delivery: manifest.delivery,
+      boundaryVintage: manifest.geography.boundaryVintage,
+      blockedManifestSha256: year.canonicalManifest.sha256,
+      featureCount: manifest.delivery.featureCount,
+      zeroVoteUnits: year.certifiedResults.zeroVoteUnits,
+      resultRows: year.certifiedResults.resultRows,
+      manifest,
+    };
+  }).map((item, _index, all) => {
+    if (new Set(all.map((row) => row.manifestId)).size !== 3) {
+      throw new Error("Maine publication manifest IDs are duplicated");
+    }
+    return item;
+  });
+}
+
+function validAuditArtifact(value) {
+  return typeof value?.path === "string"
+    && value.path.startsWith(".etl/")
+    && !value.path.includes("\\")
+    && !value.path.split("/").includes("..")
+    && /^[a-f0-9]{64}$/.test(value?.sha256 ?? "");
+}
+
+export function validateMaineHiddenLoadReceipt(value, context) {
+  const audit = value?.transaction?.productionReleaseAudit;
+  const validation = value?.validation;
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "ME"
+    || value?.decision !== "COMMITTED_HIDDEN_NOT_PUBLIC"
+    || value?.releaseCandidate?.id !== context.releaseCandidate.id
+    || value?.releaseCandidate?.path !== context.releaseCandidate.path
+    || value?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || typeof value?.committedAtUtc !== "string"
+    || Number.isNaN(Date.parse(value.committedAtUtc))
+    || Date.parse(value.committedAtUtc) > context.now
+    || !/^[a-f0-9]{64}$/.test(value?.endpointFingerprint ?? "")
+    || value?.productionMutationPerformed !== true
+    || value?.canonicalManifestChanged !== false
+    || value?.publicFileWritten !== false
+    || value?.publicDeliveryAuthorized !== false
+    || value?.transaction?.productionMutationPerformed !== true
+    || value?.transaction?.publicDeliveryAuthorized !== false
+    || validation?.productionMutationPerformed !== true
+    || validation?.publicDeliveryAuthorized !== false
+    || value?.transaction?.revision !== validation?.revision
+    || !Number.isInteger(Number(value?.transaction?.revision))
+    || Number(value.transaction.revision) < 1
+    || value?.committedAtUtc !== audit?.transaction?.executedAtUtc
+    || value?.transaction?.revision !== audit?.transaction?.publicRevision
+    || value?.authorization?.id !== audit?.authorizationId
+    || value?.authorization?.path !== audit?.authorization?.path
+    || value?.authorization?.sha256 !== audit?.authorization?.sha256
+    || value?.preflight?.path !== audit?.preflight?.path
+    || value?.preflight?.sha256 !== audit?.preflight?.sha256
+    || value?.backup?.manifestSha256 !== audit?.backupManifest?.sha256
+    || value?.backup?.dumpSha256 !== audit?.backupManifest?.dumpSha256
+    || value?.endpointFingerprint !== audit?.endpointFingerprint
+    || audit?.releasePackage?.path !== context.releaseCandidate.path
+    || audit?.releasePackage?.sha256 !== context.releaseCandidate.sha256
+    || ![
+      audit?.releasePackage,
+      audit?.authorization,
+      audit?.preflight,
+    ].every(validAuditArtifact)
+    || !/^[a-f0-9]{64}$/.test(audit?.backupManifest?.sha256 ?? "")
+    || !/^[a-f0-9]{64}$/.test(audit?.backupManifest?.dumpSha256 ?? "")
+    || !semanticallyEqual(validation?.productionReleaseAudit, audit)
+    || !semanticallyEqual(validation?.releaseCandidate, {
+      id: context.releaseCandidate.id,
+      sha256: context.releaseCandidate.sha256,
+      publicDeliveryAuthorized: false,
+    })
+    || validation?.database?.name !== value?.transaction?.database?.name
+    || typeof validation?.database?.name !== "string"
+    || !validation.database.name
+    || !Array.isArray(validation?.years)
+    || validation.years.length !== 3
+    || !semanticallyEqual(
+      validation.years.map((year) => Number(year.year)),
+      MAINE_PUBLICATION_YEARS,
+    )
+  ) {
+    throw new Error("Maine hidden-load receipt is incomplete or incompatible");
+  }
+  const totals = {
+    reportingUnits: validation.years.reduce((sum, year) => sum + year.reportingUnits, 0),
+    candidateResultRows: validation.years.reduce((sum, year) => sum + year.resultRows, 0),
+    geometryFeatures: validation.years.reduce((sum, year) => sum + year.features, 0),
+    reviewedExactCrosswalks: validation.years.reduce(
+      (sum, year) => sum + year.exactCrosswalks,
+      0,
+    ),
+    zeroVoteUnits: validation.years.reduce((sum, year) => sum + year.zeroVoteUnits, 0),
+  };
+  for (const [key, expected] of Object.entries(EXPECTED_TOTALS)) {
+    if (key === "sourceDocuments" || key === "importRuns") continue;
+    if (Number(totals[key]) !== expected) {
+      throw new Error("Maine hidden-load receipt total drifted: " + key);
+    }
+  }
+  return {
+    committedAtUtc: value.committedAtUtc,
+    databaseName: validation.database.name,
+    endpointFingerprint: value.endpointFingerprint,
+    hiddenRevision: value.transaction.revision,
+    productionReleaseAudit: audit,
+    totals,
+  };
+}
+
+export function validateMaineBlobPublicationEvidence(value, blobPlan, now = Date.now()) {
+  const origin = credentialFreeHttpsOrigin(value?.deliveryOrigin);
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "ME"
+    || value?.purpose !== "me-local-reporting-parent-scoped-immutable-geometry-publication"
+    || value?.releaseCandidate?.id !== blobPlan.releaseCandidate.id
+    || value?.releaseCandidate?.path !== blobPlan.releaseCandidate.path
+    || value?.releaseCandidate?.sha256 !== blobPlan.releaseCandidate.sha256
+    || typeof value?.publishedAtUtc !== "string"
+    || Number.isNaN(Date.parse(value.publishedAtUtc))
+    || Date.parse(value.publishedAtUtc) > now
+    || value?.assetCount !== 51
+    || value?.canonicalManifestChanged !== false
+    || value?.publicEligibilityChanged !== false
+    || !Array.isArray(value?.artifacts)
+    || value.artifacts.length !== 51
+  ) {
+    throw new Error("Maine Blob publication evidence is incomplete or incompatible");
+  }
+  const expected = new Map(blobPlan.artifacts.map((artifact) => [artifact.pathname, artifact]));
+  const seen = new Set();
+  for (const artifact of value.artifacts) {
+    const wanted = expected.get(artifact?.pathname);
+    let remote;
+    try {
+      remote = new URL(artifact?.url);
+    } catch {
+      throw new Error("Maine Blob publication evidence contains an invalid URL");
+    }
+    if (
+      !wanted
+      || seen.has(artifact.pathname)
+      || artifact.kind !== wanted.kind
+      || artifact.year !== wanted.year
+      || artifact.packageRelativePath !== wanted.packageRelativePath
+      || artifact.publicUrl !== wanted.publicUrl
+      || artifact.byteCount !== wanted.byteCount
+      || artifact.sha256 !== wanted.sha256
+      || remote.origin !== origin
+      || remote.pathname !== "/" + wanted.pathname
+      || !["created", "verified_existing"].includes(artifact.disposition)
+    ) {
+      throw new Error("Maine Blob publication artifact set drifted");
+    }
+    seen.add(artifact.pathname);
+  }
+  if (seen.size !== expected.size) {
+    throw new Error("Maine Blob publication artifact set is incomplete");
+  }
+  return {
+    publishedAtUtc: value.publishedAtUtc,
+    deliveryOrigin: origin,
+    authorizationId: value.authorizationId ?? null,
+    assetCount: seen.size,
+  };
+}
+
+export function inspectMainePublicationPlan(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const now = options.now ?? Date.now();
+  const loaded = loadPackage(root, options.packagePath, options.packageSha256);
+  const manifests = publicManifests(root, loaded);
+  const hiddenArtifact = safeEvidence(
+    root,
+    options.hiddenReceiptPath,
+    ".etl/production-release-receipts/ME",
+    options.hiddenReceiptSha256,
+  );
+  const hidden = validateMaineHiddenLoadReceipt(hiddenArtifact.value, {
+    now,
+    releaseCandidate: loaded.identity,
+  });
+  const blobArtifact = safeEvidence(
+    root,
+    options.blobEvidencePath,
+    ".etl/precinct-blob-publications/ME",
+    options.blobEvidenceSha256,
+  );
+  const blobPlan = inspectMaineLocalBlobPublicationPlan({
+    root,
+    packagePath: loaded.identity.path,
+    packageSha256: loaded.identity.sha256,
+  });
+  const blob = validateMaineBlobPublicationEvidence(blobArtifact.value, blobPlan, now);
+  const registryBytes = readFileSync(path.resolve(root, "data/precinct-geometry-manifests.json"));
+  const plan = {
+    schemaVersion: 1,
+    id: "me-local-database-publication-v1",
+    state: "ME",
+    decision: "GO_AUTHORIZATION_AND_VERIFIED_DEPLOYMENT_REQUIRED",
+    releaseCandidate: loaded.identity,
+    hiddenLoad: {
+      path: hiddenArtifact.path,
+      sha256: hiddenArtifact.sha256,
+      ...hidden,
+    },
+    blobPublication: {
+      path: blobArtifact.path,
+      sha256: blobArtifact.sha256,
+      ...blob,
+    },
+    staticRegistry: {
+      path: "data/precinct-geometry-manifests.json",
+      byteCount: registryBytes.length,
+      sha256: sha256(registryBytes),
+    },
+    manifests: manifests.map(({ manifest: _manifest, ...manifest }) => manifest),
+    expectedTotals: EXPECTED_TOTALS,
+    safety: {
+      databaseMutationPerformed: false,
+      blobMutationPerformed: false,
+      gitMutationPerformed: false,
+      deploymentMutationPerformed: false,
+      publicCutoverIsSingleDatabaseTransaction: true,
+    },
+  };
+  const bytes = serializeMainePublicationDocument(plan);
+  return {
+    root,
+    packageDocument: loaded.document,
+    plan,
+    bytes,
+    sha256: sha256(bytes),
+  };
+}
+
+export function buildMainePublicationAuthorizationTemplate(plan, planSha256) {
+  return {
+    schemaVersion: 1,
+    state: "ME",
+    decision: "NO_GO_PUBLIC",
+    activationId: null,
+    approvedBy: null,
+    authorizedAtUtc: null,
+    expiresAtUtc: null,
+    releaseCandidate: plan.releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    scopes: [...MAINE_PUBLICATION_SCOPES],
+    productionDeployment: {
+      deploymentId: null,
+      url: null,
+      gitSha: null,
+      gitTreeSha: null,
+      readyVerified: false,
+      promotedVerified: false,
+      blockedResultGateVerified: false,
+      blockedGeometryGateVerified: false,
+      verifiedAtUtc: null,
+      deliveryOrigin: plan.blobPublication.deliveryOrigin,
+      staticRegistrySha256: plan.staticRegistry.sha256,
+    },
+    rollbackTarget: {
+      deploymentId: null,
+      url: null,
+      gitSha: null,
+      gitTreeSha: null,
+      verifiedAtUtc: null,
+      gateCapableVerified: false,
+      blockedResultGateVerified: false,
+      blockedGeometryGateVerified: false,
+    },
+    evidence: {
+      hiddenLoad: { path: plan.hiddenLoad.path, sha256: plan.hiddenLoad.sha256 },
+      blobPublication: {
+        path: plan.blobPublication.path,
+        sha256: plan.blobPublication.sha256,
+      },
+    },
+  };
+}
+
+export function validateMainePublicationAuthorization(value, context) {
+  const now = context.now ?? Date.now();
+  const authorizedAt = Date.parse(value?.authorizedAtUtc);
+  const expiresAt = Date.parse(value?.expiresAtUtc);
+  const deployedAt = Date.parse(value?.productionDeployment?.verifiedAtUtc);
+  const rollbackTargetAt = Date.parse(value?.rollbackTarget?.verifiedAtUtc);
+  const recovery = context.recovery === true;
+  let deploymentUrl;
+  let rollbackTargetUrl;
+  try {
+    deploymentUrl = new URL(value?.productionDeployment?.url);
+  } catch {
+    // The common fail-closed check below reports an incompatible record.
+  }
+  try {
+    rollbackTargetUrl = new URL(value?.rollbackTarget?.url);
+  } catch {
+    // The common fail-closed check below reports an incompatible record.
+  }
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "ME"
+    || value?.decision !== "GO_PUBLIC"
+    || typeof value?.activationId !== "string"
+    || !value.activationId.trim()
+    || typeof value?.approvedBy !== "string"
+    || !value.approvedBy.trim()
+    || value?.releaseCandidate?.id !== context.plan.releaseCandidate.id
+    || value?.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
+    || value?.publicationPlan?.id !== context.plan.id
+    || value?.publicationPlan?.sha256 !== context.planSha256
+    || !semanticallyEqual(value?.scopes, MAINE_PUBLICATION_SCOPES)
+    || [authorizedAt, expiresAt, deployedAt, rollbackTargetAt].some(Number.isNaN)
+    || expiresAt <= authorizedAt
+    || deployedAt > authorizedAt
+    || typeof value?.productionDeployment?.deploymentId !== "string"
+    || !value.productionDeployment.deploymentId.trim()
+    || !/^[a-f0-9]{40}$/.test(value?.productionDeployment?.gitSha ?? "")
+    || !/^[a-f0-9]{40}$/.test(value?.productionDeployment?.gitTreeSha ?? "")
+    || value?.productionDeployment?.readyVerified !== true
+    || value?.productionDeployment?.promotedVerified !== true
+    || value?.productionDeployment?.blockedResultGateVerified !== true
+    || value?.productionDeployment?.blockedGeometryGateVerified !== true
+    || value?.productionDeployment?.deliveryOrigin
+      !== context.plan.blobPublication.deliveryOrigin
+    || value?.productionDeployment?.staticRegistrySha256
+      !== context.plan.staticRegistry.sha256
+    || deploymentUrl?.protocol !== "https:"
+    || deploymentUrl?.username
+    || deploymentUrl?.password
+    || deploymentUrl?.search
+    || deploymentUrl?.hash
+    || typeof value?.rollbackTarget?.deploymentId !== "string"
+    || !value.rollbackTarget.deploymentId.trim()
+    || value.rollbackTarget.deploymentId
+      === value.productionDeployment.deploymentId
+    || !/^[a-f0-9]{40}$/.test(value?.rollbackTarget?.gitSha ?? "")
+    || !/^[a-f0-9]{40}$/.test(value?.rollbackTarget?.gitTreeSha ?? "")
+    || value.rollbackTarget.gitTreeSha
+      === value.productionDeployment.gitTreeSha
+    || value?.rollbackTarget?.gateCapableVerified !== true
+    || value?.rollbackTarget?.blockedResultGateVerified !== true
+    || value?.rollbackTarget?.blockedGeometryGateVerified !== true
+    || rollbackTargetUrl?.protocol !== "https:"
+    || rollbackTargetUrl?.username
+    || rollbackTargetUrl?.password
+    || rollbackTargetUrl?.search
+    || rollbackTargetUrl?.hash
+    || rollbackTargetAt > authorizedAt
+    || (!recovery && (
+      authorizedAt > now
+      || now > expiresAt
+      || deployedAt > now
+      || now - deployedAt > 4 * 60 * 60 * 1000
+      || rollbackTargetAt > now
+      || now - rollbackTargetAt > 4 * 60 * 60 * 1000
+    ))
+    || value?.evidence?.hiddenLoad?.path !== context.plan.hiddenLoad.path
+    || value?.evidence?.hiddenLoad?.sha256 !== context.plan.hiddenLoad.sha256
+    || value?.evidence?.blobPublication?.path
+      !== context.plan.blobPublication.path
+    || value?.evidence?.blobPublication?.sha256
+      !== context.plan.blobPublication.sha256
+  ) {
+    throw new Error("Maine public authorization is absent, expired, or incompatible");
+  }
+  return {
+    activationId: value.activationId.trim(),
+    approvedBy: value.approvedBy.trim(),
+    productionDeployment: value.productionDeployment,
+    rollbackTarget: value.rollbackTarget,
+  };
+}
+
+export function buildMainePublicRollbackAuthorizationTemplate(
+  plan,
+  planSha256,
+  publicationReceipt,
+) {
+  return {
+    schemaVersion: 1,
+    state: "ME",
+    decision: "NO_GO_ROLLBACK",
+    rollbackId: null,
+    approvedBy: null,
+    authorizedAtUtc: null,
+    expiresAtUtc: null,
+    releaseCandidate: plan.releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    publication: {
+      activationId: publicationReceipt.activationId,
+      revision: publicationReceipt.revision,
+      changedAtUtc: publicationReceipt.changedAtUtc,
+    },
+    scopes: [...MAINE_PUBLIC_ROLLBACK_SCOPES],
+    rollbackWindow: {
+      startsAtUtc: null,
+      endsAtUtc: null,
+    },
+    applicationRollback: {
+      target: publicationReceipt.rollbackTarget,
+      databaseBlockFirstAcknowledged: false,
+      restoreAfterDatabaseRollbackAcknowledged: false,
+    },
+    evidence: {
+      publicationReceipt: {
+        path: publicationReceipt.path,
+        sha256: publicationReceipt.sha256,
+      },
+    },
+  };
+}
+
+export function validateMainePublicRollbackAuthorization(value, context) {
+  const now = context.now ?? Date.now();
+  const authorizedAt = Date.parse(value?.authorizedAtUtc);
+  const expiresAt = Date.parse(value?.expiresAtUtc);
+  const startsAt = Date.parse(value?.rollbackWindow?.startsAtUtc);
+  const endsAt = Date.parse(value?.rollbackWindow?.endsAtUtc);
+  const receipt = context.publicationReceipt;
+  const recovery = context.recovery === true;
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "ME"
+    || value?.decision !== "GO_ROLLBACK"
+    || typeof value?.rollbackId !== "string"
+    || !value.rollbackId.trim()
+    || typeof value?.approvedBy !== "string"
+    || !value.approvedBy.trim()
+    || value?.releaseCandidate?.id !== context.plan.releaseCandidate.id
+    || value?.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
+    || value?.publicationPlan?.id !== context.plan.id
+    || value?.publicationPlan?.sha256 !== context.planSha256
+    || value?.publication?.activationId !== receipt.activationId
+    || Number(value?.publication?.revision) !== receipt.revision
+    || value?.publication?.changedAtUtc !== receipt.changedAtUtc
+    || !semanticallyEqual(value?.scopes, MAINE_PUBLIC_ROLLBACK_SCOPES)
+    || [authorizedAt, expiresAt, startsAt, endsAt].some(Number.isNaN)
+    || expiresAt <= authorizedAt
+    || startsAt > endsAt
+    || (!recovery && (
+      authorizedAt > now
+      || now > expiresAt
+      || startsAt > now
+      || now > endsAt
+    ))
+    || !semanticallyEqual(
+      value?.applicationRollback?.target,
+      receipt.rollbackTarget,
+    )
+    || value?.applicationRollback?.databaseBlockFirstAcknowledged !== true
+    || value?.applicationRollback?.restoreAfterDatabaseRollbackAcknowledged
+      !== true
+    || value?.evidence?.publicationReceipt?.path !== receipt.path
+    || value?.evidence?.publicationReceipt?.sha256 !== receipt.sha256
+  ) {
+    throw new Error("Maine rollback authorization is absent, expired, or incompatible");
+  }
+  return {
+    activationId: value.rollbackId.trim(),
+    rollbackId: value.rollbackId.trim(),
+    publicationActivationId: receipt.activationId,
+    approvedBy: value.approvedBy.trim(),
+    rollbackWindow: value.rollbackWindow,
+    applicationRollback: value.applicationRollback,
+  };
+}

--- a/scripts/lib/me-local-release-candidate.mjs
+++ b/scripts/lib/me-local-release-candidate.mjs
@@ -1,0 +1,601 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+import { buildPrecinctDeliveryCandidateFeatureCollection } from "./precinct-delivery-builder.mjs";
+import { buildParentScopedPrecinctDeliveryPackage } from "./precinct-parent-delivery-builder.mjs";
+import { buildMaineLocalGisPlan } from "./me-local-gis-plan.mjs";
+import { inspectPrecinctGeometryManifest } from "../../src/lib/precinct-geography.ts";
+
+export const MAINE_RELEASE_CANDIDATE_ID = "me-local-reporting-gis-three-election-v1";
+export const MAINE_RELEASE_CANDIDATE_ROOT = ".etl/precinct-release-candidates/ME";
+export const MAINE_LOCAL_VALIDATION_REPORT = ".etl/local-db/me-public-local-gis-validation.json";
+export const MAINE_PUBLIC_RELEASE_YEARS = Object.freeze([2016, 2020, 2024]);
+export const MAINE_DELIVERY_COORDINATE_DECIMALS = 7;
+export const MAINE_DELIVERY_SIMPLIFICATION_TOLERANCE_DEGREES = 0.000005;
+export const MAINE_MAX_PARENT_DELIVERY_BYTES = 4_350_000;
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function serializeMaineReleaseDocument(value) {
+  return Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function safePath(root, relativePath, allowedRoots) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath
+    || path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !allowedRoots.some((prefix) => relativePath.startsWith(prefix))
+  ) {
+    throw new Error("Unsafe Maine release artifact path: " + relativePath);
+  }
+  const resolvedRoot = path.resolve(root);
+  const absolutePath = path.resolve(resolvedRoot, ...relativePath.split("/"));
+  if (!absolutePath.startsWith(resolvedRoot + path.sep)) {
+    throw new Error("Maine release artifact escapes repository root: " + relativePath);
+  }
+  return absolutePath;
+}
+
+function readArtifact(root, declaration, allowedRoots = ["data/", ".etl/"]) {
+  const absolutePath = safePath(root, declaration.path, allowedRoots);
+  if (!existsSync(absolutePath)) {
+    throw new Error("Maine release artifact is missing: " + declaration.path);
+  }
+  const bytes = readFileSync(absolutePath);
+  const digest = sha256(bytes);
+  if (
+    Number.isInteger(declaration.byteCount)
+    && bytes.length !== declaration.byteCount
+  ) {
+    throw new Error("Maine release artifact byte count drifted: " + declaration.path);
+  }
+  if (declaration.sha256 && digest !== declaration.sha256) {
+    throw new Error("Maine release artifact SHA-256 drifted: " + declaration.path);
+  }
+  return { path: declaration.path, byteCount: bytes.length, sha256: digest, bytes };
+}
+
+export function inspectReleaseArtifact(root, relativePath, options = {}) {
+  return readArtifact(root, {
+    path: relativePath,
+    byteCount: options.byteCount,
+    sha256: options.sha256,
+  }, options.allowedRoots ?? ["data/", ".etl/", "drizzle/", "scripts/"]);
+}
+
+function parseJsonArtifact(root, declaration, allowedRoots) {
+  const artifact = readArtifact(root, declaration, allowedRoots);
+  const payload = declaration.path.endsWith(".gz")
+    ? gunzipSync(artifact.bytes)
+    : artifact.bytes;
+  return { artifact, value: JSON.parse(payload.toString("utf8")) };
+}
+
+function validateLocalReport(report, plan) {
+  if (
+    report?.schemaVersion !== 1
+    || report?.productionMutationPerformed !== false
+    || report?.publicDeliveryAuthorized !== false
+    || report?.validation?.database?.environment !== "local"
+    || report?.validation?.database?.host !== "loopback"
+    || report?.validation?.database?.port !== 54329
+    || report?.validation?.database?.name !== "crm_clone_dev"
+    || report?.validation?.database?.readOnlySession !== true
+    || report?.validation?.invalidConstraints !== 0
+    || !Number.isInteger(report?.validation?.revision)
+    || Number.isNaN(Date.parse(report?.generatedAtUtc))
+  ) {
+    throw new Error("Maine local database validation report is not release-safe");
+  }
+  const rows = new Map(
+    (report.validation.years ?? []).map((row) => [Number(row.year), row]),
+  );
+  for (const year of plan.years) {
+    const row = rows.get(year.year);
+    const expected = {
+      reportingUnits: year.reportingUnits.length,
+      resultRows: year.resultRows.length,
+      sameYearResultRows: year.resultRows.length,
+      totalVotes: year.totals.Total,
+      zeroVoteUnits: year.zeroVoteUnits,
+      geographyVersions: 1,
+      features: year.geometry.features.length,
+      safeBlockedGeographyVersions: 1,
+      reviewedCrosswalks: year.geometry.crosswalks.length,
+      exactFeatures: year.geometry.features.length,
+      exactCrosswalks: year.geometry.crosswalks.length,
+    };
+    if (!row) throw new Error("Maine local validation is missing " + year.year);
+    for (const [key, value] of Object.entries(expected)) {
+      if (Number(row[key]) !== value) {
+        throw new Error("Maine " + year.year + " local validation " + key + " drifted");
+      }
+    }
+  }
+  if (rows.size !== plan.years.length) {
+    throw new Error("Maine local validation year set drifted");
+  }
+  return {
+    generatedAtUtc: report.generatedAtUtc,
+    revision: report.validation.revision,
+    invalidConstraints: report.validation.invalidConstraints,
+    database: report.validation.database,
+  };
+}
+
+function publicUrl(year, manifestId, indexSha256) {
+  return "/data/geography/me/"
+    + year.electionDate
+    + "/local_reporting_unit/"
+    + manifestId
+    + "-"
+    + indexSha256.slice(0, 12)
+    + "/index.json";
+}
+
+function squaredDistanceToSegment(point, start, end) {
+  const dx = end[0] - start[0];
+  const dy = end[1] - start[1];
+  if (dx === 0 && dy === 0) {
+    return (point[0] - start[0]) ** 2 + (point[1] - start[1]) ** 2;
+  }
+  const amount = Math.max(
+    0,
+    Math.min(
+      1,
+      ((point[0] - start[0]) * dx + (point[1] - start[1]) * dy)
+        / (dx * dx + dy * dy),
+    ),
+  );
+  const projectedX = start[0] + amount * dx;
+  const projectedY = start[1] + amount * dy;
+  return (point[0] - projectedX) ** 2 + (point[1] - projectedY) ** 2;
+}
+
+function simplifyLine(points, squaredTolerance) {
+  if (points.length <= 2) return points;
+  let maximumDistance = squaredTolerance;
+  let maximumIndex = -1;
+  const start = points[0];
+  const end = points[points.length - 1];
+  for (let index = 1; index < points.length - 1; index += 1) {
+    const distance = squaredDistanceToSegment(points[index], start, end);
+    if (distance > maximumDistance) {
+      maximumDistance = distance;
+      maximumIndex = index;
+    }
+  }
+  if (maximumIndex < 0) return [start, end];
+  const left = simplifyLine(points.slice(0, maximumIndex + 1), squaredTolerance);
+  const right = simplifyLine(points.slice(maximumIndex), squaredTolerance);
+  return [...left.slice(0, -1), ...right];
+}
+
+function samePoint(left, right) {
+  return left[0] === right[0] && left[1] === right[1];
+}
+
+function quantizeCoordinate(coordinate, scale) {
+  return coordinate.map((value) =>
+    Number.isFinite(value) ? Math.round(value * scale) / scale : value);
+}
+
+function simplifyRing(ring, scale, tolerance) {
+  const quantized = ring
+    .map((coordinate) => quantizeCoordinate(coordinate, scale))
+    .filter((coordinate, index, rows) =>
+      index === 0 || !samePoint(coordinate, rows[index - 1]));
+  if (
+    quantized.length > 1
+    && samePoint(quantized[0], quantized[quantized.length - 1])
+  ) {
+    quantized.pop();
+  }
+  if (new Set(quantized.map((coordinate) => coordinate.join(","))).size < 3) {
+    return null;
+  }
+
+  let anchorIndex = 0;
+  for (let index = 1; index < quantized.length; index += 1) {
+    if (
+      quantized[index][0] < quantized[anchorIndex][0]
+      || (
+        quantized[index][0] === quantized[anchorIndex][0]
+        && quantized[index][1] < quantized[anchorIndex][1]
+      )
+    ) {
+      anchorIndex = index;
+    }
+  }
+  const rotated = [
+    ...quantized.slice(anchorIndex),
+    ...quantized.slice(0, anchorIndex),
+  ];
+  let splitIndex = 1;
+  let splitDistance = -1;
+  for (let index = 1; index < rotated.length; index += 1) {
+    const distance = (rotated[index][0] - rotated[0][0]) ** 2
+      + (rotated[index][1] - rotated[0][1]) ** 2;
+    if (distance > splitDistance) {
+      splitDistance = distance;
+      splitIndex = index;
+    }
+  }
+  const squaredTolerance = tolerance ** 2;
+  const firstArc = simplifyLine(
+    rotated.slice(0, splitIndex + 1),
+    squaredTolerance,
+  );
+  const secondArc = simplifyLine(
+    [...rotated.slice(splitIndex), rotated[0]],
+    squaredTolerance,
+  );
+  const simplified = [...firstArc, ...secondArc.slice(1, -1)];
+  const usable = new Set(
+    simplified.map((coordinate) => coordinate.join(",")),
+  ).size >= 3 ? simplified : rotated;
+  return [...usable, usable[0]];
+}
+
+function simplifyPolygon(polygon, scale, tolerance) {
+  const outer = simplifyRing(polygon[0], scale, tolerance);
+  if (!outer) return null;
+  return [
+    outer,
+    ...polygon.slice(1)
+      .map((ring) => simplifyRing(ring, scale, tolerance))
+      .filter(Boolean),
+  ];
+}
+
+function simplifyGeometry(geometry, scale, tolerance) {
+  if (geometry.type === "Polygon") {
+    const polygon = simplifyPolygon(geometry.coordinates, scale, tolerance);
+    if (!polygon) {
+      throw new Error("Maine presentation simplification collapsed a polygon");
+    }
+    return {
+      type: "Polygon",
+      coordinates: polygon,
+    };
+  }
+  if (geometry.type === "MultiPolygon") {
+    const polygons = geometry.coordinates
+      .map((polygon) => simplifyPolygon(polygon, scale, tolerance))
+      .filter(Boolean);
+    if (polygons.length === 0) {
+      throw new Error("Maine presentation simplification collapsed a multipolygon");
+    }
+    return {
+      type: "MultiPolygon",
+      coordinates: polygons,
+    };
+  }
+  throw new Error("Maine delivery has an unsupported geometry type");
+}
+
+export function quantizeMaineDeliveryCollection(collection) {
+  const scale = 10 ** MAINE_DELIVERY_COORDINATE_DECIMALS;
+  const tolerance = MAINE_DELIVERY_SIMPLIFICATION_TOLERANCE_DEGREES;
+  return {
+    ...collection,
+    metadata: {
+      ...collection.metadata,
+      coordinatePrecisionDecimals: MAINE_DELIVERY_COORDINATE_DECIMALS,
+      simplificationToleranceDegrees: tolerance,
+      presentationGeometry: "source-normalized geometry is rounded to seven decimals and simplified at a 0.000005-degree presentation tolerance for county-scoped web delivery; zero-area polygon parts are omitted while source artifacts, identities, and joins remain unchanged",
+    },
+    features: collection.features.map((feature) => ({
+      ...feature,
+      geometry: simplifyGeometry(feature.geometry, scale, tolerance),
+    })),
+  };
+}
+
+function buildDraftManifest(year, delivery) {
+  const draft = JSON.parse(JSON.stringify(year.manifest));
+  const warnings = [
+    ...draft.validation.warnings,
+    "All " + year.reportingUnits.length
+      + " displayable local-result relationships are reviewed one-to-one across all 16 Maine counties.",
+    "The " + year.zeroVoteUnits
+      + " zero-presidential-vote local units remain geographic reporting units.",
+    "All " + year.manifest.crosswalk.reviewedNoDataFeatures
+      + " reviewed no-data polygons remain visible without an invented result row.",
+    "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged.",
+  ];
+  draft.validation = {
+    ...draft.validation,
+    status: "reviewed",
+    rowLevelRenderingSafe: true,
+    errors: [],
+    warnings: [...new Set(warnings)],
+  };
+  draft.delivery = {
+    format: "parent_scoped_geojson",
+    url: publicUrl(year, draft.id, delivery.indexSha256),
+    sha256: delivery.indexSha256,
+    byteCount: delivery.indexByteCount,
+    featureIdProperty: "geometryFeatureId",
+    resultUnitProperty: "resultUnitCode",
+    parentGeoidProperty: "parentGeoid",
+    parentCount: delivery.parentCount,
+    featureCount: delivery.featureCount,
+  };
+  draft.caveats = [...new Set(draft.caveats)];
+  const inspection = inspectPrecinctGeometryManifest(draft);
+  if (inspection.errors.length || inspection.publicEligibilityReasons.length) {
+    throw new Error(
+      "Maine " + year.year + " public draft is invalid: "
+      + inspection.errors.concat(inspection.publicEligibilityReasons).join("; "),
+    );
+  }
+  return draft;
+}
+
+function buildYear(root, year) {
+  const normalized = parseJsonArtifact(root, {
+    path: year.manifest.normalization.artifact,
+    byteCount: year.manifest.normalization.byteCount,
+    sha256: year.manifest.normalization.sha256,
+  }, ["data/"]);
+  const crosswalk = parseJsonArtifact(root, {
+    path: year.manifest.crosswalk.artifact,
+    byteCount: year.manifest.crosswalk.byteCount,
+    sha256: year.manifest.crosswalk.sha256,
+  }, ["data/"]);
+  const statewide = quantizeMaineDeliveryCollection(
+    buildPrecinctDeliveryCandidateFeatureCollection(
+      year.manifest,
+      normalized.value,
+      crosswalk.value,
+    ),
+  );
+  const delivery = buildParentScopedPrecinctDeliveryPackage(statewide);
+  if (
+    delivery.parentCount !== 16
+    || delivery.featureCount !== year.geometry.features.length
+    || delivery.resultUnitCount !== year.geometry.features.length
+  ) {
+    throw new Error("Maine " + year.year + " parent-scoped delivery drifted");
+  }
+  const largestParentByteCount = Math.max(
+    ...delivery.parentArtifacts.map((artifact) => artifact.byteCount),
+  );
+  if (largestParentByteCount > MAINE_MAX_PARENT_DELIVERY_BYTES) {
+    throw new Error(
+      "Maine " + year.year + " parent delivery exceeds the web response safety limit",
+    );
+  }
+  const draft = buildDraftManifest(year, delivery);
+  const draftBytes = serializeMaineReleaseDocument(draft);
+  const assetRoot = path.posix.join(
+    "delivery-assets",
+    draft.id + "-" + delivery.indexSha256.slice(0, 12),
+  );
+  const index = {
+    packageRelativePath: path.posix.join(assetRoot, "index.json"),
+    publicUrl: draft.delivery.url,
+    byteCount: delivery.indexByteCount,
+    sha256: delivery.indexSha256,
+  };
+  const parentArtifacts = delivery.parentArtifacts.map((artifact) => ({
+    parentGeoid: artifact.parentGeoid,
+    packageRelativePath: path.posix.join(assetRoot, artifact.path),
+    publicUrl: path.posix.join(path.posix.dirname(draft.delivery.url), artifact.path),
+    byteCount: artifact.byteCount,
+    sha256: artifact.sha256,
+    featureCount: artifact.featureCount,
+  }));
+  return {
+    summary: {
+      year: year.year,
+      electionId: year.electionId,
+      manifestId: year.manifest.id,
+      canonicalManifest: {
+        path: year.manifestPath,
+        sha256: year.manifestSha256,
+        byteCount: year.manifestByteCount,
+        validationStatus: "blocked",
+        rowLevelRenderingSafe:
+          year.manifest.validation.rowLevelRenderingSafe,
+        delivery: null,
+      },
+      certifiedResults: {
+        authority: year.resultSource.authority,
+        sourceId: year.resultSource.id,
+        sourceUrl: year.resultSource.url,
+        artifact: {
+          path: year.resultSource.artifact,
+          byteCount: year.resultSource.byteCount,
+          sha256: year.resultSource.sha256,
+        },
+        reportingUnits: year.reportingUnits.length,
+        resultRows: year.resultRows.length,
+        zeroVoteUnits: year.zeroVoteUnits,
+        candidateDetailSuppressedUnits: year.candidateDetailSuppressedUnits,
+        totals: year.totals,
+      },
+      reviewedGeometry: {
+        sourceAuthority: year.manifest.source.authority,
+        sourceUrl: year.manifest.source.url,
+        sourceTerms: year.manifest.source.licenseOrTerms,
+        featureCount: year.geometry.features.length,
+        parentCount: delivery.parentCount,
+        reviewedExactCrosswalks: year.geometry.crosswalks.length,
+        reviewedNoDataFeatures: year.manifest.crosswalk.reviewedNoDataFeatures,
+        publicGeographyLabel: year.year === 2016
+          ? "attributed VEST election-specific local-boundary reconstruction joined only to official Maine results"
+          : year.year === 2020
+            ? "attributed VEST election-specific local-boundary reconstruction joined only to official Maine results"
+            : "attributed New York Times official-boundary compilation plus reviewed Maine GeoLibrary gap geometry, joined only to official Maine results",
+        electionValuesInDelivery: false,
+      },
+      parentScopedDelivery: {
+        format: "parent_scoped_geojson",
+        originEnvironmentVariable: "CRM_PRECINCT_GEOGRAPHY_ORIGIN",
+        index,
+        parentCount: delivery.parentCount,
+        featureCount: delivery.featureCount,
+        deliveryIdentityCount: delivery.resultUnitCount,
+        colorableResultUnitCount: year.reportingUnits.length,
+        candidateDetailSuppressedResultUnitCount:
+          year.candidateDetailSuppressedUnits,
+        reviewedNoDataFeatureCount:
+          year.manifest.crosswalk.reviewedNoDataFeatures,
+        parentArtifactByteCount: delivery.parentArtifactByteCount,
+        largestParentByteCount,
+        coordinatePrecisionDecimals: MAINE_DELIVERY_COORDINATE_DECIMALS,
+        simplificationToleranceDegrees:
+          MAINE_DELIVERY_SIMPLIFICATION_TOLERANCE_DEGREES,
+        maximumParentByteCount: MAINE_MAX_PARENT_DELIVERY_BYTES,
+        parentArtifacts,
+        electionValuesInDelivery: false,
+        publicationPerformed: false,
+      },
+      proposedPublicDelivery: draft.delivery,
+      draftManifest: {
+        path: path.posix.join("draft-manifests", draft.id + ".json"),
+        byteCount: draftBytes.length,
+        sha256: sha256(draftBytes),
+        canonicalMutationPerformed: false,
+        reviewRequired: true,
+      },
+    },
+    draft: { path: path.posix.join("draft-manifests", draft.id + ".json"), bytes: draftBytes },
+    assets: [
+      { path: index.packageRelativePath, bytes: delivery.indexBytes },
+      ...delivery.parentArtifacts.map((artifact) => ({
+        path: path.posix.join(assetRoot, artifact.path),
+        bytes: artifact.bytes,
+      })),
+    ],
+  };
+}
+
+function sum(years, selector) {
+  return years.reduce((total, year) => total + selector(year), 0);
+}
+
+export async function buildMaineLocalReleaseCandidate(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const plan = await buildMaineLocalGisPlan({
+    root,
+    years: [...MAINE_PUBLIC_RELEASE_YEARS],
+  });
+  const validationPath = options.validationReportPath
+    ?? MAINE_LOCAL_VALIDATION_REPORT;
+  const validationArtifact = readArtifact(root, { path: validationPath }, [".etl/"]);
+  const validationValue = JSON.parse(validationArtifact.bytes.toString("utf8"));
+  const localValidation = validateLocalReport(validationValue, plan);
+  const migration0008Artifact = readArtifact(root, {
+    path: "drizzle/0008_typical_thunderbolts.sql",
+  }, ["drizzle/"]);
+  const migration0009Artifact = readArtifact(root, {
+    path: "drizzle/0009_public_wolfpack.sql",
+  }, ["drizzle/"]);
+  const yearBuilds = plan.years.map((year) => buildYear(root, year));
+  const years = yearBuilds.map((year) => year.summary);
+  const packageDocument = {
+    schemaVersion: 1,
+    id: MAINE_RELEASE_CANDIDATE_ID,
+    state: "ME",
+    stateName: "Maine",
+    scope: "reviewed 2016, 2020, and 2024 Maine presidential local-reporting GIS release preparation; 2012 remains separately blocked",
+    preparedFromLocalValidationAt: localValidation.generatedAtUtc,
+    disposition: "prepared_awaiting_explicit_production_authorization",
+    decision: "NO_GO_PRODUCTION",
+    safety: {
+      productionMutationPerformed: false,
+      publicFileWritten: false,
+      canonicalManifestChanged: false,
+      canonicalRegistryChanged: false,
+      publicEligibilityChanged: false,
+      gitPublicationPerformed: false,
+      explicitProductionAuthorizationRequired: true,
+    },
+    totals: {
+      elections: years.length,
+      countyEquivalentsPerElection: 16,
+      reportingUnits: sum(years, (year) => year.certifiedResults.reportingUnits),
+      candidateResultRows: sum(years, (year) => year.certifiedResults.resultRows),
+      zeroVoteUnits: sum(years, (year) => year.certifiedResults.zeroVoteUnits),
+      geometryFeatures: sum(years, (year) => year.reviewedGeometry.featureCount),
+      reviewedExactCrosswalks: sum(years, (year) => year.reviewedGeometry.reviewedExactCrosswalks),
+      deliveryIndexes: years.length,
+      parentDeliveryArtifacts: years.length * 16,
+    },
+    years,
+    localValidation: {
+      path: validationPath,
+      byteCount: validationArtifact.byteCount,
+      sha256: validationArtifact.sha256,
+      ...localValidation,
+    },
+    databaseActivationContract: {
+      migrations: [migration0008Artifact, migration0009Artifact].map((artifact) => ({
+        path: artifact.path,
+        byteCount: artifact.byteCount,
+        sha256: artifact.sha256,
+      })),
+      productionWriterImplemented: true,
+      productionWriterEnabled: false,
+      expectedPostLoad: {
+        reportingUnits: sum(years, (year) => year.certifiedResults.reportingUnits),
+        candidateResultRows: sum(years, (year) => year.certifiedResults.resultRows),
+        geographyVersions: 3,
+        geometryFeatures: sum(years, (year) => year.reviewedGeometry.featureCount),
+        reviewedExactCrosswalks: sum(years, (year) => year.reviewedGeometry.reviewedExactCrosswalks),
+        reviewedNoDataFeatures: 0,
+        zeroVoteUnits: sum(years, (year) => year.certifiedResults.zeroVoteUnits),
+        invalidConstraints: 0,
+      },
+    },
+    releasePolicy: {
+      officialResultsScope: "Official Maine Secretary of State presidential local reporting rows from all 16 counties. Every displayed vote is grouped to Democratic, Republican, and Other and reconciled to the retained official workbook.",
+      certifiedCanvassBoundary: "These safely colorable local rows do not replace separately published certified county or statewide totals; every aggregation and source limitation remains visible as a caveat.",
+      publicLabel: "Maine local reporting unit results with reviewed election-specific geometry",
+      blockedYear: {
+        year: 2012,
+        issue: "docs/developer/precinct-gis-implementation.md#maine",
+        reason: "Maine 2012 remains incomplete by five official result rows and eight presidential votes; the retained MGGG geometry also lacks confirmed November 2012 vintage and explicit derivative redistribution permission.",
+      },
+      hiddenLoadRequired: true,
+      immutableBlobPublicationRequired: true,
+      protectedPreviewRequired: true,
+      databasePublicationGateRequired: true,
+    },
+    goNoGoGates: [
+      { id: "official_sources_hash_pinned", status: "passed" },
+      { id: "three_year_exact_result_geometry_join", status: "passed" },
+      { id: "2012_remains_separately_blocked", status: "passed", evidence: "docs/developer/precinct-gis-implementation.md#maine" },
+      { id: "local_database_exact_validation", status: "passed", evidence: validationPath },
+      { id: "immutable_parent_scoped_delivery", status: "passed" },
+      { id: "production_hidden_load", status: "pending" },
+      { id: "blob_publication", status: "pending" },
+      { id: "protected_preview_and_public_activation", status: "pending" },
+    ],
+  };
+  return {
+    packageDocument,
+    packageBytes: serializeMaineReleaseDocument(packageDocument),
+    draftManifests: yearBuilds.map((year) => year.draft),
+    deliveryAssets: yearBuilds.flatMap((year) => year.assets),
+  };
+}
+
+export function maineReleaseCandidateOutputRoot(packageSha256) {
+  if (!/^[a-f0-9]{64}$/.test(packageSha256)) {
+    throw new Error("Maine release package hash must be SHA-256");
+  }
+  return path.posix.join(
+    MAINE_RELEASE_CANDIDATE_ROOT,
+    MAINE_RELEASE_CANDIDATE_ID + "-" + packageSha256.slice(0, 12),
+  );
+}

--- a/scripts/prepare-me-local-public-activation.mjs
+++ b/scripts/prepare-me-local-public-activation.mjs
@@ -1,0 +1,144 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  inspectMainePublicActivationPlan,
+} from "./lib/me-local-public-activation.mjs";
+
+function parseArguments(args) {
+  const packagePath = args.find((arg) => arg.startsWith("--package="))
+    ?.slice("--package=".length);
+  const packageSha256 = args.find((arg) => arg.startsWith("--package-sha256="))
+    ?.slice("--package-sha256=".length);
+  const write = args.includes("--write");
+  for (const arg of args) {
+    if (
+      arg !== "--write"
+      && !arg.startsWith("--package=")
+      && !arg.startsWith("--package-sha256=")
+    ) {
+      throw new Error("Unknown Maine public-activation option: " + arg);
+    }
+  }
+  if (!packagePath || !packageSha256) {
+    throw new Error(
+      "Maine public activation requires --package and --package-sha256",
+    );
+  }
+  return { packagePath, packageSha256, write };
+}
+
+function immutableWrite(root, relativePath, bytes) {
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ".etl", "precinct-public-activations", "ME");
+  if (!absolutePath.startsWith(allowed + path.sep)) {
+    throw new Error("Maine activation evidence escapes its fixed .etl root");
+  }
+  if (existsSync(absolutePath)) {
+    if (!readFileSync(absolutePath).equals(bytes)) {
+      throw new Error("Refusing to overwrite different Maine activation evidence");
+    }
+    return "verified_existing";
+  }
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, bytes, { mode: 0o600, flag: "wx" });
+  return "created";
+}
+
+export function writeMaineActivationTrackedOutputs(outputs) {
+  if (outputs.length !== 4 || new Set(outputs.map((item) => item.path)).size !== 4) {
+    throw new Error("Maine activation requires exactly four unique tracked outputs");
+  }
+  const staged = [];
+  const committed = [];
+  try {
+    for (const output of outputs) {
+      const before = readFileSync(output.absolutePath);
+      if (before.length !== output.preimage.byteCount) {
+        throw new Error("Maine activation target changed after plan: " + output.path);
+      }
+      const currentHash = createHash("sha256").update(before).digest("hex");
+      if (currentHash !== output.preimage.sha256) {
+        throw new Error("Maine activation target preimage drifted: " + output.path);
+      }
+      const temporaryPath = output.absolutePath
+        + ".crm-me-activation-" + randomUUID() + ".tmp";
+      writeFileSync(temporaryPath, output.bytes, { flag: "wx" });
+      staged.push({ output, before, temporaryPath });
+    }
+    for (const item of staged) {
+      renameSync(item.temporaryPath, item.output.absolutePath);
+      committed.push(item);
+    }
+  } catch (error) {
+    for (const item of staged) {
+      if (existsSync(item.temporaryPath)) unlinkSync(item.temporaryPath);
+    }
+    for (const item of committed.reverse()) {
+      const rollbackPath = item.output.absolutePath
+        + ".crm-me-rollback-" + randomUUID() + ".tmp";
+      writeFileSync(rollbackPath, item.before, { flag: "wx" });
+      renameSync(rollbackPath, item.output.absolutePath);
+    }
+    throw error;
+  }
+  return outputs.map((output) => ({
+    path: output.path,
+    sha256: output.sha256,
+    byteCount: output.byteCount,
+  }));
+}
+
+export async function prepareMainePublicActivation(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const built = inspectMainePublicActivationPlan({ ...options, root });
+  if (!options.write) {
+    return {
+      mode: "plan",
+      decision: built.plan.decision,
+      releaseCandidate: built.plan.releaseCandidate,
+      activationCandidate: {
+        path: built.outputPath,
+        sha256: built.sha256,
+        byteCount: built.bytes.length,
+      },
+      trackedOutputs: built.plan.trackedOutputs,
+      productionMutationPerformed: false,
+      publicEndpointsRemainDatabaseGated: true,
+    };
+  }
+  const trackedOutputs = writeMaineActivationTrackedOutputs(built.outputs);
+  const evidenceDisposition = immutableWrite(root, built.outputPath, built.bytes);
+  return {
+    mode: "write",
+    decision: built.plan.decision,
+    releaseCandidate: built.plan.releaseCandidate,
+    activationCandidate: {
+      path: built.outputPath,
+      sha256: built.sha256,
+      byteCount: built.bytes.length,
+      disposition: evidenceDisposition,
+    },
+    trackedOutputs,
+    productionMutationPerformed: false,
+    publicEndpointsRemainDatabaseGated: true,
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  prepareMainePublicActivation(parseArguments(process.argv.slice(2))).then(
+    (result) => console.log(JSON.stringify(result, null, 2)),
+    (error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/prepare-me-local-release-candidate.mjs
+++ b/scripts/prepare-me-local-release-candidate.mjs
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildMaineLocalReleaseCandidate,
+  maineReleaseCandidateOutputRoot,
+} from "./lib/me-local-release-candidate.mjs";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function immutableWrite(root, relativePath, bytes) {
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  const expectedRoot = path.resolve(root, ".etl", "precinct-release-candidates", "ME");
+  if (!absolutePath.startsWith(expectedRoot + path.sep)) {
+    throw new Error("Maine release output escapes its content-addressed root");
+  }
+  if (existsSync(absolutePath)) {
+    if (!readFileSync(absolutePath).equals(bytes)) {
+      throw new Error("Refusing to overwrite different Maine release bytes: " + relativePath);
+    }
+    return "verified_existing";
+  }
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, bytes);
+  return "created";
+}
+
+export async function prepareMaineLocalReleaseCandidate(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const built = await buildMaineLocalReleaseCandidate({
+    root,
+    validationReportPath: options.validationReportPath,
+  });
+  const packageSha256 = sha256(built.packageBytes);
+  const outputRoot = maineReleaseCandidateOutputRoot(packageSha256);
+  const files = [
+    { path: "release-candidate.json", bytes: built.packageBytes },
+    ...built.draftManifests,
+    ...built.deliveryAssets,
+  ];
+  const disposition = options.write
+    ? files.map((file) => immutableWrite(
+      root,
+      path.posix.join(outputRoot, file.path),
+      file.bytes,
+    ))
+    : [];
+  return {
+    mode: options.write ? "write" : "plan",
+    decision: "NO_GO_PRODUCTION",
+    state: "ME",
+    releaseCandidate: {
+      id: built.packageDocument.id,
+      path: path.posix.join(outputRoot, "release-candidate.json"),
+      sha256: packageSha256,
+      byteCount: built.packageBytes.length,
+    },
+    totals: built.packageDocument.totals,
+    fileCount: files.length,
+    createdCount: disposition.filter((value) => value === "created").length,
+    verifiedExistingCount: disposition.filter((value) => value === "verified_existing").length,
+    productionMutationPerformed: false,
+    publicFileWritten: false,
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const unknown = args.filter((arg) => arg !== "--write" && !arg.startsWith("--validation-report="));
+  if (unknown.length) throw new Error("Unknown Maine release-candidate option: " + unknown[0]);
+  const validationReportPath = args.find((arg) => arg.startsWith("--validation-report="))
+    ?.slice("--validation-report=".length);
+  console.log(JSON.stringify(await prepareMaineLocalReleaseCandidate({
+    write: args.includes("--write"),
+    validationReportPath,
+  }), null, 2));
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/publish-me-local-delivery-assets.mjs
+++ b/scripts/publish-me-local-delivery-assets.mjs
@@ -1,0 +1,264 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  inspectMaineLocalBlobPublicationPlan,
+  validateMaineBlobPublicationAuthorization,
+} from "./lib/me-local-blob-publication.mjs";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function parseArguments(args) {
+  const write = args.includes("--write");
+  const packagePath = args.find((argument) =>
+    argument.startsWith("--package="))?.slice("--package=".length);
+  const packageSha256 = args.find((argument) =>
+    argument.startsWith("--package-sha256="))
+    ?.slice("--package-sha256=".length);
+  const concurrencyValue = args.find((argument) =>
+    argument.startsWith("--concurrency="))?.slice("--concurrency=".length);
+  const concurrency = concurrencyValue ? Number(concurrencyValue) : 4;
+  for (const argument of args) {
+    if (
+      argument !== "--write"
+      && !argument.startsWith("--package=")
+      && !argument.startsWith("--package-sha256=")
+      && !argument.startsWith("--concurrency=")
+    ) {
+      throw new Error("Unknown Maine Blob publication option: " + argument);
+    }
+  }
+  if (!packagePath || !packageSha256) {
+    throw new Error(
+      "usage: npm run local-gis:delivery-publish:me -- "
+      + "--package=<release-candidate.json> --package-sha256=<sha256> "
+      + "[--concurrency=4] [--write]",
+    );
+  }
+  if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 8) {
+    throw new Error("Maine Blob publication concurrency must be 1 through 8");
+  }
+  return { write, packagePath, packageSha256, concurrency };
+}
+
+function publicPlan(plan) {
+  return {
+    schemaVersion: plan.schemaVersion,
+    state: plan.state,
+    releaseCandidate: plan.releaseCandidate,
+    decision: plan.decision,
+    assetCount: plan.assetCount,
+    indexCount: plan.indexCount,
+    parentArtifactCount: plan.parentArtifactCount,
+    totalByteCount: plan.totalByteCount,
+    uploadOrder: plan.uploadOrder,
+    canonicalManifestChanged: plan.canonicalManifestChanged,
+    publicEligibilityChanged: plan.publicEligibilityChanged,
+    artifacts: plan.artifacts.map(({ absolutePath: _absolutePath, ...artifact }) =>
+      artifact),
+  };
+}
+
+async function verifyPublicBlob(url, artifact) {
+  const response = await fetch(url, {
+    cache: "no-store",
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!response.ok) {
+    throw new Error(
+      "Published Maine geometry returned HTTP " + response.status,
+    );
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.length !== artifact.byteCount || sha256(bytes) !== artifact.sha256) {
+    throw new Error("Published Maine geometry failed byte/hash verification");
+  }
+}
+
+async function publishArtifact(artifact, sdk) {
+  let existing = null;
+  try {
+    existing = await sdk.head(artifact.pathname);
+  } catch (error) {
+    if (!(error instanceof sdk.BlobNotFoundError)) throw error;
+  }
+  if (existing) {
+    if (existing.size !== artifact.byteCount) {
+      throw new Error(
+        "Existing immutable Maine geometry has a different byte count",
+      );
+    }
+    await verifyPublicBlob(existing.url, artifact);
+    return {
+      ...artifact,
+      disposition: "verified_existing",
+      url: existing.url,
+      remoteMutationPerformed: false,
+    };
+  }
+
+  const bytes = readFileSync(artifact.absolutePath);
+  const uploaded = await sdk.put(artifact.pathname, bytes, {
+    access: "public",
+    addRandomSuffix: false,
+    allowOverwrite: false,
+    cacheControlMaxAge: 31_536_000,
+    contentType: artifact.kind === "index"
+      ? "application/json"
+      : "application/geo+json",
+    multipart: bytes.length >= 4 * 1024 * 1024,
+  });
+  if (
+    uploaded.pathname !== artifact.pathname
+    || new URL(uploaded.url).pathname !== "/" + artifact.pathname
+  ) {
+    throw new Error("Published Maine geometry URL/pathname drifted");
+  }
+  await verifyPublicBlob(uploaded.url, artifact);
+  return {
+    ...artifact,
+    disposition: "created",
+    url: uploaded.url,
+    remoteMutationPerformed: true,
+  };
+}
+
+async function publishBatch(artifacts, concurrency, sdk) {
+  const results = new Array(artifacts.length);
+  let nextIndex = 0;
+  async function worker() {
+    while (nextIndex < artifacts.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await publishArtifact(artifacts[index], sdk);
+    }
+  }
+  await Promise.all(
+    Array.from(
+      { length: Math.min(concurrency, artifacts.length) },
+      () => worker(),
+    ),
+  );
+  return results;
+}
+
+function writeEvidence(root, evidence) {
+  const bytes = Buffer.from(JSON.stringify(evidence, null, 2) + "\n", "utf8");
+  const digest = sha256(bytes);
+  const relativePath = path.posix.join(
+    ".etl",
+    "precinct-blob-publications",
+    "ME",
+    "me-local-blob-publication-"
+      + evidence.releaseCandidate.sha256.slice(0, 12)
+      + "-"
+      + digest.slice(0, 12)
+      + ".json",
+  );
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  if (existsSync(absolutePath)) {
+    if (!readFileSync(absolutePath).equals(bytes)) {
+      throw new Error("Refusing to overwrite different Blob publication evidence");
+    }
+  } else {
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, bytes, { mode: 0o600 });
+  }
+  return { path: relativePath, byteCount: bytes.length, sha256: digest };
+}
+
+export async function publishMaineLocalDeliveryAssets(options) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const plan = inspectMaineLocalBlobPublicationPlan({
+    root,
+    packagePath: options.packagePath,
+    packageSha256: options.packageSha256,
+  });
+  if (!options.write) {
+    return {
+      mode: "plan",
+      ...publicPlan(plan),
+      remoteMutationPerformed: false,
+      evidence: null,
+    };
+  }
+  const authorization = validateMaineBlobPublicationAuthorization(plan);
+  const sdk = await import("@vercel/blob");
+  const parentResults = await publishBatch(
+    plan.artifacts.filter((artifact) => artifact.kind === "parent"),
+    options.concurrency ?? 4,
+    sdk,
+  );
+  const indexResults = await publishBatch(
+    plan.artifacts.filter((artifact) => artifact.kind === "index"),
+    options.concurrency ?? 4,
+    sdk,
+  );
+  const results = [...parentResults, ...indexResults];
+  const origins = new Set(results.map((result) => new URL(result.url).origin));
+  if (origins.size !== 1) {
+    throw new Error("Maine geometry assets were not published to one origin");
+  }
+  const evidenceDocument = {
+    schemaVersion: 1,
+    state: "ME",
+    purpose: "me-local-reporting-parent-scoped-immutable-geometry-publication",
+    publishedAtUtc: new Date().toISOString(),
+    authorizationId: authorization.authorizationId,
+    releaseCandidate: plan.releaseCandidate,
+    deliveryOrigin: [...origins][0],
+    assetCount: results.length,
+    createdCount: results.filter((result) => result.disposition === "created").length,
+    verifiedExistingCount: results.filter(
+      (result) => result.disposition === "verified_existing",
+    ).length,
+    remoteMutationPerformed: results.some(
+      (result) => result.remoteMutationPerformed,
+    ),
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+    nextRequiredStep:
+      "Configure CRM_PRECINCT_GEOGRAPHY_ORIGIN to deliveryOrigin in a protected preview and verify every year/county before canonical manifest activation.",
+    artifacts: results.map(({
+      absolutePath: _absolutePath,
+      remoteMutationPerformed: _remoteMutationPerformed,
+      ...result
+    }) => result),
+  };
+  const evidence = writeEvidence(root, evidenceDocument);
+  return {
+    mode: "write",
+    decision: "ASSETS_PUBLISHED_MANIFESTS_STILL_BLOCKED",
+    releaseCandidate: plan.releaseCandidate,
+    deliveryOrigin: evidenceDocument.deliveryOrigin,
+    assetCount: evidenceDocument.assetCount,
+    createdCount: evidenceDocument.createdCount,
+    verifiedExistingCount: evidenceDocument.verifiedExistingCount,
+    remoteMutationPerformed: evidenceDocument.remoteMutationPerformed,
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+    evidence,
+  };
+}
+
+async function main() {
+  const args = parseArguments(process.argv.slice(2));
+  const result = await publishMaineLocalDeliveryAssets(args);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/publish-me-local-geography-status.mjs
+++ b/scripts/publish-me-local-geography-status.mjs
@@ -1,0 +1,1203 @@
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import postgres from "postgres";
+import {
+  buildMaineLocalExecutionContext,
+  validateMaineLocalGisClient,
+} from "./lib/me-local-gis-db.mjs";
+import { buildMaineLocalGisPlan } from "./lib/me-local-gis-plan.mjs";
+import { productionEndpointFingerprint } from "./lib/me-local-production-preflight.mjs";
+import {
+  MAINE_PUBLIC_ROLLBACK_SCOPES,
+  buildMainePublicRollbackAuthorizationTemplate,
+  buildMainePublicationAuthorizationTemplate,
+  inspectMainePublicationPlan,
+  semanticallyEqual,
+  serializeMainePublicationDocument,
+  sha256,
+  validateMainePublicRollbackAuthorization,
+  validateMainePublicationAuthorization,
+} from "./lib/me-local-publication.mjs";
+
+function parseArguments(args) {
+  const read = (name) => args.find((arg) => arg.startsWith(name + "="))
+    ?.slice(name.length + 1);
+  const parsed = {
+    packagePath: read("--package"),
+    packageSha256: read("--package-sha256"),
+    hiddenReceiptPath: read("--hidden-receipt"),
+    hiddenReceiptSha256: read("--hidden-receipt-sha256"),
+    blobEvidencePath: read("--blob-evidence"),
+    blobEvidenceSha256: read("--blob-evidence-sha256"),
+    planSha256: read("--plan-sha256"),
+    authorizationPath: read("--authorization"),
+    authorizationSha256: read("--authorization-sha256"),
+    publicationReceiptPath: read("--publication-receipt"),
+    publicationReceiptSha256: read("--publication-receipt-sha256"),
+    outputPath: read("--output"),
+    writePlan: args.includes("--write-plan"),
+    writeAuthorizationTemplate: args.includes("--write-authorization-template"),
+    apply: args.includes("--apply"),
+    recoverReceipt: args.includes("--recover-receipt"),
+    rollback: args.includes("--rollback"),
+  };
+  const allowed = new Set([
+    "--package",
+    "--package-sha256",
+    "--hidden-receipt",
+    "--hidden-receipt-sha256",
+    "--blob-evidence",
+    "--blob-evidence-sha256",
+    "--plan-sha256",
+    "--authorization",
+    "--authorization-sha256",
+    "--publication-receipt",
+    "--publication-receipt-sha256",
+    "--output",
+  ]);
+  for (const arg of args) {
+    if (
+      ![
+        "--write-plan",
+        "--write-authorization-template",
+        "--apply",
+        "--recover-receipt",
+        "--rollback",
+      ].includes(arg)
+      && ![...allowed].some((name) => arg.startsWith(name + "="))
+    ) {
+      throw new Error("Unknown Maine publication-status option: " + arg);
+    }
+  }
+  const modes = [
+    parsed.writePlan,
+    parsed.writeAuthorizationTemplate,
+    parsed.apply,
+    parsed.recoverReceipt,
+  ]
+    .filter(Boolean).length;
+  if (modes > 1) throw new Error("Maine publication-status modes are mutually exclusive");
+  for (const field of [
+    "packagePath",
+    "packageSha256",
+    "hiddenReceiptPath",
+    "hiddenReceiptSha256",
+    "blobEvidencePath",
+    "blobEvidenceSha256",
+  ]) {
+    if (!parsed[field]) throw new Error("Maine publication-status requires " + field);
+  }
+  if (
+    parsed.rollback
+    && (!parsed.publicationReceiptPath || !parsed.publicationReceiptSha256)
+  ) {
+    throw new Error("Maine rollback requires the exact publication receipt and SHA-256");
+  }
+  return parsed;
+}
+
+function safeJson(root, relativePath, expectedSha256, allowedRoot) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith(allowedRoot + "/")
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+    || !relativePath.endsWith(".json")
+    || !/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")
+  ) {
+    throw new Error("Maine publication-status JSON path is unsafe");
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...allowedRoot.split("/"));
+  if (!absolute.startsWith(allowed + path.sep) || !existsSync(absolute)) {
+    throw new Error("Maine publication-status JSON is missing");
+  }
+  const bytes = readFileSync(absolute);
+  if (sha256(bytes) !== expectedSha256) {
+    throw new Error("Maine publication-status JSON SHA-256 drifted");
+  }
+  return {
+    path: relativePath,
+    absolute,
+    bytes,
+    sha256: expectedSha256,
+    value: JSON.parse(bytes.toString("utf8")),
+  };
+}
+
+function immutableJson(root, relativePath, value, allowedRoot) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith(allowedRoot + "/")
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+    || !relativePath.endsWith(".json")
+  ) {
+    throw new Error("Maine publication-status output path is unsafe");
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...allowedRoot.split("/"));
+  if (!absolute.startsWith(allowed + path.sep)) {
+    throw new Error("Maine publication-status output escapes its fixed root");
+  }
+  const bytes = serializeMainePublicationDocument(value);
+  if (existsSync(absolute)) {
+    if (!readFileSync(absolute).equals(bytes)) {
+      throw new Error("Refusing to overwrite different Maine publication evidence");
+    }
+    return { path: relativePath, sha256: sha256(bytes), byteCount: bytes.length };
+  }
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, bytes, { flag: "wx", mode: 0o600 });
+  return { path: relativePath, sha256: sha256(bytes), byteCount: bytes.length };
+}
+
+function productionUrl(environment = process.env) {
+  const first = environment.POSTGRES_URL_NON_POOLING;
+  const second = environment.POSTGRES_DATABASE_URL_UNPOOLED;
+  if (first && second && first !== second) {
+    throw new Error("Production unpooled URL variables disagree");
+  }
+  const value = first ?? second;
+  if (!value) throw new Error("Production unpooled database URL is unavailable");
+  return value;
+}
+
+function runGit(root, args, runner = execFileSync) {
+  return runner("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    windowsHide: true,
+  }).trim();
+}
+
+export function verifyMainePublicationGitCandidate(
+  root,
+  publicAuthorization,
+  runner = execFileSync,
+) {
+  let head;
+  let headTree;
+  let productionTree;
+  let rollbackTree;
+  let trackedStatus;
+  try {
+    head = runGit(root, ["rev-parse", "HEAD"], runner);
+    headTree = runGit(root, ["rev-parse", "HEAD^{tree}"], runner);
+    productionTree = runGit(
+      root,
+      ["rev-parse", `${publicAuthorization.productionDeployment.gitSha}^{tree}`],
+      runner,
+    );
+    rollbackTree = runGit(
+      root,
+      ["rev-parse", `${publicAuthorization.rollbackTarget.gitSha}^{tree}`],
+      runner,
+    );
+    trackedStatus = runGit(
+      root,
+      ["status", "--porcelain", "--untracked-files=no"],
+      runner,
+    );
+  } catch {
+    throw new Error("Maine publication Git evidence could not be resolved locally");
+  }
+  if (
+    head !== publicAuthorization.productionDeployment.gitSha
+    || headTree !== publicAuthorization.productionDeployment.gitTreeSha
+    || productionTree !== publicAuthorization.productionDeployment.gitTreeSha
+    || rollbackTree !== publicAuthorization.rollbackTarget.gitTreeSha
+    || trackedStatus
+  ) {
+    throw new Error("Maine publication checkout or deployment Git evidence drifted");
+  }
+  return {
+    gitSha: head,
+    gitTreeSha: headTree,
+    rollbackTarget: {
+      gitSha: publicAuthorization.rollbackTarget.gitSha,
+      gitTreeSha: rollbackTree,
+    },
+    trackedWorktreeClean: true,
+  };
+}
+
+function expectedActivationMetadata(
+  context,
+  manifest,
+  previousCaveat,
+  revision,
+  changedAtUtc = context.changedAtUtc,
+) {
+  const publication = context.publicationReceipt ?? {
+    activationId: context.authorization.activationId,
+    authorizationSha256: context.authorizationSha256,
+    rollbackTarget: context.authorization.rollbackTarget,
+  };
+  return {
+    activationId: publication.activationId,
+    activationCandidateSha256: context.planSha256,
+    releasePackageSha256: context.plan.releaseCandidate.sha256,
+    blobPublicationSha256: context.plan.blobPublication.sha256,
+    deliveryOrigin: context.plan.blobPublication.deliveryOrigin,
+    authorizationSha256: publication.authorizationSha256,
+    rollbackTarget: publication.rollbackTarget,
+    mode: "publish",
+    year: manifest.year,
+    manifestId: manifest.manifestId,
+    publicManifestSha256: manifest.publicManifestSha256,
+    delivery: manifest.delivery,
+    previousCaveat,
+    changedAtUtc,
+    revision,
+  };
+}
+
+function expectedRollbackMetadata(context, revision) {
+  return {
+    rollbackId: context.authorization.rollbackId,
+    publicationActivationId: context.publicationReceipt.activationId,
+    activationCandidateSha256: context.planSha256,
+    releasePackageSha256: context.plan.releaseCandidate.sha256,
+    blobPublicationSha256: context.plan.blobPublication.sha256,
+    authorizationSha256: context.authorizationSha256,
+    publicationReceiptSha256: context.publicationReceipt.sha256,
+    rollbackTarget: context.authorization.applicationRollback.target,
+    changedAtUtc: context.changedAtUtc,
+    revision,
+    mode: "rollback",
+  };
+}
+
+async function verifyPostconditions(
+  nv,
+  context,
+  revision,
+  mode = context.mode ?? "publish",
+) {
+  const publicAuthorized = mode === "publish";
+  const wantedStatus = publicAuthorized ? "published" : "blocked";
+  const versions = await nv.unsafe([
+    "select e.year,gv.status,gv.caveat,gv.metadata",
+    "from geography_versions gv join elections e on e.id=gv.election_id",
+    "where gv.state_code='ME' and gv.geography_type='local_reporting_unit'",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+    "order by e.year",
+  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  if (versions.length !== 3) {
+    throw new Error("Maine publication postcondition has an incomplete version set");
+  }
+  for (const [index, row] of versions.entries()) {
+    const manifest = context.plan.manifests[index];
+    const previousCaveat = context.gisPlan.years[index].manifest.validation.errors
+      .join(" ");
+    const metadata = row.metadata ?? {};
+    const publicationRevision = context.publicationReceipt?.revision ?? revision;
+    const publicationChangedAt = context.publicationReceipt?.changedAtUtc
+      ?? context.changedAtUtc;
+    const originalActivation = expectedActivationMetadata(
+      context,
+      manifest,
+      previousCaveat,
+      publicationRevision,
+      publicationChangedAt,
+    );
+    const expectedActivation = publicAuthorized
+      ? originalActivation
+      : {
+        ...originalActivation,
+        rollback: expectedRollbackMetadata(context, revision),
+      };
+    const expectedCaveat = publicAuthorized
+      ? "Reviewed Maine election-specific local reporting geometry is publicly authorized under activation "
+        + originalActivation.activationId + "."
+      : previousCaveat;
+    if (
+      Number(row.year) !== manifest.year
+      || row.status !== wantedStatus
+      || String(row.caveat ?? "") !== expectedCaveat
+      || metadata.manifestId !== manifest.manifestId
+      || metadata.publicDeliveryAuthorized !== publicAuthorized
+      || metadata.releaseCandidate?.publicDeliveryAuthorized !== publicAuthorized
+      || metadata.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
+      || !semanticallyEqual(metadata.publicActivation, expectedActivation)
+    ) {
+      throw new Error("Maine " + manifest.year + " geography publication drifted");
+    }
+  }
+  const linked = await nv.unsafe([
+    "select count(*)::int total,",
+    " count(*) filter (where x.relationship_type='one_to_one'",
+    "  and x.match_method in ('exact_official_id','official_crosswalk')",
+    "  and x.review_status='reviewed'",
+    "  and x.confidence='high' and x.metadata->>'publicDeliveryAuthorized'=$2",
+    "  and x.metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from reporting_unit_geometry_crosswalks x",
+    "join geography_versions gv on gv.id=x.geometry_version_id",
+    "where gv.state_code='ME' and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (Number(linked[0]?.total) !== 1_542 || Number(linked[0]?.exact) !== 1_542) {
+    throw new Error("Maine publication crosswalk postcondition failed");
+  }
+  const units = await nv.unsafe([
+    "select count(*)::int total, count(*) filter (where",
+    " metadata->>'publicDeliveryAuthorized'=$2 and",
+    " metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from reporting_units where state_code='ME' and reporting_grain='local_reporting_unit'",
+    " and metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (Number(units[0]?.total) !== 1_542 || Number(units[0]?.exact) !== 1_542) {
+    throw new Error("Maine publication reporting-unit postcondition failed");
+  }
+  const sources = await nv.unsafe([
+    "select count(*)::int total, count(*) filter (where",
+    " metadata->>'publicDeliveryAuthorized'=$2 and",
+    " metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from source_documents where state_code='ME'",
+    " and metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (Number(sources[0]?.total) !== 6 || Number(sources[0]?.exact) !== 6) {
+    throw new Error("Maine publication source-document postcondition failed");
+  }
+  const runs = await nv.unsafe([
+    "select count(*)::int total, count(*) filter (where",
+    " summary->>'publicDeliveryAuthorized'=$2 and",
+    " summary->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from import_runs where state_code='ME'",
+    " and summary->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (Number(runs[0]?.total) !== 3 || Number(runs[0]?.exact) !== 3) {
+    throw new Error("Maine publication import-run postcondition failed");
+  }
+  const results = await nv.unsafe([
+    "select count(*)::int total from result_rows rr",
+    "join reporting_units ru on ru.id=rr.reporting_unit_id",
+    "where rr.state_code='ME' and rr.level='local_reporting_unit'",
+    " and ru.metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  if (Number(results[0]?.total) !== 4_626) {
+    throw new Error("Maine publication result-row postcondition failed");
+  }
+  const invalid = await nv.unsafe(
+    "select count(*)::int count from pg_constraint where connamespace='public'::regnamespace and not convalidated",
+  );
+  if (Number(invalid[0]?.count) !== 0) {
+    throw new Error("Maine publication left invalid public constraints");
+  }
+  const revisionRows = await nv.unsafe([
+    "select revision::int revision,reason from public_data_revisions",
+    "where scope='public'",
+  ].join("\n"));
+  const expectedReason = "Maine local reporting unit geometry " + mode + " "
+    + (publicAuthorized
+      ? context.authorization.activationId
+      : context.authorization.rollbackId);
+  if (
+    Number(revisionRows[0]?.revision) !== revision
+    || String(revisionRows[0]?.reason) !== expectedReason
+  ) {
+    throw new Error("Maine publication revision postcondition failed");
+  }
+  return {
+    mode,
+    status: wantedStatus,
+    publicDeliveryAuthorized: publicAuthorized,
+    geographyVersions: 3,
+    crosswalks: 1_542,
+    reportingUnits: 1_542,
+    sourceDocuments: 6,
+    importRuns: 3,
+    resultRows: 4_626,
+    invalidConstraints: 0,
+  };
+}
+
+export async function applyMaineGeographyPublicationTransaction(nv, context) {
+  const mode = context.mode ?? "publish";
+  if (!new Set(["publish", "rollback"]).has(mode)) {
+    throw new Error("Maine publication transaction mode is invalid");
+  }
+  const publicAuthorized = mode === "publish";
+  if (mode === "rollback" && !context.publicationReceipt) {
+    throw new Error("Maine rollback requires the exact publication receipt");
+  }
+  if (mode === "rollback" && (
+    context.authorization.publicationActivationId
+      !== context.publicationReceipt.activationId
+    || !semanticallyEqual(
+      context.authorization.applicationRollback?.target,
+      context.publicationReceipt.rollbackTarget,
+    )
+  )) {
+    throw new Error("Maine rollback authorization drifted from the publication receipt");
+  }
+  const identity = await nv.unsafe([
+    "select current_database() database_name,",
+    " current_setting('transaction_read_only') transaction_read_only",
+  ].join("\n"));
+  if (
+    identity.length !== 1
+    || String(identity[0].database_name) !== context.plan.hiddenLoad.databaseName
+    || String(identity[0].transaction_read_only) !== "off"
+  ) {
+    throw new Error("Maine publication transaction database identity drifted");
+  }
+  await nv.unsafe("select set_config('lock_timeout','30s',true)");
+  await nv.unsafe(
+    "select pg_advisory_xact_lock(hashtextextended('crm-me-local-gis-release-v1',0))",
+  );
+  const revisions = await nv.unsafe(
+    "select revision::int revision from public_data_revisions where scope='public' for update",
+  );
+  const currentRevision = Number(revisions[0]?.revision);
+  if (
+    revisions.length !== 1
+    || !Number.isInteger(currentRevision)
+    || currentRevision < 0
+  ) {
+    throw new Error("Maine public revision is missing or invalid");
+  }
+  const revision = currentRevision + 1;
+  const gisPlan = context.gisPlan;
+  if (mode === "publish") {
+    await (context.validateCurrentDatabase ?? validateMaineLocalGisClient)(nv, gisPlan, {
+      executionContext: context.executionContext,
+      readOnlySession: false,
+    });
+  }
+  const versions = await nv.unsafe([
+    "select gv.id,e.year,gv.status,gv.caveat,gv.metadata",
+    "from geography_versions gv join elections e on e.id=gv.election_id",
+    "where gv.state_code='ME' and gv.geography_type='local_reporting_unit'",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+    "order by e.year for update of gv",
+  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  if (versions.length !== 3) {
+    throw new Error("Maine publication requires three exact geography versions");
+  }
+  for (const [index, version] of versions.entries()) {
+    const manifest = context.plan.manifests[index];
+    const expectedBlockedCaveat = gisPlan.years[index].manifest.validation.errors
+      .join(" ");
+    const commonDrift = Number(version.year) !== manifest.year
+      || version.metadata?.manifestId !== manifest.manifestId
+      || version.metadata?.releaseCandidate?.sha256
+        !== context.plan.releaseCandidate.sha256;
+    const originalActivation = mode === "rollback"
+      ? expectedActivationMetadata(
+        context,
+        manifest,
+        expectedBlockedCaveat,
+        context.publicationReceipt.revision,
+        context.publicationReceipt.changedAtUtc,
+      )
+      : null;
+    if (mode === "publish" && (
+      commonDrift
+      || version.status !== "blocked"
+      || version.metadata?.manifestSha256 !== manifest.blockedManifestSha256
+      || version.metadata?.publicDeliveryAuthorized !== false
+      || version.metadata?.releaseCandidate?.publicDeliveryAuthorized !== false
+      || String(version.caveat ?? "") !== expectedBlockedCaveat
+      || Object.hasOwn(version.metadata ?? {}, "publicActivation")
+    )) {
+      throw new Error("Maine " + manifest.year + " publication precondition drifted");
+    }
+    if (mode === "rollback" && (
+      commonDrift
+      || version.status !== "published"
+      || String(version.caveat ?? "")
+        !== "Reviewed Maine election-specific local reporting geometry is publicly authorized under activation "
+          + context.publicationReceipt.activationId + "."
+      || version.metadata?.publicDeliveryAuthorized !== true
+      || version.metadata?.releaseCandidate?.publicDeliveryAuthorized !== true
+      || !semanticallyEqual(version.metadata?.publicActivation, originalActivation)
+    )) {
+      throw new Error(
+        "Maine " + manifest.year
+          + " rollback does not match the publication being reversed",
+      );
+    }
+    const activation = mode === "publish"
+      ? expectedActivationMetadata(
+        context,
+        manifest,
+        expectedBlockedCaveat,
+        revision,
+      )
+      : {
+        ...originalActivation,
+        rollback: expectedRollbackMetadata(context, revision),
+      };
+    const wantedStatus = publicAuthorized ? "published" : "blocked";
+    const wantedCaveat = publicAuthorized
+      ? "Reviewed Maine election-specific local reporting geometry is publicly authorized under activation "
+        + context.authorization.activationId + "."
+      : originalActivation.previousCaveat;
+    const currentStatus = publicAuthorized ? "blocked" : "published";
+    const updated = await nv.unsafe([
+      "update geography_versions set status=$2,",
+      " caveat=$3,",
+      " metadata=jsonb_set(jsonb_set(jsonb_set(metadata,",
+      "  '{publicDeliveryAuthorized}',$4::text::jsonb,true),",
+      "  '{releaseCandidate,publicDeliveryAuthorized}',$4::text::jsonb,true),",
+      "  '{publicActivation}',$5::text::jsonb,true),",
+      " updated_at=now() where id=$1::uuid and status=$6 returning id",
+    ].join("\n"), [
+      version.id,
+      wantedStatus,
+      wantedCaveat,
+      JSON.stringify(publicAuthorized),
+      JSON.stringify(activation),
+      currentStatus,
+    ]);
+    if (updated.length !== 1) {
+      throw new Error("Maine " + manifest.year + " publication update lost its lock");
+    }
+  }
+  const crosswalks = await nv.unsafe([
+    "update reporting_unit_geometry_crosswalks x set metadata=",
+    " jsonb_set(jsonb_set(x.metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "from geography_versions gv where gv.id=x.geometry_version_id",
+    " and gv.state_code='ME' and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+    "returning x.id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (crosswalks.length !== 1_542) {
+    throw new Error("Maine publication crosswalk update count drifted");
+  }
+  const units = await nv.unsafe([
+    "update reporting_units set metadata=",
+    " jsonb_set(jsonb_set(metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "where state_code='ME' and reporting_grain='local_reporting_unit'",
+    " and metadata->'releaseCandidate'->>'sha256'=$1 returning id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (units.length !== 1_542) {
+    throw new Error("Maine publication reporting-unit update count drifted");
+  }
+  const sources = await nv.unsafe([
+    "update source_documents set metadata=",
+    " jsonb_set(jsonb_set(metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "where state_code='ME' and metadata->'releaseCandidate'->>'sha256'=$1 returning id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (sources.length !== 6) {
+    throw new Error("Maine publication source-document update count drifted");
+  }
+  const runs = await nv.unsafe([
+    "update import_runs set summary=",
+    " jsonb_set(jsonb_set(summary,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "where state_code='ME' and summary->'releaseCandidate'->>'sha256'=$1 returning id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (runs.length !== 3) {
+    throw new Error("Maine publication import-run update count drifted");
+  }
+  const revisionRows = await nv.unsafe([
+    "update public_data_revisions set revision=revision+1,updated_at=now(),reason=$1",
+    "where scope='public' returning revision::int revision,updated_at",
+  ].join("\n"), [
+    "Maine local reporting unit geometry " + mode + " "
+      + (publicAuthorized
+        ? context.authorization.activationId
+        : context.authorization.rollbackId),
+  ]);
+  if (Number(revisionRows[0]?.revision) !== revision) {
+    throw new Error("Maine publication revision increment drifted");
+  }
+  const postconditions = await verifyPostconditions(nv, context, revision, mode);
+  return {
+    result: publicAuthorized ? "PUBLISHED" : "ROLLED_BACK",
+    mode,
+    revision,
+    changedAtUtc: context.changedAtUtc,
+    postconditions,
+    publicDeliveryAuthorized: publicAuthorized,
+  };
+}
+
+function defaultPlanPath(planSha256) {
+  return ".etl/precinct-publication-plans/ME/me-local-publication-plan-"
+    + planSha256.slice(0, 12) + ".json";
+}
+
+function defaultAuthorizationPath(planSha256, mode = "publish") {
+  return ".etl/production-authorizations/ME/me-local-" + mode + "-authorization-template-"
+    + planSha256.slice(0, 12) + ".json";
+}
+
+export function inspectMainePublicationReceipt(root, options, built) {
+  const artifact = safeJson(
+    root,
+    options.publicationReceiptPath,
+    options.publicationReceiptSha256,
+    ".etl/production-publication-receipts/ME",
+  );
+  const value = artifact.value;
+  const publicAuthorizationArtifact = safeJson(
+    root,
+    value?.authorization?.path,
+    value?.authorization?.sha256,
+    ".etl/production-authorizations/ME",
+  );
+  const publicAuthorization = validateMainePublicationAuthorization(
+    publicAuthorizationArtifact.value,
+    {
+      plan: built.plan,
+      planSha256: built.sha256,
+      now: options.now ?? Date.now(),
+      recovery: true,
+    },
+  );
+  const changedAt = Date.parse(value?.changedAtUtc);
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "ME"
+    || value?.mode !== "publish"
+    || value?.decision !== "PUBLISHED"
+    || value?.activationId !== publicAuthorization.activationId
+    || value?.approvedBy !== publicAuthorization.approvedBy
+    || !semanticallyEqual(value?.releaseCandidate, built.plan.releaseCandidate)
+    || value?.publicationPlan?.id !== built.plan.id
+    || value?.publicationPlan?.sha256 !== built.sha256
+    || value?.authorization?.path !== publicAuthorizationArtifact.path
+    || value?.authorization?.sha256 !== publicAuthorizationArtifact.sha256
+    || value?.hiddenLoad?.path !== built.plan.hiddenLoad.path
+    || value?.hiddenLoad?.sha256 !== built.plan.hiddenLoad.sha256
+    || value?.blobPublication?.path !== built.plan.blobPublication.path
+    || value?.blobPublication?.sha256 !== built.plan.blobPublication.sha256
+    || value?.blobPublication?.deliveryOrigin
+      !== built.plan.blobPublication.deliveryOrigin
+    || !semanticallyEqual(
+      value?.productionDeployment,
+      publicAuthorization.productionDeployment,
+    )
+    || !semanticallyEqual(value?.rollbackTarget, publicAuthorization.rollbackTarget)
+    || Number.isNaN(changedAt)
+    || changedAt > (options.now ?? Date.now())
+    || Date.parse(publicAuthorization.rollbackTarget.verifiedAtUtc) > changedAt
+    || !Number.isInteger(Number(value?.revision))
+    || Number(value.revision) < 1
+    || value?.postconditions?.mode !== "publish"
+    || value?.postconditions?.status !== "published"
+    || value?.postconditions?.publicDeliveryAuthorized !== true
+    || value?.postconditions?.geographyVersions !== 3
+    || value?.postconditions?.crosswalks !== 1_542
+    || value?.postconditions?.reportingUnits !== 1_542
+    || value?.postconditions?.sourceDocuments !== 6
+    || value?.postconditions?.importRuns !== 3
+    || value?.postconditions?.resultRows !== 4_626
+    || value?.postconditions?.invalidConstraints !== 0
+    || value?.productionMutationPerformed !== true
+    || value?.publicDeliveryAuthorized !== true
+  ) {
+    throw new Error("Maine publication receipt is incomplete or incompatible");
+  }
+  return {
+    artifact,
+    publicAuthorization,
+    summary: {
+      path: artifact.path,
+      sha256: artifact.sha256,
+      activationId: value.activationId,
+      authorizationSha256: publicAuthorizationArtifact.sha256,
+      revision: Number(value.revision),
+      changedAtUtc: value.changedAtUtc,
+      rollbackTarget: value.rollbackTarget,
+      productionDeployment: value.productionDeployment,
+    },
+  };
+}
+
+function defaultReceiptPath(planSha256, activationId, mode = "publish") {
+  const safeId = activationId.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 80);
+  return ".etl/production-publication-receipts/ME/me-local-" + mode + "-"
+    + planSha256.slice(0, 12) + "-" + safeId + ".json";
+}
+
+function reserveReceipt(
+  root,
+  relativePath,
+  planSha256,
+  authorizationSha256,
+  mode,
+  publicationReceiptSha256 = null,
+  options = {},
+) {
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ".etl", "production-publication-receipts", "ME");
+  if (!absolute.startsWith(allowed + path.sep) || !relativePath.endsWith(".json")) {
+    throw new Error("Maine publication receipt path is unsafe");
+  }
+  if (existsSync(absolute)) throw new Error("Maine publication receipt already exists");
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  const pending = absolute + ".pending";
+  const pendingDocument = {
+    schemaVersion: 1,
+    state: "ME",
+    purpose: "ambiguous-commit recovery marker",
+    mode,
+    planSha256,
+    authorizationSha256,
+    publicationReceiptSha256,
+  };
+  const pendingBytes = serializeMainePublicationDocument(pendingDocument);
+  if (existsSync(pending)) {
+    if (
+      options.allowExisting === true
+      && readFileSync(pending).equals(pendingBytes)
+    ) {
+      return { absolute, pending, pendingBytes, disposition: "reused" };
+    }
+    throw new Error("A Maine publication recovery marker already exists; reconcile it before retrying");
+  }
+  writeFileSync(pending, pendingBytes, { flag: "wx", mode: 0o600 });
+  return { absolute, pending, pendingBytes, disposition: "created" };
+}
+
+function finishPublicationReceipt(reservation, receipt) {
+  const receiptBytes = serializeMainePublicationDocument(receipt);
+  const temporary = reservation.absolute + ".write-"
+    + sha256(receiptBytes).slice(0, 12) + ".tmp";
+  if (existsSync(temporary)) {
+    if (!readFileSync(temporary).equals(receiptBytes)) {
+      throw new Error("Maine publication receipt temporary file drifted");
+    }
+  } else {
+    writeFileSync(temporary, receiptBytes, { flag: "wx", mode: 0o600 });
+  }
+  renameSync(temporary, reservation.absolute);
+  if (readFileSync(reservation.pending).equals(reservation.pendingBytes)) {
+    unlinkSync(reservation.pending);
+  }
+  return receiptBytes;
+}
+
+export async function runMaineGeographyPublication(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const parsed = options.packagePath ? options : parseArguments(process.argv.slice(2));
+  const mode = parsed.rollback ? "rollback" : "publish";
+  const environment = options.environment ?? process.env;
+  const clock = options.nowFactory ?? (() => options.now ?? new Date());
+  const currentTime = () => {
+    const value = clock();
+    const result = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    if (Number.isNaN(result.getTime())) {
+      throw new Error("Maine publication clock returned an invalid time");
+    }
+    return result;
+  };
+  const built = inspectMainePublicationPlan({ ...parsed, root });
+  if (parsed.planSha256 && parsed.planSha256 !== built.sha256) {
+    throw new Error("Maine publication plan SHA-256 drifted");
+  }
+  const publicationReceipt = mode === "rollback"
+    ? inspectMainePublicationReceipt(root, {
+      ...parsed,
+      now: currentTime().getTime(),
+    }, built)
+    : null;
+  if (parsed.writePlan) {
+    if (mode === "rollback") {
+      throw new Error("Maine rollback reuses the exact hash-pinned publication plan");
+    }
+    const artifact = immutableJson(
+      root,
+      parsed.outputPath ?? defaultPlanPath(built.sha256),
+      built.plan,
+      ".etl/precinct-publication-plans/ME",
+    );
+    return {
+      mode: "write_plan",
+      decision: built.plan.decision,
+      publicationPlan: artifact,
+      productionMutationPerformed: false,
+    };
+  }
+  if (parsed.writeAuthorizationTemplate) {
+    const template = mode === "rollback"
+      ? buildMainePublicRollbackAuthorizationTemplate(
+        built.plan,
+        built.sha256,
+        publicationReceipt.summary,
+      )
+      : buildMainePublicationAuthorizationTemplate(built.plan, built.sha256);
+    const artifact = immutableJson(
+      root,
+      parsed.outputPath ?? defaultAuthorizationPath(built.sha256, mode),
+      template,
+      ".etl/production-authorizations/ME",
+    );
+    return {
+      mode: "write_authorization_template",
+      operation: mode,
+      decision: mode === "rollback" ? "NO_GO_ROLLBACK" : "NO_GO_PUBLIC",
+      publicationPlanSha256: built.sha256,
+      authorizationTemplate: artifact,
+      productionMutationPerformed: false,
+    };
+  }
+  if (!parsed.apply && !parsed.recoverReceipt) {
+    return {
+      mode: "plan",
+      operation: mode,
+      decision: mode === "rollback"
+        ? "GO_ROLLBACK_AUTHORIZATION_REQUIRED"
+        : built.plan.decision,
+      publicationPlanSha256: built.sha256,
+      requiredScopes: mode === "rollback"
+        ? [...MAINE_PUBLIC_ROLLBACK_SCOPES]
+        : undefined,
+      productionMutationPerformed: false,
+      expectedTotals: built.plan.expectedTotals,
+    };
+  }
+  const authorizationArtifact = safeJson(
+    root,
+    parsed.authorizationPath,
+    parsed.authorizationSha256,
+    ".etl/production-authorizations/ME",
+  );
+  const validateAuthorizationAt = (now, recovery = false) => mode === "rollback"
+    ? validateMainePublicRollbackAuthorization(authorizationArtifact.value, {
+      plan: built.plan,
+      planSha256: built.sha256,
+      publicationReceipt: publicationReceipt.summary,
+      now: now.getTime(),
+      recovery,
+    })
+    : validateMainePublicationAuthorization(authorizationArtifact.value, {
+      plan: built.plan,
+      planSha256: built.sha256,
+      now: now.getTime(),
+      recovery,
+    });
+  const databaseUrl = productionUrl(environment);
+  const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
+  if (endpointFingerprint !== built.plan.hiddenLoad.endpointFingerprint) {
+    throw new Error("Maine publication database endpoint drifted from the hidden load");
+  }
+  const gisPlan = await buildMaineLocalGisPlan({
+    root,
+    years: [2016, 2020, 2024],
+  });
+  const executionContext = {
+    mode: "production_release",
+    releasePackageSha256: built.plan.releaseCandidate.sha256,
+    releaseCandidateId: built.plan.releaseCandidate.id,
+    databaseName: built.plan.hiddenLoad.databaseName,
+    productionReleaseAudit: built.plan.hiddenLoad.productionReleaseAudit,
+  };
+  buildMaineLocalExecutionContext(executionContext);
+  const rawOperationId = mode === "rollback"
+    ? authorizationArtifact.value?.rollbackId
+    : authorizationArtifact.value?.activationId;
+  const operationId = typeof rawOperationId === "string"
+    ? rawOperationId.trim()
+    : "";
+  const receiptPath = parsed.outputPath ?? defaultReceiptPath(
+    built.sha256,
+    operationId || "invalid-authorization",
+    mode,
+  );
+  const publicAuthorization = mode === "publish"
+    ? null
+    : publicationReceipt.publicAuthorization;
+
+  const receiptDocument = (authorization, committed, recovery = null) => {
+    const originalPublicAuthorization = mode === "publish"
+      ? authorization
+      : publicAuthorization;
+    return {
+      schemaVersion: 1,
+      state: "ME",
+      mode,
+      decision: mode === "publish" ? "PUBLISHED" : "ROLLED_BACK",
+      activationId: mode === "publish"
+        ? authorization.activationId
+        : publicationReceipt.summary.activationId,
+      ...(mode === "rollback" ? { rollbackId: authorization.rollbackId } : {}),
+      approvedBy: authorization.approvedBy,
+      releaseCandidate: built.plan.releaseCandidate,
+      publicationPlan: { id: built.plan.id, sha256: built.sha256 },
+      authorization: {
+        path: authorizationArtifact.path,
+        sha256: authorizationArtifact.sha256,
+      },
+      hiddenLoad: {
+        path: built.plan.hiddenLoad.path,
+        sha256: built.plan.hiddenLoad.sha256,
+      },
+      blobPublication: {
+        path: built.plan.blobPublication.path,
+        sha256: built.plan.blobPublication.sha256,
+        deliveryOrigin: built.plan.blobPublication.deliveryOrigin,
+      },
+      productionDeployment: originalPublicAuthorization.productionDeployment,
+      rollbackTarget: originalPublicAuthorization.rollbackTarget,
+      ...(mode === "rollback"
+        ? { publicationReceipt: publicationReceipt.summary }
+        : {}),
+      changedAtUtc: committed.changedAtUtc,
+      revision: committed.revision,
+      postconditions: committed.postconditions,
+      ...(recovery ? { recovery } : {}),
+      productionMutationPerformed: true,
+      publicDeliveryAuthorized: mode === "publish",
+    };
+  };
+
+  if (parsed.recoverReceipt) {
+    if (
+      environment.CRM_DATABASE_ENVIRONMENT !== "production-read-only"
+      || environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_RECEIPT_RECOVERY !== built.sha256
+      || environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_AUTHORIZATION_SHA256
+        !== authorizationArtifact.sha256
+      || (mode === "rollback"
+        && environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_RECEIPT_SHA256
+          !== publicationReceipt.summary.sha256)
+    ) {
+      throw new Error(
+        "Maine publication receipt recovery is not explicitly read-only and hash-authorized",
+      );
+    }
+    const reservation = reserveReceipt(
+      root,
+      receiptPath,
+      built.sha256,
+      authorizationArtifact.sha256,
+      mode,
+      publicationReceipt?.summary.sha256 ?? null,
+      { allowExisting: true },
+    );
+    let sql;
+    try {
+      sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+        max: 1,
+        connect_timeout: 10,
+        idle_timeout: 20,
+        connection: {
+          application_name: "civicresultmaps-me-local-publication-receipt-recovery",
+          default_transaction_read_only: true,
+        },
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    }
+    let recovered;
+    try {
+      recovered = await sql.begin("read only", async (nv) => {
+        const identity = await nv.unsafe([
+          "select current_database() database_name,",
+          " current_setting('transaction_read_only') transaction_read_only",
+        ].join("\n"));
+        if (
+          identity.length !== 1
+          || String(identity[0].database_name) !== built.plan.hiddenLoad.databaseName
+          || String(identity[0].transaction_read_only) !== "on"
+        ) {
+          throw new Error("Maine publication receipt recovery database identity drifted");
+        }
+        const versions = await nv.unsafe([
+          "select e.year,gv.status,gv.caveat,gv.metadata from geography_versions gv",
+          "join elections e on e.id=gv.election_id",
+          "where gv.state_code='ME' and gv.geography_type='local_reporting_unit'",
+          " and gv.metadata->'releaseCandidate'->>'sha256'=$1 order by e.year",
+        ].join("\n"), [built.plan.releaseCandidate.sha256]);
+        if (versions.length !== 3) {
+          throw new Error("Maine publication receipt recovery found an incomplete version set");
+        }
+        const operationAudit = mode === "publish"
+          ? versions[0]?.metadata?.publicActivation
+          : versions[0]?.metadata?.publicActivation?.rollback;
+        const changedAtUtc = operationAudit?.changedAtUtc;
+        const revision = Number(operationAudit?.revision);
+        const recoveryNow = currentTime();
+        if (
+          typeof changedAtUtc !== "string"
+          || Number.isNaN(Date.parse(changedAtUtc))
+          || Date.parse(changedAtUtc) > recoveryNow.getTime()
+          || !Number.isInteger(revision)
+          || revision < 1
+        ) {
+          throw new Error("Maine publication receipt recovery audit is incomplete");
+        }
+        const authorization = validateAuthorizationAt(
+          new Date(changedAtUtc),
+          true,
+        );
+        const context = {
+          mode,
+          plan: built.plan,
+          planSha256: built.sha256,
+          authorization,
+          authorizationSha256: authorizationArtifact.sha256,
+          publicationReceipt: publicationReceipt?.summary ?? null,
+          changedAtUtc,
+          gisPlan,
+          executionContext,
+        };
+        const postconditions = await verifyPostconditions(
+          nv,
+          context,
+          revision,
+          mode,
+        );
+        return { authorization, changedAtUtc, revision, postconditions };
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+    const receipt = receiptDocument(recovered.authorization, recovered, {
+      recoveredAtUtc: currentTime().toISOString(),
+      productionMutationPerformed: false,
+    });
+    const receiptBytes = finishPublicationReceipt(reservation, receipt);
+    return {
+      mode: "recover_receipt",
+      operation: mode,
+      decision: mode === "publish"
+        ? "RECOVERED_PUBLICATION_RECEIPT"
+        : "RECOVERED_ROLLBACK_RECEIPT",
+      activationId: recovered.authorization.activationId,
+      revision: recovered.revision,
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: mode === "publish",
+      receipt: {
+        path: receiptPath,
+        sha256: sha256(receiptBytes),
+        byteCount: receiptBytes.length,
+      },
+    };
+  }
+
+  const initialNow = currentTime();
+  const authorization = validateAuthorizationAt(initialNow);
+  const writeAuthorized = mode === "publish"
+    ? environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_WRITES
+        === "I_ACKNOWLEDGE_ATOMIC_MAINE_LOCAL_PUBLIC_CUTOVER"
+      && environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_ACTIVATION_ID
+        === authorization.activationId
+    : environment.CRM_ME_LOCAL_GEOGRAPHY_ROLLBACK_WRITES
+        === "I_ACKNOWLEDGE_DATABASE_FIRST_MAINE_LOCAL_PUBLIC_ROLLBACK"
+      && environment.CRM_ME_LOCAL_GEOGRAPHY_ROLLBACK_ID === authorization.rollbackId
+      && environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_RECEIPT_SHA256
+        === publicationReceipt.summary.sha256;
+  if (
+    environment.CRM_DATABASE_ENVIRONMENT !== "production"
+    || !writeAuthorized
+    || environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_PACKAGE_SHA256
+      !== built.plan.releaseCandidate.sha256
+    || environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_PLAN_SHA256 !== built.sha256
+    || environment.CRM_ME_LOCAL_GEOGRAPHY_PUBLICATION_AUTHORIZATION_SHA256
+      !== authorizationArtifact.sha256
+  ) {
+    throw new Error("Maine public " + mode + " is not explicitly hash-authorized");
+  }
+  const activePublicAuthorization = mode === "publish"
+    ? authorization
+    : publicAuthorization;
+  verifyMainePublicationGitCandidate(root, activePublicAuthorization, options.gitRunner);
+  const reservation = reserveReceipt(
+    root,
+    receiptPath,
+    built.sha256,
+    authorizationArtifact.sha256,
+    mode,
+    publicationReceipt?.summary.sha256 ?? null,
+  );
+  let sql;
+  try {
+    sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+      max: 1,
+      connect_timeout: 10,
+      idle_timeout: 20,
+      connection: { application_name: "civicresultmaps-me-local-publication-status" },
+    });
+  } catch (error) {
+    if (existsSync(reservation.pending)) unlinkSync(reservation.pending);
+    throw error;
+  }
+  let transactionBodyCompleted = false;
+  let committed;
+  try {
+    committed = await sql.begin(async (nv) => {
+      const transactionNow = currentTime();
+      const finalAuthorization = validateAuthorizationAt(transactionNow);
+      if (finalAuthorization.activationId !== authorization.activationId) {
+        throw new Error("Maine publication authorization drifted before the transaction");
+      }
+      verifyMainePublicationGitCandidate(
+        root,
+        activePublicAuthorization,
+        options.gitRunner,
+      );
+      const result = await applyMaineGeographyPublicationTransaction(nv, {
+        mode,
+        plan: built.plan,
+        planSha256: built.sha256,
+        authorization: finalAuthorization,
+        authorizationSha256: authorizationArtifact.sha256,
+        publicationReceipt: publicationReceipt?.summary ?? null,
+        changedAtUtc: transactionNow.toISOString(),
+        gisPlan,
+        executionContext,
+      });
+      transactionBodyCompleted = true;
+      return result;
+    });
+  } catch (error) {
+    if (!transactionBodyCompleted && existsSync(reservation.pending)) {
+      unlinkSync(reservation.pending);
+    }
+    throw error;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+  const receipt = receiptDocument(authorization, committed);
+  const receiptBytes = finishPublicationReceipt(reservation, receipt);
+  return {
+    mode: "apply",
+    operation: mode,
+    decision: mode === "publish" ? "PUBLISHED" : "ROLLED_BACK",
+    activationId: authorization.activationId,
+    revision: committed.revision,
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: mode === "publish",
+    receipt: {
+      path: receiptPath,
+      sha256: sha256(receiptBytes),
+      byteCount: receiptBytes.length,
+    },
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runMaineGeographyPublication().then(
+    (result) => console.log(JSON.stringify(result, null, 2)),
+    (error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/report-me-local-production-preflight.mjs
+++ b/scripts/report-me-local-production-preflight.mjs
@@ -1,0 +1,202 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import postgres from "postgres";
+import { inspectReleaseArtifact } from "./lib/me-local-release-candidate.mjs";
+import {
+  assertMaineReleaseCandidateDocument,
+  collectMaineProductionPreflight,
+  productionEndpointFingerprint,
+  sha256,
+} from "./lib/me-local-production-preflight.mjs";
+
+// Deliberately do not load .env.local. A production read is opt-in and must use
+// one explicitly supplied unpooled URL plus the exact release-package hash.
+
+function parseArguments(args) {
+  const packageArgument = args.find((arg) => arg.startsWith("--package="));
+  const reportArgument = args.find((arg) => arg.startsWith("--report="));
+  const connectReadOnly = args.includes("--connect-read-only");
+  for (const arg of args) {
+    if (
+      arg !== "--connect-read-only"
+      && !arg.startsWith("--package=")
+      && !arg.startsWith("--report=")
+    ) {
+      throw new Error("Unknown Maine production-preflight option: " + arg);
+    }
+  }
+  const packagePath = packageArgument?.slice("--package=".length);
+  if (!packagePath) {
+    throw new Error("--package is required for Maine production preflight");
+  }
+  return {
+    packagePath,
+    reportPath: reportArgument?.slice("--report=".length),
+    connectReadOnly,
+  };
+}
+
+function productionUrl() {
+  const first = process.env.POSTGRES_URL_NON_POOLING;
+  const second = process.env.POSTGRES_DATABASE_URL_UNPOOLED;
+  if (first && second && first !== second) {
+    throw new Error("Production unpooled URL variables disagree");
+  }
+  const value = first ?? second;
+  if (!value) throw new Error("Production unpooled database URL is unavailable");
+  return value;
+}
+
+function safeReportPath(root, requested, packageSha256, reportSha256) {
+  const relativePath = requested ?? path.posix.join(
+    ".etl",
+    "production-preflight-candidates",
+    "ME",
+    "me-local-production-preflight-"
+      + packageSha256.slice(0, 12)
+      + "-"
+      + reportSha256.slice(0, 12)
+      + ".json",
+  );
+  if (
+    path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !relativePath.startsWith(".etl/production-preflight-candidates/ME/")
+  ) {
+    throw new Error("Maine production preflight report must remain in its .etl root");
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ".etl", "production-preflight-candidates", "ME");
+  if (!absolute.startsWith(allowed + path.sep)) {
+    throw new Error("Maine production preflight report escapes its .etl root");
+  }
+  return { relativePath, absolute };
+}
+
+function loadReleaseCandidate(root, relativePath) {
+  if (
+    path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !relativePath.startsWith(".etl/precinct-release-candidates/ME/")
+    || !relativePath.endsWith("/release-candidate.json")
+  ) {
+    throw new Error("Maine production preflight package path is unsafe");
+  }
+  const artifact = inspectReleaseArtifact(root, relativePath, {
+    allowedRoots: [".etl/precinct-release-candidates/ME/"],
+  });
+  const document = JSON.parse(artifact.bytes.toString("utf8"));
+  const releaseCandidate = assertMaineReleaseCandidateDocument(
+    document,
+    artifact.sha256,
+  );
+  for (const manifest of releaseCandidate.canonicalManifestPreimages) {
+    const current = inspectReleaseArtifact(root, manifest.path, {
+      allowedRoots: ["data/precinct-geometry/ME/"],
+      byteCount: manifest.byteCount,
+      sha256: manifest.sha256,
+    });
+    if (!current.bytes.length) throw new Error("Canonical manifest is empty");
+  }
+  return { artifact, document, releaseCandidate };
+}
+
+export async function runMaineProductionPreflight(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const parsed = options.packagePath
+    ? options
+    : parseArguments(process.argv.slice(2));
+  const loaded = loadReleaseCandidate(root, parsed.packagePath);
+  if (!parsed.connectReadOnly) {
+    return {
+      mode: "plan",
+      state: "ME",
+      releasePackageSha256: loaded.artifact.sha256,
+      connectionOpened: false,
+      productionMutationPerformed: false,
+      requiredEnvironment: {
+        CRM_DATABASE_ENVIRONMENT: "production-read-only",
+        CRM_ME_LOCAL_GEOGRAPHY_PRODUCTION_PREFLIGHT_ACK: loaded.artifact.sha256,
+        unpooledUrl: "POSTGRES_URL_NON_POOLING or POSTGRES_DATABASE_URL_UNPOOLED",
+      },
+    };
+  }
+  if (process.env.CRM_DATABASE_ENVIRONMENT !== "production-read-only") {
+    throw new Error("Maine production preflight requires production-read-only environment");
+  }
+  if (
+    process.env.CRM_ME_LOCAL_GEOGRAPHY_PRODUCTION_PREFLIGHT_ACK
+      !== loaded.artifact.sha256
+  ) {
+    throw new Error("Maine production preflight acknowledgement must equal the package SHA-256");
+  }
+  const databaseUrl = productionUrl();
+  const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
+  const sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+    max: 1,
+    connect_timeout: 10,
+    idle_timeout: 20,
+    connection: {
+      application_name: "civicresultmaps-me-local-production-preflight",
+      default_transaction_read_only: true,
+    },
+  });
+  let report;
+  try {
+    report = await sql.begin("read only", (nv) =>
+      collectMaineProductionPreflight(nv, {
+        capturedAtUtc: new Date().toISOString(),
+        endpointFingerprint,
+        releaseCandidate: loaded.releaseCandidate,
+      }));
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+  const bytes = Buffer.from(JSON.stringify(report, null, 2) + "\n", "utf8");
+  const reportSha256 = sha256(bytes);
+  const output = safeReportPath(
+    root,
+    parsed.reportPath,
+    loaded.artifact.sha256,
+    reportSha256,
+  );
+  if (existsSync(output.absolute)) {
+    if (!readFileSync(output.absolute).equals(bytes)) {
+      throw new Error("Refusing to overwrite different Maine preflight evidence");
+    }
+  } else {
+    mkdirSync(path.dirname(output.absolute), { recursive: true });
+    writeFileSync(output.absolute, bytes);
+  }
+  return {
+    mode: "read_only_production_preflight",
+    state: "ME",
+    releasePackageSha256: loaded.artifact.sha256,
+    endpointFingerprint,
+    connectionOpened: true,
+    productionMutationPerformed: false,
+    reportPath: output.relativePath,
+    reportByteCount: bytes.length,
+    reportSha256,
+    migration0008Status: report.migration0008.status,
+    migration0009Status: report.migration0009.status,
+    invalidConstraints: report.invalidConstraints,
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    console.log(JSON.stringify(await runMaineProductionPreflight(), null, 2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}

--- a/scripts/setup-me-local-gis-local.mjs
+++ b/scripts/setup-me-local-gis-local.mjs
@@ -1,0 +1,79 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+// This command intentionally does not load .env.local. The database guard accepts
+// only an explicitly supplied loopback crm_clone_dev URL and local-write opt-in.
+process.env.CRM_DATABASE_DRIVER = "postgres";
+
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const yearsArgument = args.find((arg) => arg.startsWith("--years="));
+const reportArgument = args.find((arg) => arg.startsWith("--report="));
+const allowed = new Set(["--apply"]);
+for (const arg of args) {
+  if (
+    !allowed.has(arg)
+    && !arg.startsWith("--years=")
+    && !arg.startsWith("--report=")
+  ) {
+    throw new Error("Unknown Maine GIS setup option: " + arg);
+  }
+}
+const years = yearsArgument
+  ? yearsArgument.slice("--years=".length).split(",").map((value) => Number(value.trim()))
+  : undefined;
+
+function writeReport(relativePath, value) {
+  const etlRoot = path.resolve(".etl");
+  const target = path.resolve(relativePath);
+  if (target !== etlRoot && !target.startsWith(etlRoot + path.sep)) {
+    throw new Error("Maine GIS reports must remain under .etl");
+  }
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, JSON.stringify(value, null, 2) + "\n", "utf8");
+  return path.relative(process.cwd(), target).replaceAll("\\", "/");
+}
+
+try {
+  const {
+    buildMaineLocalGisPlan,
+    summarizeMaineLocalGisPlan,
+  } = await import("./lib/me-local-gis-plan.mjs");
+  const plan = await buildMaineLocalGisPlan({ years });
+  const summary = summarizeMaineLocalGisPlan(plan);
+  if (!apply) {
+    console.log(JSON.stringify({
+      mode: "plan",
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      ...summary,
+    }, null, 2));
+  } else {
+    const {
+      applyMaineLocalGisPlan,
+      validateMaineLocalGisDatabase,
+    } = await import("./lib/me-local-gis-db.mjs");
+    const applied = await applyMaineLocalGisPlan(plan);
+    const validation = await validateMaineLocalGisDatabase(plan);
+    const report = {
+      schemaVersion: 1,
+      generatedAtUtc: new Date().toISOString(),
+      scope: "local-only Maine local reporting unit GIS setup",
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      plan: summary,
+      applied,
+      validation,
+    };
+    const reportPath = writeReport(
+      reportArgument
+        ? reportArgument.slice("--report=".length)
+        : ".etl/local-db/me-local-gis-setup-report.json",
+      report,
+    );
+    console.log(JSON.stringify({ ...report, reportPath }, null, 2));
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/scripts/validate-me-local-gis-local.mjs
+++ b/scripts/validate-me-local-gis-local.mjs
@@ -1,0 +1,58 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+// Validation is local-only and uses a read-only startup session.
+process.env.CRM_DATABASE_DRIVER = "postgres";
+
+const args = process.argv.slice(2);
+const yearsArgument = args.find((arg) => arg.startsWith("--years="));
+const reportArgument = args.find((arg) => arg.startsWith("--report="));
+for (const arg of args) {
+  if (!arg.startsWith("--years=") && !arg.startsWith("--report=")) {
+    throw new Error("Unknown Maine GIS validation option: " + arg);
+  }
+}
+const years = yearsArgument
+  ? yearsArgument.slice("--years=".length).split(",").map((value) => Number(value.trim()))
+  : undefined;
+
+function writeReport(relativePath, value) {
+  const etlRoot = path.resolve(".etl");
+  const target = path.resolve(relativePath);
+  if (target !== etlRoot && !target.startsWith(etlRoot + path.sep)) {
+    throw new Error("Maine GIS reports must remain under .etl");
+  }
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, JSON.stringify(value, null, 2) + "\n", "utf8");
+  return path.relative(process.cwd(), target).replaceAll("\\", "/");
+}
+
+try {
+  const {
+    buildMaineLocalGisPlan,
+    summarizeMaineLocalGisPlan,
+  } = await import("./lib/me-local-gis-plan.mjs");
+  const { validateMaineLocalGisDatabase } =
+    await import("./lib/me-local-gis-db.mjs");
+  const plan = await buildMaineLocalGisPlan({ years });
+  const validation = await validateMaineLocalGisDatabase(plan);
+  const report = {
+    schemaVersion: 1,
+    generatedAtUtc: new Date().toISOString(),
+    scope: "local-only Maine local reporting unit GIS validation",
+    productionMutationPerformed: false,
+    publicDeliveryAuthorized: false,
+    plan: summarizeMaineLocalGisPlan(plan),
+    validation,
+  };
+  const reportPath = writeReport(
+    reportArgument
+      ? reportArgument.slice("--report=".length)
+      : ".etl/local-db/me-public-local-gis-validation.json",
+    report,
+  );
+  console.log(JSON.stringify({ ...report, reportPath }, null, 2));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/src/app/api/precinct-geography/route.ts
+++ b/src/app/api/precinct-geography/route.ts
@@ -48,11 +48,11 @@ export async function GET(request: NextRequest) {
         manifestId,
       );
     } catch {
-      return errorResponse("local precinct rehearsal configuration failed", 500);
+      return errorResponse("local geography rehearsal configuration failed", 500);
     }
   }
   if (!manifest && !rehearsal) {
-    return errorResponse("eligible precinct geography manifest not found", 404);
+    return errorResponse("eligible local geography manifest not found", 404);
   }
   if (
     manifest
@@ -66,7 +66,7 @@ export async function GET(request: NextRequest) {
     );
   }
   if (manifest && !(await isPrecinctGeometryManifestPublished(manifest))) {
-    return errorResponse("precinct geography publication is not active", 404);
+    return errorResponse("local geography publication is not active", 404);
   }
 
   try {
@@ -82,7 +82,7 @@ export async function GET(request: NextRequest) {
       apiEnvelope(delivery.collection, {
         source: localRehearsal
           ? "local-precinct-rehearsal-candidate"
-          : "immutable-precinct-geography-delivery",
+          : "immutable-local-geography-delivery",
         manifestId: selectedManifest.id,
         parentGeoid,
         rowCount: delivery.collection.features.length,
@@ -112,6 +112,6 @@ export async function GET(request: NextRequest) {
       { headers: publicDataCacheHeaders },
     );
   } catch {
-    return errorResponse("precinct geography delivery validation failed", 500);
+    return errorResponse("local geography delivery validation failed", 500);
   }
 }

--- a/src/app/api/results/route.ts
+++ b/src/app/api/results/route.ts
@@ -30,9 +30,15 @@ export async function GET(request: NextRequest) {
     );
   }
   const parentGeoid = parsedParentGeoid?.data;
-  if (parentGeoid && level !== "precinct") {
+  if (
+    parentGeoid
+    && level !== "precinct"
+    && level !== "local_reporting_unit"
+  ) {
     return NextResponse.json(
-      apiErrorEnvelope("parentGeoid is supported only for precinct results"),
+      apiErrorEnvelope(
+        "parentGeoid is supported only for county-scoped local results",
+      ),
       { status: 400, headers: publicApiErrorHeaders },
     );
   }

--- a/src/app/precinct-detail-map.tsx
+++ b/src/app/precinct-detail-map.tsx
@@ -26,6 +26,7 @@ import {
   type OpenStreetMapViewport,
 } from "@/lib/openstreetmap-basemap";
 import type { ResultRow } from "@/lib/types";
+import { guardedLocalGeographyLevel } from "@/lib/precinct-result-publication";
 
 type PrecinctDetailMapProps = {
   electionYear: SupportedPresidentialYear;
@@ -141,6 +142,7 @@ function isRenderableManifest(
     || !isRecord(value.election)
     || typeof value.election.year !== "number"
     || !isRecord(value.geography)
+    || typeof value.geography.level !== "string"
     || typeof value.geography.boundaryVintage !== "string"
     || !isRecord(value.source)
     || typeof value.source.authority !== "string"
@@ -152,12 +154,12 @@ function isRenderableManifest(
   return true;
 }
 
-function isResultRow(value: unknown): value is ResultRow {
+function isResultRow(value: unknown, expectedLevel: string): value is ResultRow {
   return isRecord(value)
     && typeof value.state === "string"
     && typeof value.year === "number"
     && typeof value.office === "string"
-    && value.level === "precinct"
+    && value.level === expectedLevel
     && typeof value.jurisdictionCode === "string"
     && typeof value.jurisdictionName === "string"
     && isRecord(value.votes)
@@ -276,7 +278,13 @@ export function PrecinctDetailMap({
   selectedState,
 }: PrecinctDetailMapProps) {
   const electionDate = electionDates[electionYear];
-  const manifestQueryKey = selectedState + "|" + electionDate;
+  const requestedGeographyLevel = guardedLocalGeographyLevel(selectedState)
+    ?? "precinct";
+  const manifestQueryKey = selectedState
+    + "|"
+    + electionDate
+    + "|"
+    + requestedGeographyLevel;
   const [manifestLoad, setManifestLoad] = useState<ManifestLoadState>({
     queryKey: "",
     status: "loading",
@@ -297,18 +305,19 @@ export function PrecinctDetailMap({
           geographyManifestApiPath({
             state: selectedState,
             electionDate,
+            level: requestedGeographyLevel,
           }),
           controller.signal,
         );
         if (!Array.isArray(data)) {
-          throw new Error("Precinct manifest response is not an array");
+          throw new Error("Local-geometry manifest response is not an array");
         }
         if (data.length === 0) {
           setManifestLoad({
             queryKey: manifestQueryKey,
             status: "unavailable",
             message:
-              "No reviewed, reconciled, election-date-confirmed precinct "
+              "No reviewed, reconciled, election-date-confirmed local "
               + "layer is published for this state and election.",
           });
           return;
@@ -316,15 +325,16 @@ export function PrecinctDetailMap({
         const candidates = data.filter(isRenderableManifest);
         if (candidates.length !== data.length || candidates.length !== 1) {
           throw new Error(
-            "Precinct manifest response is invalid or ambiguous",
+            "Local-geometry manifest response is invalid or ambiguous",
           );
         }
         const manifest = candidates[0];
         if (
           manifest.state !== selectedState
           || manifest.election.year !== electionYear
+          || manifest.geography.level !== requestedGeographyLevel
         ) {
-          throw new Error("Precinct manifest does not match the selected event");
+          throw new Error("Local-geometry manifest does not match the selected event");
         }
         const deliveryFormat = manifest.delivery?.format
           ?? manifest.localRehearsal?.delivery.format;
@@ -336,7 +346,7 @@ export function PrecinctDetailMap({
             queryKey: manifestQueryKey,
             status: "unavailable",
             message:
-              "The reviewed precinct layer uses a delivery format that this "
+              "The reviewed local layer uses a delivery format that this "
               + "detail map does not yet support.",
           });
           return;
@@ -355,13 +365,19 @@ export function PrecinctDetailMap({
           status: "error",
           message: error instanceof Error
             ? error.message
-            : "Precinct manifest request failed",
+            : "Local-geometry manifest request failed",
         });
       }
     })();
 
     return () => controller.abort();
-  }, [electionDate, electionYear, manifestQueryKey, selectedState]);
+  }, [
+    electionDate,
+    electionYear,
+    manifestQueryKey,
+    requestedGeographyLevel,
+    selectedState,
+  ]);
 
   const currentManifestLoad = manifestLoad.queryKey === manifestQueryKey
     ? manifestLoad
@@ -372,6 +388,13 @@ export function PrecinctDetailMap({
   const localRehearsal = manifest?.localRehearsal ?? null;
   const manifestId = manifest?.id ?? null;
   const manifestOffice = manifest?.election.office ?? null;
+  const manifestLevel = manifest?.geography.level ?? requestedGeographyLevel;
+  const unitLabel = manifestLevel === "local_reporting_unit"
+    ? "local reporting unit"
+    : "precinct";
+  const unitLabelPlural = manifestLevel === "local_reporting_unit"
+    ? "local reporting units"
+    : "precincts";
   const deliveryQueryKey = manifestId && parentGeoid
     ? manifestId + "|" + parentGeoid
     : "";
@@ -398,7 +421,7 @@ export function PrecinctDetailMap({
               + new URLSearchParams({
                 state: selectedState,
                 year: String(electionYear),
-                level: "precinct",
+                level: manifestLevel,
                 office: manifestOffice,
                 parentGeoid,
               }).toString(),
@@ -411,13 +434,13 @@ export function PrecinctDetailMap({
         );
         if (
           !Array.isArray(resultData)
-          || resultData.some((row) => !isResultRow(row))
+          || resultData.some((row) => !isResultRow(row, manifestLevel))
         ) {
-          throw new Error("Precinct result response is invalid");
+          throw new Error("Local result response is invalid");
         }
         const results = resultData.filter(
           (row): row is ResultRow =>
-            isResultRow(row)
+            isResultRow(row, manifestLevel)
             && row.state === selectedState
             && row.year === electionYear
             && row.office.toLowerCase() === manifestOffice.toLowerCase(),
@@ -425,6 +448,7 @@ export function PrecinctDetailMap({
         const rows = joinPrecinctDeliveryResults(
           collection.features,
           results,
+          manifestLevel,
         );
         if (rows.length === 0) {
           setDeliveryLoad({
@@ -447,7 +471,7 @@ export function PrecinctDetailMap({
           status: "error",
           message: error instanceof Error
             ? error.message
-            : "Precinct detail request failed",
+            : "Local detail request failed",
         });
       }
     })();
@@ -459,6 +483,7 @@ export function PrecinctDetailMap({
     manifestId,
     parentGeoid,
     manifestOffice,
+    manifestLevel,
     selectedState,
   ]);
 
@@ -510,7 +535,7 @@ export function PrecinctDetailMap({
   let body;
   if (currentManifestLoad.status === "loading") {
     body = statusPanel(
-      "Checking precinct coverage",
+      "Checking " + unitLabel + " coverage",
       "Looking for a reviewed layer for the selected election.",
     );
   } else if (currentManifestLoad.status === "unavailable") {
@@ -520,35 +545,35 @@ export function PrecinctDetailMap({
     );
   } else if (currentManifestLoad.status === "error") {
     body = statusPanel(
-      "Precinct coverage check failed",
+      unitLabel[0].toUpperCase() + unitLabel.slice(1) + " coverage check failed",
       currentManifestLoad.message,
     );
   } else if (!parentGeoid) {
     body = statusPanel(
       "Select a county first",
-      "Precinct geometry is requested only after a county is pinned, which "
+      "Local geometry is requested only after a county is pinned, which "
         + "keeps the map and transfer size bounded.",
     );
   } else if (!currentDeliveryLoad || currentDeliveryLoad.status === "loading") {
     body = statusPanel(
-      "Loading county precincts",
+      "Loading county " + unitLabelPlural,
       "Verifying the immutable geometry artifact and joining explicit "
         + "reporting-unit IDs.",
     );
   } else if (currentDeliveryLoad.status === "empty") {
     body = statusPanel(
-      "No displayable precincts",
-      "The reviewed layer contains no eligible precinct features for this "
+      "No displayable " + unitLabelPlural,
+      "The reviewed layer contains no eligible " + unitLabel + " features for this "
         + "county. County results remain available above.",
     );
   } else if (currentDeliveryLoad.status === "error") {
     body = statusPanel(
-      "Precinct detail unavailable",
+      unitLabel[0].toUpperCase() + unitLabel.slice(1) + " detail unavailable",
       currentDeliveryLoad.message,
     );
   } else if (!viewport) {
     body = statusPanel(
-      "Precinct coordinates unavailable",
+      unitLabel[0].toUpperCase() + unitLabel.slice(1) + " coordinates unavailable",
       "The county delivery passed its envelope checks but did not contain "
         + "renderable polygon coordinates.",
     );
@@ -618,7 +643,10 @@ export function PrecinctDetailMap({
                 {OPENSTREETMAP_ATTRIBUTION}
               </a>
             </div>
-            <div className="precinct-detail-legend" aria-label="Precinct map legend">
+            <div
+              className="precinct-detail-legend"
+              aria-label={unitLabel + " map legend"}
+            >
               <span><i className="dem" aria-hidden /> Democratic winner</span>
               <span><i className="rep" aria-hidden /> Republican winner</span>
               <span><i className="other" aria-hidden /> Other winner</span>
@@ -629,7 +657,7 @@ export function PrecinctDetailMap({
           </div>
           <div className="precinct-detail-controls">
             <label htmlFor="precinct-detail-selection">
-              Precinct to inspect
+              {unitLabel[0].toUpperCase() + unitLabel.slice(1)} to inspect
               <select
                 id="precinct-detail-selection"
                 onChange={(event) =>
@@ -660,7 +688,7 @@ export function PrecinctDetailMap({
                   <>
                     {selectedOutcome === "privacy_suppressed" ? (
                       <p>
-                        Clark County reports this precinct&apos;s exact total,
+                        The election authority reports this unit&apos;s exact total,
                         but suppresses the candidate allocation for ballot
                         privacy. CivicResultMaps does not estimate the hidden
                         candidate values.
@@ -746,13 +774,15 @@ export function PrecinctDetailMap({
 
   return (
     <section
-      aria-label={selectedState + " precinct detail map"}
+      aria-label={selectedState + " " + unitLabel + " detail map"}
       className="panel precinct-detail-panel"
       data-tour="precinct-detail-map"
     >
       <div className="panel-header">
         <div>
-          <h2>Precinct Detail</h2>
+          <h2>
+            {unitLabel[0].toUpperCase() + unitLabel.slice(1)} Detail
+          </h2>
           <span>
             {parentName
               ? parentName + ", " + electionYear

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -77,7 +77,7 @@ export const officeQuery = z
   .default("president");
 
 export const levelQuery = z
-  .enum(["county", "state", "district", "precinct", "city", "city_town", "town", "federal_precincts", "non_geographic"])
+  .enum(["county", "state", "district", "precinct", "local_reporting_unit", "city", "city_town", "town", "federal_precincts", "non_geographic"])
   .default("county");
 
 export const parentGeoidQuery = z

--- a/src/lib/data-access.ts
+++ b/src/lib/data-access.ts
@@ -338,7 +338,7 @@ export async function isPrecinctGeometryManifestPublished(
             and geography_features.is_geographic = true
             and reporting_units.election_id = geography_versions.election_id
             and reporting_units.state_code = geography_versions.state_code
-            and reporting_units.reporting_grain = 'precinct'
+            and reporting_units.reporting_grain = ${manifest.geography.level}
             and reporting_units.is_geographic = true
             and reporting_units.metadata->>'publicDeliveryAuthorized' = 'true'
             and reporting_units.metadata->'releaseCandidate'->>'publicDeliveryAuthorized' = 'true'
@@ -571,15 +571,19 @@ export async function listResults(input: {
     : { enabled: false } as const;
   const requiresPublicationGate = requiresPrecinctResultPublicationGate(input)
     && !minnesotaRehearsal.enabled;
-  if (parentGeoid && (input.level !== "precinct" || !/^\d{5}$/.test(parentGeoid))) {
+  const parentScopedLocalLevel = input.level === "precinct"
+    || input.level === "local_reporting_unit";
+  if (parentGeoid && (!parentScopedLocalLevel || !/^\d{5}$/.test(parentGeoid))) {
     throw new Error(
-      "parentGeoid requires precinct results and a five-digit county GEOID",
+      "parentGeoid requires county-scoped local results and a five-digit county GEOID",
     );
   }
   const matchesParent = (row: ResultRow) => !parentGeoid
     || row.jurisdictionCode.startsWith(
       "reporting:" + input.state + ":",
-    ) && row.jurisdictionCode.includes(":precinct:" + parentGeoid + ":");
+    ) && row.jurisdictionCode.includes(
+      ":" + input.level + ":" + parentGeoid + ":",
+    );
   if (!hasReadableDatabase()) {
     if (requiresPublicationGate) return [];
     return seedResults
@@ -645,7 +649,7 @@ export async function listResults(input: {
           on result_rows.reporting_unit_id = reporting_units.id
           and reporting_units.election_id = elections.id
           and reporting_units.state_code = result_rows.state_code
-          and reporting_units.reporting_grain = 'precinct'
+          and reporting_units.reporting_grain = ${input.level}
         left join source_documents on result_rows.source_document_id = source_documents.id
         where result_rows.state_code = ${input.state}
           and result_rows.level = ${input.level}
@@ -669,7 +673,7 @@ export async function listResults(input: {
                 where gate_crosswalk.reporting_unit_id = reporting_units.id
                   and gate_version.election_id = elections.id
                   and gate_version.state_code = result_rows.state_code
-                  and gate_version.geography_type = 'precinct'
+                  and gate_version.geography_type = ${input.level}
                   and gate_version.status = 'published'
                   and gate_version.metadata->>'publicDeliveryAuthorized' = 'true'
                   and gate_version.metadata->'releaseCandidate'->>'publicDeliveryAuthorized' = 'true'
@@ -750,7 +754,7 @@ export async function listResults(input: {
         on result_rows.reporting_unit_id = reporting_units.id
         and reporting_units.election_id = elections.id
         and reporting_units.state_code = result_rows.state_code
-        and reporting_units.reporting_grain = 'precinct'
+        and reporting_units.reporting_grain = ${input.level}
       left join source_documents on result_rows.source_document_id = source_documents.id
       where result_rows.state_code = ${input.state}
         and result_rows.level = ${input.level}
@@ -773,7 +777,7 @@ export async function listResults(input: {
               where gate_crosswalk.reporting_unit_id = reporting_units.id
                 and gate_version.election_id = elections.id
                 and gate_version.state_code = result_rows.state_code
-                and gate_version.geography_type = 'precinct'
+                and gate_version.geography_type = ${input.level}
                 and gate_version.status = 'published'
                 and gate_version.metadata->>'publicDeliveryAuthorized' = 'true'
                 and gate_version.metadata->'releaseCandidate'->>'publicDeliveryAuthorized' = 'true'

--- a/src/lib/precinct-map-delivery.ts
+++ b/src/lib/precinct-map-delivery.ts
@@ -377,15 +377,16 @@ export function selectPrecinctDeliveryFeatures(
 export function joinPrecinctDeliveryResults(
   features: PrecinctDeliveryFeature[],
   results: ResultRow[],
+  expectedLevel = "precinct",
 ): JoinedPrecinctDeliveryFeature[] {
   const byCode = new Map<string, ResultRow>();
   for (const result of results) {
-    if (result.level !== "precinct") {
+    if (result.level !== expectedLevel) {
       continue;
     }
     if (byCode.has(result.jurisdictionCode)) {
       throw new Error(
-        "duplicate precinct result code " + result.jurisdictionCode,
+        "duplicate local result code " + result.jurisdictionCode,
       );
     }
     byCode.set(result.jurisdictionCode, result);

--- a/src/lib/precinct-result-publication.ts
+++ b/src/lib/precinct-result-publication.ts
@@ -1,21 +1,61 @@
 import { createHash } from "node:crypto";
 import type { PrecinctGeometryManifest } from "./precinct-geography";
 
-const PRECINCT_PUBLICATION_GATED_STATES = new Set(["IA", "MN", "NV", "TX"]);
+const GUARDED_LOCAL_GEOGRAPHY_RELEASES = Object.freeze({
+  IA: {
+    geographyLevel: "precinct",
+    releaseCandidatePattern: /^ia-precinct-gis-three-election-v\d+$/,
+  },
+  ME: {
+    geographyLevel: "local_reporting_unit",
+    releaseCandidatePattern: /^me-local-reporting-gis-three-election-v\d+$/,
+  },
+  MN: {
+    geographyLevel: "precinct",
+    releaseCandidatePattern: /^mn-precinct-gis-four-election-v\d+$/,
+  },
+  NV: {
+    geographyLevel: "precinct",
+    releaseCandidatePattern: /^nv-precinct-gis-three-election-v\d+$/,
+  },
+  TX: {
+    geographyLevel: "precinct",
+    releaseCandidatePattern: /^tx-precinct-gis-four-election-v\d+$/,
+  },
+} satisfies Record<string, {
+  geographyLevel: string;
+  releaseCandidatePattern: RegExp;
+}>);
+
+type GuardedLocalGeographyState = keyof typeof GUARDED_LOCAL_GEOGRAPHY_RELEASES;
+
+function guardedReleaseContract(state: string) {
+  const normalized = state.trim().toUpperCase();
+  return Object.hasOwn(GUARDED_LOCAL_GEOGRAPHY_RELEASES, normalized)
+    ? GUARDED_LOCAL_GEOGRAPHY_RELEASES[
+        normalized as GuardedLocalGeographyState
+      ]
+    : null;
+}
+
+export function guardedLocalGeographyLevel(state: string) {
+  return guardedReleaseContract(state)?.geographyLevel ?? null;
+}
 
 export function requiresPrecinctResultPublicationGate(input: {
   state: string;
   level: string;
 }) {
-  return PRECINCT_PUBLICATION_GATED_STATES.has(input.state.toUpperCase())
-    && input.level === "precinct";
+  const contract = guardedReleaseContract(input.state);
+  return contract !== null && input.level === contract.geographyLevel;
 }
 
 export function requiresPrecinctGeometryPublicationGate(
   manifest: Pick<PrecinctGeometryManifest, "state" | "geography">,
 ) {
-  return PRECINCT_PUBLICATION_GATED_STATES.has(manifest.state)
-    && manifest.geography.level === "precinct";
+  const contract = guardedReleaseContract(manifest.state);
+  return contract !== null
+    && manifest.geography.level === contract.geographyLevel;
 }
 
 function canonicalize(value: unknown): unknown {
@@ -106,15 +146,13 @@ export function matchesPrecinctGeometryPublicationMetadata(
     ?? expectedFeatureCount;
   const releaseSha256 = releaseCandidate.sha256;
   const changedAtUtc = activation.changedAtUtc;
+  const releaseContract = guardedReleaseContract(manifest.state);
   return metadata.manifestId === manifest.id
     && metadata.publicDeliveryAuthorized === true
     && releaseCandidate.publicDeliveryAuthorized === true
     && typeof releaseCandidate.id === "string"
-    && new RegExp(
-      "^" + manifest.state.toLowerCase() + "-precinct-gis-"
-        + (["IA", "NV"].includes(manifest.state) ? "three" : "four")
-        + "-election-v\\d+$",
-    ).test(releaseCandidate.id)
+    && releaseContract !== null
+    && releaseContract.releaseCandidatePattern.test(releaseCandidate.id)
     && typeof releaseSha256 === "string"
     && /^[a-f0-9]{64}$/.test(releaseSha256)
     && recordValue(metadata.normalization)?.featureCount === expectedFeatureCount

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,7 +28,7 @@ export type ResultRow = {
   state: string;
   year: number;
   office: string;
-  level: "county" | "state" | "district" | "precinct" | "city" | "town" | "city_town" | "rest_of_county" | "federal_precincts" | "non_geographic";
+  level: "county" | "state" | "district" | "precinct" | "local_reporting_unit" | "city" | "town" | "city_town" | "rest_of_county" | "federal_precincts" | "non_geographic";
   jurisdictionCode: string;
   jurisdictionName: string;
   jurisdictionTag?: string | null;

--- a/tests/api/api-contract.test.mjs
+++ b/tests/api/api-contract.test.mjs
@@ -202,7 +202,7 @@ test("results API keeps contest offices separated", () => {
     /listResults\(\{[\s\S]*?state,[\s\S]*?year,[\s\S]*?level,[\s\S]*?office,[\s\S]*?parentGeoid,/,
   );
   assert.match(route, /parentGeoidQuery\.safeParse/);
-  assert.match(route, /parentGeoid is supported only for precinct results/);
+  assert.match(route, /parentGeoid is supported only for county-scoped local results/);
   assert.match(
     dataAccess,
     /lower\(elections\.office\) = \$\{normalizedOffice\}/,

--- a/tests/api/me-local-blob-publication.test.mjs
+++ b/tests/api/me-local-blob-publication.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { inspectMaineLocalBlobPublicationPlan } from "../../scripts/lib/me-local-blob-publication.mjs";
+import { buildMaineTestReleaseFixture } from "./me-local-release-fixture.mjs";
+
+const { prepared } = await buildMaineTestReleaseFixture({ write: true });
+const plan = inspectMaineLocalBlobPublicationPlan({
+  packagePath: prepared.releaseCandidate.path,
+  packageSha256: prepared.releaseCandidate.sha256,
+});
+
+test("Maine Blob plan pins all 48 parents before three indexes", () => {
+  assert.equal(plan.artifacts.length, 51);
+  assert.equal(plan.artifacts.filter((artifact) => artifact.kind === "parent").length, 48);
+  assert.equal(plan.artifacts.filter((artifact) => artifact.kind === "index").length, 3);
+  assert.ok(plan.artifacts.slice(0, 48).every((artifact) => artifact.kind === "parent"));
+  assert.ok(plan.artifacts.slice(48).every((artifact) => artifact.kind === "index"));
+  assert.ok(plan.artifacts.every((artifact) => artifact.pathname.startsWith("data/geography/me/")));
+  assert.equal(plan.decision, "NO_GO_PUBLICATION");
+  assert.equal(plan.canonicalManifestChanged, false);
+  assert.equal(plan.publicEligibilityChanged, false);
+});

--- a/tests/api/me-local-gis-local.test.mjs
+++ b/tests/api/me-local-gis-local.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  assertMaineGeometryVersionPrecondition,
+  canonicalJson,
+} from "../../scripts/lib/me-local-gis-db.mjs";
+import {
+  requiresPrecinctGeometryPublicationGate,
+  requiresPrecinctResultPublicationGate,
+} from "../../src/lib/precinct-result-publication.ts";
+
+test("Maine local GIS commands remain loopback-only and public-fail-closed", () => {
+  const setup = readFileSync("scripts/setup-me-local-gis-local.mjs", "utf8");
+  const validate = readFileSync("scripts/validate-me-local-gis-local.mjs", "utf8");
+  const database = readFileSync("scripts/lib/me-local-gis-db.mjs", "utf8");
+  const packageJson = JSON.parse(readFileSync("package.json"));
+  assert.match(setup, /CRM_DATABASE_DRIVER = "postgres"/);
+  assert.match(validate, /CRM_DATABASE_DRIVER = "postgres"/);
+  assert.doesNotMatch(setup + validate, /--env-file|dotenv/);
+  assert.match(database, /getLocalCloneDatabaseUrl\(\{ requireWriteOptIn: true \}\)/);
+  assert.match(database, /reporting_grain='local_reporting_unit'/);
+  assert.match(database, /status='blocked'| 'blocked'/);
+  assert.match(database, /publicDeliveryAuthorized: false/);
+  assert.doesNotMatch(database, /runNeonTransaction|@neondatabase/);
+  assert.equal(packageJson.scripts["local-gis:plan:me"], "node --experimental-strip-types scripts/setup-me-local-gis-local.mjs");
+  assert.equal(packageJson.scripts["local-gis:setup:me:local"], "node --experimental-strip-types scripts/setup-me-local-gis-local.mjs --apply");
+});
+
+test("Maine results and geometry require exact publication evidence", () => {
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ME", level: "local_reporting_unit" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ME", level: "precinct" }), false);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ia", level: "precinct" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ME", level: "county" }), false);
+  assert.equal(requiresPrecinctGeometryPublicationGate({
+    state: "ME",
+    geography: { level: "local_reporting_unit" },
+  }), true);
+});
+
+test("Maine release precondition rejects duplicate or boundary-drifted versions", () => {
+  const yearPlan = {
+    year: 2024,
+    manifest: {
+      id: "me-2024-11-05-general-local-reporting-geometry-candidate-v1",
+      geography: { boundaryVintage: "reviewed Maine 2024 local boundaries" },
+    },
+  };
+  assert.doesNotThrow(() => assertMaineGeometryVersionPrecondition([], yearPlan));
+  assert.doesNotThrow(() => assertMaineGeometryVersionPrecondition([{
+    manifest_id: yearPlan.manifest.id,
+    boundary_vintage: yearPlan.manifest.geography.boundaryVintage,
+  }], yearPlan));
+  assert.throws(() => assertMaineGeometryVersionPrecondition([{
+    manifest_id: yearPlan.manifest.id,
+    boundary_vintage: "drifted",
+  }], yearPlan), /boundary-drifted geography versions/);
+});
+
+test("Maine database validation compares nested JSON independent of key order", () => {
+  const left = {
+    z: [{ beta: 2, alpha: 1 }],
+    a: { delta: 4, gamma: 3 },
+  };
+  const right = {
+    a: { gamma: 3, delta: 4 },
+    z: [{ alpha: 1, beta: 2 }],
+  };
+  assert.deepEqual(canonicalJson(left), canonicalJson(right));
+});

--- a/tests/api/me-local-gis-plan.test.mjs
+++ b/tests/api/me-local-gis-plan.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildMaineLocalGisPlan,
+  summarizeMaineLocalGisPlan,
+} from "../../scripts/lib/me-local-gis-plan.mjs";
+
+const plan = await buildMaineLocalGisPlan();
+const summary = summarizeMaineLocalGisPlan(plan);
+
+test("Maine plan preserves three exact public-candidate universes", () => {
+  assert.deepEqual(summary.years.map((year) => ({
+    year: year.year,
+    units: year.reportingUnits,
+    rows: year.resultRows,
+    features: year.geometryFeatures,
+    relationships: year.reviewedCrosswalks,
+    total: year.totals.Total,
+    sourceGatePassed: year.sourceGatePassed,
+  })), [
+    { year: 2016, units: 532, rows: 1596, features: 532, relationships: 532, total: 743941, sourceGatePassed: true },
+    { year: 2020, units: 516, rows: 1548, features: 516, relationships: 516, total: 813742, sourceGatePassed: true },
+    { year: 2024, units: 494, rows: 1482, features: 494, relationships: 494, total: 824806, sourceGatePassed: true },
+  ]);
+});
+
+test("Maine loadable years use exact county-scoped one-to-one relationships", () => {
+  for (const year of plan.years) {
+    assert.equal(new Set(year.geometry.features.map((feature) => feature.parentGeoid)).size, 16);
+    assert.ok(year.reportingUnits.every((unit) =>
+      unit.reportingGrain === "local_reporting_unit"
+      && /^23\d{3}$/.test(unit.parentGeoid)));
+    assert.ok(year.geometry.crosswalks.every((relationship) =>
+      relationship.relationshipType === "one_to_one"
+      && relationship.reviewStatus === "reviewed"
+      && relationship.confidence === "high"));
+    assert.equal(year.resultRows.length, year.reportingUnits.length * 3);
+  }
+});
+
+test("Maine plan rejects the separately blocked 2012 package", async () => {
+  await assert.rejects(
+    buildMaineLocalGisPlan({ years: [2012] }),
+    /2012 remains blocked and cannot be loaded/,
+  );
+});

--- a/tests/api/me-local-production-release.test.mjs
+++ b/tests/api/me-local-production-release.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  assertMaineReleaseCandidateDocument,
+  sha256,
+} from "../../scripts/lib/me-local-production-preflight.mjs";
+import {
+  MAINE_PRODUCTION_RELEASE_SCOPES,
+  buildMaineProductionAuthorizationTemplate,
+  validateMaineProductionAuthorization,
+  validateMaineProductionBackupEvidence,
+  validateMaineProductionPreflightEvidence,
+} from "../../scripts/lib/me-local-production-release.mjs";
+import { buildMaineTestReleaseFixture } from "./me-local-release-fixture.mjs";
+
+const { built } = await buildMaineTestReleaseFixture();
+const packageSha256 = sha256(built.packageBytes);
+const candidate = assertMaineReleaseCandidateDocument(built.packageDocument, packageSha256);
+const now = new Date("2026-08-13T00:30:00.000Z");
+const endpointFingerprint = "a".repeat(64);
+
+test("Maine release candidate and authorization scopes are state-specific", () => {
+  assert.deepEqual(MAINE_PRODUCTION_RELEASE_SCOPES, [
+    "apply_migration_0009",
+    "load_me_local_reporting_results_and_geometry_hidden",
+    "increment_public_data_revision",
+  ]);
+  const template = buildMaineProductionAuthorizationTemplate({
+    releaseCandidate: candidate,
+    preflightSha256: "b".repeat(64),
+    backupManifestSha256: "c".repeat(64),
+  });
+  assert.equal(template.decision, "NO_GO_PRODUCTION");
+  assert.deepEqual(template.scopes, MAINE_PRODUCTION_RELEASE_SCOPES);
+  assert.equal(template.replacement, undefined);
+});
+
+test("Maine fresh empty production evidence validates and preexisting rows fail", () => {
+  const report = {
+    schemaVersion: 1,
+    state: "ME",
+    productionMutationPerformed: false,
+    database: { transactionReadOnly: true, name: "production" },
+    invalidConstraints: 0,
+    migration0008: { status: "complete" },
+    migration0009: { status: "absent" },
+    releaseCandidate: { id: candidate.id, sha256: candidate.sha256 },
+    endpointFingerprint,
+    publicRevision: 10,
+    capturedAtUtc: "2026-08-13T00:00:00.000Z",
+    maine: {
+      localYearRows: [2016, 2020, 2024].map((year) => ({
+        year,
+        reportingUnits: 0,
+        linkedLocalResultRows: 0,
+        geographyVersions: 0,
+        geometryFeatures: 0,
+        reviewedExactCrosswalks: 0,
+      })),
+      coreYearRows: [2016, 2020, 2024].map((year) => ({ year, localResultRows: 0 })),
+    },
+  };
+  assert.doesNotThrow(() => validateMaineProductionPreflightEvidence(report, {
+    releaseCandidate: candidate,
+    endpointFingerprint,
+    now,
+  }));
+  report.maine.localYearRows[1].reportingUnits = 1;
+  assert.throws(() => validateMaineProductionPreflightEvidence(report, {
+    releaseCandidate: candidate,
+    endpointFingerprint,
+    now,
+  }), /already contains local reporting release rows/);
+});
+
+test("Maine backup and authorization require exact fresh hashes", () => {
+  const preflightCapturedAtUtc = "2026-08-13T00:00:00.000Z";
+  const backup = {
+    manifestVersion: 3,
+    backupPurpose: "me-local-production-release-rollback",
+    releaseCandidate: { id: candidate.id, sha256: candidate.sha256 },
+    sourceEndpointFingerprint: endpointFingerprint,
+    dumpSha256: "d".repeat(64),
+    dumpFormat: "custom",
+    pgClientMajor: 17,
+    sourceServerVersionNum: 170000,
+    includedSchemas: ["public"],
+    excludedTableDataPatterns: [],
+    remoteMutationPerformed: false,
+    sourceInvalidConstraints: 0,
+    createdAtUtc: "2026-08-13T00:05:00.000Z",
+    sourcePublicTableCount: 2,
+    sourcePublicTableRowCounts: { elections: 4, contests: 8 },
+    restoreVerification: {
+      verified: true,
+      defaultTransactionReadOnly: true,
+      exactSourceTableSet: true,
+      exactSourceRowCounts: true,
+      invalidConstraints: 0,
+      verifiedAtUtc: "2026-08-13T00:10:00.000Z",
+      publicTableCount: 2,
+      tableDataEntryCount: 2,
+      publicTableRowCounts: { elections: 4, contests: 8 },
+    },
+  };
+  assert.doesNotThrow(() => validateMaineProductionBackupEvidence(backup, {
+    releaseCandidate: candidate,
+    endpointFingerprint,
+    preflightCapturedAtUtc,
+    now,
+  }));
+  const authorization = {
+    ...buildMaineProductionAuthorizationTemplate({
+      releaseCandidate: candidate,
+      preflightSha256: "b".repeat(64),
+      backupManifestSha256: "c".repeat(64),
+    }),
+    decision: "GO_PRODUCTION",
+    authorizationId: "me-release-1",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T00:15:00.000Z",
+    expiresAtUtc: "2026-08-13T01:15:00.000Z",
+  };
+  assert.doesNotThrow(() => validateMaineProductionAuthorization(authorization, {
+    releaseCandidate: candidate,
+    preflightSha256: "b".repeat(64),
+    backupManifestSha256: "c".repeat(64),
+    now,
+  }));
+  authorization.scopes[1] = "load_nv_precinct_results_and_geometry_hidden";
+  assert.throws(() => validateMaineProductionAuthorization(authorization, {
+    releaseCandidate: candidate,
+    preflightSha256: "b".repeat(64),
+    backupManifestSha256: "c".repeat(64),
+    now,
+  }), /incomplete or incompatible/);
+});
+
+test("Maine production runners use the correctly spelled environment guard", () => {
+  const files = [
+    "scripts/apply-me-local-release.mjs",
+    "scripts/report-me-local-production-preflight.mjs",
+    "scripts/publish-me-local-geography-status.mjs",
+  ].map((file) => readFileSync(file, "utf8")).join("\n");
+  assert.match(files, /CRM_DATABASE_ENVIRONMENT/);
+  assert.doesNotMatch(files, /CRM_DATABASE_EIAIRONMENT|NODE_EIA/);
+  assert.doesNotMatch(files, /replacement-publication-receipt|GO_PRODUCTION_UPGRADE/);
+});

--- a/tests/api/me-local-public-activation.test.mjs
+++ b/tests/api/me-local-public-activation.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { inspectMainePublicActivationPlan } from "../../scripts/lib/me-local-public-activation.mjs";
+import { buildMaineTestReleaseFixture } from "./me-local-release-fixture.mjs";
+
+const coverage = JSON.parse(readFileSync(
+  "data/precinct-geometry-coverage-inventory-2016.json",
+  "utf8",
+));
+const existingMaineRow = coverage.states.find((row) => row.state === "ME");
+const { prepared } = await buildMaineTestReleaseFixture({
+  write: true,
+  generatedAtUtc: existingMaineRow?.checkedAt,
+});
+const inspected = inspectMainePublicActivationPlan({
+  packagePath: prepared.releaseCandidate.path,
+  packageSha256: prepared.releaseCandidate.sha256,
+});
+
+test("Maine static activation adds or verifies exactly three guarded manifests", () => {
+  assert.equal(inspected.plan.manifests.length, 3);
+  assert.deepEqual(inspected.plan.manifests.map((item) => item.year), [2016, 2020, 2024]);
+  assert.equal(inspected.plan.trackedOutputs.length, 4);
+  const dispositions = new Set(
+    inspected.plan.trackedOutputs.map((output) => output.disposition),
+  );
+  assert.equal(dispositions.size, 1);
+  assert.ok(["activate", "verified_existing"].includes([...dispositions][0]));
+  assert.equal(inspected.plan.safety.productionMutationPerformed, false);
+  assert.equal(inspected.plan.safety.publicEndpointsRemainDatabaseGated, true);
+});

--- a/tests/api/me-local-publication-gate.test.mjs
+++ b/tests/api/me-local-publication-gate.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  matchesPrecinctGeometryPublicationMetadata,
+  precinctGeometryPublicManifestSha256,
+  requiresPrecinctGeometryPublicationGate,
+  requiresPrecinctResultPublicationGate,
+} from "../../src/lib/precinct-result-publication.ts";
+
+function manifest() {
+  return {
+    schemaVersion: 1,
+    id: "me-2024-11-05-general-local-reporting-geometry-candidate-v1",
+    state: "ME",
+    election: { id: "2024-11-05-general", date: "2024-11-05", year: 2024, type: "general", office: "president" },
+    geography: { level: "local_reporting_unit", parentLevel: "county", boundaryVintage: "reviewed", vintageStatus: "election_date_confirmed", derivationMethod: "secondary_reconstruction" },
+    source: {},
+    normalization: { featureCount: 2 },
+    crosswalk: {},
+    validation: {},
+    delivery: {
+      format: "parent_scoped_geojson",
+      url: "/data/geography/me/2024-11-05/local_reporting_unit/candidate/index.json",
+      sha256: "1".repeat(64),
+      byteCount: 123,
+      featureIdProperty: "geometryFeatureId",
+      resultUnitProperty: "resultUnitCode",
+      parentGeoidProperty: "parentGeoid",
+      parentCount: 1,
+      featureCount: 2,
+    },
+    caveats: [],
+  };
+}
+
+function metadata(value) {
+  const releaseSha256 = "2".repeat(64);
+  return {
+    manifestId: value.id,
+    publicDeliveryAuthorized: true,
+    normalization: { featureCount: 2 },
+    crosswalk: { reviewedRelationships: 2 },
+    releaseCandidate: { id: "me-local-reporting-gis-three-election-v1", sha256: releaseSha256, publicDeliveryAuthorized: true },
+    publicActivation: {
+      activationId: "me-public-2024",
+      activationCandidateSha256: "3".repeat(64),
+      releasePackageSha256: releaseSha256,
+      blobPublicationSha256: "4".repeat(64),
+      deliveryOrigin: "https://example.public.blob.vercel-storage.com",
+      authorizationSha256: "5".repeat(64),
+      changedAtUtc: "2026-08-12T23:59:00.000Z",
+      revision: 50,
+      mode: "publish",
+      year: 2024,
+      manifestId: value.id,
+      publicManifestSha256: precinctGeometryPublicManifestSha256(value),
+      delivery: value.delivery,
+      previousCaveat: "blocked pending release",
+    },
+  };
+}
+
+test("Maine local reporting unit results and geometry use the guarded publication path", () => {
+  const value = manifest();
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ME", level: "local_reporting_unit" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ME", level: "precinct" }), false);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ME", level: "county" }), false);
+  assert.equal(requiresPrecinctGeometryPublicationGate(value), true);
+  assert.equal(matchesPrecinctGeometryPublicationMetadata(value, metadata(value)), true);
+  const foreign = metadata(value);
+  foreign.releaseCandidate.id = "nv-precinct-gis-three-election-v2";
+  assert.equal(matchesPrecinctGeometryPublicationMetadata(value, foreign), false);
+});
+
+test("Minnesota rehearsal cannot bypass the Maine publication gate", () => {
+  const source = readFileSync("src/lib/data-access.ts", "utf8");
+  assert.match(source, /input\.state\.toUpperCase\(\) === "MN"\s*\? resolveMinnesotaPrecinctRehearsal\(\)/);
+  assert.doesNotMatch(source, /requiresPrecinctResultPublicationGate\(input\)\s*&&\s*!resolveMinnesotaPrecinctRehearsal\(\)\.enabled/);
+});

--- a/tests/api/me-local-publication.test.mjs
+++ b/tests/api/me-local-publication.test.mjs
@@ -1,0 +1,596 @@
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  MAINE_PUBLICATION_SCOPES,
+  MAINE_PUBLIC_ROLLBACK_SCOPES,
+  buildMainePublicRollbackAuthorizationTemplate,
+  buildMainePublicationAuthorizationTemplate,
+  serializeMainePublicationDocument,
+  sha256,
+  validateMaineBlobPublicationEvidence,
+  validateMainePublicRollbackAuthorization,
+  validateMainePublicationAuthorization,
+} from "../../scripts/lib/me-local-publication.mjs";
+import {
+  applyMaineGeographyPublicationTransaction,
+  inspectMainePublicationReceipt,
+  verifyMainePublicationGitCandidate,
+} from "../../scripts/publish-me-local-geography-status.mjs";
+const deliveryOrigin = "https://example.public.blob.vercel-storage.com";
+const blobReleaseCandidate = {
+  id: "me-local-reporting-gis-three-election-v1",
+  path: ".etl/precinct-release-candidates/ME/example/release-candidate.json",
+  sha256: "d".repeat(64),
+};
+const blobArtifacts = Array.from({ length: 51 }, (_, index) => {
+  const year = [2016, 2020, 2024][Math.min(2, Math.floor(index / 17))];
+  const kind = index % 17 === 16 ? "index" : "parent";
+  return {
+    kind,
+    year,
+    packageRelativePath: `delivery-assets/${year}/file-${index}.json`,
+    publicUrl: `/data/geography/me/${year}/local_reporting_unit/file-${index}.json`,
+    pathname: `data/geography/me/${year}/local_reporting_unit/file-${index}.json`,
+    byteCount: 100 + index,
+    sha256: index.toString(16).padStart(64, "0"),
+  };
+});
+const blobPlan = {
+  releaseCandidate: blobReleaseCandidate,
+  artifacts: blobArtifacts,
+};
+const evidence = {
+  schemaVersion: 1,
+  state: "ME",
+  purpose: "me-local-reporting-parent-scoped-immutable-geometry-publication",
+  releaseCandidate: blobReleaseCandidate,
+  authorizationId: "me-blob-publication-1",
+  publishedAtUtc: "2026-08-13T00:00:00.000Z",
+  deliveryOrigin,
+  assetCount: blobPlan.artifacts.length,
+  canonicalManifestChanged: false,
+  publicEligibilityChanged: false,
+  artifacts: blobPlan.artifacts.map((artifact) => ({
+    ...artifact,
+    url: `${deliveryOrigin}/${artifact.pathname}`,
+    disposition: "created",
+  })),
+};
+
+const releaseCandidate = {
+  id: "me-local-reporting-gis-three-election-v1",
+  path: ".etl/precinct-release-candidates/ME/example/release-candidate.json",
+  sha256: "1".repeat(64),
+};
+const planSha256 = "2".repeat(64);
+const rollbackTarget = {
+  deploymentId: "dpl_maine_previous",
+  url: "https://previous.civicresultmaps.org",
+  gitSha: "3".repeat(40),
+  gitTreeSha: "4".repeat(40),
+  verifiedAtUtc: "2026-08-13T00:30:00.000Z",
+  gateCapableVerified: true,
+  blockedResultGateVerified: true,
+  blockedGeometryGateVerified: true,
+};
+const authorizationPlan = {
+  id: "me-local-database-publication-v1",
+  releaseCandidate,
+  hiddenLoad: { path: "hidden.json", sha256: "5".repeat(64) },
+  blobPublication: {
+    path: "blob.json",
+    sha256: "6".repeat(64),
+    deliveryOrigin,
+  },
+  staticRegistry: { sha256: "7".repeat(64) },
+};
+
+function publicAuthorization() {
+  const value = buildMainePublicationAuthorizationTemplate(
+    authorizationPlan,
+    planSha256,
+  );
+  Object.assign(value, {
+    decision: "GO_PUBLIC",
+    activationId: "me-public-camreyn",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T00:50:00.000Z",
+    expiresAtUtc: "2026-08-13T02:00:00.000Z",
+  });
+  Object.assign(value.productionDeployment, {
+    deploymentId: "dpl_maine_public",
+    url: "https://civicresultmaps.org",
+    gitSha: "8".repeat(40),
+    gitTreeSha: "9".repeat(40),
+    readyVerified: true,
+    promotedVerified: true,
+    blockedResultGateVerified: true,
+    blockedGeometryGateVerified: true,
+    verifiedAtUtc: "2026-08-13T00:45:00.000Z",
+  });
+  Object.assign(value.rollbackTarget, rollbackTarget);
+  return value;
+}
+
+function publicationSummary() {
+  return {
+    path: ".etl/production-publication-receipts/ME/me-local-publish.json",
+    sha256: "a".repeat(64),
+    activationId: "me-public-camreyn",
+    authorizationSha256: "b".repeat(64),
+    revision: 41,
+    changedAtUtc: "2026-08-13T01:00:00.000Z",
+    rollbackTarget,
+    productionDeployment: publicAuthorization().productionDeployment,
+  };
+}
+
+test("Maine Blob evidence requires all 51 immutable artifacts", () => {
+  const result = validateMaineBlobPublicationEvidence(
+    evidence,
+    blobPlan,
+    Date.parse("2026-08-13T00:01:00.000Z"),
+  );
+  assert.equal(result.assetCount, 51);
+  assert.equal(result.deliveryOrigin, deliveryOrigin);
+  const incomplete = { ...evidence, assetCount: 50 };
+  assert.throws(
+    () => validateMaineBlobPublicationEvidence(incomplete, blobPlan),
+    /incomplete or incompatible/,
+  );
+});
+
+test("Maine public authorization pins production and rollback deployment trees", () => {
+  const value = publicAuthorization();
+  const checked = validateMainePublicationAuthorization(value, {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  assert.equal(checked.approvedBy, "Camreyn");
+  assert.deepEqual(value.scopes, MAINE_PUBLICATION_SCOPES);
+  assert.deepEqual(checked.rollbackTarget, rollbackTarget);
+
+  const sameTree = structuredClone(value);
+  sameTree.rollbackTarget.gitTreeSha = value.productionDeployment.gitTreeSha;
+  assert.throws(
+    () => validateMainePublicationAuthorization(sameTree, {
+      plan: authorizationPlan,
+      planSha256,
+      now: Date.parse("2026-08-13T01:01:00.000Z"),
+    }),
+    /incompatible/,
+  );
+});
+
+test("Maine rollback authorization is bound to the exact publication receipt", () => {
+  const receipt = publicationSummary();
+  const value = buildMainePublicRollbackAuthorizationTemplate(
+    authorizationPlan,
+    planSha256,
+    receipt,
+  );
+  Object.assign(value, {
+    decision: "GO_ROLLBACK",
+    rollbackId: "me-rollback-camreyn",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T01:10:00.000Z",
+    expiresAtUtc: "2026-08-13T02:00:00.000Z",
+  });
+  Object.assign(value.rollbackWindow, {
+    startsAtUtc: "2026-08-13T01:10:00.000Z",
+    endsAtUtc: "2026-08-13T01:50:00.000Z",
+  });
+  value.applicationRollback.databaseBlockFirstAcknowledged = true;
+  value.applicationRollback.restoreAfterDatabaseRollbackAcknowledged = true;
+  const checked = validateMainePublicRollbackAuthorization(value, {
+    plan: authorizationPlan,
+    planSha256,
+    publicationReceipt: receipt,
+    now: Date.parse("2026-08-13T01:20:00.000Z"),
+  });
+  assert.equal(checked.rollbackId, "me-rollback-camreyn");
+  assert.deepEqual(value.scopes, MAINE_PUBLIC_ROLLBACK_SCOPES);
+
+  const substituted = structuredClone(value);
+  substituted.applicationRollback.target.deploymentId = "dpl_substituted";
+  assert.throws(
+    () => validateMainePublicRollbackAuthorization(substituted, {
+      plan: authorizationPlan,
+      planSha256,
+      publicationReceipt: receipt,
+      now: Date.parse("2026-08-13T01:20:00.000Z"),
+    }),
+    /incompatible/,
+  );
+});
+
+test("Maine publication receipt reloads its exact original public authorization", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "crm-me-publication-"));
+  const authorizationPath =
+    ".etl/production-authorizations/ME/me-local-public-authorization.json";
+  const receiptPath =
+    ".etl/production-publication-receipts/ME/me-local-publish-receipt.json";
+  const authorization = publicAuthorization();
+  const authorizationBytes = serializeMainePublicationDocument(authorization);
+  const authorizationSha256 = sha256(authorizationBytes);
+  const plan = {
+    ...authorizationPlan,
+    hiddenLoad: authorizationPlan.hiddenLoad,
+    blobPublication: authorizationPlan.blobPublication,
+  };
+  const receipt = {
+    schemaVersion: 1,
+    state: "ME",
+    mode: "publish",
+    decision: "PUBLISHED",
+    activationId: authorization.activationId,
+    approvedBy: authorization.approvedBy,
+    releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    authorization: { path: authorizationPath, sha256: authorizationSha256 },
+    hiddenLoad: plan.hiddenLoad,
+    blobPublication: {
+      ...plan.blobPublication,
+      deliveryOrigin,
+    },
+    productionDeployment: authorization.productionDeployment,
+    rollbackTarget,
+    changedAtUtc: "2026-08-13T01:00:00.000Z",
+    revision: 41,
+    postconditions: {
+      mode: "publish",
+      status: "published",
+      publicDeliveryAuthorized: true,
+      geographyVersions: 3,
+      crosswalks: 1_542,
+      reportingUnits: 1_542,
+      sourceDocuments: 6,
+      importRuns: 3,
+      resultRows: 4_626,
+      invalidConstraints: 0,
+    },
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: true,
+  };
+  for (const [relative, bytes] of [
+    [authorizationPath, authorizationBytes],
+    [receiptPath, serializeMainePublicationDocument(receipt)],
+  ]) {
+    const absolute = path.resolve(root, ...relative.split("/"));
+    mkdirSync(path.dirname(absolute), { recursive: true });
+    writeFileSync(absolute, bytes);
+  }
+  const receiptBytes = readFileSync(path.resolve(root, ...receiptPath.split("/")));
+  const inspected = inspectMainePublicationReceipt(root, {
+    publicationReceiptPath: receiptPath,
+    publicationReceiptSha256: sha256(receiptBytes),
+    now: Date.parse("2026-08-13T01:10:00.000Z"),
+  }, { plan, sha256: planSha256 });
+  assert.equal(inspected.summary.activationId, authorization.activationId);
+
+  const substituted = structuredClone(receipt);
+  substituted.rollbackTarget.deploymentId = "dpl_substituted";
+  const substitutedPath =
+    ".etl/production-publication-receipts/ME/me-local-substituted-receipt.json";
+  const substitutedBytes = serializeMainePublicationDocument(substituted);
+  writeFileSync(
+    path.resolve(root, ...substitutedPath.split("/")),
+    substitutedBytes,
+  );
+  assert.throws(
+    () => inspectMainePublicationReceipt(root, {
+      publicationReceiptPath: substitutedPath,
+      publicationReceiptSha256: sha256(substitutedBytes),
+      now: Date.parse("2026-08-13T01:10:00.000Z"),
+    }, { plan, sha256: planSha256 }),
+    /incomplete or incompatible/,
+  );
+});
+
+test("Maine Git verifier resolves both the live and rollback deployment trees", () => {
+  const authorization = validateMainePublicationAuthorization(publicAuthorization(), {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  const outputs = new Map([
+    ["rev-parse HEAD", authorization.productionDeployment.gitSha],
+    ["rev-parse HEAD^{tree}", authorization.productionDeployment.gitTreeSha],
+    [
+      `rev-parse ${authorization.productionDeployment.gitSha}^{tree}`,
+      authorization.productionDeployment.gitTreeSha,
+    ],
+    [
+      `rev-parse ${authorization.rollbackTarget.gitSha}^{tree}`,
+      authorization.rollbackTarget.gitTreeSha,
+    ],
+    ["status --porcelain --untracked-files=no", ""],
+  ]);
+  const runner = (_command, args) => outputs.get(args.join(" ")) + "\n";
+  assert.equal(
+    verifyMainePublicationGitCandidate(process.cwd(), authorization, runner)
+      .trackedWorktreeClean,
+    true,
+  );
+  outputs.set(
+    `rev-parse ${authorization.rollbackTarget.gitSha}^{tree}`,
+    "f".repeat(40),
+  );
+  assert.throws(
+    () => verifyMainePublicationGitCandidate(process.cwd(), authorization, runner),
+    /drifted/,
+  );
+});
+
+function rollbackTransactionFixture() {
+  const manifests = [2016, 2020, 2024].map((year, index) => ({
+    year,
+    manifestId: `me-${year}-manifest`,
+    publicManifestSha256: String(index + 3).repeat(64).slice(0, 64),
+    blockedManifestSha256: String(index + 6).repeat(64).slice(0, 64),
+    delivery: {
+      format: "parent_scoped_geojson",
+      featureCount: [532, 516, 494][index],
+      parentCount: 16,
+      indexPath: `/data/geography/me/${year}/local_reporting_unit/index.json`,
+    },
+  }));
+  const plan = {
+    id: authorizationPlan.id,
+    releaseCandidate,
+    hiddenLoad: { databaseName: "neondb" },
+    blobPublication: {
+      sha256: "6".repeat(64),
+      deliveryOrigin,
+    },
+    manifests,
+  };
+  const publicationReceipt = publicationSummary();
+  const gisPlan = {
+    years: manifests.map((manifest) => ({
+      manifest: { validation: { errors: [`blocked ${manifest.year}`] } },
+    })),
+  };
+  const versions = manifests.map((manifest, index) => {
+    const previousCaveat = gisPlan.years[index].manifest.validation.errors.join(" ");
+    return {
+      id: `00000000-0000-0000-0000-00000000${index + 1}`,
+      year: manifest.year,
+      status: "published",
+      caveat: "Reviewed Maine election-specific local reporting geometry is publicly authorized under activation "
+        + publicationReceipt.activationId + ".",
+      metadata: {
+        manifestId: manifest.manifestId,
+        publicDeliveryAuthorized: true,
+        releaseCandidate: {
+          sha256: releaseCandidate.sha256,
+          publicDeliveryAuthorized: true,
+        },
+        publicActivation: {
+          activationId: publicationReceipt.activationId,
+          activationCandidateSha256: planSha256,
+          releasePackageSha256: releaseCandidate.sha256,
+          blobPublicationSha256: plan.blobPublication.sha256,
+          deliveryOrigin,
+          authorizationSha256: publicationReceipt.authorizationSha256,
+          rollbackTarget,
+          mode: "publish",
+          year: manifest.year,
+          manifestId: manifest.manifestId,
+          publicManifestSha256: manifest.publicManifestSha256,
+          delivery: manifest.delivery,
+          previousCaveat,
+          changedAtUtc: publicationReceipt.changedAtUtc,
+          revision: publicationReceipt.revision,
+        },
+      },
+    };
+  });
+  const authorization = {
+    activationId: "me-rollback-camreyn",
+    rollbackId: "me-rollback-camreyn",
+    publicationActivationId: publicationReceipt.activationId,
+    approvedBy: "Camreyn",
+    applicationRollback: { target: rollbackTarget },
+  };
+  return { plan, publicationReceipt, gisPlan, versions, authorization };
+}
+
+function rollbackClient(fixture) {
+  let revision = 41;
+  let reason = "Maine local reporting unit geometry publish me-public-camreyn";
+  let versionUpdateCount = 0;
+  const unsafe = async (statement, parameters = []) => {
+    const sql = String(statement);
+    if (sql.includes("current_database()")) {
+      return [{ database_name: "neondb", transaction_read_only: "off" }];
+    }
+    if (sql.includes("set_config") || sql.includes("pg_advisory_xact_lock")) {
+      return [];
+    }
+    if (sql.includes("for update") && sql.includes("public_data_revisions")) {
+      return [{ revision }];
+    }
+    if (sql.includes("for update of gv")) return fixture.versions;
+    if (sql.startsWith("update geography_versions")) {
+      const row = fixture.versions.find((item) => item.id === parameters[0]);
+      row.status = parameters[1];
+      row.caveat = parameters[2];
+      row.metadata.publicDeliveryAuthorized = JSON.parse(parameters[3]);
+      row.metadata.releaseCandidate.publicDeliveryAuthorized = JSON.parse(parameters[3]);
+      row.metadata.publicActivation = JSON.parse(parameters[4]);
+      versionUpdateCount += 1;
+      return [{ id: row.id }];
+    }
+    if (sql.startsWith("update reporting_unit_geometry_crosswalks")) {
+      return Array.from({ length: 1_542 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update reporting_units")) {
+      return Array.from({ length: 1_542 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update source_documents")) {
+      return Array.from({ length: 6 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update import_runs")) {
+      return Array.from({ length: 3 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update public_data_revisions")) {
+      revision += 1;
+      reason = parameters[0];
+      return [{ revision }];
+    }
+    if (sql.includes("select e.year,gv.status")) return fixture.versions;
+    if (sql.includes("from reporting_unit_geometry_crosswalks")) {
+      assert.match(sql, /x\.match_method in \('exact_official_id','official_crosswalk'\)/);
+      return [{ total: 1_542, exact: 1_542 }];
+    }
+    if (sql.includes("from reporting_units where")) {
+      return [{ total: 1_542, exact: 1_542 }];
+    }
+    if (sql.includes("from source_documents where")) {
+      return [{ total: 6, exact: 6 }];
+    }
+    if (sql.includes("from import_runs where")) {
+      return [{ total: 3, exact: 3 }];
+    }
+    if (sql.includes("from result_rows rr")) return [{ total: 4_626 }];
+    if (sql.includes("from pg_constraint")) return [{ count: 0 }];
+    if (sql.includes("from public_data_revisions")) return [{ revision, reason }];
+    throw new Error("Unexpected Maine publication SQL: " + sql);
+  };
+  return { unsafe, get versionUpdateCount() { return versionUpdateCount; } };
+}
+
+test("Maine rollback atomically blocks database delivery and preserves publish audit", async () => {
+  const fixture = rollbackTransactionFixture();
+  const client = rollbackClient(fixture);
+  const result = await applyMaineGeographyPublicationTransaction(client, {
+    mode: "rollback",
+    plan: fixture.plan,
+    planSha256,
+    authorization: fixture.authorization,
+    authorizationSha256: "c".repeat(64),
+    publicationReceipt: fixture.publicationReceipt,
+    changedAtUtc: "2026-08-13T01:30:00.000Z",
+    gisPlan: fixture.gisPlan,
+  });
+  assert.equal(result.result, "ROLLED_BACK");
+  assert.equal(result.publicDeliveryAuthorized, false);
+  assert.equal(client.versionUpdateCount, 3);
+  for (const [index, version] of fixture.versions.entries()) {
+    assert.equal(version.status, "blocked");
+    assert.equal(version.caveat, `blocked ${[2016, 2020, 2024][index]}`);
+    assert.equal(version.metadata.publicDeliveryAuthorized, false);
+    assert.equal(version.metadata.publicActivation.activationId, "me-public-camreyn");
+    assert.equal(
+      version.metadata.publicActivation.rollback.rollbackId,
+      "me-rollback-camreyn",
+    );
+    assert.equal(
+      version.metadata.publicActivation.rollback.publicationReceiptSha256,
+      fixture.publicationReceipt.sha256,
+    );
+  }
+});
+
+test("Maine publication atomically records the pinned rollback target", async () => {
+  const fixture = rollbackTransactionFixture();
+  for (const [index, version] of fixture.versions.entries()) {
+    version.status = "blocked";
+    version.caveat = `blocked ${version.year}`;
+    version.metadata = {
+      manifestId: fixture.plan.manifests[index].manifestId,
+      manifestSha256: fixture.plan.manifests[index].blockedManifestSha256,
+      publicDeliveryAuthorized: false,
+      releaseCandidate: {
+        sha256: releaseCandidate.sha256,
+        publicDeliveryAuthorized: false,
+      },
+    };
+  }
+  const authorization = validateMainePublicationAuthorization(publicAuthorization(), {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  const client = rollbackClient(fixture);
+  const result = await applyMaineGeographyPublicationTransaction(client, {
+    mode: "publish",
+    plan: fixture.plan,
+    planSha256,
+    authorization,
+    authorizationSha256: "b".repeat(64),
+    changedAtUtc: "2026-08-13T01:02:00.000Z",
+    gisPlan: fixture.gisPlan,
+    executionContext: {},
+    validateCurrentDatabase: async () => ({ validated: true }),
+  });
+  assert.equal(result.result, "PUBLISHED");
+  assert.equal(result.publicDeliveryAuthorized, true);
+  assert.equal(client.versionUpdateCount, 3);
+  for (const version of fixture.versions) {
+    assert.equal(version.status, "published");
+    assert.equal(version.metadata.publicDeliveryAuthorized, true);
+    assert.equal(
+      version.metadata.publicActivation.activationId,
+      authorization.activationId,
+    );
+    assert.deepEqual(
+      version.metadata.publicActivation.rollbackTarget,
+      rollbackTarget,
+    );
+    assert.equal(
+      Object.hasOwn(version.metadata.publicActivation, "rollback"),
+      false,
+    );
+  }
+});
+
+test("Maine rollback transaction rejects a substituted live rollback target", async () => {
+  const fixture = rollbackTransactionFixture();
+  fixture.authorization.applicationRollback.target = {
+    ...rollbackTarget,
+    deploymentId: "dpl_substituted",
+  };
+  const client = rollbackClient(fixture);
+  await assert.rejects(
+    () => applyMaineGeographyPublicationTransaction(client, {
+      mode: "rollback",
+      plan: fixture.plan,
+      planSha256,
+      authorization: fixture.authorization,
+      authorizationSha256: "c".repeat(64),
+      publicationReceipt: fixture.publicationReceipt,
+      changedAtUtc: "2026-08-13T01:30:00.000Z",
+      gisPlan: fixture.gisPlan,
+    }),
+    /drifted from the publication receipt/,
+  );
+  assert.equal(client.versionUpdateCount, 0);
+});
+
+test("Maine publication runner contains database-first rollback and read-only recovery guards", () => {
+  const source = readFileSync(
+    "scripts/publish-me-local-geography-status.mjs",
+    "utf8",
+  );
+  assert.match(source, /--rollback/);
+  assert.match(source, /--publication-receipt-sha256/);
+  assert.match(
+    source,
+    /I_ACKNOWLEDGE_DATABASE_FIRST_MAINE_LOCAL_PUBLIC_ROLLBACK/,
+  );
+  assert.match(source, /sql\.begin\("read only"/);
+  assert.match(source, /publicationReceiptSha256/);
+  assert.match(source, /transactionBodyCompleted/);
+  assert.match(source, /disposition === "created"/);
+});

--- a/tests/api/me-local-release-candidate.test.mjs
+++ b/tests/api/me-local-release-candidate.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { inspectPrecinctGeometryManifest } from "../../src/lib/precinct-geography.ts";
+import {
+  MAINE_DELIVERY_COORDINATE_DECIMALS,
+  MAINE_MAX_PARENT_DELIVERY_BYTES,
+} from "../../scripts/lib/me-local-release-candidate.mjs";
+import { buildMaineTestReleaseFixture } from "./me-local-release-fixture.mjs";
+
+const { built } = await buildMaineTestReleaseFixture();
+
+test("Maine release candidate freezes three complete county-scoped deliveries", () => {
+  const document = built.packageDocument;
+  assert.equal(document.id, "me-local-reporting-gis-three-election-v1");
+  assert.equal(document.decision, "NO_GO_PRODUCTION");
+  assert.deepEqual(document.totals, {
+    elections: 3,
+    countyEquivalentsPerElection: 16,
+    reportingUnits: 1542,
+    candidateResultRows: 4626,
+    zeroVoteUnits: 1,
+    geometryFeatures: 1542,
+    reviewedExactCrosswalks: 1542,
+    deliveryIndexes: 3,
+    parentDeliveryArtifacts: 48,
+  });
+  assert.equal(built.deliveryAssets.length, 51);
+  for (const year of document.years) {
+    assert.equal(year.parentScopedDelivery.parentCount, 16);
+    assert.equal(year.parentScopedDelivery.parentArtifacts.length, 16);
+    assert.equal(year.parentScopedDelivery.coordinatePrecisionDecimals, MAINE_DELIVERY_COORDINATE_DECIMALS);
+    assert.ok(year.parentScopedDelivery.largestParentByteCount <= MAINE_MAX_PARENT_DELIVERY_BYTES);
+    assert.equal(year.parentScopedDelivery.electionValuesInDelivery, false);
+    assert.equal(year.canonicalManifest.validationStatus, "blocked");
+    assert.equal(year.canonicalManifest.delivery, null);
+  }
+});
+
+test("Maine draft manifests are eligible without changing canonical manifests", () => {
+  assert.equal(built.draftManifests.length, 3);
+  for (const draft of built.draftManifests) {
+    const value = JSON.parse(draft.bytes);
+    const inspection = inspectPrecinctGeometryManifest(value);
+    assert.deepEqual(inspection.errors, []);
+    assert.deepEqual(inspection.publicEligibilityReasons, []);
+    assert.equal(value.delivery.format, "parent_scoped_geojson");
+    assert.equal(value.delivery.parentCount, 16);
+    assert.equal(value.geography.level, "local_reporting_unit");
+    assert.equal(value.crosswalk.reviewedNoDataFeatures, 0);
+  }
+});

--- a/tests/api/me-local-release-fixture.mjs
+++ b/tests/api/me-local-release-fixture.mjs
@@ -1,0 +1,69 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { buildMaineLocalGisPlan } from "../../scripts/lib/me-local-gis-plan.mjs";
+import { buildMaineLocalReleaseCandidate } from "../../scripts/lib/me-local-release-candidate.mjs";
+import { prepareMaineLocalReleaseCandidate } from "../../scripts/prepare-me-local-release-candidate.mjs";
+
+export const MAINE_TEST_VALIDATION_PATH =
+  `.etl/test-artifacts/ME/${process.pid}-me-public-local-gis-validation.json`;
+
+async function writeSyntheticValidationReport(
+  root,
+  generatedAtUtc = "2026-08-12T23:58:58.000Z",
+) {
+  const plan = await buildMaineLocalGisPlan({
+    root,
+    years: [2016, 2020, 2024],
+  });
+  const report = {
+    schemaVersion: 1,
+    generatedAtUtc,
+    productionMutationPerformed: false,
+    publicDeliveryAuthorized: false,
+    validation: {
+      database: {
+        environment: "local",
+        host: "loopback",
+        port: 54329,
+        name: "crm_clone_dev",
+        readOnlySession: true,
+      },
+      invalidConstraints: 0,
+      revision: 1,
+      years: plan.years.map((year) => ({
+        year: year.year,
+        reportingUnits: year.reportingUnits.length,
+        resultRows: year.resultRows.length,
+        sameYearResultRows: year.resultRows.length,
+        totalVotes: year.totals.Total,
+        zeroVoteUnits: year.zeroVoteUnits,
+        geographyVersions: 1,
+        features: year.geometry.features.length,
+        safeBlockedGeographyVersions: 1,
+        reviewedCrosswalks: year.geometry.crosswalks.length,
+        exactFeatures: year.geometry.features.length,
+        exactCrosswalks: year.geometry.crosswalks.length,
+      })),
+    },
+  };
+  const absolute = path.resolve(root, ...MAINE_TEST_VALIDATION_PATH.split("/"));
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, JSON.stringify(report, null, 2) + "\n");
+}
+
+export async function buildMaineTestReleaseFixture(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  await writeSyntheticValidationReport(root, options.generatedAtUtc);
+  const built = await buildMaineLocalReleaseCandidate({
+    root,
+    validationReportPath: MAINE_TEST_VALIDATION_PATH,
+  });
+  const prepared = options.write
+    ? await prepareMaineLocalReleaseCandidate({
+      root,
+      validationReportPath: MAINE_TEST_VALIDATION_PATH,
+      write: true,
+    })
+    : null;
+  return { built, prepared };
+}

--- a/tests/api/mn-precinct-local-rehearsal.test.mjs
+++ b/tests/api/mn-precinct-local-rehearsal.test.mjs
@@ -127,7 +127,11 @@ test("the API and UI use the marked rehearsal path without requesting blocked la
   assert.match(dataAccess, /resolveMinnesotaPrecinctRehearsal/);
   assert.match(
     dataAccess,
-    /requiresPrecinctResultPublicationGate\(input\)\s*&& !resolveMinnesotaPrecinctRehearsal\(\)\.enabled/,
+    /input\.state\.toUpperCase\(\) === "MN"\s*\? resolveMinnesotaPrecinctRehearsal\(\)/,
+  );
+  assert.match(
+    dataAccess,
+    /requiresPrecinctResultPublicationGate\(input\)\s*&& !minnesotaRehearsal\.enabled/,
   );
   assert.match(
     api,

--- a/tests/api/mn-precinct-result-publication-gate.test.mjs
+++ b/tests/api/mn-precinct-result-publication-gate.test.mjs
@@ -181,5 +181,5 @@ test("precinct geometry fails closed on the same database publication state", ()
   assert.match(dataAccess, /authorizedLinkCount/);
   assert.match(dataAccess, /matchesPrecinctGeometryPublicationMetadata/);
   assert.match(route, /await isPrecinctGeometryManifestPublished\(manifest\)/);
-  assert.match(route, /precinct geography publication is not active/);
+  assert.match(route, /local geography publication is not active/);
 });

--- a/tests/api/precinct-map-delivery.test.mjs
+++ b/tests/api/precinct-map-delivery.test.mjs
@@ -192,6 +192,24 @@ test("delivery joins use explicit resultUnitCode rather than display name", () =
 
   assert.throws(
     () => joinPrecinctDeliveryResults([mapFeature], [matching, matching]),
-    /duplicate precinct result code/,
+    /duplicate local result code/,
   );
+});
+
+test("delivery joins accept Maine local reporting units explicitly", () => {
+  const mapFeature = feature("ME1", "23001");
+  mapFeature.properties.geographyType = "local_reporting_unit";
+  mapFeature.properties.resultUnitCode =
+    "reporting:ME:2024-11-05-general:local_reporting_unit:23001:ME1";
+  const matching = {
+    ...result(mapFeature.properties.resultUnitCode, "Auburn"),
+    state: "ME",
+    level: "local_reporting_unit",
+  };
+  const joined = joinPrecinctDeliveryResults(
+    [mapFeature],
+    [matching],
+    "local_reporting_unit",
+  );
+  assert.equal(joined[0].result?.jurisdictionCode, matching.jurisdictionCode);
 });

--- a/tests/api/precinct-map-ui.test.mjs
+++ b/tests/api/precinct-map-ui.test.mjs
@@ -15,7 +15,9 @@ test("precinct detail stays county-gated and eligible-manifest-only", () => {
   assert.match(component, /office: manifestOffice/);
   assert.match(component, /parentGeoid,/);
   assert.match(component, /row\.office\.toLowerCase\(\) === manifestOffice\.toLowerCase\(\)/);
-  assert.match(component, /level: "precinct"/);
+  assert.match(component, /level: manifestLevel/);
+  assert.match(component, /guardedLocalGeographyLevel/);
+  assert.match(component, /local_reporting_unit/);
   assert.match(component, /joinPrecinctDeliveryResults/);
   assert.match(component, /resultOutcomeDescription/);
   assert.match(component, /No votes reported/);
@@ -58,7 +60,7 @@ test("precinct map has one keyboard control rather than focusable GIS paths", ()
     "src/app/precinct-detail-map.tsx",
     "utf8",
   );
-  assert.match(component, /Precinct to inspect/);
+  assert.match(component, /\{unitLabel\[0\]\.toUpperCase\(\)/);
   assert.match(component, /<select/);
   assert.match(component, /aria-hidden="true"/);
   assert.match(component, /focusable="false"/);


### PR DESCRIPTION
## What changed

- Adds deterministic local database, release-candidate, production preflight/backup, hidden-load, immutable Blob, static activation, public cutover, rollback, and receipt-recovery tooling for Maine 2016, 2020, and 2024.
- Preserves Maine’s real `local_reporting_unit` grain through manifests, SQL gates, result APIs, delivery joins, map labels, and accessibility text instead of calling every unit a precinct.
- Seals 1,542 reporting units, 4,626 candidate-result rows, 1,542 polygons, and 1,542 reviewed relationships into 48 county assets plus three indexes.
- Keeps Maine 2012 excluded and fail-closed; remaining geometry/vintage/reuse work is tracked in #230.
- Adds a reproducible `test:local-gis:me` suite and repairs two stale Minnesota gate assertions exposed by the generalized wording.

## Why

The merged Maine collection package had reviewed, reconciled source artifacts but no safe path to load, deliver, and atomically publish them. Existing release implementations assumed the geography level was always `precinct`, which would mislabel Maine’s mixed towns, plantations, townships, voting districts, and combined local units.

## Safety and user impact

The static manifest and database publication gates remain independent and fail-closed. This PR performs no production database mutation, Blob upload, Vercel configuration/deployment, canonical activation, or public eligibility change. Once the later guarded activation sequence is executed, the map can display Maine 2016/2020/2024 with accurate local-reporting-unit labels.

## Validation

- Local Docker load and independent read-only validation: exact counts/totals, zero invalid constraints, all public flags false
- `npm.cmd run test:local-gis:me` — 31/31 pass
- Cross-state IA/MN/NV/TX gate regression suite — 18/18 pass
- Focused app/API/release suite — 43/43 pass
- `npm.cmd test` — pass, including 183 Python tests (1 expected skip)
- `npm.cmd run typecheck`
- `npm.cmd run build`
- `npm.cmd run validate:maps`
- `npm.cmd run validate:provenance`
- `npm.cmd run validate:source-packages`
- `npm.cmd run validate:turnout-packages`
- Maine native ETL validation/import and advisory report: 512 review rows, 42 advisory indicators across 16 counties; these are review signals, not evidence of misconduct
- Independent app/gate, local-DB, and release-safety reviews: clean

## Sources and caveats

Displayed votes remain solely from retained Maine Secretary of State workbooks. The 2016/2020 geometry terms and 2024 noncommercial terms/attribution remain pinned in the source package. Maine 2012 remains blocked because five source rows/eight votes lack uniquely attributable geometry, the exact election vintage is unconfirmed, and derivative redistribution permission is unresolved.