### PR TITLE
Fix Alaska publication receipt recovery

### DIFF
--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -7495,3 +7495,15 @@ evidence against its verified top-level package.
   fallback data; the post-deployment check requires database-backed responses
   and requires the public alias to report the exact triggering deployment Git
   SHA. Neither check mutates election data or publication state.
+
+### 2026-08-14 - Alaska publication receipt recovery correction
+
+- Alaska's read-only public-cutover receipt recovery now requires all four
+  election geography versions. The prior guard incorrectly retained a
+  three-version count from a three-year release pattern, which would have
+  rejected recovery after an ambiguous successful Alaska commit.
+
+- A focused regression assertion pins the four-version recovery contract and
+  rejects reintroduction of the stale three-version condition. The normal
+  publication transaction, source artifacts, manifests, and public eligibility
+  are unchanged.

--- a/scripts/publish-ak-precinct-geography-status.mjs
+++ b/scripts/publish-ak-precinct-geography-status.mjs
@@ -233,6 +233,13 @@ export function verifyAlaskaPublicationGitCandidate(
   };
 }
 
+export function assertAlaskaPublicationRecoveryVersionSet(versions) {
+  if (!Array.isArray(versions) || versions.length !== 4) {
+    throw new Error("Alaska publication receipt recovery found an incomplete version set");
+  }
+  return versions;
+}
+
 function expectedActivationMetadata(
   context,
   manifest,
@@ -1025,9 +1032,7 @@ export async function runAlaskaGeographyPublication(options = {}) {
           "where gv.state_code='AK' and gv.geography_type='precinct'",
           " and gv.metadata->'releaseCandidate'->>'sha256'=$1 order by e.year",
         ].join("\n"), [built.plan.releaseCandidate.sha256]);
-        if (versions.length !== 3) {
-          throw new Error("Alaska publication receipt recovery found an incomplete version set");
-        }
+        assertAlaskaPublicationRecoveryVersionSet(versions);
         const operationAudit = mode === "publish"
           ? versions[0]?.metadata?.publicActivation
           : versions[0]?.metadata?.publicActivation?.rollback;

--- a/tests/api/ak-precinct-publication.test.mjs
+++ b/tests/api/ak-precinct-publication.test.mjs
@@ -21,6 +21,7 @@ import {
 } from "../../scripts/lib/ak-precinct-publication.mjs";
 import {
   applyAlaskaGeographyPublicationTransaction,
+  assertAlaskaPublicationRecoveryVersionSet,
   inspectAlaskaPublicationReceipt,
   verifyAlaskaPublicationGitCandidate,
 } from "../../scripts/publish-ak-precinct-geography-status.mjs";
@@ -595,4 +596,13 @@ test("Alaska publication runner contains database-first rollback and read-only r
   assert.match(source, /publicationReceiptSha256/);
   assert.match(source, /transactionBodyCompleted/);
   assert.match(source, /disposition === "created"/);
+});
+
+test("Alaska publication receipt recovery requires all four geography versions", () => {
+  const versions = [2012, 2016, 2020, 2024].map((year) => ({ year }));
+  assert.equal(assertAlaskaPublicationRecoveryVersionSet(versions), versions);
+  assert.throws(
+    () => assertAlaskaPublicationRecoveryVersionSet(versions.slice(0, 3)),
+    /incomplete version set/,
+  );
 });


### PR DESCRIPTION
## What changed

- correct Alaska publication-receipt recovery to require all four election geography versions
- route the cardinality check through a directly testable fail-closed helper
- add a regression test proving four versions pass and three versions fail
- record the production-safety correction in the precinct GIS implementation ledger

## Why

The recovery branch retained a three-version count from a three-year state pattern. Alaska releases 2012, 2016, 2020, and 2024, so an ambiguous successful commit could have been impossible to reconcile through the documented read-only receipt-recovery path.

The normal publication transaction was already four-year guarded. This PR only restores the recovery path to the same four-year contract; it does not change data, manifests, eligibility, or publication state.

## Validation

- `npm.cmd run typecheck`
- `node --experimental-strip-types --test tests/api/ak-precinct-publication.test.mjs` — 10/10 passed
- `npm.cmd run test:precinct-geometry:ak` — 39/39 passed
- `git diff --check`
- independent read-only review — approved, no blocker

## Production impact

None on merge. The hotfix performs no database, Blob, Vercel, or canonical-manifest mutation. It makes the already documented read-only recovery procedure usable for Alaska's four-election publication.
