### PR TITLE
Activate guarded Alaska precinct maps

### DIFF
--- a/data/precinct-geometry-coverage-inventory-2012.json
+++ b/data/precinct-geometry-coverage-inventory-2012.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-14T04:30:00.000Z",
+  "updatedAt": "2026-08-14T14:40:03.296Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2012-11-06-general",
@@ -39,7 +39,7 @@
       "official_geometry_unavailable": 0,
       "blocked": 1
     },
-    "publicEligibleJurisdictions": 2
+    "publicEligibleJurisdictions": 3
   },
   "states": [
     {
@@ -49,7 +49,7 @@
       "programStatus": "reviewed",
       "wave": 8,
       "disposition": "mapped",
-      "checkedAt": "2026-08-14T04:30:00.000Z",
+      "checkedAt": "2026-08-14T14:40:03.296Z",
       "sourceTiers": [
         "tier_1_official_export_database",
         "tier_3_secondary_geometry"
@@ -83,7 +83,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 438,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 558,
@@ -93,10 +93,8 @@
         "nonGeographicResultUnits": 120,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Immutable delivery, hidden production load, deployment verification, and atomic database publication remain pending."
-      ],
-      "nextAction": "Run the guarded four-election release; keep the secondary 2012 polygon custody and unstated formal license visible in provenance.",
+      "blockers": [],
+      "nextAction": "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
       "notes": [
         "Official Alaska Division of Elections artifacts are the sole vote source. The commit-pinned public mirror contributes polygon custody only.",
         "All 120 absentee, early-voting, questioned-ballot, federal-overseas, and administrative units remain non-geographic and are never assigned to precinct polygons.",

--- a/data/precinct-geometry-coverage-inventory-2016.json
+++ b/data/precinct-geometry-coverage-inventory-2016.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-14T04:30:00.000Z",
+  "updatedAt": "2026-08-14T14:40:03.296Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2016-11-08-general",
@@ -39,7 +39,7 @@
       "official_geometry_unavailable": 0,
       "blocked": 0
     },
-    "publicEligibleJurisdictions": 5
+    "publicEligibleJurisdictions": 6
   },
   "states": [
     {
@@ -49,7 +49,7 @@
       "programStatus": "reviewed",
       "wave": 8,
       "disposition": "mapped",
-      "checkedAt": "2026-08-14T04:30:00.000Z",
+      "checkedAt": "2026-08-14T14:40:03.296Z",
       "sourceTiers": [
         "tier_1_official_export_database"
       ],
@@ -79,7 +79,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 441,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 562,
@@ -89,10 +89,8 @@
         "nonGeographicResultUnits": 121,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Immutable delivery, hidden production load, deployment verification, and atomic database publication remain pending."
-      ],
-      "nextAction": "Run the guarded four-election release while keeping non-geographic units outside polygon delivery.",
+      "blockers": [],
+      "nextAction": "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
       "notes": [
         "Official Alaska Division of Elections artifacts supply both displayed votes and election-applicable geometry.",
         "All 121 administrative buckets remain non-geographic and are never assigned to precinct polygons.",

--- a/data/precinct-geometry-coverage-inventory-2020.json
+++ b/data/precinct-geometry-coverage-inventory-2020.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-14T04:30:00.000Z",
+  "updatedAt": "2026-08-14T14:40:03.296Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2020-11-03-general",
@@ -39,7 +39,7 @@
       "official_geometry_unavailable": 0,
       "blocked": 0
     },
-    "publicEligibleJurisdictions": 5
+    "publicEligibleJurisdictions": 6
   },
   "states": [
     {
@@ -49,7 +49,7 @@
       "programStatus": "reviewed",
       "wave": 8,
       "disposition": "mapped",
-      "checkedAt": "2026-08-14T04:30:00.000Z",
+      "checkedAt": "2026-08-14T14:40:03.296Z",
       "sourceTiers": [
         "tier_1_official_export_database"
       ],
@@ -79,7 +79,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 441,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 562,
@@ -89,10 +89,8 @@
         "nonGeographicResultUnits": 121,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Immutable delivery, hidden production load, deployment verification, and atomic database publication remain pending."
-      ],
-      "nextAction": "Run the guarded four-election release while keeping non-geographic units outside polygon delivery.",
+      "blockers": [],
+      "nextAction": "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
       "notes": [
         "Official Alaska Division of Elections artifacts supply displayed votes and election-applicable geometry; all 41 official SOVC PDFs restore the write-ins omitted from the text export.",
         "All 121 administrative buckets remain non-geographic and are never assigned to precinct polygons.",

--- a/data/precinct-geometry-coverage-inventory.json
+++ b/data/precinct-geometry-coverage-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-14T04:30:00.000Z",
+  "updatedAt": "2026-08-14T14:40:03.296Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2024-11-05-general",
@@ -39,7 +39,7 @@
       "official_geometry_unavailable": 0,
       "blocked": 0
     },
-    "publicEligibleJurisdictions": 5
+    "publicEligibleJurisdictions": 6
   },
   "states": [
     {
@@ -49,7 +49,7 @@
       "programStatus": "reviewed",
       "wave": 8,
       "disposition": "mapped",
-      "checkedAt": "2026-08-14T04:30:00.000Z",
+      "checkedAt": "2026-08-14T14:40:03.296Z",
       "sourceTiers": [
         "tier_1_official_export_database"
       ],
@@ -79,7 +79,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 402,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 523,
@@ -89,10 +89,8 @@
         "nonGeographicResultUnits": 121,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Immutable delivery, hidden production load, deployment verification, and atomic database publication remain pending."
-      ],
-      "nextAction": "Run the guarded four-election release while keeping non-geographic units outside polygon delivery.",
+      "blockers": [],
+      "nextAction": "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
       "notes": [
         "Official Alaska Division of Elections artifacts supply both displayed votes and election-applicable geometry.",
         "All 121 administrative buckets remain non-geographic and are never assigned to precinct polygons.",

--- a/data/precinct-geometry-manifests.json
+++ b/data/precinct-geometry-manifests.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-14T00:06:29.584Z",
+  "updatedAt": "2026-08-14T14:40:03.296Z",
   "manifests": [
     {
       "schemaVersion": 1,
@@ -1739,6 +1739,434 @@
         "All displayed vote values come from the retained Maine Secretary of State workbook; secondary-source vote attributes are stripped and never imported.",
         "The NYT source marks every retained Maine shape official_boundary=true but combines 34 small official source rows into 16 boundary units; those rows are summed exactly and their identities are retained. T22 MD uses a Maine GeoLibrary gap geometry whose area and bounds are unchanged between the retained 2015 archive and current official service.",
         "NYT C-UDA terms limit redistribution to non-commercial use with attribution. CivicResultMaps must preserve the terms and attribution with any public delivery."
+      ]
+    },
+    {
+      "schemaVersion": 1,
+      "id": "ak-2012-11-06-general-precinct-geometry-candidate-v1",
+      "state": "AK",
+      "election": {
+        "id": "2012-11-06-general",
+        "date": "2012-11-06",
+        "year": 2012,
+        "type": "general",
+        "office": "president"
+      },
+      "geography": {
+        "level": "precinct",
+        "parentLevel": "house_district",
+        "boundaryVintage": "April 5, 2012 amended-proclamation precinct plan",
+        "vintageStatus": "election_date_confirmed",
+        "derivationMethod": "hybrid_reconstruction"
+      },
+      "source": {
+        "authority": "Alaska Division of Elections results and boundary-plan evidence with a commit-pinned 2012 polygon mirror",
+        "url": "https://www.elections.alaska.gov/Core/Archive/ElectionReturns_2012_GENR.php",
+        "retrievedAt": "2026-08-14T04:30:00Z",
+        "artifact": "data/precinct-geometry/AK/2012-11-06-general/source-evidence.json",
+        "sha256": "812818592d3193647f8bc801c43409f75ab504fea892566772b550ceb612bb8e",
+        "byteCount": 29962,
+        "format": "precinct-source-evidence+json",
+        "licenseOrTerms": "Official Alaska election and boundary-plan evidence. The exact polygon archive is retained through a commit-pinned public mirror that states no formal license; public release requires preserving this custody/reuse caveat or replacing it with a redistributable official copy."
+      },
+      "normalization": {
+        "script": "scripts/collect-ak-precinct-geometry.mjs",
+        "sourceCrs": "GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\",SPHEROID[\"WGS_1984\",6378137,298.25722356]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]]",
+        "servedCrs": "EPSG:4326",
+        "artifact": "data/precinct-geometry/AK/2012-11-06-general/normalized/ak-2012-precincts.geojson.gz",
+        "sha256": "d7850088a516ff5fac49b907ea420feb4ae8117fafc4a0f71333ee01fb61e761",
+        "byteCount": 7376957,
+        "featureCount": 438,
+        "sourceFeatureIdFields": [
+          "CRM_FEATURE_ID"
+        ],
+        "parentIdFields": [
+          "CRM_PARENT_GEOID"
+        ]
+      },
+      "crosswalk": {
+        "status": "reviewed",
+        "resultSourceId": "ak-2012-official-precinct-results",
+        "artifact": "data/precinct-geometry/AK/2012-11-06-general/crosswalk/ak-2012-precinct-result-crosswalk.json",
+        "sha256": "7c18bd5553b255d4ec9a0fdfca228e745e5413241acaf5e0a1e3e7742dd66011",
+        "byteCount": 412857,
+        "resultUnits": 558,
+        "colorableResultUnits": 438,
+        "matchedResultUnits": 438,
+        "unmatchedResultUnits": 0,
+        "nonGeographicResultUnits": 120,
+        "sourceAliasResultUnits": 0,
+        "relationships": {
+          "oneToOne": 438,
+          "oneToMany": 0,
+          "manyToOne": 0,
+          "unmatched": 0,
+          "nonGeographic": 120,
+          "sourceAlias": 0,
+          "pendingReview": 0
+        },
+        "reviewedRelationshipRecords": 558,
+        "reviewedNoDataFeatures": 0,
+        "methods": [
+          "exact_official_id",
+          "official_crosswalk"
+        ]
+      },
+      "validation": {
+        "status": "reviewed",
+        "geometryValid": true,
+        "rowLevelRenderingSafe": true,
+        "parentTotalsReconciled": true,
+        "errors": [],
+        "warnings": [
+          "Alaska results contain separately reported absentee, early-voting, questioned-ballot, and federal-overseas buckets. They are preserved for statewide reconciliation but are non-geographic and are never assigned to a precinct polygon.",
+          "The map is parent-scoped by Alaska House District, not by county or county equivalent. No precinct is centroid-assigned or proportionally allocated to a borough or census area.",
+          "Each election retains its own boundary vintage. Precinct IDs and shapes are not assumed comparable across elections; cross-year trend comparison requires a separate reviewed common-geography crosswalk.",
+          "The 2012 statewide polygon archive is a commit-pinned public mirror of the April 5, 2012 amended-proclamation plan. Official Alaska results/media independently confirm all 438 displayed IDs except one reviewed DBF typo: source 36-616 is Lake Iliamna No. 1 and is corrected to official result ID 36-040 after identical topology, area, and population are confirmed in the official 2013 successor plan.",
+          "The 2012 mirror states no formal license. Its custody and reuse limitation must remain visible until an official redistributable replacement or explicit permission is retained.",
+          "All 438 displayable precinct relationships are reviewed one-to-one across all 40 Alaska House Districts.",
+          "All 120 administrative reporting units remain explicitly non-geographic and are never assigned to a polygon.",
+          "The 1 zero-presidential-vote precincts remain geographic reporting units.",
+          "All 0 reviewed no-data polygons remain visible without an invented result row.",
+          "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged."
+        ]
+      },
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/ak/2012-11-06/precinct/ak-2012-11-06-general-precinct-geometry-candidate-v1-a7abef9984a4/index.json",
+        "sha256": "a7abef9984a4eb4960c7bab8c94e763ea40945959086539e9ed2235442e4a66f",
+        "byteCount": 8408,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 40,
+        "featureCount": 438
+      },
+      "caveats": [
+        "Alaska results contain separately reported absentee, early-voting, questioned-ballot, and federal-overseas buckets. They are preserved for statewide reconciliation but are non-geographic and are never assigned to a precinct polygon.",
+        "The map is parent-scoped by Alaska House District, not by county or county equivalent. No precinct is centroid-assigned or proportionally allocated to a borough or census area.",
+        "Each election retains its own boundary vintage. Precinct IDs and shapes are not assumed comparable across elections; cross-year trend comparison requires a separate reviewed common-geography crosswalk.",
+        "The 2012 statewide polygon archive is a commit-pinned public mirror of the April 5, 2012 amended-proclamation plan. Official Alaska results/media independently confirm all 438 displayed IDs except one reviewed DBF typo: source 36-616 is Lake Iliamna No. 1 and is corrected to official result ID 36-040 after identical topology, area, and population are confirmed in the official 2013 successor plan.",
+        "The 2012 mirror states no formal license. Its custody and reuse limitation must remain visible until an official redistributable replacement or explicit permission is retained."
+      ]
+    },
+    {
+      "schemaVersion": 1,
+      "id": "ak-2016-11-08-general-precinct-geometry-candidate-v1",
+      "state": "AK",
+      "election": {
+        "id": "2016-11-08-general",
+        "date": "2016-11-08",
+        "year": 2016,
+        "type": "general",
+        "office": "president"
+      },
+      "geography": {
+        "level": "precinct",
+        "parentLevel": "house_district",
+        "boundaryVintage": "July 14, 2013 proclamation precinct plan",
+        "vintageStatus": "election_date_confirmed",
+        "derivationMethod": "official_export"
+      },
+      "source": {
+        "authority": "Alaska Division of Elections",
+        "url": "https://www.elections.alaska.gov/results/16GENR/",
+        "retrievedAt": "2026-08-14T04:30:00Z",
+        "artifact": "data/precinct-geometry/AK/2016-11-08-general/source-evidence.json",
+        "sha256": "6d84230b507c9d1938031658451d7bbbfafdbab6a49dd4287c0e6cc2b0c2d900",
+        "byteCount": 5870,
+        "format": "precinct-source-evidence+json",
+        "licenseOrTerms": "Official Alaska public election and GIS records; the source pages state no additional redistribution restriction. Preserve Alaska Division of Elections attribution and source links."
+      },
+      "normalization": {
+        "script": "scripts/collect-ak-precinct-geometry.mjs",
+        "sourceCrs": "GEOGCS[\"GCS_GRS_1980\",DATUM[\"D_GRS_1980\",SPHEROID[\"GRS_1980\",6378137,298.2572221]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]]",
+        "servedCrs": "EPSG:4326",
+        "artifact": "data/precinct-geometry/AK/2016-11-08-general/normalized/ak-2016-precincts.geojson.gz",
+        "sha256": "3b9090edd217ba8f8dc1c3ea39ef52405a292709cb0f69e69a3eb70bc1e808d4",
+        "byteCount": 7294203,
+        "featureCount": 441,
+        "sourceFeatureIdFields": [
+          "CRM_FEATURE_ID"
+        ],
+        "parentIdFields": [
+          "CRM_PARENT_GEOID"
+        ]
+      },
+      "crosswalk": {
+        "status": "reviewed",
+        "resultSourceId": "ak-2016-official-precinct-results",
+        "artifact": "data/precinct-geometry/AK/2016-11-08-general/crosswalk/ak-2016-precinct-result-crosswalk.json",
+        "sha256": "e39f312ff2ff05e0eb2e348c5304ab84307506f0e48558dc376a5084987d690e",
+        "byteCount": 415249,
+        "resultUnits": 562,
+        "colorableResultUnits": 441,
+        "matchedResultUnits": 441,
+        "unmatchedResultUnits": 0,
+        "nonGeographicResultUnits": 121,
+        "sourceAliasResultUnits": 0,
+        "relationships": {
+          "oneToOne": 441,
+          "oneToMany": 0,
+          "manyToOne": 0,
+          "unmatched": 0,
+          "nonGeographic": 121,
+          "sourceAlias": 0,
+          "pendingReview": 0
+        },
+        "reviewedRelationshipRecords": 562,
+        "reviewedNoDataFeatures": 0,
+        "methods": [
+          "exact_official_id",
+          "official_crosswalk"
+        ]
+      },
+      "validation": {
+        "status": "reviewed",
+        "geometryValid": true,
+        "rowLevelRenderingSafe": true,
+        "parentTotalsReconciled": true,
+        "errors": [],
+        "warnings": [
+          "Alaska results contain separately reported absentee, early-voting, questioned-ballot, and federal-overseas buckets. They are preserved for statewide reconciliation but are non-geographic and are never assigned to a precinct polygon.",
+          "The map is parent-scoped by Alaska House District, not by county or county equivalent. No precinct is centroid-assigned or proportionally allocated to a borough or census area.",
+          "Each election retains its own boundary vintage. Precinct IDs and shapes are not assumed comparable across elections; cross-year trend comparison requires a separate reviewed common-geography crosswalk.",
+          "All 441 displayable precinct relationships are reviewed one-to-one across all 40 Alaska House Districts.",
+          "All 121 administrative reporting units remain explicitly non-geographic and are never assigned to a polygon.",
+          "The 0 zero-presidential-vote precincts remain geographic reporting units.",
+          "All 0 reviewed no-data polygons remain visible without an invented result row.",
+          "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged."
+        ]
+      },
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/ak/2016-11-08/precinct/ak-2016-11-08-general-precinct-geometry-candidate-v1-efbace8b62e8/index.json",
+        "sha256": "efbace8b62e86fc2083d65b3195c0bc96523369d298af031e14ab565d8997b20",
+        "byteCount": 8200,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 40,
+        "featureCount": 441
+      },
+      "caveats": [
+        "Alaska results contain separately reported absentee, early-voting, questioned-ballot, and federal-overseas buckets. They are preserved for statewide reconciliation but are non-geographic and are never assigned to a precinct polygon.",
+        "The map is parent-scoped by Alaska House District, not by county or county equivalent. No precinct is centroid-assigned or proportionally allocated to a borough or census area.",
+        "Each election retains its own boundary vintage. Precinct IDs and shapes are not assumed comparable across elections; cross-year trend comparison requires a separate reviewed common-geography crosswalk."
+      ]
+    },
+    {
+      "schemaVersion": 1,
+      "id": "ak-2020-11-03-general-precinct-geometry-candidate-v1",
+      "state": "AK",
+      "election": {
+        "id": "2020-11-03-general",
+        "date": "2020-11-03",
+        "year": 2020,
+        "type": "general",
+        "office": "president"
+      },
+      "geography": {
+        "level": "precinct",
+        "parentLevel": "house_district",
+        "boundaryVintage": "July 14, 2013 proclamation precinct plan",
+        "vintageStatus": "election_date_confirmed",
+        "derivationMethod": "official_export"
+      },
+      "source": {
+        "authority": "Alaska Division of Elections",
+        "url": "https://www.elections.alaska.gov/results/20GENR/",
+        "retrievedAt": "2026-08-14T04:30:00Z",
+        "artifact": "data/precinct-geometry/AK/2020-11-03-general/source-evidence.json",
+        "sha256": "50942a6f294fa4f1ecd08ab827cb258ca7ca769277c1555c31eb85feb9d85ecc",
+        "byteCount": 27621,
+        "format": "precinct-source-evidence+json",
+        "licenseOrTerms": "Official Alaska public election and GIS records; the source pages state no additional redistribution restriction. Preserve Alaska Division of Elections attribution and source links."
+      },
+      "normalization": {
+        "script": "scripts/collect-ak-precinct-geometry.mjs",
+        "sourceCrs": "GEOGCS[\"GCS_GRS_1980\",DATUM[\"D_GRS_1980\",SPHEROID[\"GRS_1980\",6378137,298.2572221]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]]",
+        "servedCrs": "EPSG:4326",
+        "artifact": "data/precinct-geometry/AK/2020-11-03-general/normalized/ak-2020-precincts.geojson.gz",
+        "sha256": "adfd10606cff597c965f3259e3d14949682e02b34c3f0a668b917d01e6926f21",
+        "byteCount": 7294220,
+        "featureCount": 441,
+        "sourceFeatureIdFields": [
+          "CRM_FEATURE_ID"
+        ],
+        "parentIdFields": [
+          "CRM_PARENT_GEOID"
+        ]
+      },
+      "crosswalk": {
+        "status": "reviewed",
+        "resultSourceId": "ak-2020-official-precinct-results",
+        "artifact": "data/precinct-geometry/AK/2020-11-03-general/crosswalk/ak-2020-precinct-result-crosswalk.json",
+        "sha256": "48dbdc1c4edc99281671c5b77e184d8d622c0cfc2b7a84c751094d1001d73f50",
+        "byteCount": 415261,
+        "resultUnits": 562,
+        "colorableResultUnits": 441,
+        "matchedResultUnits": 441,
+        "unmatchedResultUnits": 0,
+        "nonGeographicResultUnits": 121,
+        "sourceAliasResultUnits": 0,
+        "relationships": {
+          "oneToOne": 441,
+          "oneToMany": 0,
+          "manyToOne": 0,
+          "unmatched": 0,
+          "nonGeographic": 121,
+          "sourceAlias": 0,
+          "pendingReview": 0
+        },
+        "reviewedRelationshipRecords": 562,
+        "reviewedNoDataFeatures": 0,
+        "methods": [
+          "exact_official_id",
+          "official_crosswalk"
+        ]
+      },
+      "validation": {
+        "status": "reviewed",
+        "geometryValid": true,
+        "rowLevelRenderingSafe": true,
+        "parentTotalsReconciled": true,
+        "errors": [],
+        "warnings": [
+          "Alaska results contain separately reported absentee, early-voting, questioned-ballot, and federal-overseas buckets. They are preserved for statewide reconciliation but are non-geographic and are never assigned to a precinct polygon.",
+          "The map is parent-scoped by Alaska House District, not by county or county equivalent. No precinct is centroid-assigned or proportionally allocated to a borough or census area.",
+          "Each election retains its own boundary vintage. Precinct IDs and shapes are not assumed comparable across elections; cross-year trend comparison requires a separate reviewed common-geography crosswalk.",
+          "The official text export omits write-in rows. All 41 official SOVC PDFs are parsed to restore exact precinct/reporting-unit write-ins; presidential and Senate totals then reconcile exactly to the certified summary.",
+          "All 441 displayable precinct relationships are reviewed one-to-one across all 40 Alaska House Districts.",
+          "All 121 administrative reporting units remain explicitly non-geographic and are never assigned to a polygon.",
+          "The 1 zero-presidential-vote precincts remain geographic reporting units.",
+          "All 0 reviewed no-data polygons remain visible without an invented result row.",
+          "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged."
+        ]
+      },
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/ak/2020-11-03/precinct/ak-2020-11-03-general-precinct-geometry-candidate-v1-01f6ebefb477/index.json",
+        "sha256": "01f6ebefb477eb49ca8b5ce8df2450a4398d58ef4d7d7c536574a54cc7b03dcd",
+        "byteCount": 8200,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 40,
+        "featureCount": 441
+      },
+      "caveats": [
+        "Alaska results contain separately reported absentee, early-voting, questioned-ballot, and federal-overseas buckets. They are preserved for statewide reconciliation but are non-geographic and are never assigned to a precinct polygon.",
+        "The map is parent-scoped by Alaska House District, not by county or county equivalent. No precinct is centroid-assigned or proportionally allocated to a borough or census area.",
+        "Each election retains its own boundary vintage. Precinct IDs and shapes are not assumed comparable across elections; cross-year trend comparison requires a separate reviewed common-geography crosswalk.",
+        "The official text export omits write-in rows. All 41 official SOVC PDFs are parsed to restore exact precinct/reporting-unit write-ins; presidential and Senate totals then reconcile exactly to the certified summary."
+      ]
+    },
+    {
+      "schemaVersion": 1,
+      "id": "ak-2024-11-05-general-precinct-geometry-candidate-v1",
+      "state": "AK",
+      "election": {
+        "id": "2024-11-05-general",
+        "date": "2024-11-05",
+        "year": 2024,
+        "type": "general",
+        "office": "president"
+      },
+      "geography": {
+        "level": "precinct",
+        "parentLevel": "house_district",
+        "boundaryVintage": "May 15, 2023 final-proclamation precinct plan approved and adopted for elections in April 2024",
+        "vintageStatus": "election_date_confirmed",
+        "derivationMethod": "official_export"
+      },
+      "source": {
+        "authority": "Alaska Division of Elections",
+        "url": "https://www.elections.alaska.gov/results/24GENR/ENRbyPrecinct.csv",
+        "retrievedAt": "2026-08-14T04:30:00Z",
+        "artifact": "data/precinct-geometry/AK/2024-11-05-general/source-evidence.json",
+        "sha256": "b7b827b850795b51dd8492f1fda191f81eea746100768b6401e9bde0d2e872bf",
+        "byteCount": 5488,
+        "format": "precinct-source-evidence+json",
+        "licenseOrTerms": "Official Alaska public election and GIS records; the source pages state no additional redistribution restriction. Preserve Alaska Division of Elections attribution and source links."
+      },
+      "normalization": {
+        "script": "scripts/collect-ak-precinct-geometry.mjs",
+        "sourceCrs": "PROJCS[\"WGS_1984_Web_Mercator_Auxiliary_Sphere\",GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\",SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Mercator_Auxiliary_Sphere\"],PARAMETER[\"False_Easting\",0.0],PARAMETER[\"False_Northing\",0.0],PARAMETER[\"Central_Meridian\",0.0],PARAMETER[\"Standard_Parallel_1\",0.0],PARAMETER[\"Auxiliary_Sphere_Type\",0.0],UNIT[\"Meter\",1.0]]",
+        "servedCrs": "EPSG:4326",
+        "artifact": "data/precinct-geometry/AK/2024-11-05-general/normalized/ak-2024-precincts.geojson.gz",
+        "sha256": "64775ee450a8aa7f39c03d73154511daa5b2a42225b36b9257aca3916a3fcb06",
+        "byteCount": 12574615,
+        "featureCount": 402,
+        "sourceFeatureIdFields": [
+          "CRM_FEATURE_ID"
+        ],
+        "parentIdFields": [
+          "CRM_PARENT_GEOID"
+        ]
+      },
+      "crosswalk": {
+        "status": "reviewed",
+        "resultSourceId": "ak-2024-official-precinct-results",
+        "artifact": "data/precinct-geometry/AK/2024-11-05-general/crosswalk/ak-2024-precinct-result-crosswalk.json",
+        "sha256": "99e50bff8f9b7337028fa39f455c4b0f5313c9092bd59fa1003ec86c50b95897",
+        "byteCount": 389622,
+        "resultUnits": 523,
+        "colorableResultUnits": 402,
+        "matchedResultUnits": 402,
+        "unmatchedResultUnits": 0,
+        "nonGeographicResultUnits": 121,
+        "sourceAliasResultUnits": 0,
+        "relationships": {
+          "oneToOne": 402,
+          "oneToMany": 0,
+          "manyToOne": 0,
+          "unmatched": 0,
+          "nonGeographic": 121,
+          "sourceAlias": 0,
+          "pendingReview": 0
+        },
+        "reviewedRelationshipRecords": 523,
+        "reviewedNoDataFeatures": 0,
+        "methods": [
+          "exact_official_id",
+          "official_crosswalk"
+        ]
+      },
+      "validation": {
+        "status": "reviewed",
+        "geometryValid": true,
+        "rowLevelRenderingSafe": true,
+        "parentTotalsReconciled": true,
+        "errors": [],
+        "warnings": [
+          "Alaska results contain separately reported absentee, early-voting, questioned-ballot, and federal-overseas buckets. They are preserved for statewide reconciliation but are non-geographic and are never assigned to a precinct polygon.",
+          "The map is parent-scoped by Alaska House District, not by county or county equivalent. No precinct is centroid-assigned or proportionally allocated to a borough or census area.",
+          "Each election retains its own boundary vintage. Precinct IDs and shapes are not assumed comparable across elections; cross-year trend comparison requires a separate reviewed common-geography crosswalk.",
+          "The 2024 ENR precinct CSV fully reconciles presidential votes. Its U.S. House rows omit 750 statewide write-in votes, so the House comparison is retained as named-candidate context only and is not represented as a complete contest total.",
+          "All 402 displayable precinct relationships are reviewed one-to-one across all 40 Alaska House Districts.",
+          "All 121 administrative reporting units remain explicitly non-geographic and are never assigned to a polygon.",
+          "The 0 zero-presidential-vote precincts remain geographic reporting units.",
+          "All 0 reviewed no-data polygons remain visible without an invented result row.",
+          "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged."
+        ]
+      },
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/ak/2024-11-05/precinct/ak-2024-11-05-general-precinct-geometry-candidate-v1-e5c08ed19f3a/index.json",
+        "sha256": "e5c08ed19f3aee261d41a94692c6eb279f53249b67b5464f7af3c899a45acd2a",
+        "byteCount": 8266,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 40,
+        "featureCount": 402
+      },
+      "caveats": [
+        "Alaska results contain separately reported absentee, early-voting, questioned-ballot, and federal-overseas buckets. They are preserved for statewide reconciliation but are non-geographic and are never assigned to a precinct polygon.",
+        "The map is parent-scoped by Alaska House District, not by county or county equivalent. No precinct is centroid-assigned or proportionally allocated to a borough or census area.",
+        "Each election retains its own boundary vintage. Precinct IDs and shapes are not assumed comparable across elections; cross-year trend comparison requires a separate reviewed common-geography crosswalk.",
+        "The 2024 ENR precinct CSV fully reconciles presidential votes. Its U.S. House rows omit 750 statewide write-in votes, so the House comparison is retained as named-candidate context only and is not represented as a complete contest total."
       ]
     }
   ]

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -7457,3 +7457,27 @@ evidence against its verified top-level package.
   environment/deployment change, canonical activation, or public eligibility
   transition. The reviewed sequence is documented in
   `docs/developer/ak-precinct-gis-runbook.md`.
