### PR TITLE
Fix Alaska four-election backup guard

### DIFF
--- a/scripts/backup-ak-precinct-production.ps1
+++ b/scripts/backup-ak-precinct-production.ps1
@@ -60,7 +60,7 @@ function Assert-ReleasePackage {
     $document.decision -ne 'NO_GO_PRODUCTION' -or
     $document.safety.productionMutationPerformed -ne $false -or
     $document.safety.canonicalManifestChanged -ne $false -or
-    $document.totals.elections -ne 3
+    $document.totals.elections -ne 4
   ) {
     Fail 'The release package contract is incompatible.'
   }

--- a/tests/api/ak-precinct-production-release.test.mjs
+++ b/tests/api/ak-precinct-production-release.test.mjs
@@ -147,3 +147,13 @@ test("Alaska production runners use the correctly spelled environment guard", ()
   assert.doesNotMatch(files, /CRM_DATABASE_EIAIRONMENT|NODE_EIA/);
   assert.doesNotMatch(files, /replacement-publication-receipt|GO_PRODUCTION_UPGRADE/);
 });
+
+test("Alaska backup guard accepts only the four-election release package", () => {
+  const backupScript = readFileSync(
+    "scripts/backup-ak-precinct-production.ps1",
+    "utf8",
+  );
+  assert.equal(built.packageDocument.totals.elections, 4);
+  assert.match(backupScript, /\$document\.totals\.elections -ne 4/);
+  assert.doesNotMatch(backupScript, /\$document\.totals\.elections -ne 3/);
+});


### PR DESCRIPTION
## What changed

- Correct Alaska's production backup package guard to require four elections, matching the reviewed 2012, 2016, 2020, and 2024 release candidate.
- Add a regression test that locks the backup script to the four-election contract and rejects the copied three-election assumption.

## Why

The guarded backup command failed closed before opening production because the PowerShell package assertion still expected `totals.elections` to equal 3. Alaska's sealed release candidate correctly contains four elections, so the required restore-verified backup could not begin.

## Impact

This permits the reviewed Alaska four-election package to reach the backup-plan and backup-execution stages. It does not change election data, public manifests, database rows, Blob objects, Vercel configuration, or public eligibility.

## Validation

- `npm.cmd run test:precinct-geometry:ak` — 38/38 passed
- `npm.cmd run precinct-gis:production-backup:ak -- -ReleasePackagePath <sealed-package> -ReleasePackageSha256 <sha>` — plan passed with `NO_BACKUP_CREATED`
- `git diff --check` — clean
