### PR TITLE
Fix historical year handling in Exports & API

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5039,6 +5039,18 @@ td {
   grid-template-columns: repeat(4, minmax(130px, 1fr));
 }
 
+.export-downloads {
+  display: grid;
+  gap: 10px;
+}
+
+.export-availability-note {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+  margin: 0;
+}
+
 .export-summary-grid {
   border-top: 1px solid var(--line);
   grid-template-columns: repeat(4, minmax(130px, 1fr));
@@ -5058,9 +5070,14 @@ td {
   padding: 0 12px;
 }
 
-.export-grid button:hover {
+.export-grid button:hover:not(:disabled) {
   border-color: var(--accent-line);
   color: var(--accent);
+}
+
+.export-grid button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .contact-card,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,6 +41,7 @@ import {
 import { buildStateSocialPreview } from "@/lib/social-preview";
 import { listSecurityIncidentStateSummaries } from "@/lib/security-incidents";
 import { historicalCountyRowsToResults } from "@/lib/state-year-results";
+import { workspaceTabSupportsHistoricalYear } from "@/lib/workspace-navigation";
 
 const mapModes = new Set(["winner", "margin", "volume", "method", "equipment", "security"]);
 const securityIncidentStateSummaries = listSecurityIncidentStateSummaries(2024);
@@ -103,9 +104,13 @@ async function loadDisplayResults(state: string, year: SupportedPresidentialYear
   };
 }
 
-async function loadDisplaySources(state: string, year: SupportedPresidentialYear) {
+async function loadDisplaySources(
+  state: string,
+  year: SupportedPresidentialYear,
+  fallbackTo2024 = true,
+) {
   const sources = await listSources({ state, year });
-  if (sources.length || year === 2024) {
+  if (sources.length || year === 2024 || !fallbackTo2024) {
     return sources;
   }
   return listSources({ state, year: 2024 });
@@ -159,7 +164,8 @@ export default async function Home({ searchParams }: HomeProps) {
   const selectedState = (params?.state ?? "WA").slice(0, 2).toUpperCase();
   const activeTab = resolveVisibleWorkspaceTabV2(layoutManifest, params?.tab);
   const requestedYear = parseYear(params?.year);
-  const selectedYear = activeTab === "map" ? requestedYear : 2024;
+  const selectedYear = workspaceTabSupportsHistoricalYear(activeTab) ? requestedYear : 2024;
+  const workspaceSummaryYear = activeTab === "exports" ? selectedYear : 2024;
   const requestedMapMode = mapModes.has(params?.mode ?? "")
     ? params?.mode as "winner" | "margin" | "volume" | "method" | "equipment" | "security"
     : undefined;
@@ -173,8 +179,10 @@ export default async function Home({ searchParams }: HomeProps) {
   const needsIndicators = activeTab === "map" || needsReview;
   const needsTurnout = ["history", "data", "exports"].includes(activeTab);
   const needsHistory = ["history", "data", "exports"].includes(activeTab);
-  const needsMethods = selectedYear === 2024 && ["map", "electronic", "data", "exports"].includes(activeTab);
-  const needsSecurity = selectedYear === 2024 && ["map", "data", "exports"].includes(activeTab);
+  const needsMethods = (selectedYear === 2024 || activeTab === "exports")
+    && ["map", "electronic", "data", "exports"].includes(activeTab);
+  const needsSecurity = (selectedYear === 2024 || activeTab === "exports")
+    && ["map", "data", "exports"].includes(activeTab);
   const needsImports = ["review", "data", "exports", "imports"].includes(activeTab);
 
   const [
@@ -197,24 +205,24 @@ export default async function Home({ searchParams }: HomeProps) {
     sourceRecordsRequests,
   ] = await Promise.all([
     listStates(),
-    listCompletenessReport({ year: 2024 }),
+    listCompletenessReport({ year: workspaceSummaryYear }),
     loadDisplayResults(selectedState, selectedYear),
-    loadDisplaySources(selectedState, selectedYear),
+    loadDisplaySources(selectedState, selectedYear, activeTab !== "exports"),
     getCoverageSummary({ state: selectedState, year: selectedYear }),
     needsImports ? listImportRuns() : Promise.resolve([]),
     needsIndicators ? listIndicators({ state: selectedState, year: selectedYear }) : Promise.resolve([]),
     needsReview
       ? listReviewRows({ state: selectedState, year: selectedYear, includeMetrics: true, limit: 5000 })
       : Promise.resolve([]),
-    needsTurnout ? listTurnoutRows({ state: selectedState, year: 2024, limit: 20000 }) : Promise.resolve([]),
+    needsTurnout ? listTurnoutRows({ state: selectedState, year: selectedYear, limit: 20000 }) : Promise.resolve([]),
     needsHistory ? listHistoricalResultRows({ state: selectedState, limit: 5000 }) : Promise.resolve([]),
-    needsMethods ? listVoteMethodRows({ state: selectedState, year: 2024, limit: 20000 }) : Promise.resolve([]),
-    needsMethods ? listEquipmentRows({ state: selectedState, year: 2024, limit: 20000 }) : Promise.resolve([]),
-    needsSecurity ? listSecurityIncidents({ state: selectedState, year: 2024, limit: 5000 }) : Promise.resolve([]),
-    listAdminSourceStatuses({ state: selectedState, year: 2024 }),
-    listElectronicIntegrityArtifacts({ state: selectedState, year: 2024 }),
-    listElectronicIntegrityRequests({ state: selectedState, year: 2024 }),
-    listSourceRecordsRequests({ state: selectedState, year: 2024 }),
+    needsMethods ? listVoteMethodRows({ state: selectedState, year: selectedYear, limit: 20000 }) : Promise.resolve([]),
+    needsMethods ? listEquipmentRows({ state: selectedState, year: selectedYear, limit: 20000 }) : Promise.resolve([]),
+    needsSecurity ? listSecurityIncidents({ state: selectedState, year: selectedYear, limit: 5000 }) : Promise.resolve([]),
+    listAdminSourceStatuses({ state: selectedState, year: workspaceSummaryYear }),
+    listElectronicIntegrityArtifacts({ state: selectedState, year: workspaceSummaryYear }),
+    listElectronicIntegrityRequests({ state: selectedState, year: workspaceSummaryYear }),
+    listSourceRecordsRequests({ state: selectedState, year: workspaceSummaryYear }),
   ]);
 
   const {
@@ -392,7 +400,7 @@ export default async function Home({ searchParams }: HomeProps) {
               />
             </section>
 
-            <NationalOverview report={completenessReport} year={2024} />
+            <NationalOverview report={completenessReport} year={workspaceSummaryYear} />
           </section>
         </section>
       </div>

--- a/src/app/workspace-context-bar.tsx
+++ b/src/app/workspace-context-bar.tsx
@@ -10,6 +10,7 @@ import {
   workspaceNavigationContextFromSearchParams,
   workspaceNavigationHref,
   workspaceStateHref,
+  workspaceTabSupportsHistoricalYear,
   type WorkspaceContextChangeDetail,
   type WorkspaceMapMode,
   type WorkspaceNavigationContext,
@@ -167,7 +168,7 @@ export function WorkspaceContextBar({
               navigate(workspaceNavigationHref({
                 ...currentContext(),
                 fips: undefined,
-                tab: "map",
+                tab: workspaceTabSupportsHistoricalYear(activeTab) ? activeTab : "map",
                 year,
               }));
             }}

--- a/src/app/workspace-tabs.tsx
+++ b/src/app/workspace-tabs.tsx
@@ -40,6 +40,7 @@ import { WorkspaceLayoutGroupsV3 } from "./workspace-layout-v3-groups";
 import { rowsToCsv } from "@/lib/csv";
 import type { SupportedPresidentialYear } from "@/lib/api-version";
 import { equipmentClusterDiagnostics } from "@/lib/equipment-diagnostics";
+import { candidateNamesForYear } from "@/lib/state-year-results";
 import {
   type WorkspaceSectionId,
   type WorkspaceTabId,
@@ -65,6 +66,7 @@ import {
   workspaceLayoutSettingsV3,
   workspaceRuntimeGroupsV3,
 } from "@/lib/workspace-layout-v3-runtime";
+import { workspaceTabSupportsHistoricalYear } from "@/lib/workspace-navigation";
 import type {
   AnalysisIndicator,
   AdminSourceStatusSummary,
@@ -2930,8 +2932,10 @@ export function WorkspaceTabs({
     const tab = layoutTabs.some((item) => item.key === requested) ? requested : "map";
     setActiveTab(tab);
     const url = new URL(window.location.href);
-    if (tab !== "map") {
+    if (!workspaceTabSupportsHistoricalYear(tab)) {
       url.searchParams.set("year", "2024");
+    }
+    if (tab !== "map") {
       url.searchParams.delete("mode");
       url.searchParams.delete("fips");
     }
@@ -3463,7 +3467,10 @@ export function WorkspaceTabs({
     : [];
   const pendingCapabilities = capabilityEntries.filter(([, value]) => !value);
   const readyCapabilities = capabilityEntries.filter(([, value]) => value);
-  const selectedImportRuns = importRuns.filter((run) => run.state === selectedStateCode);
+  const selectedImportRuns = importRuns.filter((run) => (
+    run.state === selectedStateCode
+    && (activeTab !== "exports" || run.electionYear === electionYear)
+  ));
   const latestRun = selectedImportRuns[0];
   const sourcesWithoutUrls = sources.filter((source) => !source.sourceUrl.trim());
   const currentImportIsLegacyOnly = hasLegacyImport(selectedImportRuns) && !hasNativeImport(selectedImportRuns);
@@ -3713,13 +3720,24 @@ export function WorkspaceTabs({
       equipmentRows.length,
     ],
   );
-  const exportSlug = `${selectedStateCode.toLowerCase()}-2024-president`;
-  const resultExportHeaders = ["jurisdiction", "winner", "harris", "trump", "other", "total", "margin_votes", "margin_pct", "source"];
+  const electionCandidates = candidateNamesForYear(electionYear);
+  const exportSlug = `${selectedStateCode.toLowerCase()}-${electionYear}-president`;
+  const resultExportHeaders = [
+    "jurisdiction",
+    "winner",
+    electionCandidates.dem.toLowerCase(),
+    electionCandidates.rep.toLowerCase(),
+    "other",
+    "total",
+    "margin_votes",
+    "margin_pct",
+    "source",
+  ];
   const resultExportRows = results.map((row) => [
     row.jurisdictionName,
     row.winner,
-    row.votes.Harris ?? 0,
-    row.votes.Trump ?? 0,
+    row.votes[electionCandidates.dem] ?? 0,
+    row.votes[electionCandidates.rep] ?? 0,
     row.votes.Other ?? 0,
     row.totalVotes,
     row.marginVotes,
@@ -3798,17 +3816,19 @@ export function WorkspaceTabs({
     "total_votes",
     "source",
   ];
-  const historicalExportRows = historicalRows.map((row) => [
-    row.electionYear,
-    row.jurisdictionName,
-    row.localUnit,
-    row.sourceLevel,
-    row.demVotes ?? "",
-    row.repVotes ?? "",
-    row.otherVotes ?? "",
-    row.totalVotes ?? "",
-    row.sourceId,
-  ]);
+  const historicalExportRows = historicalRows
+    .filter((row) => electionYear === 2024 || row.electionYear === electionYear)
+    .map((row) => [
+      row.electionYear,
+      row.jurisdictionName,
+      row.localUnit,
+      row.sourceLevel,
+      row.demVotes ?? "",
+      row.repVotes ?? "",
+      row.otherVotes ?? "",
+      row.totalVotes ?? "",
+      row.sourceId,
+    ]);
   const sourceExportHeaders = ["category", "title", "authority", "source_url", "local_artifact", "parser", "timestamp_basis", "confidence", "status"];
   const sourceExportRows = sources.map((source) => [
     source.category,
@@ -3908,7 +3928,7 @@ export function WorkspaceTabs({
     sources,
     state: selectedStateCode,
     stateName,
-    year: 2024,
+    year: electionYear,
   };
   const importSummary = {
     completeness: selectedCompleteness ?? null,
@@ -3919,7 +3939,7 @@ export function WorkspaceTabs({
     selectedImportRuns,
     state: selectedStateCode,
     stateName,
-    year: 2024,
+    year: electionYear,
   };
 
   const reviewPacketManifest: ExportPacketManifest = {
@@ -3945,11 +3965,11 @@ export function WorkspaceTabs({
     },
     state: selectedStateCode,
     stateName,
-    year: 2024,
+    year: electionYear,
   };
 
   const reviewPacketMarkdown = [
-    `# ${stateName} (${selectedStateCode}) 2024 Review Packet`,
+    `# ${stateName} (${selectedStateCode}) ${electionYear} Review Packet`,
     "",
     "Advisory flags and screening charts are review prompts only. This package does not assert fraud, tampering, misconduct, intent, or causation.",
     "",
@@ -4041,7 +4061,7 @@ export function WorkspaceTabs({
     const { default: JSZip } = await import("jszip");
     const zip = new JSZip();
     const readme = [
-      `Civic Result Maps review package for ${stateName} (${selectedStateCode}), 2024 President`,
+      `Civic Result Maps review package for ${stateName} (${selectedStateCode}), ${electionYear} President`,
       "",
       "Use these normalized files with the source manifest, caveats, readiness summary, indicator summary, missing-data checklist, and issue links.",
       "Advisory flags and screening charts are triage prompts, not proof by themselves.",
@@ -6583,51 +6603,58 @@ export function WorkspaceTabs({
                 <Database aria-hidden size={18} />
               </div>
             </div>))}
-            {captureProduction("downloads", (<div className="export-grid" style={{ order: Math.min(workspaceSectionState(layoutManifest, "exports", "downloads").order, workspaceSectionState(layoutManifest, "exports", "review-packet").order) }}>
-              <button onClick={exportResults} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Results CSV
-              </button>
-              <button onClick={exportIndicators} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Review CSV
-              </button>
-              <button disabled={!reviewRows.length} onClick={exportReviewRows} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Review Rows CSV
-              </button>
-              <button disabled={!turnoutRows.length} onClick={exportTurnoutRows} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Turnout CSV
-              </button>
-              <button disabled={!historicalRows.length} onClick={exportHistoricalRows} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Historical Rows CSV
-              </button>
-              <button onClick={exportSources} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Sources CSV
-              </button>
-              <button onClick={exportCoverage} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Coverage CSV
-              </button>
-              <button disabled={!voteMethodRows.length} onClick={exportVoteMethods} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Vote Methods CSV
-              </button>
-              <button disabled={!equipmentRows.length} onClick={exportEquipmentRows} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Equipment CSV
-              </button>
-              <button onClick={exportSourceManifest} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Source Manifest JSON
-              </button>
-              <button onClick={exportImportSummary} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
-                <Download aria-hidden size={16} />
-                Import Summary JSON
-              </button>
+            {captureProduction("downloads", (<div className="export-downloads" style={{ order: Math.min(workspaceSectionState(layoutManifest, "exports", "downloads").order, workspaceSectionState(layoutManifest, "exports", "review-packet").order) }}>
+              <div className="export-grid">
+                <button onClick={exportResults} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Results CSV
+                </button>
+                <button onClick={exportIndicators} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Review CSV
+                </button>
+                <button disabled={!reviewRows.length} onClick={exportReviewRows} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Review Rows CSV
+                </button>
+                <button disabled={!turnoutRows.length} onClick={exportTurnoutRows} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Turnout CSV
+                </button>
+                <button disabled={!historicalExportRows.length} onClick={exportHistoricalRows} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Historical Rows CSV
+                </button>
+                <button onClick={exportSources} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Sources CSV
+                </button>
+                <button onClick={exportCoverage} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Coverage CSV
+                </button>
+                <button disabled={!voteMethodRows.length} onClick={exportVoteMethods} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Vote Methods CSV
+                </button>
+                <button disabled={!equipmentRows.length} onClick={exportEquipmentRows} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Equipment CSV
+                </button>
+                <button onClick={exportSourceManifest} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Source Manifest JSON
+                </button>
+                <button onClick={exportImportSummary} type="button" {...layoutSectionProps(layoutManifest, "exports", "downloads")}>
+                  <Download aria-hidden size={16} />
+                  Import Summary JSON
+                </button>
+              </div>
+              {!reviewRows.length && (
+                <p className="export-availability-note" role="status">
+                  No {electionYear} review rows are loaded for {stateName}. Review Rows CSV is unavailable; use Results CSV for election totals when results are available.
+                </p>
+              )}
             </div>))}
             {captureProduction("review-packet", (<div className="export-grid">
               <button data-tour="export-review-packet" onClick={exportReviewPackage} type="button" {...layoutSectionProps(layoutManifest, "exports", "review-packet")}>
@@ -6678,35 +6705,35 @@ export function WorkspaceTabs({
               </li>
               <li>
                 <strong>Results</strong>
-                <code>/api/results?state={selectedStateCode}&amp;year=2024&amp;level=county</code>
+                <code>/api/results?state={selectedStateCode}&amp;year={electionYear}&amp;level={results[0]?.level ?? "county"}</code>
               </li>
               <li>
                 <strong>Indicators</strong>
-                <code>/api/indicators?state={selectedStateCode}&amp;year=2024</code>
+                <code>/api/indicators?state={selectedStateCode}&amp;year={electionYear}</code>
               </li>
               <li>
                 <strong>Raw review rows</strong>
-                <code>/api/review-rows?state={selectedStateCode}&amp;year=2024&amp;limit=500&amp;includeMetrics=true</code>
+                <code>/api/review-rows?state={selectedStateCode}&amp;year={electionYear}&amp;limit=500&amp;includeMetrics=true</code>
               </li>
               <li>
                 <strong>Turnout</strong>
-                <code>/api/turnout?state={selectedStateCode}&amp;year=2024&amp;limit=500</code>
+                <code>/api/turnout?state={selectedStateCode}&amp;year={electionYear}&amp;limit=500</code>
               </li>
               <li>
                 <strong>Vote methods</strong>
-                <code>/api/vote-methods?state={selectedStateCode}&amp;year=2024&amp;limit=500</code>
+                <code>/api/vote-methods?state={selectedStateCode}&amp;year={electionYear}&amp;limit=500</code>
               </li>
               <li>
                 <strong>Equipment context</strong>
-                <code>/api/equipment?state={selectedStateCode}&amp;year=2024&amp;limit=500</code>
+                <code>/api/equipment?state={selectedStateCode}&amp;year={electionYear}&amp;limit=500</code>
               </li>
               <li>
                 <strong>Security incidents</strong>
-                <code>/api/security-incidents?state={selectedStateCode}&amp;year=2024&amp;limit=500</code>
+                <code>/api/security-incidents?state={selectedStateCode}&amp;year={electionYear}&amp;limit=500</code>
               </li>
               <li>
                 <strong>Admin source statuses</strong>
-                <code>/api/admin-sources?state={selectedStateCode}&amp;year=2024</code>
+                <code>/api/admin-sources?state={selectedStateCode}&amp;year={electionYear}</code>
               </li>
               <li>
                 <strong>Historical baselines</strong>
@@ -6714,15 +6741,15 @@ export function WorkspaceTabs({
               </li>
               <li>
                 <strong>Sources</strong>
-                <code>/api/sources?state={selectedStateCode}&amp;year=2024</code>
+                <code>/api/sources?state={selectedStateCode}&amp;year={electionYear}</code>
               </li>
               <li>
                 <strong>Coverage</strong>
-                <code>/api/coverage?state={selectedStateCode}&amp;year=2024</code>
+                <code>/api/coverage?state={selectedStateCode}&amp;year={electionYear}</code>
               </li>
               <li>
                 <strong>Completeness</strong>
-                <code>/api/completeness?year=2024</code>
+                <code>/api/completeness?year={electionYear}</code>
               </li>
             </ul>))}
           </section>

--- a/src/lib/workspace-navigation.ts
+++ b/src/lib/workspace-navigation.ts
@@ -42,6 +42,10 @@ const workspaceTabs = new Set<WorkspaceTabId>([
 ]);
 const historicalMapModes = new Set<WorkspaceMapMode>(["winner", "margin", "volume"]);
 
+export function workspaceTabSupportsHistoricalYear(tab: WorkspaceTabId) {
+  return tab === "map" || tab === "exports";
+}
+
 function normalizeState(value: string | null | undefined, fallback: string) {
   const normalized = value?.trim().slice(0, 2).toUpperCase();
   return /^[A-Z]{2}$/.test(normalized ?? "") ? normalized! : fallback;
@@ -73,7 +77,7 @@ export function workspaceNavigationContextFromSearchParams(
   fallback: WorkspaceNavigationContext,
 ): WorkspaceNavigationContext {
   const tab = normalizeTab(searchParams.get("tab"), fallback.tab);
-  const year = tab === "map"
+  const year = workspaceTabSupportsHistoricalYear(tab)
     ? normalizeYear(searchParams.get("year"), fallback.year)
     : 2024;
   const mode = tab === "map" ? normalizeMapMode(searchParams.get("mode")) : undefined;
@@ -91,7 +95,7 @@ export function workspaceNavigationContextFromSearchParams(
 export function workspaceNavigationHref(context: WorkspaceNavigationContext): `/?${string}` {
   const state = normalizeState(context.state, "WA");
   const tab = normalizeTab(context.tab, "map");
-  const year = tab === "map" ? normalizeYear(context.year, 2024) : 2024;
+  const year = workspaceTabSupportsHistoricalYear(tab) ? normalizeYear(context.year, 2024) : 2024;
   const mode = tab === "map" ? normalizeMapMode(context.mode) : undefined;
   const fips = tab === "map" ? normalizeFips(context.fips) : undefined;
   const params = new URLSearchParams({
@@ -127,7 +131,7 @@ export function contextualizeWorkspaceHref(href: string, context: WorkspaceNavig
   const params = new URLSearchParams(url.searchParams);
   const tab = normalizeTab(params.get("tab"), context.tab);
   const state = normalizeState(params.get("state"), context.state);
-  const year = tab === "map"
+  const year = workspaceTabSupportsHistoricalYear(tab)
     ? normalizeYear(params.get("year"), context.year)
     : 2024;
   params.set("state", state);

--- a/tests/api/historical-indicators.test.mjs
+++ b/tests/api/historical-indicators.test.mjs
@@ -66,3 +66,14 @@ test("historical maps load same-year indicators and distinguish not evaluated", 
   assert.match(explorer, /demCorrelation/);
   assert.match(explorer, /repCorrelation/);
 });
+
+test("historical exports keep one election context across data, metadata, and API examples", () => {
+  assert.match(page, /workspaceTabSupportsHistoricalYear\(activeTab\) \? requestedYear : 2024/);
+  assert.match(page, /loadDisplaySources\(selectedState, selectedYear, activeTab !== "exports"\)/);
+  assert.match(page, /listTurnoutRows\(\{ state: selectedState, year: selectedYear/);
+  assert.match(workspaceTabs, /selectedStateCode\.toLowerCase\(\)\}-\$\{electionYear\}-president/);
+  assert.match(workspaceTabs, /candidateNamesForYear\(electionYear\)/);
+  assert.match(workspaceTabs, /activeTab !== "exports" \|\| run\.electionYear === electionYear/);
+  assert.match(workspaceTabs, /year=\{electionYear\}/);
+  assert.match(workspaceTabs, /No \{electionYear\} review rows are loaded/);
+});

--- a/tests/api/workspace-navigation.test.mjs
+++ b/tests/api/workspace-navigation.test.mjs
@@ -29,6 +29,27 @@ test("secondary workspace destinations retain their tab and canonical 2024 conte
   );
 });
 
+test("exports preserve the selected historical election while removing map-only context", () => {
+  assert.equal(
+    workspaceStateHref({ ...mapContext, tab: "exports" }, "AK"),
+    "/?state=AK&year=2020&tab=exports",
+  );
+
+  assert.deepEqual(
+    workspaceNavigationContextFromSearchParams(
+      new URLSearchParams("state=AK&year=2016&tab=exports&mode=margin&fips=02020"),
+      mapContext,
+    ),
+    {
+      fips: undefined,
+      mode: undefined,
+      state: "AK",
+      tab: "exports",
+      year: 2016,
+    },
+  );
+});
+
 test("historical navigation removes administration-only map layers", () => {
   assert.equal(
     workspaceNavigationHref({ ...mapContext, mode: "equipment", year: 2016 }),
@@ -63,6 +84,17 @@ test("custom workspace links inherit state context and discard map-only context 
   assert.equal(url.searchParams.has("fips"), false);
   assert.equal(url.searchParams.has("mode"), false);
   assert.equal(url.hash, "#catalog");
+});
+
+test("custom exports links inherit the selected historical election", () => {
+  const href = contextualizeWorkspaceHref("/?tab=exports#downloads", mapContext);
+  const url = new URL(href, "https://civicresultmaps.local");
+  assert.equal(url.searchParams.get("state"), "WA");
+  assert.equal(url.searchParams.get("year"), "2020");
+  assert.equal(url.searchParams.get("tab"), "exports");
+  assert.equal(url.searchParams.has("fips"), false);
+  assert.equal(url.searchParams.has("mode"), false);
+  assert.equal(url.hash, "#downloads");
 });
 
 test("bare workspace links retain map context while external and non-workspace paths remain unchanged", () => {

--- a/tests/e2e/workspace-layout.spec.ts
+++ b/tests/e2e/workspace-layout.spec.ts
@@ -157,6 +157,26 @@ test("workspace synchronizes automatic map-layer fallbacks", async ({ page }) =>
     .toHaveAttribute("href", /^\/\?state=[A-Z]{2}&year=2024&tab=map&mode=winner$/);
 });
 
+test("historical election context remains selected in Exports and API examples", async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.goto("/?state=AK&year=2020&tab=exports");
+
+  const workspaceContext = page.getByRole("region", { name: "Election workspace context" });
+  await expect(workspaceContext.getByLabel("Workspace election year")).toHaveValue("2020");
+  await expect(page).toHaveURL(/state=AK&year=2020&tab=exports/);
+  await expect(page).not.toHaveURL(/mode=/);
+  await expect(workspaceContext.getByRole("heading", { level: 1 })).toContainText("2020 President");
+  await expect(page.getByRole("heading", { name: "Exports & API", exact: true })).toBeVisible();
+  await expect(page.locator("code").filter({ hasText: "/api/review-rows?state=AK&year=2020" })).toBeVisible();
+  await expect(page.locator("code").filter({ hasText: "/api/results?state=AK&year=2020" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Review Rows CSV", exact: true })).toBeDisabled();
+  await expect(page.getByText(/No 2020 review rows are loaded for AK/i)).toBeVisible();
+
+  await workspaceContext.getByLabel("Workspace election year").selectOption("2016");
+  await expect(page).toHaveURL(/state=AK&year=2016&tab=exports/);
+  await expect(workspaceContext.getByLabel("Workspace election year")).toHaveValue("2016");
+});
+
 test("layout administration fails safely when Clerk is not configured", async ({ page }) => {
   await page.goto("/admin/layout");
   await expect(page.getByRole("heading", { name: "Layout editor setup required" })).toBeVisible();


### PR DESCRIPTION
## Scope
- Preserve 2012/2016/2020 when opening **Exports & API** instead of forcing 2024.
- Keep year changes inside Exports and remove only map-specific mode/geography parameters.
- Make export filenames, candidate columns, manifests, packets, source/import metadata, and API examples match the selected election.
- Disable unavailable Review Rows CSV with a clear explanation instead of silently substituting another year.

## Data and sources
- No election source artifacts or normalized data changed.
- Historical export source records and import runs are now strictly scoped to the selected year; 2024 fallback data is not mislabeled as historical.

## Verification
- `node --experimental-strip-types --test tests/api/workspace-navigation.test.mjs tests/api/historical-indicators.test.mjs` (14/14)
- `npm.cmd run test:layout`
- `npm.cmd run typecheck`
- `npm.cmd run build`
- Focused Playwright regression for `/?state=AK&year=2020&tab=exports` and in-tab change to 2016

## Website/API path checked
- Alaska → 2020 General → More → Exports & API
- Direct historical Exports URL
- Selected-year Results and Review Rows API examples

## Caveat
- Review Rows CSV remains unavailable when that separate analytical dataset has no rows for the selected state-year. Results CSV remains the election-total export when results are loaded.