+
+### 2026-08-14 - Alaska guarded production staging and static activation
+
+- A fresh package resealed from merged commit `4406cbb7` is
+  `ak-precinct-gis-four-election-v1`, SHA-256
+  `0eefe7cc4690876a76d8cc7b5e5ae5ea7fc04264ead3304a12e98dcfe218c3e5`.
+  A fresh production preflight found no preexisting Alaska release rows, and a
+  full 31-table public-schema backup was restored with exact table and row
+  counts before the guarded write.
+
+- The four-election package is now loaded in production in the hidden,
+  database-blocked state at public data revision 16. Both Alaska result and
+  geography APIs were checked after the transaction and remained closed. The
+  164 immutable delivery objects were then uploaded parent-first, downloaded,
+  and hash-verified; the Blob evidence SHA-256 is
+  `a7a979c1e2f523973a5935036eb81e3b948021e14bc28b8bd15eb592aa072064`.
+
+- The static activation candidate SHA-256 is
+  `d386d7210e25bf8bab1c027cb42de56429095f836ec359cd4ddb16a6ea816c61`.
+  It changes only the manifest registry and the four year-specific coverage
+  inventories. An off-by-one guard in the atomic writer was corrected to
+  require those exact five outputs. Deployment of these files still cannot
+  expose Alaska data until the separately authorized atomic database
+  publication transaction succeeds.

--- a/scripts/prepare-ak-precinct-public-activation.mjs
+++ b/scripts/prepare-ak-precinct-public-activation.mjs
@@ -54,8 +54,8 @@ function immutableWrite(root, relativePath, bytes) {
 }
 
 export function writeAlaskaActivationTrackedOutputs(outputs) {
-  if (outputs.length !== 4 || new Set(outputs.map((item) => item.path)).size !== 4) {
-    throw new Error("Alaska activation requires exactly four unique tracked outputs");
+  if (outputs.length !== 5 || new Set(outputs.map((item) => item.path)).size !== 5) {
+    throw new Error("Alaska activation requires exactly five unique tracked outputs");
   }
   const staged = [];
   const committed = [];

--- a/tests/api/ak-precinct-geometry.test.mjs
+++ b/tests/api/ak-precinct-geometry.test.mjs
@@ -160,7 +160,7 @@ test("Alaska election vintages are independent rather than treated as an apples-
   assert.notEqual(manifests[2].normalization.sha256, manifests[3].normalization.sha256);
 });
 
-test("Alaska coverage ledgers retain all four reviewed packages as public-ineligible", () => {
+test("Alaska coverage ledgers activate all four reviewed packages", () => {
   const inventoryPaths = new Map([
     [2012, "data/precinct-geometry-coverage-inventory-2012.json"],
     [2016, "data/precinct-geometry-coverage-inventory-2016.json"],
@@ -178,11 +178,11 @@ test("Alaska coverage ledgers retain all four reviewed packages as public-inelig
       `ak-${spec.electionId}-precinct-geometry-candidate-v1`,
     ]);
     assert.equal(row.geometry.featureCount, spec.features);
-    assert.equal(row.geometry.publicEligibleManifestCount, 0);
+    assert.equal(row.geometry.publicEligibleManifestCount, 1);
     assert.equal(row.crosswalk.resultUnits, spec.units);
     assert.equal(row.crosswalk.matchedResultUnits, spec.features);
     assert.equal(row.crosswalk.nonGeographicResultUnits, spec.nonGeographic);
-    assert.ok(row.blockers.length > 0);
+    assert.deepEqual(row.blockers, []);
     assert.equal(
       inventory.summary.publicEligibleJurisdictions,
       inventory.states.filter((candidate) => (

--- a/tests/api/ak-precinct-public-activation.test.mjs
+++ b/tests/api/ak-precinct-public-activation.test.mjs
@@ -1,8 +1,21 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { inspectAlaskaPublicActivationPlan } from "../../scripts/lib/ak-precinct-public-activation.mjs";
+import { writeAlaskaActivationTrackedOutputs } from "../../scripts/prepare-ak-precinct-public-activation.mjs";
 import { buildAlaskaTestReleaseFixture } from "./ak-precinct-release-fixture.mjs";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
 
 const coverage = JSON.parse(readFileSync(
   "data/precinct-geometry-coverage-inventory-2016.json",
@@ -29,4 +42,30 @@ test("Alaska static activation adds or verifies exactly four guarded manifests",
   assert.ok(["activate", "verified_existing"].includes([...dispositions][0]));
   assert.equal(inspected.plan.safety.productionMutationPerformed, false);
   assert.equal(inspected.plan.safety.publicEndpointsRemainDatabaseGated, true);
+});
+
+test("Alaska activation atomically writes its registry and four inventories", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "crm-ak-activation-"));
+  try {
+    const outputs = Array.from({ length: 5 }, (_, index) => {
+      const absolutePath = path.join(root, `target-${index}.json`);
+      const before = Buffer.from(`before-${index}\n`, "utf8");
+      const bytes = Buffer.from(`after-${index}\n`, "utf8");
+      writeFileSync(absolutePath, before);
+      return {
+        path: `data/target-${index}.json`,
+        absolutePath,
+        preimage: { byteCount: before.length, sha256: sha256(before) },
+        byteCount: bytes.length,
+        sha256: sha256(bytes),
+        bytes,
+      };
+    });
+    assert.equal(writeAlaskaActivationTrackedOutputs(outputs).length, 5);
+    for (const output of outputs) {
+      assert.deepEqual(readFileSync(output.absolutePath), output.bytes);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

- activate the reviewed Alaska 2012, 2016, 2020, and 2024 precinct manifests
- update the four coverage inventories from blocked to one public-eligible Alaska manifest each
- fix the activation writer's off-by-one guard so it atomically requires the registry plus all four inventories
- record the hidden-load and immutable-asset publication staging evidence

## Sources and data scope

No source artifacts are replaced in this PR. It activates the four election-specific packages already reviewed in #233/#234. Displayed votes remain Alaska Division of Elections values; geometry remains election-vintage-specific and House-District-scoped.

Release package SHA-256: `0eefe7cc4690876a76d8cc7b5e5ae5ea7fc04264ead3304a12e98dcfe218c3e5`

Blob evidence SHA-256: `a7a979c1e2f523973a5935036eb81e3b948021e14bc28b8bd15eb592aa072064`

Static activation candidate SHA-256: `d386d7210e25bf8bab1c027cb42de56429095f836ec359cd4ddb16a6ea816c61`

## Safety

- production hidden load completed with all public-delivery flags false
- 164 immutable Blob objects were uploaded parent-first and downloaded again for hash verification
- both Alaska results and geometry APIs remained closed after the hidden load
- this PR does not perform the final database publication transaction
- after deployment, both endpoints remain database-gated until a separately authorized atomic cutover

## Validation

- `npm.cmd run test:precinct-geometry:ak` — 39/39 passed
- cross-state publication gates (IA, ME, MN, NV, TX) — 20/20 passed
- `npm.cmd run typecheck` — passed
- `npm.cmd run build` — passed
- Preview and Production geography origins exactly match the verified Blob origin
- `git diff --check` — passed

## Website/API path checked

Before static activation, production `/api/results` returned no Alaska precinct rows and `/api/precinct-geography` returned 404 for the reviewed Alaska manifest, confirming fail-closed behavior. After this PR deploys, those same checks must remain closed until the database cutover.

## Caveats and remaining risks

- each election retains its own boundary vintage; the map does not imply precinct-level apples-to-apples comparison across years
- non-geographic result buckets remain preserved but are not assigned to polygons
- the final public database transaction and live browser verification remain separate post-deployment steps

## Review

Current execution policy did not permit launching an unrequested review subagent. Coordinator diff review found no blocker; CI and deployment review remain required before merge.
