### PR TITLE
Add guarded South Carolina precinct release

### DIFF
--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -24,6 +24,8 @@ For Maine's four-year local-reporting-unit collection, mixed-grain labeling rule
 
 For Michigan's official four-election precinct source packages, hash-pinned replay, allocation-free 2024 crosswalk, historical blockers, and cross-year comparison rules, read [`docs/developer/mi-precinct-gis-runbook.md`](mi-precinct-gis-runbook.md).
 
+For the guarded South Carolina 2016/2020/2024 precinct release, county-scoped immutable delivery, non-geographic reconciliation rules, database-gated cutover, and separately blocked 2012 package, read [`docs/developer/sc-precinct-gis-runbook.md`](sc-precinct-gis-runbook.md).
+
 For the feature-gated election-equipment catalog, immutable source revisions, editorial lifecycle, version semantics, 3D fidelity rules, and publication gates, read [`docs/equipment-evidence-workflow.md`](../equipment-evidence-workflow.md).
 
 ## Coordinator Protocol

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -7625,3 +7625,32 @@ evidence against its verified top-level package.
   41 `vote_share_pattern` rows and 37 `average_down_ballot_difference` rows.
   These are review signals only, not evidence of fraud or misconduct. This
   source-package task does not promote staging or mutate production data.
+
+### 2026-08-15 - South Carolina guarded three-election release tooling
+
+- The guarded release plan now accepts only 2016, 2020, and 2024 and rejects
+  2012 before any database or delivery action. It loads 7,396 reporting units,
+  20,403 official candidate rows, 6,805 geometry features, and 7,396 reviewed
+  relationships. All 595 administrative units remain non-geographic, and the
+  four reviewed no-data features remain visible without invented results.
+- Local clone rehearsal completed with three blocked geography versions,
+  exact per-year result and geometry counts, public delivery disabled, and
+  zero invalid constraints. The deterministic local-development candidate
+  `sc-precinct-gis-three-election-v1` was sealed from that validation as
+  SHA-256 `f3ee8f4bb78ee154eab8e89c427951b01386ea18a19d0b0bef22ee95667a6bed`.
+  It contains 138 county-scoped GeoJSON objects followed by three indexes, with
+  no election values in geometry delivery. Production evidence must use a new
+  candidate resealed from the exact clean merged commit.
+- South Carolina is added to the shared fail-closed publication contract. The
+  API accepts its explicitly reviewed `reviewed_name` relationships only for
+  South Carolina; existing guarded states retain the narrower exact-ID or
+  official-crosswalk methods. Static activation changes only the registry and
+  the 2016, 2020, and 2024 coverage inventories while database status remains
+  blocked.
+- The production tooling includes read-only preflight, full restore-verified
+  backup, hash-pinned hidden load and receipt recovery, immutable Blob
+  publication, four-file static activation, exact deployment/rollback-tree
+  verification, atomic public publication, database-first rollback, and
+  read-only publication-receipt recovery. No production database, Blob,
+  Vercel, canonical registry, or public eligibility mutation occurs in this
+  tooling change.

--- a/docs/developer/sc-precinct-gis-runbook.md
+++ b/docs/developer/sc-precinct-gis-runbook.md
@@ -1,0 +1,251 @@
+# South Carolina precinct GIS release runbook
+
+This runbook covers the guarded South Carolina presidential precinct release for
+2016, 2020, and 2024. The three elections use separate election-specific
+boundaries and county-scoped delivery assets. The 2012 diagnostic package is not
+part of this release and must remain absent from the public manifest registry.
+
+## Reviewed release universe
+
+| Year | Reporting units | Geographic result units | Non-geographic units | Result rows | Geometry features | Reviewed no-data features | Geographic presidential votes | Official presidential votes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 2016 | 2,551 | 2,232 | 319 | 6,696 | 2,234 | 2 | 1,589,961 | 2,103,027 |
+| 2020 | 2,399 | 2,261 | 138 | 6,783 | 2,263 | 2 | 2,504,220 | 2,513,329 |
+| 2024 | 2,446 | 2,308 | 138 | 6,924 | 2,308 | 0 | 2,541,877 | 2,548,140 |
+
+The South Carolina Election Commission CSVs are the sole vote authority. VEST
+and NYT vote fields are stripped before normalized geometry is written. Reviewed
+administrative rows remain in the database for reconciliation but never receive
+a polygon. The two 2016 and two 2020 features without a result row remain visible
+as explicit no-data shapes.
+
+The 2016 and 2020 geometry is retained VEST election-specific geometry attributed
+to South Carolina Revenue and Fiscal Affairs. The 2024 geometry is NYT
+official-boundary geometry under retained non-commercial attribution terms.
+These secondary geometry sources do not replace the official result totals.
+
+## Fail-closed conditions
+
+- Only 2016, 2020, and 2024 are accepted by the release plan.
+- 2012 remains blocked because the retained 2013 archive does not prove the
+  November 2012 boundary vintage, lacks a reviewed result crosswalk, and lacks
+  affirmative derivative-redistribution terms.
+- The release contains 7,396 reporting units, 20,403 candidate result rows,
+  6,805 features, and 7,396 reviewed relationships.
+- All 595 administrative reporting units are non-geographic.
+- Delivery contains 138 county files and three indexes: 141 immutable objects.
+- The static manifest and results APIs remain closed until the final database
+  publication transaction.
+- No precinct is compared across election years by name or shape alone. Each
+  election retains its own boundary vintage; trend comparison needs a separate
+  reviewed common-geography crosswalk.
+
+## 1. Local clone rehearsal
+
+Use a clean checkout at the exact reviewed commit. The database URL must be the
+fixed loopback clone, never a remote endpoint.
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='local'
+$env:CRM_DATABASE_STRICT='true'
+$env:CRM_DATABASE_LOCAL_WRITES='true'
+$env:DATABASE_URL='postgresql://crm_clone_admin:crm_clone_local_only@127.0.0.1:54329/crm_clone_dev'
+
+npm.cmd run precinct-gis:plan:sc
+npm.cmd run precinct-gis:setup:sc:local
+npm.cmd run precinct-gis:validate:sc:local
+```
+
+The validation report is `.etl/local-db/sc-precinct-gis-validation.json`. It
+must show invalid constraints `0`, three blocked geography versions, exact
+per-year counts, and `publicDeliveryAuthorized: false`. It must contain no 2012
+row.
+
+## 2. Seal the deterministic candidate
+
+```powershell
+npm.cmd run precinct-gis:release-candidate:sc
+npm.cmd run precinct-gis:release-candidate:sc:write
+```
+
+Record the exact candidate path and SHA-256 as `$PKG` and `$PKG_SHA`. The sealed
+package contains one release document, three draft manifests, 138 county assets,
+and three indexes. Candidate creation changes no canonical manifest, registry,
+database, Blob object, deployment, or Git ref.
+
+Before production work, run the focused South Carolina suite, typecheck, build,
+and the hermetic API integration test:
+
+```powershell
+npm.cmd run test:precinct-geometry:sc
+npm.cmd run typecheck
+npm.cmd run build
+npm.cmd run test:e2e:api
+```
+
+## 3. Read-only production preflight
+
+Use exactly one explicit unpooled production URL. Do not load `.env.local` into
+the release shell.
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production-read-only'
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PRODUCTION_PREFLIGHT_ACK=$PKG_SHA
+$env:POSTGRES_URL_NON_POOLING='<explicit unpooled production URL>'
+
+npm.cmd run precinct-gis:production-preflight:sc -- --package=$PKG --connect-read-only
+```
+
+Retain the report path, report SHA-256, database name, public revision, and
+64-hex endpoint fingerprint. The preflight must prove that no South Carolina
+release rows already exist. It is valid for four hours.
+
+## 4. Full restore-verified backup
+
+Run this after the preflight so the backup represents a state at least as new as
+the inspected database. The backup script requires PostgreSQL 17 tools, backs up
+the complete public schema without exclusions, restores it to the fixed local
+container, and compares the exact table set and row counts.
+
+```powershell
+$env:CRM_SC_PRECINCT_GEOGRAPHY_BACKUP_ACK='CREATE_FULL_PUBLIC_SCHEMA_ROLLBACK_BACKUP'
+$env:CRM_SC_PRECINCT_GEOGRAPHY_BACKUP_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_SC_PRECINCT_GEOGRAPHY_BACKUP_ENDPOINT_FINGERPRINT=$ENDPOINT_FINGERPRINT
+
+npm.cmd run precinct-gis:production-backup:sc -- -ReleasePackagePath $PKG -ReleasePackageSha256 $PKG_SHA -Execute
+```
+
+Retain the dump, manifest, and manifest SHA-256. The backup and restore
+verification must still be within four hours when the hidden load starts.
+
+## 5. Hidden production load
+
+Generate the default `NO_GO_PRODUCTION` authorization template with the exact
+candidate, preflight, and backup evidence. Store a reviewed `GO_PRODUCTION`
+artifact under `.etl/production-authorizations/SC/` and record its SHA-256.
+
+```powershell
+npm.cmd run precinct-gis:production-release:sc -- --package=$PKG --package-sha256=$PKG_SHA --preflight=$PREFLIGHT --preflight-sha256=$PREFLIGHT_SHA --backup-manifest=$BACKUP --backup-manifest-sha256=$BACKUP_SHA --write-authorization-template
+```
+
+The only allowed scopes are `apply_migration_0009`,
+`load_sc_precinct_results_and_geometry_hidden`, and
+`increment_public_data_revision`.
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production'
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PRODUCTION_WRITES=$PKG_SHA
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PRODUCTION_AUTHORIZATION_ID=$AUTH_ID
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PRODUCTION_AUTHORIZATION_SHA256=$AUTH_SHA
+
+npm.cmd run precinct-gis:production-release:sc -- --package=$PKG --package-sha256=$PKG_SHA --preflight=$PREFLIGHT --preflight-sha256=$PREFLIGHT_SHA --backup-manifest=$BACKUP --backup-manifest-sha256=$BACKUP_SHA --authorization=$AUTH --authorization-sha256=$AUTH_SHA --apply
+```
+
+Migration 0009 and the hidden load are one guarded transaction. Do not apply the
+migration separately. The receipt decision must be
+`COMMITTED_HIDDEN_NOT_PUBLIC`; all three versions remain blocked and both public
+API gates remain closed.
+
+If the command loses the commit acknowledgement or cannot retain its receipt,
+do not rerun the write. Preserve the `.pending` marker and use the guarded
+`--recover-receipt` mode with `CRM_DATABASE_ENVIRONMENT=production-read-only`,
+the exact package and authorization hashes, and
+`CRM_SC_PRECINCT_GEOGRAPHY_HIDDEN_RECEIPT_RECOVERY=$PKG_SHA`.
+
+## 6. Immutable geometry publication
+
+Plan first:
+
+```powershell
+npm.cmd run precinct-gis:delivery-publish:sc -- --package=$PKG --package-sha256=$PKG_SHA
+```
+
+Then explicitly authorize the immutable upload to the public Vercel Blob store:
+
+```powershell
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PUBLIC_FILE_WRITES='I_ACKNOWLEDGE_PUBLIC_IMMUTABLE_GEOMETRY_UPLOAD'
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PUBLIC_FILE_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID=$BLOB_AUTH_ID
+
+npm.cmd run precinct-gis:delivery-publish:sc -- --package=$PKG --package-sha256=$PKG_SHA --write
+```
+
+The publisher uploads all 138 county assets before the three indexes, refuses
+different bytes at an existing path, re-downloads and re-hashes every object,
+and records one credential-free HTTPS delivery origin.
+
+## 7. Static activation and deployment gate
+
+Generate the activation plan, review the four-file diff, then write it on a
+dedicated branch:
+
+```powershell
+npm.cmd run precinct-gis:public-activation:sc -- --package=$PKG --package-sha256=$PKG_SHA
+npm.cmd run precinct-gis:public-activation:sc -- --package=$PKG --package-sha256=$PKG_SHA --write
+```
+
+The change is exactly the canonical registry plus the 2016, 2020, and 2024
+coverage inventories. It adds no 2012 registry manifest. Configure the exact
+Blob origin for Preview, deploy the activation tree to a protected preview, and
+verify both APIs stay closed while the database versions are blocked. Configure
+the same origin for Production, merge the reviewed activation tree to `main`,
+wait for the exact commit to be READY and PROMOTED, and verify both gates are
+still closed. Record the immediately previous gate-capable deployment as the
+rollback target.
+
+## 8. Atomic public cutover
+
+Build and write the publication plan and `NO_GO_PUBLIC` authorization template
+from the exact hidden-load receipt and Blob evidence:
+
+```powershell
+npm.cmd run precinct-gis:publication-status:sc -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_EVIDENCE --blob-evidence-sha256=$BLOB_SHA --write-plan --write-authorization-template
+```
+
+The reviewed `GO_PUBLIC` authorization must pin the plan SHA, authorization SHA,
+READY/PROMOTED deployment commit and tree, closed result and geometry checks,
+Blob origin, static registry SHA, and prior rollback deployment.
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production'
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_WRITES='I_ACKNOWLEDGE_ATOMIC_SOUTH_CAROLINA_PRECINCT_PUBLIC_CUTOVER'
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_ACTIVATION_ID=$ACTIVATION_ID
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_PLAN_SHA256=$PLAN_SHA
+$env:CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_AUTHORIZATION_SHA256=$PUBLIC_AUTH_SHA
+
+npm.cmd run precinct-gis:publication-status:sc -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_EVIDENCE --blob-evidence-sha256=$BLOB_SHA --plan-sha256=$PLAN_SHA --authorization=$PUBLIC_AUTH --authorization-sha256=$PUBLIC_AUTH_SHA --apply
+```
+
+This database transaction is the public cutover. It publishes exactly three
+geography versions, authorizes 7,396 reporting units and crosswalks, retains all
+non-geographic exclusions, and increments the public revision once.
+
+## 9. Post-cutover verification
+
+For every year and several counties, verify:
+
+- `/api/geography-manifests?state=SC&year=<year>&level=precinct` returns exactly
+  one eligible manifest;
+- `/api/precinct-geography?manifestId=<id>&parentGeoid=<county GEOID>` returns
+  the expected county-scoped GeoJSON;
+- `/api/results?state=SC&year=<year>&level=precinct&office=president&parentGeoid=<county GEOID>`
+  returns database-backed rows that join one-for-one to colorable features;
+- 2016/2020 no-data SRS features remain visible with no invented results;
+- administrative categories do not appear as polygons;
+- 2012 has no public manifest or precinct delivery;
+- the base map is OpenStreetMap and the selected year stays pinned in Exports &
+  API links.
+
+Run the production API smoke against the exact deployed Git SHA with
+`--expect-source=database`. Preserve the publication receipt and verification
+evidence.
+
+## Rollback
+
+Rollback requires a distinct hash-pinned `GO_ROLLBACK` authorization and the
+exact successful publication receipt. Block the database first while the
+gate-capable application is live, verify both APIs close, and only then restore
+the exact pinned prior deployment. Hold other `main` deployments until rollback
+verification is complete. Receipt recovery is read-only and cannot perform the
+initial publish or rollback.

--- a/package.json
+++ b/package.json
@@ -347,7 +347,18 @@
     "precinct-gis:collect:mi": "node --experimental-strip-types scripts/build-mi-reviewed-precincts.mjs",
     "test:precinct-geometry:mi": "node --experimental-strip-types --test tests/api/mi-precinct-geometry.test.mjs",
     "precinct-gis:collect:sc": "node --experimental-strip-types scripts/build-sc-reviewed-precincts.mjs",
-    "test:precinct-geometry:sc": "node --experimental-strip-types --test tests/api/sc-precinct-geometry.test.mjs"
+    "precinct-gis:plan:sc": "node --experimental-strip-types scripts/setup-sc-precinct-gis-local.mjs",
+    "precinct-gis:setup:sc:local": "node --experimental-strip-types scripts/setup-sc-precinct-gis-local.mjs --apply",
+    "precinct-gis:validate:sc:local": "node --experimental-strip-types scripts/validate-sc-precinct-gis-local.mjs",
+    "precinct-gis:release-candidate:sc": "node --max-old-space-size=4096 --experimental-strip-types scripts/prepare-sc-precinct-release-candidate.mjs",
+    "precinct-gis:release-candidate:sc:write": "node --max-old-space-size=4096 --experimental-strip-types scripts/prepare-sc-precinct-release-candidate.mjs --write",
+    "precinct-gis:delivery-publish:sc": "node --experimental-strip-types scripts/publish-sc-precinct-delivery-assets.mjs",
+    "precinct-gis:production-preflight:sc": "node --experimental-strip-types scripts/report-sc-precinct-production-preflight.mjs",
+    "precinct-gis:production-backup:sc": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/backup-sc-precinct-production.ps1",
+    "precinct-gis:production-release:sc": "node --max-old-space-size=4096 --experimental-strip-types scripts/apply-sc-precinct-release.mjs",
+    "precinct-gis:public-activation:sc": "node --experimental-strip-types scripts/prepare-sc-precinct-public-activation.mjs",
+    "precinct-gis:publication-status:sc": "node --max-old-space-size=4096 --experimental-strip-types scripts/publish-sc-precinct-geography-status.mjs",
+    "test:precinct-geometry:sc": "node --experimental-strip-types --test tests/api/sc-precinct-geometry.test.mjs tests/api/sc-precinct-gis-plan.test.mjs tests/api/sc-precinct-gis-local.test.mjs tests/api/sc-precinct-release-candidate.test.mjs tests/api/sc-precinct-blob-publication.test.mjs tests/api/sc-precinct-production-release.test.mjs tests/api/sc-precinct-public-activation.test.mjs tests/api/sc-precinct-publication-gate.test.mjs tests/api/sc-precinct-publication.test.mjs"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.5.18",

--- a/scripts/apply-sc-precinct-release.mjs
+++ b/scripts/apply-sc-precinct-release.mjs
@@ -1,0 +1,668 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import postgres from "postgres";
+import {
+  applySouthCarolinaPrecinctGisTransaction,
+  readSouthCarolinaPersistedProductionReleaseAudit,
+  validateSouthCarolinaPrecinctGisClient,
+} from "./lib/sc-precinct-gis-db.mjs";
+import { buildSouthCarolinaPrecinctGisPlan } from "./lib/sc-precinct-gis-plan.mjs";
+import { inspectReleaseArtifact } from "./lib/sc-precinct-release-candidate.mjs";
+import {
+  assertSouthCarolinaReleaseCandidateDocument,
+  productionEndpointFingerprint,
+} from "./lib/sc-precinct-production-preflight.mjs";
+import {
+  buildSouthCarolinaProductionAuthorizationTemplate,
+  sha256,
+  validateSouthCarolinaProductionAuthorization,
+  validateSouthCarolinaProductionBackupEvidence,
+  validateSouthCarolinaProductionPreflightEvidence,
+} from "./lib/sc-precinct-production-release.mjs";
+
+function parseArguments(args) {
+  const value = (name) => args.find((arg) => arg.startsWith(name + "="))
+    ?.slice(name.length + 1);
+  const parsed = {
+    apply: args.includes("--apply"),
+    recoverReceipt: args.includes("--recover-receipt"),
+    writeAuthorizationTemplate: args.includes("--write-authorization-template"),
+    packagePath: value("--package"),
+    packageSha256: value("--package-sha256"),
+    preflightPath: value("--preflight"),
+    preflightSha256: value("--preflight-sha256"),
+    backupManifestPath: value("--backup-manifest"),
+    backupManifestSha256: value("--backup-manifest-sha256"),
+    authorizationPath: value("--authorization"),
+    authorizationSha256: value("--authorization-sha256"),
+    authorizationTemplatePath: value("--authorization-template"),
+    receiptPath: value("--receipt"),
+  };
+  const known = new Set([
+    "--apply",
+    "--recover-receipt",
+    "--write-authorization-template",
+    "--package",
+    "--package-sha256",
+    "--preflight",
+    "--preflight-sha256",
+    "--backup-manifest",
+    "--backup-manifest-sha256",
+    "--authorization",
+    "--authorization-sha256",
+    "--authorization-template",
+    "--receipt",
+  ]);
+  for (const arg of args) {
+    const key = arg.split("=")[0];
+    if (!known.has(key)) throw new Error("Unknown South Carolina production-release option: " + arg);
+  }
+  if (!parsed.packagePath || !parsed.packageSha256) {
+    throw new Error("South Carolina production release requires --package and --package-sha256");
+  }
+  if ([parsed.apply, parsed.recoverReceipt, parsed.writeAuthorizationTemplate]
+    .filter(Boolean).length > 1) {
+    throw new Error("South Carolina production release modes are mutually exclusive");
+  }
+  return parsed;
+}
+
+function safeEtlPath(root, relativePath, requiredPrefix) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith(requiredPrefix)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+  ) {
+    throw new Error("Unsafe South Carolina release evidence path: " + relativePath);
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...requiredPrefix.replace(/\/$/, "").split("/"));
+  if (!absolute.startsWith(allowed + path.sep)) {
+    throw new Error("South Carolina release evidence escapes its .etl root");
+  }
+  return absolute;
+}
+
+function readEtlJson(root, relativePath, expectedSha256, prefix) {
+  if (!/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")) {
+    throw new Error("South Carolina release evidence requires an exact SHA-256");
+  }
+  const absolute = safeEtlPath(root, relativePath, prefix);
+  const bytes = readFileSync(absolute);
+  if (sha256(bytes) !== expectedSha256) {
+    throw new Error("South Carolina release evidence SHA-256 drifted: " + relativePath);
+  }
+  return { path: relativePath, absolute, bytes, sha256: expectedSha256, value: JSON.parse(bytes) };
+}
+
+function readBackupManifest(relativeOrAbsolutePath, expectedSha256, root) {
+  if (!/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")) {
+    throw new Error("South Carolina backup manifest requires an exact SHA-256");
+  }
+  const absolute = path.isAbsolute(relativeOrAbsolutePath)
+    ? path.resolve(relativeOrAbsolutePath)
+    : path.resolve(root, relativeOrAbsolutePath);
+  const bytes = readFileSync(absolute);
+  if (sha256(bytes) !== expectedSha256) {
+    throw new Error("South Carolina backup manifest SHA-256 drifted");
+  }
+  return { absolute, bytes, sha256: expectedSha256, value: JSON.parse(bytes) };
+}
+
+function productionUrl(environment = process.env) {
+  const first = environment.POSTGRES_URL_NON_POOLING?.trim() || "";
+  const second = environment.POSTGRES_DATABASE_URL_UNPOOLED?.trim() || "";
+  if (!first && !second) {
+    throw new Error("South Carolina production release requires an explicit unpooled PostgreSQL URL");
+  }
+  if (first && second && first !== second) {
+    throw new Error("South Carolina production release found conflicting unpooled PostgreSQL URLs");
+  }
+  return first || second;
+}
+
+function immutableJson(root, relativePath, value) {
+  const absolute = safeEtlPath(root, relativePath, path.posix.dirname(relativePath) + "/");
+  const bytes = Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+  if (existsSync(absolute)) {
+    if (!readFileSync(absolute).equals(bytes)) {
+      throw new Error("Refusing to overwrite different South Carolina release evidence");
+    }
+    return { path: relativePath, byteCount: bytes.length, sha256: sha256(bytes), disposition: "verified_existing" };
+  }
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, bytes, { flag: "wx" });
+  return { path: relativePath, byteCount: bytes.length, sha256: sha256(bytes), disposition: "created" };
+}
+
+function reserveReceipt(
+  root,
+  relativePath,
+  packageSha256,
+  authorizationSha256,
+  options = {},
+) {
+  const absolute = safeEtlPath(
+    root,
+    relativePath,
+    ".etl/production-release-receipts/SC/",
+  );
+  if (existsSync(absolute)) throw new Error("South Carolina production receipt already exists");
+  const pending = absolute + ".pending";
+  const pendingBytes = Buffer.from(JSON.stringify({
+    schemaVersion: 1,
+    state: "SC",
+    packageSha256,
+    authorizationSha256,
+    purpose: "ambiguous-commit recovery marker",
+  }, null, 2) + "\n");
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  if (existsSync(pending)) {
+    if (
+      options.allowExisting === true
+      && readFileSync(pending).equals(pendingBytes)
+    ) {
+      return {
+        absolute,
+        pending,
+        pendingBytes,
+        disposition: "reused",
+      };
+    }
+    throw new Error("A South Carolina release recovery marker already exists; reconcile it before retrying");
+  }
+  writeFileSync(pending, pendingBytes, { flag: "wx" });
+  return { absolute, pending, pendingBytes, disposition: "created" };
+}
+
+function finishReceipt(reservation, value) {
+  const bytes = Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+  const temporary = reservation.absolute + ".write-" + sha256(bytes).slice(0, 12) + ".tmp";
+  if (existsSync(temporary)) {
+    if (!readFileSync(temporary).equals(bytes)) {
+      throw new Error("South Carolina hidden receipt temporary file drifted");
+    }
+  } else {
+    writeFileSync(temporary, bytes, { flag: "wx" });
+  }
+  renameSync(temporary, reservation.absolute);
+  if (readFileSync(reservation.pending).equals(reservation.pendingBytes)) {
+    unlinkSync(reservation.pending);
+  }
+  return { byteCount: bytes.length, sha256: sha256(bytes) };
+}
+
+function defaultTemplatePath(packageSha256) {
+  return ".etl/production-authorizations/SC/sc-precinct-authorization-template-"
+    + packageSha256.slice(0, 12)
+    + ".json";
+}
+
+function defaultReceiptPath(packageSha256, authorizationId) {
+  const safeId = authorizationId.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 80);
+  return ".etl/production-release-receipts/SC/sc-precinct-hidden-load-"
+    + packageSha256.slice(0, 12)
+    + "-"
+    + safeId
+    + ".json";
+}
+
+async function ensureSouthCarolinaDerivationConstraint(tx, migrationArtifact) {
+  const inspect = async () => tx.unsafe([
+    "select pg_get_constraintdef(oid) definition from pg_constraint",
+    "where connamespace='public'::regnamespace",
+    " and conname='geography_versions_derivation_method_check'",
+  ].join("\n"));
+  const beforeRows = await inspect();
+  if (beforeRows.length !== 1) {
+    throw new Error("South Carolina derivation-method constraint is missing or ambiguous");
+  }
+  const beforeDefinition = String(beforeRows[0].definition ?? "");
+  const complete = beforeDefinition.includes("secondary_reconstruction")
+    && beforeDefinition.includes("hybrid_reconstruction");
+  if (complete) {
+    return { before: "complete", after: "complete", statementsApplied: 0 };
+  }
+  if (
+    !beforeDefinition.includes("official_export")
+    || !beforeDefinition.includes("official_service")
+    || !beforeDefinition.includes("digitized_map")
+    || !beforeDefinition.includes("official_crosswalk")
+  ) {
+    throw new Error("South Carolina derivation-method constraint preimage drifted");
+  }
+  const statements = migrationArtifact.bytes.toString("utf8")
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+  if (statements.length !== 2) {
+    throw new Error("South Carolina migration 0009 statement set drifted");
+  }
+  for (const statement of statements) await tx.unsafe(statement);
+  const afterRows = await inspect();
+  const afterDefinition = String(afterRows[0]?.definition ?? "");
+  if (
+    afterRows.length !== 1
+    || !afterDefinition.includes("secondary_reconstruction")
+    || !afterDefinition.includes("hybrid_reconstruction")
+  ) {
+    throw new Error("South Carolina migration 0009 did not establish the required constraint");
+  }
+  return { before: "absent", after: "complete", statementsApplied: 2 };
+}
+
+export async function runSouthCarolinaProductionRelease(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const parsed = options.packagePath ? options : parseArguments(process.argv.slice(2));
+  const packageArtifact = inspectReleaseArtifact(root, parsed.packagePath, {
+    allowedRoots: [".etl/precinct-release-candidates/SC/"],
+    sha256: parsed.packageSha256,
+  });
+  const packageDocument = JSON.parse(packageArtifact.bytes.toString("utf8"));
+  const releaseCandidate = assertSouthCarolinaReleaseCandidateDocument(
+    packageDocument,
+    packageArtifact.sha256,
+  );
+  const migration0009Declaration = releaseCandidate.migrations.find(
+    (migration) => migration.path === "drizzle/0009_public_wolfpack.sql",
+  );
+  const migration0009Artifact = inspectReleaseArtifact(
+    root,
+    migration0009Declaration.path,
+    {
+      allowedRoots: ["drizzle/"],
+      byteCount: migration0009Declaration.byteCount,
+      sha256: migration0009Declaration.sha256,
+    },
+  );
+  const environment = options.environment ?? process.env;
+  const clock = options.nowFactory ?? (() => options.now ?? new Date());
+  const currentTime = () => {
+    const value = clock();
+    const result = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    if (Number.isNaN(result.getTime())) {
+      throw new Error("South Carolina production release clock returned an invalid time");
+    }
+    return result;
+  };
+  if (parsed.writeAuthorizationTemplate) {
+    const relativePath = parsed.authorizationTemplatePath
+      ?? defaultTemplatePath(packageArtifact.sha256);
+    const artifact = immutableJson(root, relativePath, buildSouthCarolinaProductionAuthorizationTemplate({
+      releaseCandidate,
+      preflightSha256: parsed.preflightSha256,
+      backupManifestSha256: parsed.backupManifestSha256,
+    }));
+    return {
+      mode: "write_authorization_template",
+      decision: "NO_GO_PRODUCTION",
+      releaseCandidate,
+      authorizationTemplate: artifact,
+      productionMutationPerformed: false,
+    };
+  }
+  if (!parsed.apply && !parsed.recoverReceipt) {
+    return {
+      mode: "plan",
+      decision: "NO_GO_PRODUCTION",
+      releaseCandidate,
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      requiredEvidence: [
+        "fresh read-only production preflight",
+        "fresh full public-schema backup with exact restore verification",
+        "hash-pinned GO_PRODUCTION authorization",
+      ],
+    };
+  }
+  const databaseUrl = productionUrl(environment);
+  const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
+  const preflight = readEtlJson(
+    root,
+    parsed.preflightPath,
+    parsed.preflightSha256,
+    ".etl/production-preflight-candidates/SC/",
+  );
+  const backup = readBackupManifest(
+    parsed.backupManifestPath,
+    parsed.backupManifestSha256,
+    root,
+  );
+  const authorization = readEtlJson(
+    root,
+    parsed.authorizationPath,
+    parsed.authorizationSha256,
+    ".etl/production-authorizations/SC/",
+  );
+  const validateEvidenceAt = (now) => {
+    const preflightSummary = validateSouthCarolinaProductionPreflightEvidence(
+      preflight.value,
+      { releaseCandidate, endpointFingerprint, now },
+    );
+    const backupSummary = validateSouthCarolinaProductionBackupEvidence(backup.value, {
+      releaseCandidate,
+      endpointFingerprint,
+      preflightCapturedAtUtc: preflightSummary.capturedAtUtc,
+      now,
+    });
+    const authorizationSummary = validateSouthCarolinaProductionAuthorization(
+      authorization.value,
+      {
+        releaseCandidate,
+        preflightSha256: preflight.sha256,
+        backupManifestSha256: backup.sha256,
+        now,
+      },
+    );
+    return { preflightSummary, backupSummary, authorizationSummary };
+  };
+  const rawAuthorizationId = typeof authorization.value?.authorizationId === "string"
+    ? authorization.value.authorizationId.trim()
+    : "";
+  const receiptPath = parsed.receiptPath ?? defaultReceiptPath(
+    packageArtifact.sha256,
+    rawAuthorizationId || "invalid-authorization",
+  );
+  const plan = await buildSouthCarolinaPrecinctGisPlan({
+    root,
+    years: [2016, 2020, 2024],
+  });
+
+  if (parsed.recoverReceipt) {
+    if (
+      environment.CRM_DATABASE_ENVIRONMENT !== "production-read-only"
+      || environment.CRM_SC_PRECINCT_GEOGRAPHY_HIDDEN_RECEIPT_RECOVERY
+        !== packageArtifact.sha256
+      || environment.CRM_SC_PRECINCT_GEOGRAPHY_PRODUCTION_AUTHORIZATION_SHA256
+        !== authorization.sha256
+    ) {
+      throw new Error("South Carolina hidden receipt recovery is not explicitly read-only and hash-authorized");
+    }
+    const reservation = reserveReceipt(
+      root,
+      receiptPath,
+      packageArtifact.sha256,
+      authorization.sha256,
+      { allowExisting: true },
+    );
+    let sql;
+    try {
+      sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+        max: 1,
+        connect_timeout: 10,
+        idle_timeout: 20,
+        connection: {
+          application_name: "civicresultmaps-sc-precinct-hidden-receipt-recovery",
+          default_transaction_read_only: true,
+        },
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    }
+    let recovered;
+    try {
+      recovered = await sql.begin("read only", async (nv) => {
+        const persistedAudit = await readSouthCarolinaPersistedProductionReleaseAudit(
+          nv,
+          { id: releaseCandidate.id, sha256: packageArtifact.sha256 },
+        );
+        const committedAt = new Date(persistedAudit.transaction.executedAtUtc);
+        if (committedAt.getTime() > currentTime().getTime()) {
+          throw new Error("South Carolina hidden receipt recovery found a future commit timestamp");
+        }
+        const evidence = validateEvidenceAt(committedAt);
+        const expectedAudit = {
+          releasePackage: { path: parsed.packagePath, sha256: packageArtifact.sha256 },
+          authorization: { path: parsed.authorizationPath, sha256: authorization.sha256 },
+          preflight: { path: parsed.preflightPath, sha256: preflight.sha256 },
+          backupManifest: {
+            sha256: backup.sha256,
+            dumpSha256: evidence.backupSummary.dumpSha256,
+          },
+          authorizationId: evidence.authorizationSummary.authorizationId,
+          endpointFingerprint,
+          transaction: persistedAudit.transaction,
+        };
+        if (JSON.stringify(persistedAudit) !== JSON.stringify(expectedAudit)) {
+          throw new Error("South Carolina hidden receipt recovery evidence does not match the durable database audit");
+        }
+        const executionContext = {
+          mode: "production_release",
+          releasePackageSha256: packageArtifact.sha256,
+          releaseCandidateId: releaseCandidate.id,
+          databaseName: evidence.preflightSummary.databaseName,
+          productionReleaseAudit: persistedAudit,
+        };
+        const validation = await validateSouthCarolinaPrecinctGisClient(nv, plan, {
+          executionContext,
+          readOnlySession: true,
+        });
+        if (Number(validation.revision) !== persistedAudit.transaction.publicRevision) {
+          throw new Error("South Carolina hidden receipt recovery public revision drifted");
+        }
+        return { persistedAudit, evidence, validation, executionContext };
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+    const recoveredTransaction = {
+      database: recovered.validation.database,
+      executionMode: "production_release",
+      productionMutationPerformed: true,
+      publicDeliveryAuthorized: false,
+      releaseCandidate: recovered.validation.releaseCandidate,
+      productionReleaseAudit: recovered.persistedAudit,
+      revision: recovered.persistedAudit.transaction.publicRevision,
+      years: recovered.validation.years,
+      disposition: "recovered_existing",
+    };
+    const receiptDocument = {
+      schemaVersion: 1,
+      state: "SC",
+      decision: "COMMITTED_HIDDEN_NOT_PUBLIC",
+      releaseCandidate: {
+        id: releaseCandidate.id,
+        path: parsed.packagePath,
+        sha256: packageArtifact.sha256,
+      },
+      committedAtUtc: recovered.persistedAudit.transaction.executedAtUtc,
+      endpointFingerprint,
+      authorization: {
+        id: recovered.evidence.authorizationSummary.authorizationId,
+        path: authorization.path,
+        sha256: authorization.sha256,
+        approvedBy: recovered.evidence.authorizationSummary.approvedBy,
+      },
+      preflight: { path: preflight.path, sha256: preflight.sha256 },
+      backup: {
+        manifestSha256: backup.sha256,
+        dumpSha256: recovered.evidence.backupSummary.dumpSha256,
+      },
+      transaction: recoveredTransaction,
+      validation: recovered.validation,
+      recovery: {
+        recoveredAtUtc: currentTime().toISOString(),
+        productionMutationPerformed: false,
+      },
+      productionMutationPerformed: true,
+      canonicalManifestChanged: false,
+      publicFileWritten: false,
+      publicDeliveryAuthorized: false,
+    };
+    const receiptArtifact = finishReceipt(reservation, receiptDocument);
+    return {
+      mode: "recover_receipt",
+      decision: "RECOVERED_HIDDEN_RECEIPT",
+      releaseCandidate: receiptDocument.releaseCandidate,
+      revision: recoveredTransaction.revision,
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      receipt: { path: receiptPath, ...receiptArtifact },
+    };
+  }
+
+  const initialEvidence = validateEvidenceAt(currentTime());
+  if (
+    environment.CRM_DATABASE_ENVIRONMENT !== "production"
+    || environment.CRM_SC_PRECINCT_GEOGRAPHY_PRODUCTION_WRITES !== packageArtifact.sha256
+  ) {
+    throw new Error("South Carolina production writes are not explicitly package-authorized");
+  }
+  if (
+    environment.CRM_SC_PRECINCT_GEOGRAPHY_PRODUCTION_AUTHORIZATION_ID
+      !== initialEvidence.authorizationSummary.authorizationId
+    || environment.CRM_SC_PRECINCT_GEOGRAPHY_PRODUCTION_AUTHORIZATION_SHA256
+      !== authorization.sha256
+  ) {
+    throw new Error("South Carolina production authorization environment acknowledgement drifted");
+  }
+  const reservation = reserveReceipt(
+    root,
+    receiptPath,
+    packageArtifact.sha256,
+    authorization.sha256,
+  );
+  let sql;
+  try {
+    sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+      max: 1,
+      connect_timeout: 10,
+      idle_timeout: 20,
+      connection: { application_name: "civicresultmaps-sc-precinct-production-release" },
+    });
+  } catch (error) {
+    if (existsSync(reservation.pending)) unlinkSync(reservation.pending);
+    throw error;
+  }
+  let transactionBodyCompleted = false;
+  let committed;
+  try {
+    committed = await sql.begin(async (nv) => {
+      const transactionNow = currentTime();
+      const finalEvidence = validateEvidenceAt(transactionNow);
+      const migration0009 = await ensureSouthCarolinaDerivationConstraint(
+        nv,
+        migration0009Artifact,
+      );
+      const revisions = await nv.unsafe(
+        "select revision::int revision from public_data_revisions where scope='public' for update",
+      );
+      if (revisions.length !== 1) throw new Error("South Carolina production public revision is missing");
+      const expectedRevision = Number(revisions[0].revision) + 1;
+      const releaseAudit = {
+        releasePackage: { path: parsed.packagePath, sha256: packageArtifact.sha256 },
+        authorization: { path: parsed.authorizationPath, sha256: authorization.sha256 },
+        preflight: { path: parsed.preflightPath, sha256: preflight.sha256 },
+        backupManifest: {
+          sha256: backup.sha256,
+          dumpSha256: finalEvidence.backupSummary.dumpSha256,
+        },
+        authorizationId: finalEvidence.authorizationSummary.authorizationId,
+        endpointFingerprint,
+        transaction: {
+          executedAtUtc: transactionNow.toISOString(),
+          publicRevision: expectedRevision,
+        },
+      };
+      const executionContext = {
+        mode: "production_release",
+        releasePackageSha256: packageArtifact.sha256,
+        releaseCandidateId: releaseCandidate.id,
+        databaseName: finalEvidence.preflightSummary.databaseName,
+        productionReleaseAudit: releaseAudit,
+      };
+      const applied = await applySouthCarolinaPrecinctGisTransaction(nv, plan, {
+        executionContext,
+      });
+      if (applied.revision !== expectedRevision) {
+        throw new Error("South Carolina production public revision increment drifted");
+      }
+      const validation = await validateSouthCarolinaPrecinctGisClient(nv, plan, {
+        executionContext,
+        readOnlySession: false,
+      });
+      transactionBodyCompleted = true;
+      return {
+        applied: { ...applied, migration0009 },
+        validation,
+        releaseAudit,
+      };
+    });
+  } catch (error) {
+    // A post-COMMIT connection failure is ambiguous. Keep the pending marker
+    // once the transaction body completed so a retry cannot double-apply.
+    if (!transactionBodyCompleted && existsSync(reservation.pending)) {
+      unlinkSync(reservation.pending);
+    }
+    throw error;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+  const receiptDocument = {
+    schemaVersion: 1,
+    state: "SC",
+    decision: "COMMITTED_HIDDEN_NOT_PUBLIC",
+    releaseCandidate: {
+      id: releaseCandidate.id,
+      path: parsed.packagePath,
+      sha256: packageArtifact.sha256,
+    },
+    committedAtUtc: committed.releaseAudit.transaction.executedAtUtc,
+    endpointFingerprint,
+    authorization: {
+      id: initialEvidence.authorizationSummary.authorizationId,
+      path: authorization.path,
+      sha256: authorization.sha256,
+      approvedBy: initialEvidence.authorizationSummary.approvedBy,
+    },
+    preflight: { path: preflight.path, sha256: preflight.sha256 },
+    backup: {
+      manifestSha256: backup.sha256,
+      dumpSha256: initialEvidence.backupSummary.dumpSha256,
+    },
+    transaction: committed.applied,
+    validation: committed.validation,
+    productionMutationPerformed: true,
+    canonicalManifestChanged: false,
+    publicFileWritten: false,
+    publicDeliveryAuthorized: false,
+  };
+  const receiptArtifact = finishReceipt(reservation, receiptDocument);
+  return {
+    mode: "apply",
+    decision: receiptDocument.decision,
+    releaseCandidate: receiptDocument.releaseCandidate,
+    revision: committed.applied.revision,
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: false,
+    receipt: { path: receiptPath, ...receiptArtifact },
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runSouthCarolinaProductionRelease().then(
+    (result) => console.log(JSON.stringify(result, null, 2)),
+    (error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/backup-sc-precinct-production.ps1
+++ b/scripts/backup-sc-precinct-production.ps1
@@ -1,0 +1,393 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ReleasePackagePath,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[a-f0-9]{64}$')]
+  [string]$ReleasePackageSha256,
+
+  [switch]$Execute
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$CloneContainer = 'crm-db-clone-postgres'
+$CloneHost = '127.0.0.1'
+$ClonePort = 54329
+$CloneAdminDatabase = 'crm_clone_admin'
+$CloneUser = 'crm_clone_admin'
+$VerifyDatabase = 'crm_sc_precinct_restore_verify'
+$BackupRoot = 'C:\tmp\crm-db-clone\sc-precinct-release-backups'
+$ContainerBackupRoot = '/backups/sc-precinct-release-backups'
+$ExpectedLegacyEndpointFingerprint = 'bf2bf2213814'
+
+function Fail([string]$Message) {
+  throw "South Carolina production backup aborted: $Message"
+}
+
+function Get-Sha256([byte[]]$Bytes) {
+  $algorithm = [Security.Cryptography.SHA256]::Create()
+  try {
+    return ([BitConverter]::ToString($algorithm.ComputeHash($Bytes)) -replace '-', '').ToLowerInvariant()
+  }
+  finally {
+    $algorithm.Dispose()
+  }
+}
+
+function Assert-ReleasePackage {
+  $candidateRoot = [IO.Path]::GetFullPath((Join-Path $RepoRoot '.etl\precinct-release-candidates\SC'))
+  $candidatePath = [IO.Path]::GetFullPath((Join-Path $RepoRoot $ReleasePackagePath))
+  if (
+    -not $candidatePath.StartsWith($candidateRoot + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase) -or
+    [IO.Path]::GetFileName($candidatePath) -ne 'release-candidate.json' -or
+    -not (Test-Path -LiteralPath $candidatePath -PathType Leaf)
+  ) {
+    Fail 'The release package must be an existing release-candidate.json under .etl/precinct-release-candidates/SC.'
+  }
+  $bytes = [IO.File]::ReadAllBytes($candidatePath)
+  if ((Get-Sha256 $bytes) -ne $ReleasePackageSha256) {
+    Fail 'The release package SHA-256 does not match the exact acknowledgement.'
+  }
+  $document = [Text.Encoding]::UTF8.GetString($bytes) | ConvertFrom-Json
+  if (
+    $document.schemaVersion -ne 1 -or
+    $document.id -ne 'sc-precinct-gis-three-election-v1' -or
+    $document.state -ne 'SC' -or
+    $document.decision -ne 'NO_GO_PRODUCTION' -or
+    $document.safety.productionMutationPerformed -ne $false -or
+    $document.safety.canonicalManifestChanged -ne $false -or
+    $document.totals.elections -ne 3
+  ) {
+    Fail 'The release package contract is incompatible.'
+  }
+  return [ordered]@{
+    id = $document.id
+    path = $ReleasePackagePath.Replace('\', '/')
+    sha256 = $ReleasePackageSha256
+  }
+}
+
+function Require-Command([string]$Name) {
+  $command = Get-Command $Name -ErrorAction SilentlyContinue
+  if (-not $command) {
+    Fail "Required command '$Name' was not found on PATH."
+  }
+  return $command.Source
+}
+
+function Get-RequiredSourceUrl {
+  $first = [Environment]::GetEnvironmentVariable('POSTGRES_URL_NON_POOLING')
+  $second = [Environment]::GetEnvironmentVariable('POSTGRES_DATABASE_URL_UNPOOLED')
+  if ([string]::IsNullOrWhiteSpace($first) -and [string]::IsNullOrWhiteSpace($second)) {
+    Fail 'Set POSTGRES_URL_NON_POOLING or POSTGRES_DATABASE_URL_UNPOOLED in this process environment.'
+  }
+  if (
+    -not [string]::IsNullOrWhiteSpace($first) -and
+    -not [string]::IsNullOrWhiteSpace($second) -and
+    $first -ne $second
+  ) {
+    Fail 'The two allowed production URL variables disagree.'
+  }
+  if (-not [string]::IsNullOrWhiteSpace($first)) { return $first }
+  return $second
+}
+
+function Assert-RemoteSource([string]$Url) {
+  try { $uri = [Uri]$Url } catch { Fail 'The production URL is not a valid PostgreSQL URI.' }
+  if (
+    $uri.Scheme -notin @('postgres', 'postgresql') -or
+    [string]::IsNullOrWhiteSpace($uri.Host) -or
+    $uri.Host.ToLowerInvariant() -in @('localhost', '127.0.0.1', '::1', $CloneHost) -or
+    $uri.Port -eq $ClonePort
+  ) {
+    Fail 'The production URL is not an allowed remote PostgreSQL endpoint.'
+  }
+}
+
+function Get-EndpointFingerprint([string]$Url) {
+  $uri = [Uri]$Url
+  $database = [Uri]::UnescapeDataString($uri.AbsolutePath.TrimStart('/'))
+  $port = if ($uri.IsDefaultPort) { '5432' } else { [string]$uri.Port }
+  $identity = @($uri.Host.ToLowerInvariant(), $port, $database) -join "`n"
+  return Get-Sha256 ([Text.Encoding]::UTF8.GetBytes($identity))
+}
+
+function Get-LegacyEndpointFingerprint([string]$Url) {
+  $uri = [Uri]$Url
+  $bytes = [Text.Encoding]::UTF8.GetBytes($uri.Host.ToLowerInvariant() + $uri.AbsolutePath)
+  return (Get-Sha256 $bytes).Substring(0, 12)
+}
+
+function Get-RemoteExecEnv([string]$Url) {
+  $uri = [Uri]$Url
+  $userinfo = [Uri]::UnescapeDataString($uri.UserInfo)
+  $separator = $userinfo.IndexOf(':')
+  if ($separator -lt 1) { Fail 'The production URL must include a username and password.' }
+  $database = [Uri]::UnescapeDataString($uri.AbsolutePath.TrimStart('/'))
+  if ([string]::IsNullOrWhiteSpace($database)) { Fail 'The production URL must include a database name.' }
+  $port = if ($uri.IsDefaultPort) { '5432' } else { [string]$uri.Port }
+  return @(
+    '--env', "PGHOST=$($uri.Host)",
+    '--env', "PGPORT=$port",
+    '--env', "PGDATABASE=$database",
+    '--env', "PGUSER=$($userinfo.Substring(0, $separator))",
+    '--env', "PGPASSWORD=$($userinfo.Substring($separator + 1))",
+    '--env', 'PGSSLMODE=require',
+    '--env', 'PGCHANNELBINDING=require',
+    '--env', 'PGOPTIONS=-c default_transaction_read_only=on'
+  )
+}
+
+function Assert-CloneContainer {
+  $container = @((& $script:Docker inspect $CloneContainer) | ConvertFrom-Json)
+  if ($LASTEXITCODE -ne 0 -or $container.Count -ne 1) { Fail 'Docker inspection failed.' }
+  $container = $container[0]
+  if (
+    $container.Name -ne "/$CloneContainer" -or
+    $container.Config.Labels.'com.civicresultmaps.purpose' -ne 'isolated-production-clone' -or
+    $container.State.Health.Status -ne 'healthy'
+  ) {
+    Fail 'The running clone container identity, purpose, or health is invalid.'
+  }
+  $bindings = @($container.NetworkSettings.Ports.'5432/tcp')
+  if (
+    $bindings.Count -ne 1 -or
+    $bindings[0].HostIp -ne $CloneHost -or
+    $bindings[0].HostPort -ne "$ClonePort"
+  ) {
+    Fail 'The clone container is not restricted to the reserved loopback port.'
+  }
+  $mounts = @($container.Mounts | Where-Object {
+    $_.Type -eq 'bind' -and $_.Destination -eq '/backups' -and $_.RW -eq $true
+  })
+  if ($mounts.Count -ne 1) { Fail 'The clone container does not have the required backup bind mount.' }
+}
+
+function Assert-ContainerTools {
+  $versions = @(
+    (& $script:Docker exec --user postgres $CloneContainer psql --version)
+    (& $script:Docker exec --user postgres $CloneContainer pg_dump --version)
+    (& $script:Docker exec --user postgres $CloneContainer pg_restore --version)
+  )
+  $majors = @($versions | ForEach-Object {
+    if ($_ -match '(\d+)(?:\.\d+)?') { [int]$Matches[1] }
+  })
+  if ($LASTEXITCODE -ne 0 -or $majors.Count -ne 3 -or @($majors | Where-Object { $_ -ne 17 }).Count) {
+    Fail 'The clone container must provide PostgreSQL 17 psql, pg_dump, and pg_restore.'
+  }
+}
+
+function Invoke-RemoteRows([string]$Sql, [string]$Description) {
+  $rows = & $script:Docker exec --user postgres @script:RemoteExecEnv $CloneContainer psql --no-psqlrc --set ON_ERROR_STOP=1 --tuples-only --no-align --quiet --command $Sql
+  if ($LASTEXITCODE -ne 0) { Fail "$Description failed." }
+  return @($rows)
+}
+
+function Invoke-LocalRows([string]$Database, [string]$Sql, [string]$Description) {
+  $rows = & $script:Docker exec --user postgres $CloneContainer psql --no-psqlrc --set ON_ERROR_STOP=1 --tuples-only --no-align --quiet --username $CloneUser --dbname $Database --command $Sql
+  if ($LASTEXITCODE -ne 0) { Fail "$Description failed." }
+  return @($rows)
+}
+
+function Invoke-LocalAdmin([string]$Sql, [string]$Description) {
+  $null = Invoke-LocalRows $CloneAdminDatabase $Sql $Description
+}
+
+function Get-TableCounts([string[]]$Tables, [scriptblock]$Runner) {
+  $counts = [ordered]@{}
+  foreach ($table in $Tables) {
+    if ($table -notmatch '^[a-z0-9_]+$') { Fail 'A public table name is unsafe.' }
+    $sql = "SELECT count(*) FROM public.`"$table`";"
+    $value = @(& $Runner $sql)
+    if ($value.Count -ne 1 -or $value[0].Trim() -notmatch '^\d+$') {
+      Fail "Could not obtain an exact row count for public.$table."
+    }
+    $counts[$table] = [int64]$value[0].Trim()
+  }
+  return $counts
+}
+
+function Assert-EqualCounts($Source, $Restored) {
+  if ($Source.Count -ne $Restored.Count) { Fail 'Restored public table count differs from production.' }
+  foreach ($key in $Source.Keys) {
+    if (-not $Restored.Contains($key) -or [int64]$Restored[$key] -ne [int64]$Source[$key]) {
+      Fail "Restored row count differs for public.$key."
+    }
+  }
+}
+
+function Restrict-BackupAccess([string[]]$Paths) {
+  $icacls = Get-Command icacls -ErrorAction SilentlyContinue
+  if (-not $icacls -or $env:OS -ne 'Windows_NT') {
+    Fail 'Restrictive Windows ACL tooling is unavailable.'
+  }
+  $user = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+  foreach ($target in $Paths) {
+    $isDirectory = Test-Path -LiteralPath $target -PathType Container
+    $userGrant = if ($isDirectory) { "$user`:(OI)(CI)F" } else { "$user`:F" }
+    $systemGrant = if ($isDirectory) { 'SYSTEM:(OI)(CI)F' } else { 'SYSTEM:F' }
+    & $icacls.Source $target '/inheritance:r' '/grant:r' $userGrant '/grant:r' $systemGrant | Out-Null
+    if ($LASTEXITCODE -ne 0) { Fail "Could not restrict ACLs on $target." }
+  }
+}
+
+$releaseCandidate = Assert-ReleasePackage
+if (-not $Execute) {
+  [ordered]@{
+    mode = 'plan'
+    decision = 'NO_BACKUP_CREATED'
+    releaseCandidate = $releaseCandidate
+    sourceEndpointFingerprint = 'computed_during_execution'
+    sourceEndpointLegacyApprovalFingerprint = $ExpectedLegacyEndpointFingerprint
+    includedSchemas = @('public')
+    excludedTableDataPatterns = @()
+    restoreVerificationRequired = $true
+    remoteMutationPerformed = $false
+    outputDirectory = $BackupRoot
+    acknowledgementRequired = @(
+      'CRM_SC_PRECINCT_GEOGRAPHY_BACKUP_ACK=CREATE_FULL_PUBLIC_SCHEMA_ROLLBACK_BACKUP',
+      'CRM_SC_PRECINCT_GEOGRAPHY_BACKUP_ENDPOINT_FINGERPRINT=<fresh 64-hex preflight endpoint fingerprint>'
+    )
+  } | ConvertTo-Json -Depth 6
+  exit 0
+}
+
+if (
+  [Environment]::GetEnvironmentVariable('CRM_SC_PRECINCT_GEOGRAPHY_BACKUP_ACK') -ne 'CREATE_FULL_PUBLIC_SCHEMA_ROLLBACK_BACKUP' -or
+  [Environment]::GetEnvironmentVariable('CRM_SC_PRECINCT_GEOGRAPHY_BACKUP_PACKAGE_SHA256') -ne $ReleasePackageSha256
+) {
+  Fail 'Execution requires the exact backup acknowledgement and release package SHA-256.'
+}
+
+$sourceUrl = Get-RequiredSourceUrl
+Assert-RemoteSource $sourceUrl
+if ((Get-LegacyEndpointFingerprint $sourceUrl) -ne $ExpectedLegacyEndpointFingerprint) {
+  Fail 'The production endpoint fingerprint is not approved.'
+}
+$sourceEndpointFingerprint = Get-EndpointFingerprint $sourceUrl
+if (
+  $sourceEndpointFingerprint -notmatch '^[a-f0-9]{64}$' -or
+  [Environment]::GetEnvironmentVariable('CRM_SC_PRECINCT_GEOGRAPHY_BACKUP_ENDPOINT_FINGERPRINT') -ne $sourceEndpointFingerprint
+) {
+  Fail 'Execution requires the exact fresh 64-hex preflight endpoint fingerprint acknowledgement.'
+}
+$script:Docker = Require-Command docker
+$script:RemoteExecEnv = @(Get-RemoteExecEnv $sourceUrl)
+Assert-CloneContainer
+Assert-ContainerTools
+
+$identity = ((Invoke-RemoteRows "SELECT current_setting('server_version_num') || '|' || pg_database_size(current_database()) || '|' || current_setting('transaction_read_only') || '|' || (SELECT string_agg(lanname, ',' ORDER BY lanname) FROM pg_language WHERE lanispl);" 'Production identity preflight') -join '').Trim().Split('|')
+if (
+  $identity.Count -ne 4 -or
+  $identity[0] -notmatch '^\d{5,6}$' -or
+  [int](([int]$identity[0]) / 10000) -ne 17 -or
+  $identity[2] -ne 'on' -or
+  $identity[3] -ne 'plpgsql'
+) {
+  Fail 'The production identity or read-only session contract is incompatible.'
+}
+
+$sourceTables = @(Invoke-RemoteRows "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;" 'Production public table inventory')
+if (
+  $sourceTables.Count -lt 27 -or
+  @($sourceTables | Where-Object { $_ -notmatch '^[a-z0-9_]+$' }).Count -ne 0
+) {
+  Fail 'The production public table inventory is incomplete or unsafe.'
+}
+$sourceCounts = Get-TableCounts $sourceTables { param($sql) Invoke-RemoteRows $sql 'Production public table count' }
+$sourceInvalidConstraints = [int](((Invoke-RemoteRows "SELECT count(*) FROM pg_constraint WHERE connamespace='public'::regnamespace AND NOT convalidated;" 'Production constraint check') -join '').Trim())
+if ($sourceInvalidConstraints -ne 0) { Fail 'Production has invalid public constraints.' }
+
+New-Item -ItemType Directory -Force -Path $BackupRoot | Out-Null
+Restrict-BackupAccess @($BackupRoot)
+$stamp = [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssZ')
+$dumpFile = "sc-precinct-full-public-$stamp.dump"
+$dumpPath = Join-Path $BackupRoot $dumpFile
+$containerDumpPath = "$ContainerBackupRoot/$dumpFile"
+$manifestPath = Join-Path $BackupRoot "sc-precinct-full-public-$stamp.manifest.json"
+$createdAtUtc = [DateTime]::UtcNow.ToString('o')
+
+& $script:Docker exec --user postgres @script:RemoteExecEnv $CloneContainer pg_dump --format=custom --schema=public --file=$containerDumpPath
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $dumpPath -PathType Leaf)) {
+  Fail 'The full public-schema pg_dump failed.'
+}
+Restrict-BackupAccess @($dumpPath)
+
+$list = @(& $script:Docker exec --user postgres $CloneContainer pg_restore --list $containerDumpPath)
+if ($LASTEXITCODE -ne 0) { Fail 'Could not inspect the full dump archive.' }
+$tableDataEntries = @($list | ForEach-Object {
+  if ($_ -match ' TABLE DATA public ([^ ]+) ') { $Matches[1] }
+} | Sort-Object -Unique)
+if (@(Compare-Object $sourceTables $tableDataEntries).Count -ne 0) {
+  Fail 'The dump archive does not contain TABLE DATA entries for every public table.'
+}
+
+Invoke-LocalAdmin "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$VerifyDatabase' AND pid <> pg_backend_pid();" 'Terminate prior verification clients'
+Invoke-LocalAdmin "DROP DATABASE IF EXISTS `"$VerifyDatabase`";" 'Drop prior verification database'
+Invoke-LocalAdmin "CREATE DATABASE `"$VerifyDatabase`" OWNER `"$CloneUser`";" 'Create verification database'
+$null = Invoke-LocalRows $VerifyDatabase 'DROP SCHEMA public CASCADE;' 'Prepare verification database'
+& $script:Docker exec --user postgres $CloneContainer pg_restore --exit-on-error --no-owner --no-privileges --username=$CloneUser --dbname=$VerifyDatabase $containerDumpPath
+if ($LASTEXITCODE -ne 0) { Fail 'Restoring the full backup into the isolated verification database failed.' }
+
+$restoredTables = @(Invoke-LocalRows $VerifyDatabase "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;" 'Restored public table inventory')
+if (@(Compare-Object $sourceTables $restoredTables).Count -ne 0) {
+  Fail 'The restored public table set differs from production.'
+}
+$restoredCounts = Get-TableCounts $restoredTables { param($sql) Invoke-LocalRows $VerifyDatabase $sql 'Restored public table count' }
+Assert-EqualCounts $sourceCounts $restoredCounts
+$restoredInvalidConstraints = [int](((Invoke-LocalRows $VerifyDatabase "SELECT count(*) FROM pg_constraint WHERE connamespace='public'::regnamespace AND NOT convalidated;" 'Restored constraint check') -join '').Trim())
+if ($restoredInvalidConstraints -ne 0) { Fail 'The restored backup has invalid public constraints.' }
+Invoke-LocalAdmin "ALTER DATABASE `"$VerifyDatabase`" SET default_transaction_read_only=on;" 'Lock verification database read-only by default'
+
+$manifest = [ordered]@{
+  manifestVersion = 3
+  backupPurpose = 'sc-precinct-production-release-rollback'
+  createdAtUtc = $createdAtUtc
+  releaseCandidate = $releaseCandidate
+  dumpFile = $dumpFile
+  dumpSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $dumpPath).Hash.ToLowerInvariant()
+  dumpFormat = 'custom'
+  includedSchemas = @('public')
+  excludedTableDataPatterns = @()
+  sourceEndpointFingerprint = $sourceEndpointFingerprint
+  sourceEndpointLegacyApprovalFingerprint = $ExpectedLegacyEndpointFingerprint
+  sourceServerVersionNum = [int]$identity[0]
+  sourceDatabaseBytes = [int64]$identity[1]
+  sourcePublicTableCount = $sourceTables.Count
+  sourcePublicTableRowCounts = $sourceCounts
+  sourceInvalidConstraints = $sourceInvalidConstraints
+  pgClientMajor = 17
+  remoteMutationPerformed = $false
+  restoreVerification = [ordered]@{
+    verified = $true
+    verifiedAtUtc = [DateTime]::UtcNow.ToString('o')
+    database = $VerifyDatabase
+    defaultTransactionReadOnly = $true
+    publicTableCount = $restoredTables.Count
+    publicTableRowCounts = $restoredCounts
+    invalidConstraints = $restoredInvalidConstraints
+    tableDataEntryCount = $tableDataEntries.Count
+    exactSourceTableSet = $true
+    exactSourceRowCounts = $true
+  }
+}
+$json = $manifest | ConvertTo-Json -Depth 8
+[IO.File]::WriteAllText($manifestPath, $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+Restrict-BackupAccess @($manifestPath)
+
+[ordered]@{
+  mode = 'execute'
+  decision = 'BACKUP_AND_RESTORE_VERIFIED'
+  releaseCandidate = $releaseCandidate
+  dumpFile = $dumpPath
+  dumpSha256 = $manifest.dumpSha256
+  manifest = $manifestPath
+  sourcePublicTableCount = $sourceTables.Count
+  restoredPublicTableCount = $restoredTables.Count
+  restoreVerified = $true
+  remoteMutationPerformed = $false
+} | ConvertTo-Json -Depth 6

--- a/scripts/lib/sc-precinct-blob-publication.mjs
+++ b/scripts/lib/sc-precinct-blob-publication.mjs
@@ -1,0 +1,216 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function safeReleasePackage(root, relativePath) {
+  if (
+    typeof relativePath !== "string"
+    || !/^\.etl\/precinct-release-candidates\/SC\/[^/]+\/release-candidate\.json$/.test(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+  ) {
+    throw new Error("South Carolina Blob publication package path is unsafe");
+  }
+  const resolvedRoot = path.resolve(root);
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  if (!absolutePath.startsWith(resolvedRoot + path.sep)) {
+    throw new Error("South Carolina Blob publication package escapes the repository");
+  }
+  return absolutePath;
+}
+
+function safePackageAsset(releaseRoot, relativePath) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith("delivery-assets/")
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+  ) {
+    throw new Error("South Carolina Blob publication asset path is unsafe");
+  }
+  const absolutePath = path.resolve(releaseRoot, ...relativePath.split("/"));
+  if (!absolutePath.startsWith(path.resolve(releaseRoot) + path.sep)) {
+    throw new Error("South Carolina Blob publication asset escapes the package");
+  }
+  return absolutePath;
+}
+
+function publicPathname(publicUrl) {
+  if (
+    typeof publicUrl !== "string"
+    || !publicUrl.startsWith("/data/geography/sc/")
+    || publicUrl.includes("\\")
+    || publicUrl.includes("?")
+    || publicUrl.includes("#")
+  ) {
+    throw new Error("South Carolina Blob publication URL is not a safe geography path");
+  }
+  const segments = publicUrl.split("/").filter(Boolean);
+  if (segments.some((segment) => {
+    try {
+      const decoded = decodeURIComponent(segment);
+      return decoded === "."
+        || decoded === ".."
+        || decoded.includes("/")
+        || decoded.includes("\\");
+    } catch {
+      return true;
+    }
+  })) {
+    throw new Error("South Carolina Blob publication URL has an unsafe segment");
+  }
+  return publicUrl.slice(1);
+}
+
+function inspectAsset(releaseRoot, declaration, kind, year) {
+  const absolutePath = safePackageAsset(
+    releaseRoot,
+    declaration.packageRelativePath,
+  );
+  if (!existsSync(absolutePath)) {
+    throw new Error(
+      "South Carolina " + year + " " + kind + " asset is missing",
+    );
+  }
+  const bytes = readFileSync(absolutePath);
+  const digest = sha256(bytes);
+  if (
+    bytes.length !== declaration.byteCount
+    || digest !== declaration.sha256
+  ) {
+    throw new Error(
+      "South Carolina " + year + " " + kind + " asset hash or byte count drifted",
+    );
+  }
+  return {
+    kind,
+    year,
+    packageRelativePath: declaration.packageRelativePath,
+    publicUrl: declaration.publicUrl,
+    pathname: publicPathname(declaration.publicUrl),
+    byteCount: bytes.length,
+    sha256: digest,
+    absolutePath,
+  };
+}
+
+export function inspectSouthCarolinaPrecinctBlobPublicationPlan(options) {
+  const root = path.resolve(options.root ?? process.cwd());
+  if (!/^[a-f0-9]{64}$/.test(options.packageSha256 ?? "")) {
+    throw new Error("South Carolina Blob publication requires the exact package SHA-256");
+  }
+  const packageAbsolutePath = safeReleasePackage(root, options.packagePath);
+  if (!existsSync(packageAbsolutePath)) {
+    throw new Error("South Carolina Blob publication package is missing");
+  }
+  const packageBytes = readFileSync(packageAbsolutePath);
+  if (sha256(packageBytes) !== options.packageSha256) {
+    throw new Error("South Carolina Blob publication package SHA-256 does not match");
+  }
+  const document = JSON.parse(packageBytes.toString("utf8"));
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "sc-precinct-gis-three-election-v1"
+    || document?.state !== "SC"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.safety?.publicFileWritten !== false
+    || document?.safety?.canonicalManifestChanged !== false
+    || document?.safety?.publicEligibilityChanged !== false
+    || document?.totals?.elections !== 3
+    || !Array.isArray(document.years)
+    || document.years.length !== 3
+  ) {
+    throw new Error("South Carolina Blob publication package contract is incompatible");
+  }
+  const releaseRoot = path.dirname(packageAbsolutePath);
+  const artifacts = [];
+  for (const year of document.years) {
+    const delivery = year.parentScopedDelivery;
+    if (
+      ![2016, 2020, 2024].includes(year.year)
+      || delivery?.format !== "parent_scoped_geojson"
+      || delivery?.publicationPerformed !== false
+      || delivery?.electionValuesInDelivery !== false
+      || delivery?.parentCount !== 46
+      || delivery?.featureCount !== year.reviewedGeometry?.featureCount
+      || !Array.isArray(delivery?.parentArtifacts)
+      || delivery.parentArtifacts.length !== 46
+      || year.proposedPublicDelivery?.format !== "parent_scoped_geojson"
+      || year.proposedPublicDelivery?.sha256 !== delivery.index?.sha256
+      || year.proposedPublicDelivery?.byteCount !== delivery.index?.byteCount
+      || year.proposedPublicDelivery?.url !== delivery.index?.publicUrl
+    ) {
+      throw new Error(
+        "South Carolina " + year.year + " parent-scoped publication contract drifted",
+      );
+    }
+    for (const parent of delivery.parentArtifacts) {
+      if (!/^45\d{3}$/.test(parent.parentGeoid ?? "")) {
+        throw new Error(
+          "South Carolina " + year.year + " publication has an invalid parent GEOID",
+        );
+      }
+      artifacts.push(inspectAsset(releaseRoot, parent, "parent", year.year));
+    }
+    artifacts.push(inspectAsset(
+      releaseRoot,
+      delivery.index,
+      "index",
+      year.year,
+    ));
+  }
+  const pathnames = new Set(artifacts.map((artifact) => artifact.pathname));
+  if (artifacts.length !== 141 || pathnames.size !== artifacts.length) {
+    throw new Error("South Carolina Blob publication asset set is incomplete or duplicated");
+  }
+  artifacts.sort((left, right) => {
+    if (left.kind !== right.kind) return left.kind === "parent" ? -1 : 1;
+    return left.pathname.localeCompare(right.pathname);
+  });
+  return {
+    schemaVersion: 1,
+    state: "SC",
+    releaseCandidate: {
+      id: document.id,
+      path: options.packagePath,
+      sha256: options.packageSha256,
+    },
+    decision: "NO_GO_PUBLICATION",
+    assetCount: artifacts.length,
+    indexCount: artifacts.filter((artifact) => artifact.kind === "index").length,
+    parentArtifactCount: artifacts.filter((artifact) => artifact.kind === "parent").length,
+    totalByteCount: artifacts.reduce((sum, artifact) => sum + artifact.byteCount, 0),
+    uploadOrder: "all parent artifacts before indexes",
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+    artifacts,
+  };
+}
+
+export function validateSouthCarolinaBlobPublicationAuthorization(
+  plan,
+  environment = process.env,
+) {
+  if (
+    environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLIC_FILE_WRITES
+      !== "I_ACKNOWLEDGE_PUBLIC_IMMUTABLE_GEOMETRY_UPLOAD"
+    || environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLIC_FILE_PACKAGE_SHA256
+      !== plan.releaseCandidate.sha256
+    || typeof environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID
+      !== "string"
+    || !environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID.trim()
+  ) {
+    throw new Error(
+      "South Carolina public immutable geometry upload is not explicitly authorized",
+    );
+  }
+  return {
+    authorizationId:
+      environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID.trim(),
+  };
+}

--- a/scripts/lib/sc-precinct-gis-db.mjs
+++ b/scripts/lib/sc-precinct-gis-db.mjs
@@ -1,0 +1,1432 @@
+import postgres from "postgres";
+import {
+  getDatabaseDriver,
+  getLocalCloneDatabaseUrl,
+} from "../../src/db/database-driver.ts";
+import { reportingUnitCode } from "../../src/lib/precinct-geography.ts";
+
+const STATE = "SC";
+const SETUP_PARSER = "southCarolinaPrecinctReportingGisSetup";
+const APPLICATION_NAME = "civicresultmaps-local-sc-precinct-gis";
+
+const LOCAL_EXECUTION_CONTEXT = Object.freeze({
+  mode: "local",
+  importParser: SETUP_PARSER,
+  importScope: "local-only",
+  resultParser: "scripts/setup-sc-precinct-gis-local.mjs",
+  reviewedBy: "repository-reviewed",
+  revisionReason: "Local-only South Carolina reviewed precinct GIS setup",
+  database: {
+    environment: "local",
+    host: "loopback",
+    port: 54329,
+    name: "crm_clone_dev",
+  },
+  releaseCandidate: null,
+  productionReleaseAudit: null,
+});
+
+const PRODUCTION_RELEASE_AUDIT_KEYS = Object.freeze([
+  "releasePackage",
+  "authorization",
+  "preflight",
+  "backupManifest",
+  "authorizationId",
+  "endpointFingerprint",
+  "transaction",
+]);
+
+const PRODUCTION_RELEASE_AUDIT_ARTIFACT_KEYS = Object.freeze([
+  "releasePackage",
+  "authorization",
+  "preflight",
+]);
+
+function validatedProductionReleaseAudit(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Production South Carolina execution requires durable release-audit metadata");
+  }
+  const output = {};
+  for (const key of PRODUCTION_RELEASE_AUDIT_ARTIFACT_KEYS) {
+    const item = value[key];
+    if (
+      typeof item?.path !== "string"
+      || !item.path.startsWith(".etl/")
+      || item.path.includes("\\")
+      || item.path.split("/").includes("..")
+      || !/^[a-f0-9]{64}$/.test(item?.sha256 ?? "")
+    ) {
+      throw new Error("Production South Carolina execution release-audit metadata is invalid: " + key);
+    }
+    output[key] = Object.freeze({
+      path: item.path,
+      sha256: item.sha256,
+    });
+  }
+  if (
+    !value.backupManifest
+    || Object.keys(value.backupManifest).sort().join(",") !== "dumpSha256,sha256"
+    || !/^[a-f0-9]{64}$/.test(value.backupManifest.sha256 ?? "")
+    || !/^[a-f0-9]{64}$/.test(value.backupManifest.dumpSha256 ?? "")
+    || typeof value.authorizationId !== "string"
+    || !value.authorizationId.trim()
+    || !/^[a-f0-9]{64}$/.test(value.endpointFingerprint ?? "")
+    || !value.transaction
+    || Object.keys(value.transaction).sort().join(",")
+      !== "executedAtUtc,publicRevision"
+    || typeof value.transaction.executedAtUtc !== "string"
+    || Number.isNaN(Date.parse(value.transaction.executedAtUtc))
+    || !Number.isInteger(Number(value.transaction.publicRevision))
+    || Number(value.transaction.publicRevision) < 1
+  ) {
+    throw new Error("Production South Carolina execution release-audit metadata is invalid");
+  }
+  output.backupManifest = Object.freeze({
+    sha256: value.backupManifest.sha256,
+    dumpSha256: value.backupManifest.dumpSha256,
+  });
+  output.authorizationId = value.authorizationId.trim();
+  output.endpointFingerprint = value.endpointFingerprint;
+  output.transaction = Object.freeze({
+    executedAtUtc: value.transaction.executedAtUtc,
+    publicRevision: Number(value.transaction.publicRevision),
+  });
+  if (Object.keys(value).length !== PRODUCTION_RELEASE_AUDIT_KEYS.length) {
+    throw new Error("Production South Carolina execution release-audit metadata has extra fields");
+  }
+  return Object.freeze(output);
+}
+
+export function buildSouthCarolinaPrecinctExecutionContext(options = {}) {
+  if (!options.mode || options.mode === "local") return LOCAL_EXECUTION_CONTEXT;
+  if (options.mode !== "production_release") {
+    throw new Error("Unknown South Carolina precinct unit execution mode");
+  }
+  if (!/^[a-f0-9]{64}$/.test(options.releasePackageSha256 ?? "")) {
+    throw new Error("Production South Carolina execution requires a release-package SHA-256");
+  }
+  if (!/^sc-precinct-gis-three-election-v\d+$/.test(options.releaseCandidateId ?? "")) {
+    throw new Error("Production South Carolina execution requires the reviewed release-candidate ID");
+  }
+  if (typeof options.databaseName !== "string" || !options.databaseName.trim()) {
+    throw new Error("Production South Carolina execution requires the preflight database name");
+  }
+  return Object.freeze({
+    mode: "production_release",
+    importParser: "southCarolinaPrecinctGisProductionRelease",
+    importScope: "production-release-hidden-load",
+    resultParser: "scripts/apply-sc-precinct-release.mjs",
+    reviewedBy: "repository-reviewed-release",
+    revisionReason:
+      "South Carolina three-election precinct GIS hidden load "
+      + options.releasePackageSha256,
+    database: {
+      environment: "production",
+      host: "remote",
+      port: null,
+      name: options.databaseName,
+    },
+    releaseCandidate: Object.freeze({
+      id: options.releaseCandidateId,
+      sha256: options.releasePackageSha256,
+      publicDeliveryAuthorized: false,
+    }),
+    productionReleaseAudit: validatedProductionReleaseAudit(
+      options.productionReleaseAudit,
+    ),
+  });
+}
+
+export function assertSouthCarolinaGeometryVersionPrecondition(versions, yearPlan) {
+  if (
+    !Array.isArray(versions)
+    || versions.length > 1
+    || versions.some((row) =>
+      row.manifest_id !== yearPlan.manifest.id
+      || row.boundary_vintage !== yearPlan.manifest.geography.boundaryVintage
+    )
+  ) {
+    throw new Error(
+      "South Carolina "
+      + yearPlan.year
+      + " has multiple, foreign, or boundary-drifted geography versions",
+    );
+  }
+}
+
+function executionMetadata(context) {
+  return context.releaseCandidate
+    ? {
+      releaseCandidate: context.releaseCandidate,
+      productionReleaseAudit: context.productionReleaseAudit,
+    }
+    : {};
+}
+
+const FORBIDDEN_ELECTION_PROPERTY =
+  /^(?:USPRS|USSEN|VOTES?|TOTALVOTES?|TOTVOTING|REG7AM|EDR|CANDIDATE|PARTY)/i;
+
+function assertNoElectionValueProperties(value, context) {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertNoElectionValueProperties(item, context + "[" + index + "]"));
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_ELECTION_PROPERTY.test(key)) {
+      throw new Error(context + " contains election-value property " + key);
+    }
+    assertNoElectionValueProperties(child, context + "." + key);
+  }
+}
+
+export function canonicalJson(value) {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonicalJson(value[key])]),
+  );
+}
+
+function query(client, lines, params = []) {
+  return client.unsafe(Array.isArray(lines) ? lines.join("\n") : lines, params);
+}
+
+function chunks(rows, size = 400) {
+  const output = [];
+  for (let index = 0; index < rows.length; index += size) {
+    output.push(rows.slice(index, index + size));
+  }
+  return output;
+}
+
+async function sourceDocument(tx, document) {
+  const rows = await query(tx, [
+    "insert into source_documents (",
+    " slug, state_code, election_year, category, title, source_url, authority,",
+    " local_artifact, parser, timestamp_basis, confidence, status, metadata",
+    ") values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::text::jsonb)",
+    "on conflict (slug) do update set",
+    " election_year=excluded.election_year, category=excluded.category,",
+    " title=excluded.title, source_url=excluded.source_url,",
+    " authority=excluded.authority, local_artifact=excluded.local_artifact,",
+    " parser=excluded.parser, timestamp_basis=excluded.timestamp_basis,",
+    " confidence=excluded.confidence, status=excluded.status,",
+    " metadata=excluded.metadata",
+    "where source_documents.state_code=excluded.state_code",
+    "returning id",
+  ], [
+    document.slug,
+    STATE,
+    document.year,
+    document.category,
+    document.title,
+    document.sourceUrl,
+    document.authority,
+    document.localArtifact,
+    document.parser,
+    document.timestampBasis,
+    document.confidence,
+    document.status,
+    JSON.stringify(document.metadata),
+  ]);
+  if (rows.length !== 1) {
+    throw new Error("Source-document slug belongs to another state: " + document.slug);
+  }
+  return String(rows[0].id);
+}
+
+async function electionAndContest(tx, yearPlan) {
+  const existing = await query(tx, [
+    "select id,election_date from elections",
+    "where year=$1 and office='president'",
+  ], [yearPlan.year]);
+  if (existing.length && String(existing[0].election_date) !== yearPlan.electionDate) {
+    throw new Error(
+      "Existing " + yearPlan.year + " presidential date is "
+      + existing[0].election_date + ", expected " + yearPlan.electionDate,
+    );
+  }
+  const elections = await query(tx, [
+    "insert into elections (year,office,election_date,label)",
+    "values ($1,'president',$2,$3)",
+    "on conflict (year,office) do update set label=excluded.label",
+    "returning id",
+  ], [yearPlan.year, yearPlan.electionDate, yearPlan.year + " General Election"]);
+  const electionId = String(elections[0].id);
+  const contests = await query(tx, [
+    "insert into contests (election_id,state_code,office,title)",
+    "values ($1::uuid,$2,'president',$3)",
+    "on conflict (election_id,state_code,office) do update set title=excluded.title",
+    "returning id",
+  ], [electionId, STATE, "South Carolina " + yearPlan.year + " President"]);
+  return { electionId, contestId: String(contests[0].id) };
+}
+
+async function candidates(tx, contestId, yearPlan) {
+  const records = [];
+  const seen = new Set();
+  for (const row of yearPlan.resultRows) {
+    const key = row.candidateName + "|" + row.party;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    records.push({
+      name: row.candidateName,
+      party: row.party,
+      order: records.length + 1,
+    });
+  }
+  for (const record of records) {
+    await query(tx, [
+      "insert into candidates (contest_id,name,party,ballot_order)",
+      "values ($1::uuid,$2,$3,$4)",
+      "on conflict (contest_id,name,party) do update set ballot_order=excluded.ballot_order",
+    ], [contestId, record.name, record.party, record.order]);
+  }
+}
+
+async function importRun(tx, yearPlan, resultSourceDocumentId, context) {
+  const found = await query(tx, [
+    "select id from import_runs",
+    "where state_code=$1 and election_year=$2 and parser=$3",
+    " and source_document_id=$4::uuid",
+    "order by started_at,id limit 1",
+  ], [STATE, yearPlan.year, context.importParser, resultSourceDocumentId]);
+  const summary = JSON.stringify({
+    scope: context.importScope,
+    electionId: yearPlan.electionId,
+    reportingUnits: yearPlan.reportingUnits.length,
+    resultRows: yearPlan.resultRows.length,
+    geometryDisposition: yearPlan.geometry.disposition,
+    geometryFeatures: yearPlan.geometry.features.length,
+    crosswalks: yearPlan.geometry.crosswalks.length,
+    publicDeliveryAuthorized: false,
+    ...executionMetadata(context),
+  });
+  if (found.length) {
+    await query(tx, [
+      "update import_runs set status='promoted',finished_at=now(),",
+      " summary=$2::text::jsonb where id=$1::uuid",
+    ], [found[0].id, summary]);
+    return String(found[0].id);
+  }
+  const inserted = await query(tx, [
+    "insert into import_runs (state_code,election_year,parser,source_document_id,",
+    " status,started_at,finished_at,summary)",
+    "values ($1,$2,$3,$4::uuid,'promoted',now(),now(),$5::text::jsonb)",
+    "returning id",
+  ], [STATE, yearPlan.year, context.importParser, resultSourceDocumentId, summary]);
+  return String(inserted[0].id);
+}
+
+async function reportingUnits(
+  tx,
+  yearPlan,
+  electionId,
+  resultSourceDocumentId,
+  context,
+) {
+  for (const batch of chunks(yearPlan.reportingUnits)) {
+    const records = batch.map((unit) => ({
+      reporting_grain: unit.reportingGrain,
+      parent_geoid: unit.parentGeoid,
+      source_unit_id: unit.sourceUnitId,
+      source_display_name: unit.sourceDisplayName,
+      is_geographic: unit.isGeographic,
+      metadata: {
+        electionEventId: yearPlan.electionId,
+        reportingUnitCode: unit.code,
+        setupTool: context.resultParser,
+        resultStatus: unit.resultStatus,
+        ...(unit.resultStatus === "candidate_detail_suppressed"
+          ? {
+            reportedRegistration: unit.reportedRegistration,
+            reportedTurnout: unit.reportedTurnout,
+            reportedTotalVotes: unit.reportedTotalVotes,
+          }
+          : {}),
+        ...executionMetadata(context),
+      },
+    }));
+    await query(tx, [
+      "insert into reporting_units (state_code,election_id,reporting_grain,",
+      " parent_geoid,source_unit_id,source_display_name,is_geographic,",
+      " source_document_id,metadata)",
+      "select $1,$2::uuid,incoming.reporting_grain,incoming.parent_geoid,",
+      " incoming.source_unit_id,incoming.source_display_name,incoming.is_geographic,",
+      " $3::uuid,incoming.metadata",
+      "from jsonb_to_recordset($4::text::jsonb) incoming (",
+      " reporting_grain text,parent_geoid text,source_unit_id text,",
+      " source_display_name text,is_geographic boolean,metadata jsonb)",
+      "on conflict on constraint reporting_units_state_election_grain_parent_source_unique",
+      "do update set source_display_name=excluded.source_display_name,",
+      " is_geographic=excluded.is_geographic,",
+      " source_document_id=excluded.source_document_id,metadata=excluded.metadata,",
+      " updated_at=now()",
+    ], [STATE, electionId, resultSourceDocumentId, JSON.stringify(records)]);
+  }
+  const stored = await query(tx, [
+    "select id,reporting_grain,parent_geoid,source_unit_id",
+    "from reporting_units",
+    "where state_code=$1 and election_id=$2::uuid",
+    " and reporting_grain in ('precinct','administrative_reporting_unit')",
+    " and source_document_id=$3::uuid",
+  ], [STATE, electionId, resultSourceDocumentId]);
+  if (stored.length !== yearPlan.reportingUnits.length) {
+    throw new Error("South Carolina " + yearPlan.year + " reporting-unit count drifted");
+  }
+  const ids = new Map();
+  for (const row of stored) {
+    const code = reportingUnitCode({
+      state: STATE,
+      electionId: yearPlan.electionId,
+      reportingGrain: String(row.reporting_grain),
+      parentGeoid: row.parent_geoid ? String(row.parent_geoid) : null,
+      sourceUnitId: String(row.source_unit_id),
+    });
+    ids.set(code, String(row.id));
+  }
+  for (const unit of yearPlan.reportingUnits) {
+    if (!ids.has(unit.code)) throw new Error("Missing precinct " + unit.code);
+  }
+  return ids;
+}
+
+async function results(tx, yearPlan, contestId, importRunId, sourceDocumentId, unitIds) {
+  for (const batch of chunks(yearPlan.resultRows)) {
+    const records = batch.map((row) => ({
+      jurisdiction_code: row.jurisdictionCode,
+      jurisdiction_name: row.jurisdictionName,
+      candidate_name: row.candidateName,
+      party: row.party,
+      votes: row.votes,
+      reporting_unit_id: unitIds.get(row.jurisdictionCode),
+    }));
+    if (records.some((row) => !row.reporting_unit_id)) {
+      throw new Error("South Carolina " + yearPlan.year + " result lacks reporting unit");
+    }
+    await query(tx, [
+      "insert into result_rows (import_run_id,contest_id,state_code,",
+      " jurisdiction_code,jurisdiction_name,jurisdiction_tag,level,",
+      " candidate_name,party,votes,reporting_unit_id,source_document_id)",
+      "select $1::uuid,$2::uuid,$3,incoming.jurisdiction_code,",
+      " incoming.jurisdiction_name,null,'precinct',incoming.candidate_name,",
+      " incoming.party,incoming.votes,incoming.reporting_unit_id,$4::uuid",
+      "from jsonb_to_recordset($5::text::jsonb) incoming (",
+      " jurisdiction_code text,jurisdiction_name text,candidate_name text,",
+      " party text,votes integer,reporting_unit_id uuid)",
+      "on conflict (contest_id,level,jurisdiction_code,candidate_name,party)",
+      "do update set jurisdiction_name=excluded.jurisdiction_name,",
+      " state_code=excluded.state_code,jurisdiction_tag=excluded.jurisdiction_tag,",
+      " level=excluded.level,votes=excluded.votes,",
+      " reporting_unit_id=excluded.reporting_unit_id,",
+      " source_document_id=excluded.source_document_id,",
+      " import_run_id=excluded.import_run_id",
+    ], [importRunId, contestId, STATE, sourceDocumentId, JSON.stringify(records)]);
+  }
+  const stored = await query(tx, [
+    "select jurisdiction_code,jurisdiction_name,candidate_name,party,votes,",
+    " reporting_unit_id from result_rows",
+    "where contest_id=$1::uuid and state_code=$2 and level='precinct'",
+    " and jurisdiction_code like $3",
+  ], [contestId, STATE, "reporting:" + STATE + ":" + yearPlan.electionId + ":%"]);
+  if (stored.length !== yearPlan.resultRows.length) {
+    throw new Error("South Carolina " + yearPlan.year + " local-result count drifted");
+  }
+  const expected = new Map(yearPlan.resultRows.map((row) => [
+    [row.jurisdictionCode, row.candidateName, row.party].join("|"),
+    row,
+  ]));
+  for (const row of stored) {
+    const key = [row.jurisdiction_code, row.candidate_name, row.party].join("|");
+    const wanted = expected.get(key);
+    if (
+      !wanted
+      || Number(row.votes) !== wanted.votes
+      || String(row.jurisdiction_name) !== wanted.jurisdictionName
+      || String(row.reporting_unit_id) !== unitIds.get(wanted.jurisdictionCode)
+    ) {
+      throw new Error("South Carolina " + yearPlan.year + " result drift at " + key);
+    }
+  }
+}
+
+async function clearLocalReplayRows(tx, yearPlan, electionId, contestId, context) {
+  if (context.mode !== "local") return;
+  await query(tx, [
+    "delete from reporting_unit_geometry_crosswalks crosswalk",
+    "using geography_versions version",
+    "where crosswalk.geometry_version_id=version.id",
+    " and version.state_code=$1 and version.election_id=$2::uuid",
+    " and version.geography_type='precinct'",
+  ], [STATE, electionId]);
+  // A reviewed local replay may legitimately replace an earlier blocked
+  // boundary snapshot. Never delete a release-attributed or published version;
+  // either condition survives this cleanup and the normal precondition below
+  // rejects the replay.
+  await query(tx, [
+    "delete from geography_versions",
+    "where state_code=$1 and election_id=$2::uuid",
+    " and geography_type='precinct' and status='blocked'",
+    " and metadata->'releaseCandidate' is null",
+  ], [STATE, electionId]);
+  await query(tx, [
+    "delete from result_rows",
+    "where contest_id=$1::uuid and state_code=$2 and level='precinct'",
+    " and jurisdiction_code like $3",
+  ], [contestId, STATE, `reporting:${STATE}:${yearPlan.electionId}:%`]);
+  await query(tx, [
+    "delete from reporting_units",
+    "where state_code=$1 and election_id=$2::uuid",
+    " and reporting_grain in ('precinct','administrative_reporting_unit')",
+    " and metadata->>'setupTool'=$3",
+  ], [STATE, electionId, context.resultParser]);
+}
+
+async function geometry(
+  tx,
+  yearPlan,
+  electionId,
+  sourceDocumentId,
+  unitIds,
+  context,
+) {
+  if (yearPlan.geometry.disposition === "blocked") {
+    const existing = await query(tx, [
+      "select count(*)::int count from geography_versions",
+      "where state_code=$1 and election_id=$2::uuid and geography_type='precinct'",
+    ], [STATE, electionId]);
+    if (Number(existing[0].count) !== 0) {
+      throw new Error("Blocked South Carolina " + yearPlan.year + " already has geometry");
+    }
+    return { geographyVersions: 0, features: 0, crosswalks: 0 };
+  }
+
+  const versions = await query(tx, [
+    "select id,boundary_vintage,metadata->>'manifestId' manifest_id from geography_versions",
+    "where state_code=$1 and election_id=$2::uuid and geography_type='precinct'",
+  ], [STATE, electionId]);
+  assertSouthCarolinaGeometryVersionPrecondition(versions, yearPlan);
+
+  const upserted = await query(tx, [
+    "insert into geography_versions (state_code,election_id,geography_type,",
+    " boundary_vintage,vintage_status,source_document_id,source_layer,",
+    " source_crs,served_crs,derivation_method,status,caveat,metadata,updated_at)",
+    "values ($1,$2::uuid,'precinct',$3,$4,$5::uuid,$6,$7,$8,$9,",
+    " 'blocked',$10,$11::text::jsonb,now())",
+    "on conflict (state_code,election_id,geography_type,boundary_vintage)",
+    "do update set vintage_status=excluded.vintage_status,",
+    " source_document_id=excluded.source_document_id,source_layer=excluded.source_layer,",
+    " source_crs=excluded.source_crs,served_crs=excluded.served_crs,",
+    " derivation_method=excluded.derivation_method,status='blocked',",
+    " caveat=excluded.caveat,metadata=excluded.metadata,updated_at=now()",
+    "returning id",
+  ], [
+    STATE,
+    electionId,
+    yearPlan.manifest.geography.boundaryVintage,
+    yearPlan.manifest.geography.vintageStatus,
+    sourceDocumentId,
+    yearPlan.manifest.id,
+    yearPlan.manifest.normalization.sourceCrs,
+    yearPlan.manifest.normalization.servedCrs,
+    yearPlan.manifest.geography.derivationMethod,
+    yearPlan.manifest.validation.errors.join(" "),
+    JSON.stringify({
+      manifestId: yearPlan.manifest.id,
+      manifestPath: yearPlan.manifestPath,
+      manifestSha256: yearPlan.manifestSha256,
+      manifestByteCount: yearPlan.manifestByteCount,
+      source: {
+        artifact: yearPlan.manifest.source.artifact,
+        sha256: yearPlan.manifest.source.sha256,
+        byteCount: yearPlan.artifactByteCounts.source,
+      },
+      normalization: {
+        artifact: yearPlan.manifest.normalization.artifact,
+        sha256: yearPlan.manifest.normalization.sha256,
+        byteCount: yearPlan.artifactByteCounts.normalization,
+        featureCount: yearPlan.geometry.features.length,
+      },
+      crosswalk: {
+        artifact: yearPlan.manifest.crosswalk.artifact,
+        sha256: yearPlan.manifest.crosswalk.sha256,
+        byteCount: yearPlan.artifactByteCounts.crosswalk,
+        reviewedRelationships: yearPlan.geometry.crosswalks.length,
+        reviewedNoDataFeatures:
+          yearPlan.manifest.crosswalk.reviewedNoDataFeatures,
+      },
+      licenseOrTerms: yearPlan.manifest.source.licenseOrTerms,
+      publicDeliveryAuthorized: false,
+      ...executionMetadata(context),
+    }),
+  ]);
+  const versionId = String(upserted[0].id);
+
+  for (const batch of chunks(yearPlan.geometry.features, 250)) {
+    const records = batch.map((feature) => ({
+      source_feature_id: feature.sourceFeatureId,
+      parent_geoid: feature.parentGeoid,
+      name: feature.name,
+      geometry_key: feature.geometryKey,
+      is_geographic: feature.isGeographic,
+      properties: feature.properties,
+    }));
+    await query(tx, [
+      "insert into geography_features (geometry_version_id,source_feature_id,",
+      " parent_geoid,name,geometry_key,is_geographic,properties)",
+      "select $1::uuid,incoming.source_feature_id,incoming.parent_geoid,",
+      " incoming.name,incoming.geometry_key,incoming.is_geographic,incoming.properties",
+      "from jsonb_to_recordset($2::text::jsonb) incoming (",
+      " source_feature_id text,parent_geoid text,name text,geometry_key text,",
+      " is_geographic boolean,properties jsonb)",
+      "on conflict (geometry_version_id,source_feature_id) do update set",
+      " parent_geoid=excluded.parent_geoid,name=excluded.name,",
+      " geometry_key=excluded.geometry_key,is_geographic=excluded.is_geographic,",
+      " properties=excluded.properties",
+    ], [versionId, JSON.stringify(records)]);
+  }
+  await query(tx, [
+    "delete from geography_features feature",
+    "where feature.geometry_version_id=$1::uuid and not exists (",
+    " select 1 from jsonb_array_elements_text($2::text::jsonb) ids(value)",
+    " where ids.value=feature.source_feature_id)",
+  ], [
+    versionId,
+    JSON.stringify(yearPlan.geometry.features.map((row) => row.sourceFeatureId)),
+  ]);
+  const storedFeatures = await query(tx, [
+    "select id,source_feature_id from geography_features",
+    "where geometry_version_id=$1::uuid",
+  ], [versionId]);
+  if (storedFeatures.length !== yearPlan.geometry.features.length) {
+    throw new Error("South Carolina " + yearPlan.year + " geography-feature count drifted");
+  }
+  const featureIds = new Map(
+    storedFeatures.map((row) => [String(row.source_feature_id), String(row.id)]),
+  );
+
+  await query(tx, [
+    "delete from reporting_unit_geometry_crosswalks",
+    "where geometry_version_id=$1::uuid",
+  ], [versionId]);
+  for (const batch of chunks(yearPlan.geometry.crosswalks)) {
+    const records = batch.map((row) => ({
+      reporting_unit_id: unitIds.get(row.reportingUnitCode),
+      geography_feature_id: row.sourceFeatureId === null
+        ? null
+        : featureIds.get(row.sourceFeatureId),
+      relationship_type: row.relationshipType,
+      match_method: row.matchMethod,
+      review_status: row.reviewStatus,
+      confidence: row.confidence,
+      note: row.note,
+      metadata: {
+        manifestId: yearPlan.manifest.id,
+        resultUnitCode: row.reportingUnitCode,
+        sourceFeatureId: row.sourceFeatureId,
+        publicDeliveryAuthorized: false,
+        ...executionMetadata(context),
+      },
+    }));
+    if (records.some((row) => (
+      !row.reporting_unit_id
+      || (
+        ["one_to_one", "one_to_many", "many_to_one"].includes(
+          row.relationship_type,
+        )
+        && !row.geography_feature_id
+      )
+      || (
+        ["unmatched", "non_geographic", "source_alias"].includes(
+          row.relationship_type,
+        )
+        && row.geography_feature_id !== null
+      )
+    ))) {
+      throw new Error("South Carolina " + yearPlan.year + " cannot resolve crosswalk UUIDs");
+    }
+    await query(tx, [
+      "insert into reporting_unit_geometry_crosswalks (reporting_unit_id,",
+      " geometry_version_id,geography_feature_id,relationship_type,match_method,",
+      " review_status,confidence,source_document_id,reviewed_by,note,metadata)",
+      "select incoming.reporting_unit_id,$1::uuid,incoming.geography_feature_id,",
+      " incoming.relationship_type,incoming.match_method,incoming.review_status,",
+      " incoming.confidence,$2::uuid,$3,incoming.note,",
+      " incoming.metadata",
+      "from jsonb_to_recordset($4::text::jsonb) incoming (",
+      " reporting_unit_id uuid,geography_feature_id uuid,relationship_type text,",
+      " match_method text,review_status text,confidence text,note text,metadata jsonb)",
+    ], [versionId, sourceDocumentId, context.reviewedBy, JSON.stringify(records)]);
+  }
+  const counts = await query(tx, [
+    "select count(*)::int total,",
+    " count(*) filter (where review_status='reviewed')::int reviewed",
+    "from reporting_unit_geometry_crosswalks",
+    "where geometry_version_id=$1::uuid",
+  ], [versionId]);
+  const expected = yearPlan.geometry.crosswalks.length;
+  if (["total", "reviewed"]
+    .some((key) => Number(counts[0][key]) !== expected)) {
+    throw new Error("South Carolina " + yearPlan.year + " crosswalk count drifted");
+  }
+  return { geographyVersions: 1, features: storedFeatures.length, crosswalks: expected };
+}
+
+async function applyYear(tx, yearPlan, context) {
+  const ids = await electionAndContest(tx, yearPlan);
+  await clearLocalReplayRows(
+    tx,
+    yearPlan,
+    ids.electionId,
+    ids.contestId,
+    context,
+  );
+  await candidates(tx, ids.contestId, yearPlan);
+
+  const resultSourceId = await sourceDocument(tx, {
+    slug: yearPlan.resultSource.slug,
+    year: yearPlan.year,
+    category: "Official presidential precinct and administrative reporting results",
+    title: "South Carolina " + yearPlan.year + " presidential precinct results",
+    sourceUrl: yearPlan.resultSource.url,
+    authority: yearPlan.resultSource.authority,
+    localArtifact: yearPlan.resultSource.artifact,
+    parser: context.resultParser,
+    timestampBasis: yearPlan.resultSource.timestampBasis,
+    confidence: "Official South Carolina Election Commission rows. Administrative reporting buckets are retained for reconciliation but are never assigned to precinct polygons.",
+    status: "loaded",
+    metadata: {
+      sourceId: yearPlan.resultSource.id,
+      sha256: yearPlan.resultSource.sha256,
+      byteCount: yearPlan.resultSource.byteCount,
+      electionEventId: yearPlan.electionId,
+      reportingUnits: yearPlan.reportingUnits.length,
+      zeroVoteUnits: yearPlan.zeroVoteUnits,
+      totals: yearPlan.totals,
+      officialTotals: yearPlan.officialTotals,
+      supplementalArtifacts: yearPlan.resultSource.supplementalArtifacts ?? [],
+      publicDeliveryAuthorized: false,
+      ...executionMetadata(context),
+    },
+  });
+  const geometrySourceId = await sourceDocument(tx, {
+    slug: yearPlan.geometrySourceSlug,
+    year: yearPlan.year,
+    category: yearPlan.geometry.disposition === "blocked"
+      ? "Precinct geometry availability evidence"
+      : "Reviewed election-applicable statewide precinct boundaries",
+    title: "South Carolina " + yearPlan.year + " precinct geometry package",
+    sourceUrl: yearPlan.manifest.source.url,
+    authority: yearPlan.manifest.source.authority,
+    localArtifact: yearPlan.manifest.source.artifact,
+    parser: yearPlan.manifest.normalization.script,
+    timestampBasis: yearPlan.manifest.geography.boundaryVintage,
+    confidence: yearPlan.geometry.disposition === "blocked"
+      ? "Retained official evidence; geometry remains fail-closed."
+      : "Reviewed election-specific precinct package with exact official IDs, explicit non-geographic exclusions, and retained provenance caveats.",
+    status: yearPlan.geometry.disposition === "blocked" ? "needs_data" : "loaded",
+    metadata: {
+      manifestId: yearPlan.manifest.id,
+      manifestPath: yearPlan.manifestPath,
+      manifestSha256: yearPlan.manifestSha256,
+      manifestByteCount: yearPlan.manifestByteCount,
+      source: {
+        artifact: yearPlan.manifest.source.artifact,
+        sha256: yearPlan.manifest.source.sha256,
+        byteCount: yearPlan.artifactByteCounts.source,
+      },
+      normalization: {
+        artifact: yearPlan.manifest.normalization.artifact,
+        sha256: yearPlan.manifest.normalization.sha256,
+        byteCount: yearPlan.artifactByteCounts.normalization,
+      },
+      crosswalk: {
+        artifact: yearPlan.manifest.crosswalk.artifact,
+        sha256: yearPlan.manifest.crosswalk.sha256,
+        byteCount: yearPlan.artifactByteCounts.crosswalk,
+      },
+      geometryDisposition: yearPlan.geometry.disposition,
+      blockCode: yearPlan.geometry.blockCode,
+      licenseOrTerms: yearPlan.manifest.source.licenseOrTerms,
+      publicDeliveryAuthorized: false,
+      ...executionMetadata(context),
+    },
+  });
+
+  const runId = await importRun(tx, yearPlan, resultSourceId, context);
+  const unitIds = await reportingUnits(
+    tx,
+    yearPlan,
+    ids.electionId,
+    resultSourceId,
+    context,
+  );
+  await results(tx, yearPlan, ids.contestId, runId, resultSourceId, unitIds);
+  const geometryCounts = await geometry(
+    tx,
+    yearPlan,
+    ids.electionId,
+    geometrySourceId,
+    unitIds,
+    context,
+  );
+  return {
+    year: yearPlan.year,
+    electionId: yearPlan.electionId,
+    reportingUnits: unitIds.size,
+    resultRows: yearPlan.resultRows.length,
+    zeroVoteUnits: yearPlan.zeroVoteUnits,
+    totals: yearPlan.totals,
+    geometryDisposition: yearPlan.geometry.disposition,
+    ...geometryCounts,
+  };
+}
+
+export async function applySouthCarolinaPrecinctGisTransaction(
+  tx,
+  plan,
+  options = {},
+) {
+  const context = buildSouthCarolinaPrecinctExecutionContext(
+    options.executionContext,
+  );
+  const identity = await query(tx, [
+    "select current_database() database_name,",
+    " current_setting('transaction_read_only') transaction_read_only",
+  ]);
+  if (
+    identity.length !== 1
+    || String(identity[0].transaction_read_only) !== "off"
+    || String(identity[0].database_name) !== context.database.name
+  ) {
+    throw new Error(
+      "South Carolina precinct unit release transaction database identity or write mode drifted",
+    );
+  }
+
+  await query(tx, "select set_config('lock_timeout','30s',true)");
+  await query(
+    tx,
+    "select pg_advisory_xact_lock(hashtextextended('crm-sc-precinct-gis-release-v1',0))",
+  );
+  const tables = await query(tx, [
+    "select count(*)::int count from unnest(array[",
+    " 'elections','contests','candidates','source_documents','import_runs',",
+    " 'result_rows','reporting_units','geography_versions','geography_features',",
+    " 'reporting_unit_geometry_crosswalks']) required(name)",
+    "where to_regclass('public.'||required.name) is not null",
+  ]);
+  if (Number(tables[0].count) !== 10) {
+    throw new Error(
+      context.database.name + " lacks the complete migration 0008 local geography schema",
+    );
+  }
+  if (context.mode === "production_release") {
+    const targetYears = plan.years.map((year) => year.year);
+    const existing = await query(tx, [
+      "select",
+      " (select count(*)::int from reporting_units ru",
+      "  join elections e on e.id=ru.election_id",
+      "  where ru.state_code='SC'",
+      "   and ru.reporting_grain in ('precinct','administrative_reporting_unit')",
+      "   and e.office='president' and e.year=any($1::int[])) reporting_units,",
+      " (select count(*)::int from result_rows rr",
+      "  join contests c on c.id=rr.contest_id",
+      "  join elections e on e.id=c.election_id",
+      "  where rr.state_code='SC' and rr.level='precinct'",
+      "   and e.office='president' and e.year=any($1::int[])) result_rows,",
+      " (select count(*)::int from geography_versions gv",
+      "  join elections e on e.id=gv.election_id",
+      "  where gv.state_code='SC' and gv.geography_type='precinct'",
+      "   and e.office='president' and e.year=any($1::int[])) geography_versions",
+    ], [targetYears]);
+    const counts = existing[0] ?? {};
+    if (
+      Number(counts.reporting_units) !== 0
+      || Number(counts.result_rows) !== 0
+      || Number(counts.geography_versions) !== 0
+    ) {
+      throw new Error(
+        "South Carolina production hidden load refuses existing precinct release rows; "
+        + "use read-only receipt recovery or a separately reviewed rollback path",
+      );
+    }
+  }
+  await query(tx, [
+    "insert into states (code,name,authority) values ($1,$2,$3)",
+    "on conflict (code) do update set name=excluded.name,authority=excluded.authority",
+  ], [STATE, plan.stateName, plan.authority]);
+
+  const years = [];
+  for (const yearPlan of plan.years) {
+    years.push(await applyYear(tx, yearPlan, context));
+    if (
+      process.env.NODE_ENV === "test"
+      && options.testOnlyFailAfterYear === yearPlan.year
+    ) {
+      throw new Error("Intentional South Carolina GIS rollback after " + yearPlan.year);
+    }
+  }
+  const revisions = await query(tx, [
+    "insert into public_data_revisions (scope,revision,updated_at,reason)",
+    "values ('public',1,now(),$1)",
+    "on conflict (scope) do update set",
+    " revision=public_data_revisions.revision+1,updated_at=now(),reason=excluded.reason",
+    "returning revision::int revision",
+  ], [context.revisionReason]);
+  return {
+    database: context.database,
+    executionMode: context.mode,
+    productionMutationPerformed: context.mode === "production_release",
+    publicDeliveryAuthorized: false,
+    releaseCandidate: context.releaseCandidate,
+    productionReleaseAudit: context.productionReleaseAudit,
+    revision: Number(revisions[0].revision),
+    years,
+  };
+}
+
+export async function applySouthCarolinaPrecinctGisPlan(plan, options = {}) {
+  if (getDatabaseDriver() !== "postgres") {
+    throw new Error("South Carolina precinct GIS setup requires CRM_DATABASE_DRIVER=postgres");
+  }
+  const databaseUrl = getLocalCloneDatabaseUrl({ requireWriteOptIn: true });
+  const sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+    max: 1,
+    connect_timeout: 10,
+    idle_timeout: 20,
+    connection: { application_name: APPLICATION_NAME },
+  });
+  try {
+    return await sql.begin((tx) => applySouthCarolinaPrecinctGisTransaction(
+      tx,
+      plan,
+      {
+        executionContext: { mode: "local" },
+        testOnlyFailAfterYear: options.testOnlyFailAfterYear,
+      },
+    ));
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+async function validateSourceDocumentRecords(sql, yearPlan, context) {
+  const rows = await query(sql, [
+    "select slug,election_year,category,title,source_url,authority,local_artifact,",
+    " parser,timestamp_basis,status,metadata",
+    "from source_documents where state_code=$1 and slug in ($2,$3)",
+  ], [STATE, yearPlan.resultSource.slug, yearPlan.geometrySourceSlug]);
+  if (rows.length !== 2) {
+    throw new Error("South Carolina " + yearPlan.year + " source-document count drifted");
+  }
+  const bySlug = new Map(rows.map((row) => [String(row.slug), row]));
+  const result = bySlug.get(yearPlan.resultSource.slug);
+  const geometry = bySlug.get(yearPlan.geometrySourceSlug);
+  const resultMetadata = result?.metadata ?? {};
+  const geometryMetadata = geometry?.metadata ?? {};
+  if (
+    !result
+    || Number(result.election_year) !== yearPlan.year
+    || String(result.source_url) !== yearPlan.resultSource.url
+    || String(result.authority) !== yearPlan.resultSource.authority
+    || String(result.local_artifact) !== yearPlan.resultSource.artifact
+    || String(result.parser) !== context.resultParser
+    || String(result.timestamp_basis) !== yearPlan.resultSource.timestampBasis
+    || String(result.status) !== "loaded"
+    || resultMetadata.sha256 !== yearPlan.resultSource.sha256
+    || Number(resultMetadata.byteCount) !== yearPlan.resultSource.byteCount
+    || resultMetadata.electionEventId !== yearPlan.electionId
+    || resultMetadata.publicDeliveryAuthorized !== false
+    || JSON.stringify(canonicalJson(resultMetadata.supplementalArtifacts ?? []))
+      !== JSON.stringify(canonicalJson(yearPlan.resultSource.supplementalArtifacts ?? []))
+    || JSON.stringify(canonicalJson(resultMetadata.releaseCandidate ?? null))
+      !== JSON.stringify(canonicalJson(context.releaseCandidate))
+    || JSON.stringify(canonicalJson(resultMetadata.productionReleaseAudit ?? null))
+      !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
+  ) {
+    throw new Error("South Carolina " + yearPlan.year + " result provenance drifted");
+  }
+  const geometryStatus = yearPlan.geometry.disposition === "blocked" ? "needs_data" : "loaded";
+  if (
+    !geometry
+    || Number(geometry.election_year) !== yearPlan.year
+    || String(geometry.source_url) !== yearPlan.manifest.source.url
+    || String(geometry.authority) !== yearPlan.manifest.source.authority
+    || String(geometry.local_artifact) !== yearPlan.manifest.source.artifact
+    || String(geometry.parser) !== yearPlan.manifest.normalization.script
+    || String(geometry.timestamp_basis) !== yearPlan.manifest.geography.boundaryVintage
+    || String(geometry.status) !== geometryStatus
+    || geometryMetadata.manifestId !== yearPlan.manifest.id
+    || geometryMetadata.manifestPath !== yearPlan.manifestPath
+    || geometryMetadata.manifestSha256 !== yearPlan.manifestSha256
+    || Number(geometryMetadata.manifestByteCount) !== yearPlan.manifestByteCount
+    || geometryMetadata.source?.artifact !== yearPlan.manifest.source.artifact
+    || geometryMetadata.source?.sha256 !== yearPlan.manifest.source.sha256
+    || Number(geometryMetadata.source?.byteCount) !== yearPlan.artifactByteCounts.source
+    || geometryMetadata.normalization?.artifact !== yearPlan.manifest.normalization.artifact
+    || geometryMetadata.normalization?.sha256 !== yearPlan.manifest.normalization.sha256
+    || Number(geometryMetadata.normalization?.byteCount)
+      !== yearPlan.artifactByteCounts.normalization
+    || geometryMetadata.crosswalk?.artifact !== yearPlan.manifest.crosswalk.artifact
+    || geometryMetadata.crosswalk?.sha256 !== yearPlan.manifest.crosswalk.sha256
+    || Number(geometryMetadata.crosswalk?.byteCount) !== yearPlan.artifactByteCounts.crosswalk
+    || geometryMetadata.licenseOrTerms !== yearPlan.manifest.source.licenseOrTerms
+    || geometryMetadata.blockCode !== yearPlan.geometry.blockCode
+    || geometryMetadata.geometryDisposition !== yearPlan.geometry.disposition
+    || geometryMetadata.publicDeliveryAuthorized !== false
+    || JSON.stringify(canonicalJson(geometryMetadata.releaseCandidate ?? null))
+      !== JSON.stringify(canonicalJson(context.releaseCandidate))
+    || JSON.stringify(canonicalJson(geometryMetadata.productionReleaseAudit ?? null))
+      !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
+  ) {
+    throw new Error("South Carolina " + yearPlan.year + " geometry provenance drifted");
+  }
+  return {
+    resultSourceSlug: yearPlan.resultSource.slug,
+    geometrySourceSlug: yearPlan.geometrySourceSlug,
+  };
+}
+
+async function validateStoredProductionAudit(
+  sql,
+  yearPlan,
+  electionId,
+  context,
+) {
+  if (!context.releaseCandidate) return;
+  const audit = JSON.stringify(context.productionReleaseAudit);
+  // `audit` is serialized JSON text. Preserve the intermediate text cast so
+  // Postgres.js does not encode the parameter as a JSON string scalar.
+  const units = await query(sql, [
+    "select count(*)::int total,",
+    " count(*) filter (where metadata->'productionReleaseAudit'=$3::text::jsonb)::int exact_audit",
+    "from reporting_units where state_code=$1 and election_id=$2::uuid",
+    " and reporting_grain in ('precinct','administrative_reporting_unit')",
+  ], [STATE, electionId, audit]);
+  if (
+    Number(units[0]?.total) !== yearPlan.reportingUnits.length
+    || Number(units[0]?.exact_audit) !== yearPlan.reportingUnits.length
+  ) {
+    throw new Error("South Carolina " + yearPlan.year + " reporting-unit release audit drifted");
+  }
+  const imports = await query(sql, [
+    "select count(distinct ir.id)::int import_runs,count(rr.id)::int result_rows,",
+    " count(rr.id) filter (where ir.summary->'productionReleaseAudit'=$4::text::jsonb)::int exact_audit_rows",
+    "from import_runs ir",
+    "join result_rows rr on rr.import_run_id=ir.id and rr.state_code=$1",
+    "join contests c on c.id=rr.contest_id and c.election_id=$2::uuid",
+    "where ir.state_code=$1 and ir.election_year=$3 and ir.parser=$5",
+    " and rr.level='precinct'",
+  ], [STATE, electionId, yearPlan.year, audit, context.importParser]);
+  if (
+    Number(imports[0]?.import_runs) !== 1
+    || Number(imports[0]?.result_rows) !== yearPlan.resultRows.length
+    || Number(imports[0]?.exact_audit_rows) !== yearPlan.resultRows.length
+  ) {
+    throw new Error("South Carolina " + yearPlan.year + " import-run release audit drifted");
+  }
+}
+
+async function validateStoredGeometryRecords(sql, yearPlan, electionId, context) {
+  if (yearPlan.geometry.disposition === "blocked") {
+    return { exactFeatures: 0, exactCrosswalks: 0 };
+  }
+  const versions = await query(sql, [
+    "select metadata from geography_versions",
+    "where state_code=$1 and election_id=$2::uuid and geography_type='precinct'",
+  ], [STATE, electionId]);
+  const expectedVersionMetadata = {
+    manifestId: yearPlan.manifest.id,
+    manifestPath: yearPlan.manifestPath,
+    manifestSha256: yearPlan.manifestSha256,
+    manifestByteCount: yearPlan.manifestByteCount,
+    source: {
+      artifact: yearPlan.manifest.source.artifact,
+      sha256: yearPlan.manifest.source.sha256,
+      byteCount: yearPlan.artifactByteCounts.source,
+    },
+    normalization: {
+      artifact: yearPlan.manifest.normalization.artifact,
+      sha256: yearPlan.manifest.normalization.sha256,
+      byteCount: yearPlan.artifactByteCounts.normalization,
+      featureCount: yearPlan.geometry.features.length,
+    },
+    crosswalk: {
+      artifact: yearPlan.manifest.crosswalk.artifact,
+      sha256: yearPlan.manifest.crosswalk.sha256,
+      byteCount: yearPlan.artifactByteCounts.crosswalk,
+      reviewedRelationships: yearPlan.geometry.crosswalks.length,
+      reviewedNoDataFeatures:
+        yearPlan.manifest.crosswalk.reviewedNoDataFeatures,
+    },
+    licenseOrTerms: yearPlan.manifest.source.licenseOrTerms,
+    publicDeliveryAuthorized: false,
+    ...executionMetadata(context),
+  };
+  if (
+    versions.length !== 1
+    || JSON.stringify(canonicalJson(versions[0].metadata))
+      !== JSON.stringify(canonicalJson(expectedVersionMetadata))
+  ) {
+    throw new Error("South Carolina " + yearPlan.year + " geography-version provenance drifted");
+  }
+  const features = await query(sql, [
+    "select gf.source_feature_id,gf.parent_geoid,gf.name,gf.geometry_key,",
+    " gf.is_geographic,gf.properties",
+    "from geography_features gf",
+    "join geography_versions gv on gv.id=gf.geometry_version_id",
+    "where gv.state_code=$1 and gv.election_id=$2::uuid",
+    " and gv.geography_type='precinct' and gv.metadata->>'manifestId'=$3",
+    "order by gf.source_feature_id",
+  ], [STATE, electionId, yearPlan.manifest.id]);
+  const expectedFeatures = new Map(
+    yearPlan.geometry.features.map((feature) => [feature.sourceFeatureId, feature]),
+  );
+  if (features.length !== expectedFeatures.size) {
+    throw new Error("South Carolina " + yearPlan.year + " exact feature count drifted");
+  }
+  const seenFeatures = new Set();
+  for (const row of features) {
+    const sourceFeatureId = String(row.source_feature_id);
+    const expected = expectedFeatures.get(sourceFeatureId);
+    assertNoElectionValueProperties(
+      row.properties,
+      "South Carolina " + yearPlan.year + " stored feature " + sourceFeatureId,
+    );
+    if (
+      !expected
+      || seenFeatures.has(sourceFeatureId)
+      || String(row.parent_geoid) !== expected.parentGeoid
+      || String(row.name) !== expected.name
+      || String(row.geometry_key) !== expected.geometryKey
+      || row.is_geographic !== expected.isGeographic
+      || JSON.stringify(canonicalJson(row.properties))
+        !== JSON.stringify(canonicalJson(expected.properties))
+    ) {
+      throw new Error("South Carolina " + yearPlan.year + " stored feature drifted at " + sourceFeatureId);
+    }
+    seenFeatures.add(sourceFeatureId);
+  }
+
+  const crosswalks = await query(sql, [
+    "select ru.reporting_grain,ru.parent_geoid,ru.source_unit_id,",
+    " gf.source_feature_id,x.relationship_type,x.match_method,x.review_status,",
+    " x.confidence,x.reviewed_by,x.note,x.metadata",
+    "from reporting_unit_geometry_crosswalks x",
+    "join geography_versions gv on gv.id=x.geometry_version_id",
+    "join reporting_units ru on ru.id=x.reporting_unit_id",
+    "left join geography_features gf on gf.id=x.geography_feature_id",
+    "join source_documents sd on sd.id=x.source_document_id",
+    "where gv.state_code=$1 and gv.election_id=$2::uuid",
+    " and ru.state_code=$1 and ru.election_id=$2::uuid",
+    " and gv.metadata->>'manifestId'=$3 and sd.slug=$4",
+    "order by ru.parent_geoid,ru.source_unit_id",
+  ], [STATE, electionId, yearPlan.manifest.id, yearPlan.geometrySourceSlug]);
+  const expectedCrosswalks = new Map(yearPlan.geometry.crosswalks.map((crosswalk) => [
+    `${crosswalk.reportingUnitCode}|${crosswalk.sourceFeatureId}`,
+    crosswalk,
+  ]));
+  if (crosswalks.length !== expectedCrosswalks.size) {
+    throw new Error("South Carolina " + yearPlan.year + " exact crosswalk count drifted");
+  }
+  const seenCrosswalks = new Set();
+  for (const row of crosswalks) {
+    const reportingCode = reportingUnitCode({
+      state: STATE,
+      electionId: yearPlan.electionId,
+      reportingGrain: String(row.reporting_grain),
+      parentGeoid: row.parent_geoid ? String(row.parent_geoid) : null,
+      sourceUnitId: String(row.source_unit_id),
+    });
+    const crosswalkKey = `${reportingCode}|${row.source_feature_id}`;
+    const expected = expectedCrosswalks.get(crosswalkKey);
+    const metadata = row.metadata ?? {};
+    if (
+      !expected
+      || seenCrosswalks.has(crosswalkKey)
+      || (row.source_feature_id === null
+        ? expected.sourceFeatureId !== null
+        : String(row.source_feature_id) !== expected.sourceFeatureId)
+      || String(row.relationship_type) !== expected.relationshipType
+      || String(row.match_method) !== expected.matchMethod
+      || String(row.review_status) !== expected.reviewStatus
+      || String(row.confidence) !== expected.confidence
+      || String(row.reviewed_by) !== context.reviewedBy
+      || String(row.note ?? "") !== expected.note
+      || metadata.manifestId !== yearPlan.manifest.id
+      || metadata.resultUnitCode !== reportingCode
+      || metadata.sourceFeatureId !== expected.sourceFeatureId
+      || metadata.publicDeliveryAuthorized !== false
+      || JSON.stringify(canonicalJson(metadata.releaseCandidate ?? null))
+        !== JSON.stringify(canonicalJson(context.releaseCandidate))
+      || JSON.stringify(canonicalJson(metadata.productionReleaseAudit ?? null))
+        !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
+    ) {
+      throw new Error("South Carolina " + yearPlan.year + " stored crosswalk drifted at " + reportingCode);
+    }
+    seenCrosswalks.add(crosswalkKey);
+  }
+  return { exactFeatures: features.length, exactCrosswalks: crosswalks.length };
+}
+
+export async function readSouthCarolinaPersistedProductionReleaseAudit(
+  sql,
+  releaseCandidate,
+) {
+  if (
+    typeof releaseCandidate?.id !== "string"
+    || !/^[a-f0-9]{64}$/.test(releaseCandidate?.sha256 ?? "")
+  ) {
+    throw new Error("South Carolina hidden receipt recovery requires an exact release candidate");
+  }
+  const rows = await query(sql, [
+    "select e.year,gv.status,gv.metadata",
+    "from geography_versions gv",
+    "join elections e on e.id=gv.election_id",
+    "where gv.state_code='SC' and gv.geography_type='precinct'",
+    " and gv.metadata->'releaseCandidate'->>'id'=$1",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$2",
+    "order by e.year",
+  ], [releaseCandidate.id, releaseCandidate.sha256]);
+  const expectedYears = [2016, 2020, 2024];
+  if (
+    rows.length !== expectedYears.length
+    || rows.some((row, index) => Number(row.year) !== expectedYears[index])
+  ) {
+    throw new Error("South Carolina hidden receipt recovery found an incomplete year set");
+  }
+  const firstAudit = rows[0]?.metadata?.productionReleaseAudit;
+  const audit = validatedProductionReleaseAudit(firstAudit);
+  for (const row of rows) {
+    if (
+      String(row.status) !== "blocked"
+      || row.metadata?.publicDeliveryAuthorized !== false
+      || JSON.stringify(canonicalJson(row.metadata?.releaseCandidate ?? null))
+        !== JSON.stringify(canonicalJson({
+          id: releaseCandidate.id,
+          sha256: releaseCandidate.sha256,
+          publicDeliveryAuthorized: false,
+        }))
+      || JSON.stringify(canonicalJson(row.metadata?.productionReleaseAudit ?? null))
+        !== JSON.stringify(canonicalJson(audit))
+    ) {
+      throw new Error("South Carolina hidden receipt recovery audit drifted across years");
+    }
+  }
+  return audit;
+}
+
+export async function validateSouthCarolinaPrecinctGisClient(
+  sql,
+  plan,
+  options = {},
+) {
+    const context = buildSouthCarolinaPrecinctExecutionContext(
+      options.executionContext,
+    );
+    const output = [];
+    for (const yearPlan of plan.years) {
+      const rows = await query(sql, [
+        "select e.id election_id,",
+        " (select count(*)::int from reporting_units ru",
+        "  where ru.state_code=$1 and ru.election_id=e.id",
+        "   and ru.reporting_grain in ('precinct','administrative_reporting_unit')) reporting_units,",
+        " (select count(*)::int from result_rows rr join contests c on c.id=rr.contest_id",
+        "  where rr.state_code=$1 and c.election_id=e.id and c.office='president'",
+        "   and rr.level='precinct' and rr.jurisdiction_code like $3) result_rows,",
+        " (select count(*)::int from result_rows rr",
+        "  join contests c on c.id=rr.contest_id",
+        "  join reporting_units ru on ru.id=rr.reporting_unit_id",
+        "  where rr.state_code=$1 and c.election_id=e.id and c.office='president'",
+        "   and rr.level='precinct' and rr.jurisdiction_code like $3",
+        "   and ru.state_code=$1 and ru.election_id=e.id and ru.reporting_grain='precinct')",
+        "  same_year_result_rows,",
+        " (select count(*)::int from geography_versions gv",
+        "  where gv.state_code=$1 and gv.election_id=e.id",
+        "   and gv.geography_type='precinct') geography_versions,",
+        " (select count(*)::int from geography_versions gv",
+        "  where gv.state_code=$1 and gv.election_id=e.id",
+        "   and gv.geography_type='precinct' and gv.status='blocked'",
+        "   and gv.metadata->>'manifestId'=$4::text and gv.metadata->>'manifestSha256'=$5::text",
+        "   and gv.metadata->>'publicDeliveryAuthorized'='false')",
+        "  safe_geography_versions,",
+        " (select count(*)::int from geography_features gf",
+        "  join geography_versions gv on gv.id=gf.geometry_version_id",
+        "  where gv.state_code=$1 and gv.election_id=e.id",
+        "   and gv.geography_type='precinct') features,",
+        " (select count(*)::int from reporting_unit_geometry_crosswalks x",
+        "  join geography_versions gv on gv.id=x.geometry_version_id",
+        "  join reporting_units ru on ru.id=x.reporting_unit_id",
+        "  where gv.state_code=$1 and gv.election_id=e.id and ru.election_id=e.id",
+        "   and x.review_status='reviewed') crosswalks",
+        "from elections e where e.year=$2 and e.office='president'",
+      ], [
+        STATE,
+        yearPlan.year,
+        "reporting:" + STATE + ":" + yearPlan.electionId + ":%",
+        yearPlan.manifest.id,
+        yearPlan.manifestSha256,
+      ]);
+      if (rows.length !== 1) throw new Error("Missing " + yearPlan.year + " election");
+      const row = rows[0];
+      const expectedGeometry = yearPlan.geometry.disposition === "blocked"
+        ? { versions: 0, features: 0, crosswalks: 0 }
+        : {
+          versions: 1,
+          features: yearPlan.geometry.features.length,
+          crosswalks: yearPlan.geometry.crosswalks.length,
+        };
+      if (
+        Number(row.reporting_units) !== yearPlan.reportingUnits.length
+        || Number(row.result_rows) !== yearPlan.resultRows.length
+        || Number(row.geography_versions) !== expectedGeometry.versions
+        || Number(row.features) !== expectedGeometry.features
+        || Number(row.same_year_result_rows) !== yearPlan.resultRows.length
+        || Number(row.crosswalks) !== expectedGeometry.crosswalks
+        || Number(row.safe_geography_versions) !== expectedGeometry.versions
+      ) {
+        throw new Error("South Carolina " + yearPlan.year + " database counts drifted: " + JSON.stringify({
+          actual: row,
+          expected: {
+            reportingUnits: yearPlan.reportingUnits.length,
+            resultRows: yearPlan.resultRows.length,
+            sameYearResultRows: yearPlan.resultRows.length,
+            geographyVersions: expectedGeometry.versions,
+            features: expectedGeometry.features,
+            crosswalks: expectedGeometry.crosswalks,
+            safeGeographyVersions: expectedGeometry.versions,
+          },
+        }));
+      }
+      const provenance = await validateSourceDocumentRecords(
+        sql,
+        yearPlan,
+        context,
+      );
+      await validateStoredProductionAudit(
+        sql,
+        yearPlan,
+        row.election_id,
+        context,
+      );
+      const exactGeometry = await validateStoredGeometryRecords(
+        sql,
+        yearPlan,
+        row.election_id,
+        context,
+      );
+
+      const totals = await query(sql, [
+        "select candidate_name,sum(votes)::bigint votes from result_rows rr",
+        "join contests c on c.id=rr.contest_id",
+        "where rr.state_code=$1 and c.election_id=$2::uuid and rr.level='precinct'",
+        " and rr.jurisdiction_code like $3",
+        "group by candidate_name order by candidate_name",
+      ], [
+        STATE,
+        row.election_id,
+        "reporting:" + STATE + ":" + yearPlan.electionId + ":%",
+      ]);
+      const actualTotals = Object.fromEntries(
+        totals.map((item) => [String(item.candidate_name), Number(item.votes)]),
+      );
+      const expectedTotals = {};
+      for (const result of yearPlan.resultRows) {
+        expectedTotals[result.candidateName] =
+          (expectedTotals[result.candidateName] ?? 0) + result.votes;
+      }
+      for (const [name, votes] of Object.entries(expectedTotals)) {
+        if (actualTotals[name] !== votes) {
+          throw new Error("South Carolina " + yearPlan.year + " " + name + " total drifted");
+        }
+      }
+      if (Object.keys(actualTotals).length !== Object.keys(expectedTotals).length) {
+        throw new Error("South Carolina " + yearPlan.year + " candidate grouping drifted");
+      }
+      const zero = await query(sql, [
+        "select count(*)::int count from (",
+        " select rr.reporting_unit_id from result_rows rr",
+        " join contests c on c.id=rr.contest_id",
+        " where rr.state_code=$1 and c.election_id=$2::uuid and rr.level='precinct'",
+        "  and rr.jurisdiction_code like $3",
+        " group by rr.reporting_unit_id having sum(rr.votes)=0) units",
+      ], [
+        STATE,
+        row.election_id,
+        "reporting:" + STATE + ":" + yearPlan.electionId + ":%",
+      ]);
+      if (Number(zero[0].count) !== yearPlan.zeroVoteUnits) {
+        throw new Error("South Carolina " + yearPlan.year + " zero-vote count drifted");
+      }
+      output.push({
+        year: yearPlan.year,
+        electionId: yearPlan.electionId,
+        reportingUnits: Number(row.reporting_units),
+        resultRows: Number(row.result_rows),
+        sameYearResultRows: Number(row.same_year_result_rows),
+        candidateTotals: actualTotals,
+        totalVotes: Object.values(actualTotals).reduce((sum, value) => sum + value, 0),
+        zeroVoteUnits: Number(zero[0].count),
+        resultSourceSlug: provenance.resultSourceSlug,
+        geometrySourceSlug: provenance.geometrySourceSlug,
+        geometryDisposition: yearPlan.geometry.disposition,
+        geographyVersions: Number(row.geography_versions),
+        features: Number(row.features),
+        safeBlockedGeographyVersions: Number(row.safe_geography_versions),
+        reviewedCrosswalks: Number(row.crosswalks),
+        exactFeatures: exactGeometry.exactFeatures,
+        exactCrosswalks: exactGeometry.exactCrosswalks,
+      });
+    }
+    const invalid = await query(sql, [
+      "select count(*)::int count from pg_constraint",
+      "where connamespace='public'::regnamespace and not convalidated",
+    ]);
+    if (Number(invalid[0].count) !== 0) {
+      throw new Error("South Carolina precinct unit database has unvalidated public constraints");
+    }
+    const revision = await query(sql, [
+      "select revision::int revision from public_data_revisions where scope='public'",
+    ]);
+    return {
+      database: {
+        ...context.database,
+        readOnlySession: options.readOnlySession ?? context.mode === "local",
+      },
+      executionMode: context.mode,
+      productionMutationPerformed: context.mode === "production_release",
+      publicDeliveryAuthorized: false,
+      releaseCandidate: context.releaseCandidate,
+      productionReleaseAudit: context.productionReleaseAudit,
+      invalidConstraints: 0,
+      revision: revision.length ? Number(revision[0].revision) : null,
+      years: output,
+    };
+}
+
+export async function validateSouthCarolinaPrecinctGisDatabase(plan, options = {}) {
+  if (getDatabaseDriver() !== "postgres") {
+    throw new Error("South Carolina precinct GIS validation requires CRM_DATABASE_DRIVER=postgres");
+  }
+  const databaseUrl = getLocalCloneDatabaseUrl();
+  const sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+    max: 1,
+    connect_timeout: 10,
+    idle_timeout: 20,
+    connection: {
+      application_name: APPLICATION_NAME + "-validator",
+      default_transaction_read_only: true,
+    },
+  });
+  try {
+    return await validateSouthCarolinaPrecinctGisClient(sql, plan, {
+      executionContext: { mode: "local" },
+      readOnlySession: true,
+    });
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}

--- a/scripts/lib/sc-precinct-gis-plan.mjs
+++ b/scripts/lib/sc-precinct-gis-plan.mjs
@@ -1,0 +1,653 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+import {
+  inspectPrecinctGeometryManifest,
+  reportingUnitCode,
+} from "../../src/lib/precinct-geography.ts";
+import { validateManifestArtifacts } from "./precinct-geometry-validation.mjs";
+
+const STATE = "SC";
+const GEOGRAPHY_LEVEL = "precinct";
+const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+export const SOUTH_CAROLINA_PRECINCT_GIS_YEAR_SPECS = Object.freeze([
+  {
+    year: 2016,
+    electionId: "2016-11-08-general",
+    electionDate: "2016-11-08",
+    manifestSha256: "8a66de16908c768930f1d53ac75314b3bf02d163c2bc368fb7df5266b5bd54b0",
+    manifestByteCount: 4_386,
+    geometryByteCount: 15_662_362,
+    resultsSha256: "b0068408c18d50157408886f463d23891e6c35125703382c40d78b6851263b5d",
+    resultsByteCount: 124_534,
+    crosswalkByteCount: 1_748_197,
+    expectedUnits: 2_551,
+    expectedSourceGeographicUnits: 2_233,
+    expectedGeographicUnits: 2_232,
+    expectedNonGeographicUnits: 319,
+    expectedFeatures: 2_234,
+    expectedCrosswalkRecords: 2_551,
+    expectedNoDataFeatures: 2,
+    expectedZeroVoteUnits: 0,
+    expectedGeographicVotes: 1_589_961,
+    expectedTotalVotes: 2_103_027,
+    democratic: {
+      name: "Hillary Rodham Clinton and Timothy Michael Kaine",
+      party: "DEM",
+    },
+    republican: {
+      name: "Donald J. Trump and Michael R. Pence",
+      party: "REP",
+    },
+    resultSourceUrl:
+      "https://sc.elstats.civera.com/api/download_contest/5292_table.csv?split_party=false",
+  },
+  {
+    year: 2020,
+    electionId: "2020-11-03-general",
+    electionDate: "2020-11-03",
+    manifestSha256: "3e250643ba5224b2a5b852f7f741a34b8c42fb0062592ca2781a7e6d0d15fac2",
+    manifestByteCount: 4_296,
+    geometryByteCount: 17_757_242,
+    resultsSha256: "86cfb63c778729da6a5c23e6d30d5575f0dc3a1f503bf7fe91084466ebbd471c",
+    resultsByteCount: 108_839,
+    crosswalkByteCount: 1_641_445,
+    expectedUnits: 2_399,
+    expectedSourceGeographicUnits: 2_261,
+    expectedGeographicUnits: 2_261,
+    expectedNonGeographicUnits: 138,
+    expectedFeatures: 2_263,
+    expectedCrosswalkRecords: 2_399,
+    expectedNoDataFeatures: 2,
+    expectedZeroVoteUnits: 2,
+    expectedGeographicVotes: 2_504_220,
+    expectedTotalVotes: 2_513_329,
+    democratic: {
+      name: "Joseph R Biden and Kamala D. Harris",
+      party: "DEM",
+    },
+    republican: {
+      name: "Donald J. Trump and Michael R. Pence",
+      party: "REP",
+    },
+    resultSourceUrl:
+      "https://sc.elstats.civera.com/api/download_contest/1974_table.csv?split_party=false",
+  },
+  {
+    year: 2024,
+    electionId: "2024-11-05-general",
+    electionDate: "2024-11-05",
+    manifestSha256: "7ea2454b22404feac80de8117879a0aebc28e9178facf60c46347dedbe74c6e8",
+    manifestByteCount: 4_249,
+    geometryByteCount: 35_604_614,
+    resultsSha256: "f41e21a8f92c8f14b5fb530226a2c46104665c4f6a0fdcd6abfe27a70828e3c9",
+    resultsByteCount: 120_074,
+    crosswalkByteCount: 1_778_403,
+    expectedUnits: 2_446,
+    expectedSourceGeographicUnits: 2_308,
+    expectedGeographicUnits: 2_308,
+    expectedNonGeographicUnits: 138,
+    expectedFeatures: 2_308,
+    expectedCrosswalkRecords: 2_446,
+    expectedNoDataFeatures: 0,
+    expectedZeroVoteUnits: 0,
+    expectedGeographicVotes: 2_541_877,
+    expectedTotalVotes: 2_548_140,
+    democratic: {
+      name: "Kamala D. Harris and Tim Walz",
+      party: "DEM",
+    },
+    republican: {
+      name: "Donald J. Trump and JD Vance",
+      party: "REP",
+    },
+    resultSourceUrl:
+      "https://sc.elstats.civera.com/api/download_contest/7131_table.csv?split_party=false",
+  },
+].map((spec) => Object.freeze({
+  ...spec,
+  manifestPath:
+    `data/precinct-geometry/SC/${spec.electionId}/manifest.json`,
+  resultsPath:
+    `data/precinct-geometry/SC/${spec.electionId}/normalized/sc-${spec.year}-official-president-results.json.gz`,
+  geometrySourceSlug: `sc-${spec.year}-precinct-geometry`,
+  resultSource: Object.freeze({
+    id: `sc-${spec.year}-official-precinct-results`,
+    slug: `sc-${spec.year}-official-precinct-results`,
+    url: spec.resultSourceUrl,
+    artifact:
+      `data/precinct-geometry/SC/${spec.electionId}/normalized/sc-${spec.year}-official-president-results.json.gz`,
+    sha256: spec.resultsSha256,
+    byteCount: spec.resultsByteCount,
+    timestampBasis:
+      "Official South Carolina Election Commission precinct results; administrative reporting units remain separately identified and are never assigned to polygons.",
+    authority: "South Carolina Election Commission",
+  }),
+})));
+
+function insideRoot(root, relativePath) {
+  if (
+    typeof relativePath !== "string"
+    || path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+  ) {
+    throw new Error(`Unsafe South Carolina artifact path: ${relativePath}`);
+  }
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, ...relativePath.split("/"));
+  if (
+    resolved !== resolvedRoot
+    && !resolved.startsWith(resolvedRoot + path.sep)
+  ) {
+    throw new Error(`South Carolina artifact escapes root: ${relativePath}`);
+  }
+  return resolved;
+}
+
+function verified(root, relativePath, expectedSha, expectedBytes, label) {
+  const target = insideRoot(root, relativePath);
+  if (!existsSync(target)) {
+    throw new Error(`${label} is missing: ${relativePath}`);
+  }
+  const bytes = readFileSync(target);
+  if (bytes.length !== expectedBytes || sha256(bytes) !== expectedSha) {
+    throw new Error(`${label} bytes or SHA-256 drifted`);
+  }
+  return bytes;
+}
+
+function forbiddenProperties(value, context) {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) =>
+      forbiddenProperties(entry, `${context}[${index}]`));
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (/^(?:VOTES?|TOTALVOTES?|CANDIDATE|PARTY|G\d{2}PRE)/i.test(key)) {
+      throw new Error(`${context} contains election-value property ${key}`);
+    }
+    forbiddenProperties(child, `${context}.${key}`);
+  }
+}
+
+function safeResultRow(row, context) {
+  const values = [
+    row.democratic,
+    row.republican,
+    row.other,
+    row.total,
+    row.ballotsCast,
+  ].map(Number);
+  if (
+    values.some((value) => !Number.isSafeInteger(value) || value < 0)
+    || values[3] !== values[0] + values[1] + values[2]
+    || values[4] < values[3]
+  ) {
+    throw new Error(`${context} result totals drifted`);
+  }
+  return {
+    democratic: values[0],
+    republican: values[1],
+    other: values[2],
+    total: values[3],
+    ballotsCast: values[4],
+  };
+}
+
+function buildResultPlan(spec, document) {
+  if (
+    document.schemaVersion !== 1
+    || document.state !== STATE
+    || document.electionId !== spec.electionId
+    || document.reportingGrain !== GEOGRAPHY_LEVEL
+    || document.sourceUnitCount !== spec.expectedUnits
+    || document.geographicSourceUnitCount
+      !== spec.expectedSourceGeographicUnits
+    || document.colorableUnitCount !== spec.expectedGeographicUnits
+    || document.excludedUnitCount !== spec.expectedNonGeographicUnits
+    || document.rows?.length !== spec.expectedGeographicUnits
+    || document.exclusions?.length !== spec.expectedNonGeographicUnits
+  ) {
+    throw new Error(
+      `South Carolina ${spec.year} normalized result contract drifted`,
+    );
+  }
+  const reportingUnits = [];
+  const resultRows = [];
+  const seenCodes = new Set();
+  const totals = { Democratic: 0, Republican: 0, Other: 0, Total: 0 };
+  const officialTotals = {
+    Democratic: Number(document.officialTotals?.democraticVotes),
+    Republican: Number(document.officialTotals?.republicanVotes),
+    Other: Number(document.officialTotals?.otherVotes),
+    Total: Number(document.officialTotals?.totalVotes),
+  };
+  let zeroVoteUnits = 0;
+
+  for (const row of document.rows) {
+    const code = reportingUnitCode({
+      state: STATE,
+      electionId: spec.electionId,
+      reportingGrain: GEOGRAPHY_LEVEL,
+      parentGeoid: row.parentGeoid,
+      sourceUnitId: row.sourceUnitId,
+    });
+    if (
+      code !== row.resultUnitCode
+      || !/^45\d{3}$/.test(row.parentGeoid)
+      || typeof row.sourceDisplayName !== "string"
+      || !row.sourceDisplayName.trim()
+      || seenCodes.has(code)
+    ) {
+      throw new Error(
+        `South Carolina ${spec.year} geographic result identity drifted`,
+      );
+    }
+    seenCodes.add(code);
+    const values = safeResultRow(
+      row,
+      `South Carolina ${spec.year} ${code}`,
+    );
+    if (values.total === 0) zeroVoteUnits += 1;
+    reportingUnits.push({
+      code,
+      sourceUnitId: row.sourceUnitId,
+      sourceDisplayName: row.sourceDisplayName,
+      parentGeoid: row.parentGeoid,
+      reportingGrain: GEOGRAPHY_LEVEL,
+      isGeographic: true,
+      resultStatus: "candidate_detail_complete",
+    });
+    resultRows.push(
+      {
+        jurisdictionCode: code,
+        jurisdictionName: row.sourceDisplayName,
+        candidateName: spec.democratic.name,
+        party: spec.democratic.party,
+        votes: values.democratic,
+      },
+      {
+        jurisdictionCode: code,
+        jurisdictionName: row.sourceDisplayName,
+        candidateName: spec.republican.name,
+        party: spec.republican.party,
+        votes: values.republican,
+      },
+      {
+        jurisdictionCode: code,
+        jurisdictionName: row.sourceDisplayName,
+        candidateName: "Other",
+        party: "OTHER",
+        votes: values.other,
+      },
+    );
+    totals.Democratic += values.democratic;
+    totals.Republican += values.republican;
+    totals.Other += values.other;
+    totals.Total += values.total;
+  }
+
+  for (const row of document.exclusions) {
+    const reportingGrain = "administrative_reporting_unit";
+    const code = reportingUnitCode({
+      state: STATE,
+      electionId: spec.electionId,
+      reportingGrain,
+      parentGeoid: row.parentGeoid,
+      sourceUnitId: row.sourceUnitId,
+    });
+    if (
+      code !== row.resultUnitCode
+      || !/^45\d{3}$/.test(row.parentGeoid)
+      || typeof row.sourceDisplayName !== "string"
+      || !row.sourceDisplayName.trim()
+      || seenCodes.has(code)
+    ) {
+      throw new Error(
+        `South Carolina ${spec.year} administrative result identity drifted`,
+      );
+    }
+    seenCodes.add(code);
+    safeResultRow(row, `South Carolina ${spec.year} ${code}`);
+    reportingUnits.push({
+      code,
+      sourceUnitId: row.sourceUnitId,
+      sourceDisplayName: row.sourceDisplayName,
+      parentGeoid: row.parentGeoid,
+      reportingGrain,
+      isGeographic: false,
+      resultStatus: "non_geographic_reconciliation_only",
+    });
+  }
+
+  if (
+    reportingUnits.length !== spec.expectedUnits
+    || resultRows.length !== spec.expectedGeographicUnits * 3
+    || zeroVoteUnits !== spec.expectedZeroVoteUnits
+    || totals.Total !== spec.expectedGeographicVotes
+    || officialTotals.Total !== spec.expectedTotalVotes
+    || totals.Democratic !== document.geographicTotals?.democraticVotes
+    || totals.Republican !== document.geographicTotals?.republicanVotes
+    || totals.Other !== document.geographicTotals?.otherVotes
+    || totals.Total !== document.geographicTotals?.totalVotes
+    || officialTotals.Democratic !== document.officialTotals?.democraticVotes
+    || officialTotals.Republican !== document.officialTotals?.republicanVotes
+    || officialTotals.Other !== document.officialTotals?.otherVotes
+  ) {
+    throw new Error(`South Carolina ${spec.year} official total drifted`);
+  }
+  return {
+    reportingUnits,
+    resultRows,
+    totals,
+    officialTotals,
+    zeroVoteUnits,
+    candidateDetailSuppressedUnits: 0,
+    source: spec.resultSource,
+  };
+}
+
+function buildGeometryPlan(root, spec, manifest, results) {
+  const inspection = validateManifestArtifacts(manifest, {
+    root,
+    skipDelivery: true,
+  });
+  if (inspection.errors.length) {
+    throw new Error(
+      `South Carolina ${spec.year} artifact validation failed: ${inspection.errors.join("; ")}`,
+    );
+  }
+  if (
+    manifest.geography.level !== GEOGRAPHY_LEVEL
+    || manifest.crosswalk.status !== "reviewed"
+    || manifest.crosswalk.resultUnits !== spec.expectedUnits
+    || manifest.crosswalk.matchedResultUnits !== spec.expectedGeographicUnits
+    || manifest.crosswalk.unmatchedResultUnits !== 0
+    || manifest.crosswalk.nonGeographicResultUnits
+      !== spec.expectedNonGeographicUnits
+    || manifest.crosswalk.reviewedRelationshipRecords
+      !== spec.expectedCrosswalkRecords
+    || manifest.crosswalk.reviewedNoDataFeatures
+      !== spec.expectedNoDataFeatures
+    || manifest.validation.rowLevelRenderingSafe !== true
+    || manifest.delivery !== null
+  ) {
+    throw new Error(
+      `South Carolina ${spec.year} reviewed local geometry contract drifted`,
+    );
+  }
+  const geometryBytes = verified(
+    root,
+    manifest.normalization.artifact,
+    manifest.normalization.sha256,
+    spec.geometryByteCount,
+    `South Carolina ${spec.year} geometry`,
+  );
+  const normalized = JSON.parse(gunzipSync(geometryBytes).toString("utf8"));
+  const features = [];
+  const featureByKey = new Map();
+  for (const feature of normalized.features ?? []) {
+    const parent = String(feature.properties?.CRM_PARENT_GEOID ?? "");
+    const id = String(feature.properties?.CRM_FEATURE_ID ?? "");
+    const sourceFeatureId = `${parent}|${id}`;
+    forbiddenProperties(
+      feature.properties,
+      `South Carolina ${spec.year} feature ${sourceFeatureId}`,
+    );
+    if (
+      !/^45\d{3}$/.test(parent)
+      || !id
+      || !["Polygon", "MultiPolygon"].includes(feature.geometry?.type)
+      || featureByKey.has(sourceFeatureId)
+    ) {
+      throw new Error(
+        `South Carolina ${spec.year} normalized feature identity drifted`,
+      );
+    }
+    const record = {
+      sourceFeatureId,
+      parentGeoid: parent,
+      name: String(feature.properties.SOURCE_NAME ?? id),
+      geometryKey: sourceFeatureId,
+      isGeographic: true,
+      properties: feature.properties,
+    };
+    features.push(record);
+    featureByKey.set(sourceFeatureId, record);
+  }
+  if (features.length !== spec.expectedFeatures) {
+    throw new Error(
+      `South Carolina ${spec.year} normalized feature count drifted`,
+    );
+  }
+  const crosswalkBytes = verified(
+    root,
+    manifest.crosswalk.artifact,
+    manifest.crosswalk.sha256,
+    spec.crosswalkByteCount,
+    `South Carolina ${spec.year} crosswalk`,
+  );
+  const crosswalk = JSON.parse(crosswalkBytes.toString("utf8"));
+  if (
+    crosswalk.state !== STATE
+    || crosswalk.electionId !== spec.electionId
+    || crosswalk.geographyLevel !== GEOGRAPHY_LEVEL
+    || crosswalk.resultSourceId !== manifest.crosswalk.resultSourceId
+  ) {
+    throw new Error(
+      `South Carolina ${spec.year} crosswalk envelope drifted`,
+    );
+  }
+  const unitsByCode = new Map(
+    results.reportingUnits.map((unit) => [unit.code, unit]),
+  );
+  const seenUnits = new Set();
+  const crosswalks = [];
+  for (const [index, row] of (crosswalk.rows ?? []).entries()) {
+    const unit = unitsByCode.get(row.resultUnitCode);
+    if (
+      !unit
+      || row.sourceUnitId !== unit.sourceUnitId
+      || row.parentGeoid !== unit.parentGeoid
+      || row.reportingGrain !== unit.reportingGrain
+      || row.isGeographic !== unit.isGeographic
+      || seenUnits.has(row.resultUnitCode)
+      || !Array.isArray(row.relationships)
+      || row.relationships.length !== 1
+    ) {
+      throw new Error(
+        `South Carolina ${spec.year} crosswalk identity drift at row ${index}`,
+      );
+    }
+    seenUnits.add(row.resultUnitCode);
+    const relationship = row.relationships[0];
+    forbiddenProperties(
+      relationship,
+      `South Carolina ${spec.year} crosswalk row ${index}`,
+    );
+    const commonRelationshipValid = relationship.reviewStatus === "reviewed"
+      && relationship.confidence === "high"
+      && ["reviewed_name", "exact_official_id"].includes(
+        relationship.matchMethod,
+      );
+    const geographicRelationshipValid = unit.isGeographic
+      && relationship.relationshipType === "one_to_one"
+      && relationship.matchMethod === "reviewed_name"
+      && featureByKey.has(relationship.sourceFeatureId);
+    const nonGeographicRelationshipValid = !unit.isGeographic
+      && relationship.relationshipType === "non_geographic"
+      && relationship.matchMethod === "exact_official_id"
+      && relationship.sourceFeatureId === null;
+    if (
+      !commonRelationshipValid
+      || (!geographicRelationshipValid && !nonGeographicRelationshipValid)
+    ) {
+      throw new Error(
+        `South Carolina ${spec.year} crosswalk relationship drift at row ${index}`,
+      );
+    }
+    crosswalks.push({
+      reportingUnitCode: row.resultUnitCode,
+      sourceFeatureId: relationship.sourceFeatureId,
+      relationshipType: relationship.relationshipType,
+      matchMethod: relationship.matchMethod,
+      reviewStatus: relationship.reviewStatus,
+      confidence: relationship.confidence,
+      note: String(relationship.note ?? ""),
+    });
+  }
+  if (
+    seenUnits.size !== spec.expectedUnits
+    || crosswalks.length !== spec.expectedCrosswalkRecords
+    || crosswalks.filter((row) => row.sourceFeatureId !== null).length
+      !== spec.expectedGeographicUnits
+  ) {
+    throw new Error(`South Carolina ${spec.year} crosswalk counts drifted`);
+  }
+  return {
+    disposition: "loadable_reviewed",
+    sourceGatePassed: true,
+    publicReleaseEligible: false,
+    blockCode: null,
+    reasons: [...manifest.validation.errors],
+    features,
+    crosswalks,
+    artifactWarnings: inspection.warnings,
+  };
+}
+
+async function loadYear(root, spec) {
+  const manifestBytes = verified(
+    root,
+    spec.manifestPath,
+    spec.manifestSha256,
+    spec.manifestByteCount,
+    `South Carolina ${spec.year} manifest`,
+  );
+  const manifest = JSON.parse(manifestBytes.toString("utf8"));
+  const contract = inspectPrecinctGeometryManifest(manifest);
+  if (
+    contract.errors.length
+    || manifest.state !== STATE
+    || manifest.election.id !== spec.electionId
+    || manifest.election.date !== spec.electionDate
+    || manifest.geography.level !== GEOGRAPHY_LEVEL
+  ) {
+    throw new Error(
+      `South Carolina ${spec.year} manifest contract drifted: ${contract.errors.join("; ")}`,
+    );
+  }
+  const resultBytes = verified(
+    root,
+    spec.resultsPath,
+    spec.resultsSha256,
+    spec.resultsByteCount,
+    `South Carolina ${spec.year} normalized results`,
+  );
+  const results = buildResultPlan(
+    spec,
+    JSON.parse(gunzipSync(resultBytes).toString("utf8")),
+  );
+  return {
+    year: spec.year,
+    electionId: spec.electionId,
+    electionDate: spec.electionDate,
+    manifestPath: spec.manifestPath,
+    manifestSha256: spec.manifestSha256,
+    manifestByteCount: spec.manifestByteCount,
+    artifactByteCounts: {
+      source: manifest.source.byteCount,
+      normalization: spec.geometryByteCount,
+      crosswalk: spec.crosswalkByteCount,
+    },
+    manifest,
+    resultSource: results.source,
+    reportingUnits: results.reportingUnits,
+    resultRows: results.resultRows,
+    totals: results.totals,
+    officialTotals: results.officialTotals,
+    zeroVoteUnits: results.zeroVoteUnits,
+    candidateDetailSuppressedUnits: 0,
+    sourceRows: results.reportingUnits.length,
+    geometry: buildGeometryPlan(root, spec, manifest, results),
+    geometrySourceSlug: spec.geometrySourceSlug,
+  };
+}
+
+export async function buildSouthCarolinaPrecinctGisPlan(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const selected = options.years
+    ? new Set(options.years.map(Number))
+    : new Set(
+      SOUTH_CAROLINA_PRECINCT_GIS_YEAR_SPECS.map((spec) => spec.year),
+    );
+  for (const selectedYear of selected) {
+    if (
+      !SOUTH_CAROLINA_PRECINCT_GIS_YEAR_SPECS.some(
+        (spec) => spec.year === selectedYear,
+      )
+    ) {
+      throw new Error(
+        "Supported South Carolina public-release years are 2016, 2020, and 2024; 2012 remains separately blocked",
+      );
+    }
+  }
+  const years = [];
+  for (const spec of SOUTH_CAROLINA_PRECINCT_GIS_YEAR_SPECS.filter(
+    (entry) => selected.has(entry.year),
+  )) {
+    years.push(await loadYear(root, spec));
+  }
+  if (!years.length) {
+    throw new Error("Select at least one South Carolina precinct GIS year");
+  }
+  return {
+    schemaVersion: 1,
+    state: STATE,
+    stateName: "South Carolina",
+    authority: "South Carolina Election Commission",
+    scope:
+      "local-only 2016, 2020, and 2024 presidential general-election precinct GIS setup; 2012 remains separately blocked",
+    geographyLevel: GEOGRAPHY_LEVEL,
+    years,
+  };
+}
+
+export function summarizeSouthCarolinaPrecinctGisPlan(plan) {
+  return {
+    schemaVersion: plan.schemaVersion,
+    state: plan.state,
+    scope: plan.scope,
+    geographyLevel: plan.geographyLevel,
+    years: plan.years.map((year) => ({
+      year: year.year,
+      electionId: year.electionId,
+      manifestId: year.manifest.id,
+      manifestSha256: year.manifestSha256,
+      reportingUnits: year.reportingUnits.length,
+      geographicReportingUnits: year.reportingUnits.filter(
+        (unit) => unit.isGeographic,
+      ).length,
+      nonGeographicReportingUnits: year.reportingUnits.filter(
+        (unit) => !unit.isGeographic,
+      ).length,
+      resultRows: year.resultRows.length,
+      zeroVoteUnits: year.zeroVoteUnits,
+      totals: year.totals,
+      officialTotals: year.officialTotals,
+      geometryDisposition: year.geometry.disposition,
+      geometryFeatures: year.geometry.features.length,
+      reviewedCrosswalks: year.geometry.crosswalks.length,
+      reviewedNoDataFeatures: year.manifest.crosswalk.reviewedNoDataFeatures,
+      sourceGatePassed: year.geometry.sourceGatePassed,
+      publicReleaseEligible: year.geometry.publicReleaseEligible,
+      publicDeliveryAuthorized: false,
+      blockers: year.geometry.reasons,
+      caveats: year.manifest.caveats,
+    })),
+  };
+}

--- a/scripts/lib/sc-precinct-production-preflight.mjs
+++ b/scripts/lib/sc-precinct-production-preflight.mjs
@@ -1,0 +1,353 @@
+import { createHash } from "node:crypto";
+
+const LOOPBACK_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "[::1]",
+]);
+
+const PRECINCT_TABLES = Object.freeze([
+  "geography_features",
+  "geography_versions",
+  "reporting_unit_geometry_crosswalks",
+  "reporting_units",
+]);
+
+const REPORTING_UNIT_COLUMNS = Object.freeze([
+  ["result_rows", "reporting_unit_id"],
+  ["review_rows", "reporting_unit_id"],
+  ["turnout_rows", "reporting_unit_id"],
+]);
+
+function query(client, lines, params = []) {
+  return client.unsafe(Array.isArray(lines) ? lines.join("\n") : lines, params);
+}
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function productionEndpointFingerprint(databaseUrl) {
+  let parsed;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    throw new Error("South Carolina production preflight requires a valid PostgreSQL URL");
+  }
+  if (!/^postgres(?:ql)?:$/.test(parsed.protocol)) {
+    throw new Error("South Carolina production preflight requires a PostgreSQL URL");
+  }
+  if (LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase())) {
+    throw new Error("South Carolina production preflight refuses a loopback database URL");
+  }
+  const databaseName = decodeURIComponent(parsed.pathname).replace(/^\//, "");
+  if (!databaseName) {
+    throw new Error("South Carolina production preflight requires a database name");
+  }
+  return createHash("sha256")
+    .update([
+      parsed.hostname.toLowerCase(),
+      parsed.port || "5432",
+      databaseName,
+    ].join("\n"))
+    .digest("hex");
+}
+
+export function assertSouthCarolinaReleaseCandidateDocument(
+  document,
+  packageSha256,
+) {
+  if (!/^[a-f0-9]{64}$/.test(packageSha256 ?? "")) {
+    throw new Error("South Carolina release package SHA-256 is invalid");
+  }
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "sc-precinct-gis-three-election-v1"
+    || document?.state !== "SC"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.safety?.explicitProductionAuthorizationRequired !== true
+    || document?.safety?.productionMutationPerformed !== false
+    || document?.safety?.publicFileWritten !== false
+    || document?.safety?.canonicalManifestChanged !== false
+    || document?.safety?.canonicalRegistryChanged !== false
+  ) {
+    throw new Error("South Carolina release candidate does not match the guarded contract");
+  }
+  const expectedTotals = {
+    elections: 3,
+    reportingUnits: 7_396,
+    candidateResultRows: 20_403,
+    zeroVoteUnits: 2,
+    geometryFeatures: 6_805,
+    reviewedRelationships: 7_396,
+  };
+  for (const [key, value] of Object.entries(expectedTotals)) {
+    if (Number(document?.totals?.[key]) !== value) {
+      throw new Error("South Carolina release candidate total drifted: " + key);
+    }
+  }
+  const migrations = document?.databaseActivationContract?.migrations;
+  const expectedMigrationPaths = [
+    "drizzle/0008_typical_thunderbolts.sql",
+    "drizzle/0009_public_wolfpack.sql",
+  ];
+  if (
+    !Array.isArray(migrations)
+    || migrations.length !== expectedMigrationPaths.length
+    || migrations.some((migration, index) =>
+      migration?.path !== expectedMigrationPaths[index]
+      || !Number.isSafeInteger(migration?.byteCount)
+      || migration.byteCount <= 0
+      || !/^[a-f0-9]{64}$/.test(migration?.sha256 ?? ""))
+  ) {
+    throw new Error("South Carolina release candidate migration pins are invalid");
+  }
+  const years = (document.years ?? []).map((year) => Number(year.year));
+  if (JSON.stringify(years) !== JSON.stringify([2016, 2020, 2024])) {
+    throw new Error("South Carolina release candidate year set drifted");
+  }
+  return {
+    id: document.id,
+    sha256: packageSha256,
+    migrations,
+    totals: expectedTotals,
+    canonicalManifestPreimages: document.years.map((year) => ({
+      year: year.year,
+      path: year.canonicalManifest.path,
+      byteCount: year.canonicalManifest.byteCount,
+      sha256: year.canonicalManifest.sha256,
+      validationStatus: year.canonicalManifest.validationStatus,
+      rowLevelRenderingSafe: year.canonicalManifest.rowLevelRenderingSafe,
+      delivery: year.canonicalManifest.delivery,
+    })),
+  };
+}
+
+function migrationState(tableRows, columnRows) {
+  const tables = new Set(tableRows.map((row) => String(row.table_name)));
+  const columns = new Set(
+    columnRows.map((row) => `${row.table_name}.${row.column_name}`),
+  );
+  const presentTables = PRECINCT_TABLES.filter((name) => tables.has(name));
+  const presentColumns = REPORTING_UNIT_COLUMNS.filter(([table, column]) =>
+    columns.has(`${table}.${column}`));
+  const absent = presentTables.length === 0 && presentColumns.length === 0;
+  const complete = presentTables.length === PRECINCT_TABLES.length
+    && presentColumns.length === REPORTING_UNIT_COLUMNS.length;
+  return {
+    status: absent ? "absent" : complete ? "complete" : "partial_blocked",
+    expectedTables: [...PRECINCT_TABLES],
+    presentTables,
+    expectedReportingUnitColumns: REPORTING_UNIT_COLUMNS.map(
+      ([table, column]) => `${table}.${column}`,
+    ),
+    presentReportingUnitColumns: presentColumns.map(
+      ([table, column]) => `${table}.${column}`,
+    ),
+  };
+}
+
+function derivationConstraintState(rows, schemaStatus) {
+  if (schemaStatus === "absent") {
+    return { status: "absent", definition: null };
+  }
+  if (rows.length !== 1) {
+    return { status: "partial_blocked", definition: null };
+  }
+  const definition = String(rows[0].definition ?? "");
+  return {
+    status: definition.includes("secondary_reconstruction")
+        && definition.includes("hybrid_reconstruction")
+      ? "complete"
+      : "absent",
+    definition,
+  };
+}
+
+export function buildSouthCarolinaProductionPreflightReport(snapshot, context) {
+  if (String(snapshot.identity?.transaction_read_only) !== "on") {
+    throw new Error("South Carolina production preflight did not use a read-only transaction");
+  }
+  const schema = migrationState(snapshot.precinctTables, snapshot.precinctColumns);
+  if (schema.status === "partial_blocked") {
+    throw new Error("South Carolina production schema is partially migrated; release is blocked");
+  }
+  const invalidConstraints = Number(snapshot.invalidConstraints ?? NaN);
+  if (!Number.isInteger(invalidConstraints)) {
+    throw new Error("South Carolina production preflight constraint count is invalid");
+  }
+  const migration0009 = derivationConstraintState(
+    snapshot.derivationConstraint,
+    schema.status,
+  );
+  if (migration0009.status === "partial_blocked") {
+    throw new Error("South Carolina production derivation-method constraint is ambiguous");
+  }
+  const report = {
+    schemaVersion: 1,
+    state: "SC",
+    scope: "read-only South Carolina precinct unit GIS production preflight",
+    capturedAtUtc: context.capturedAtUtc,
+    releaseCandidate: context.releaseCandidate,
+    endpointFingerprint: context.endpointFingerprint,
+    database: {
+      name: String(snapshot.identity.database_name),
+      serverVersionNum: String(snapshot.identity.server_version_num),
+      databaseBytes: String(snapshot.identity.database_bytes),
+      transactionReadOnly: true,
+    },
+    productionMutationPerformed: false,
+    canonicalManifestChanged: false,
+    publicFileWritten: false,
+    publicTableCount: snapshot.publicTables.length,
+    publicTables: snapshot.publicTables.map((row) => String(row.table_name)),
+    migration0008: schema,
+    migration0009,
+    invalidConstraints,
+    publicRevision: snapshot.revision.length
+      ? Number(snapshot.revision[0].revision)
+      : null,
+    southCarolina: {
+      coreYearRows: snapshot.coreYears.map((row) => ({
+        year: Number(row.year),
+        electionDate: String(row.election_date),
+        resultRows: Number(row.result_rows),
+        localResultRows: Number(row.local_result_rows),
+        countyResultRows: Number(row.county_result_rows),
+      })),
+      localYearRows: snapshot.localYears.map((row) => ({
+        year: Number(row.year),
+        reportingUnits: Number(row.reporting_units),
+        linkedLocalResultRows: Number(row.linked_local_result_rows),
+        geographyVersions: Number(row.geography_versions),
+        geometryFeatures: Number(row.geometry_features),
+        reviewedRelationships: Number(row.reviewed_relationships),
+      })),
+      sourceDocuments: snapshot.sourceDocuments.map((row) => ({
+        slug: String(row.slug),
+        electionYear: Number(row.election_year),
+        status: String(row.status),
+        localArtifact: String(row.local_artifact ?? ""),
+      })),
+    },
+    canonicalManifestPreimages:
+      context.releaseCandidate.canonicalManifestPreimages,
+    stopConditions: [
+      "migration0008.status is partial_blocked",
+      "migration0009.status is partial_blocked",
+      "any invalid public constraint exists",
+      "the endpoint fingerprint or database name differs from authorization",
+      "any South Carolina year or row set differs before the write transaction",
+      "any canonical manifest preimage differs from the release package",
+    ],
+  };
+  return report;
+}
+
+export async function collectSouthCarolinaProductionPreflight(sql, context) {
+  const identityRows = await query(sql, [
+    "select current_database() database_name,",
+    " current_setting('server_version_num') server_version_num,",
+    " current_setting('transaction_read_only') transaction_read_only,",
+    " pg_database_size(current_database())::text database_bytes",
+  ]);
+  if (identityRows.length !== 1) {
+    throw new Error("South Carolina production preflight database identity is missing");
+  }
+  const publicTables = await query(sql, [
+    "select tablename table_name from pg_catalog.pg_tables",
+    "where schemaname='public' order by tablename",
+  ]);
+  const precinctTables = await query(sql, [
+    "select table_name from information_schema.tables",
+    "where table_schema='public' and table_name = any($1::text[])",
+    "order by table_name",
+  ], [[...PRECINCT_TABLES]]);
+  const precinctColumns = await query(sql, [
+    "select table_name,column_name from information_schema.columns",
+    "where table_schema='public' and (table_name,column_name) in (",
+    " ('result_rows','reporting_unit_id'),",
+    " ('review_rows','reporting_unit_id'),",
+    " ('turnout_rows','reporting_unit_id'))",
+    "order by table_name,column_name",
+  ]);
+  const invalid = await query(sql, [
+    "select count(*)::int count from pg_constraint",
+    "where connamespace='public'::regnamespace and not convalidated",
+  ]);
+  const revision = await query(sql, [
+    "select revision::int revision from public_data_revisions where scope='public'",
+  ]);
+  const derivationConstraint = await query(sql, [
+    "select pg_get_constraintdef(oid) definition from pg_constraint",
+    "where connamespace='public'::regnamespace",
+    " and conname='geography_versions_derivation_method_check'",
+  ]);
+  const coreYears = await query(sql, [
+    "select e.year,e.election_date,",
+    " count(rr.id)::int result_rows,",
+    " count(rr.id) filter (where rr.level='precinct')::int local_result_rows,",
+    " count(rr.id) filter (where rr.level='county')::int county_result_rows",
+    "from elections e",
+    "left join contests c on c.election_id=e.id and c.state_code='SC'",
+    "left join result_rows rr on rr.contest_id=c.id and rr.state_code='SC'",
+    "where e.office='president' and (c.id is not null or e.year in (2016,2020,2024))",
+    "group by e.year,e.election_date order by e.year",
+  ]);
+  const sourceDocuments = await query(sql, [
+    "select slug,election_year,status,local_artifact from source_documents",
+    "where state_code='SC' order by election_year,slug",
+  ]);
+
+  const state = migrationState(precinctTables, precinctColumns);
+  let localYears = [];
+  if (state.status === "complete") {
+    localYears = await query(sql, [
+      "select e.year,",
+      " (select count(*)::int from reporting_units ru",
+      "  where ru.state_code='SC' and ru.election_id=e.id",
+    "   and ru.reporting_grain in ('precinct','administrative_reporting_unit')) reporting_units,",
+      " (select count(*)::int from result_rows rr",
+      "  join contests c on c.id=rr.contest_id",
+      "  where rr.state_code='SC' and c.election_id=e.id",
+      "   and rr.level='precinct' and rr.reporting_unit_id is not null)",
+      "  linked_local_result_rows,",
+      " (select count(*)::int from geography_versions gv",
+      "  where gv.state_code='SC' and gv.election_id=e.id",
+      "   and gv.geography_type='precinct') geography_versions,",
+      " (select count(*)::int from geography_features gf",
+      "  join geography_versions gv on gv.id=gf.geometry_version_id",
+      "  where gv.state_code='SC' and gv.election_id=e.id",
+      "   and gv.geography_type='precinct') geometry_features,",
+      " (select count(*)::int from reporting_unit_geometry_crosswalks x",
+      "  join geography_versions gv on gv.id=x.geometry_version_id",
+      "  join reporting_units ru on ru.id=x.reporting_unit_id",
+      "  where gv.state_code='SC' and gv.election_id=e.id",
+      "   and ru.election_id=e.id and x.relationship_type='one_to_one'",
+      "   and x.match_method in ('exact_official_id','official_crosswalk')",
+      "   and x.review_status='reviewed' and x.confidence='high')",
+      "  reviewed_relationships",
+      "from elections e where e.office='president'",
+    " and e.year in (2016,2020,2024) order by e.year",
+    ]);
+  }
+
+  return buildSouthCarolinaProductionPreflightReport({
+    identity: identityRows[0],
+    publicTables,
+    precinctTables,
+    precinctColumns,
+    derivationConstraint,
+    invalidConstraints: invalid[0]?.count,
+    revision,
+    coreYears,
+    localYears,
+    sourceDocuments,
+  }, context);
+}
+
+export const southCarolinaPrecinctSchemaContract = Object.freeze({
+  tables: PRECINCT_TABLES,
+  reportingUnitColumns: REPORTING_UNIT_COLUMNS,
+});

--- a/scripts/lib/sc-precinct-production-release.mjs
+++ b/scripts/lib/sc-precinct-production-release.mjs
@@ -1,0 +1,235 @@
+import { createHash } from "node:crypto";
+
+export const SOUTH_CAROLINA_PRODUCTION_RELEASE_SCOPES = Object.freeze([
+  "apply_migration_0009",
+  "load_sc_precinct_results_and_geometry_hidden",
+  "increment_public_data_revision",
+]);
+export const SOUTH_CAROLINA_MAX_RELEASE_EVIDENCE_AGE_MS = 4 * 60 * 60 * 1000;
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function validIso(value) {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function normalizeIdentity(value) {
+  return typeof value === "string"
+    ? value.trim().normalize("NFKC").replace(/\s+/gu, " ").toLocaleLowerCase("en-US")
+    : "";
+}
+
+function semantic(value) {
+  if (Array.isArray(value)) return value.map(semantic);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, semantic(value[key])]),
+  );
+}
+
+function semanticallyEqual(left, right) {
+  return JSON.stringify(semantic(left)) === JSON.stringify(semantic(right));
+}
+
+function validArtifact(value, prefix) {
+  return typeof value?.path === "string"
+    && value.path.startsWith(prefix)
+    && !value.path.includes("\\")
+    && !value.path.split("/").includes("..")
+    && /^[a-f0-9]{64}$/.test(value?.sha256 ?? "");
+}
+
+function expectedScopes() {
+  return [...SOUTH_CAROLINA_PRODUCTION_RELEASE_SCOPES];
+}
+
+export function buildSouthCarolinaProductionAuthorizationTemplate(context) {
+  return {
+    schemaVersion: 1,
+    state: "SC",
+    decision: "NO_GO_PRODUCTION",
+    authorizationId: null,
+    releaseCandidate: {
+      id: context.releaseCandidate.id,
+      sha256: context.releaseCandidate.sha256,
+    },
+    evidence: {
+      preflightSha256: context.preflightSha256 ?? null,
+      backupManifestSha256: context.backupManifestSha256 ?? null,
+    },
+    approvedBy: null,
+    authorizedAtUtc: null,
+    expiresAtUtc: null,
+    scopes: expectedScopes(),
+    acknowledgement:
+      "This template is not authorization. GO_PRODUCTION authorizes only migration 0009, the hidden South Carolina load, and one public revision increment; public geometry and result visibility remain blocked.",
+  };
+}
+
+export function validateSouthCarolinaProductionPreflightEvidence(report, context) {
+  const targetYears = [2016, 2020, 2024];
+  const localYearRows = report?.southCarolina?.localYearRows;
+  const coreYearRows = report?.southCarolina?.coreYearRows;
+  const expectedYearRows = targetYears.map((year) => ({
+      year,
+      reportingUnits: 0,
+      resultRows: 0,
+      geometryFeatures: 0,
+      reviewedRelationships: 0,
+    }));
+  if (
+    report?.schemaVersion !== 1
+    || report?.state !== "SC"
+    || report?.productionMutationPerformed !== false
+    || report?.database?.transactionReadOnly !== true
+    || report?.invalidConstraints !== 0
+    || report?.migration0008?.status !== "complete"
+    || !["absent", "complete"].includes(report?.migration0009?.status)
+    || report?.releaseCandidate?.id !== context.releaseCandidate.id
+    || report?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || report?.endpointFingerprint !== context.endpointFingerprint
+    || !/^[a-f0-9]{64}$/.test(report?.endpointFingerprint ?? "")
+    || !Number.isInteger(Number(report?.publicRevision))
+    || Number(report.publicRevision) < 1
+    || !validIso(report?.capturedAtUtc)
+    || !Array.isArray(localYearRows)
+    || !Array.isArray(coreYearRows)
+    || JSON.stringify(localYearRows.map((row) => Number(row.year)))
+      !== JSON.stringify(targetYears)
+    || localYearRows.some((row, index) => {
+      const expected = expectedYearRows[index];
+      return Number(row.reportingUnits) !== expected.reportingUnits
+        || Number(row.linkedLocalResultRows) !== expected.resultRows
+        || Number(row.geographyVersions) !== 0
+        || Number(row.geometryFeatures) !== expected.geometryFeatures
+        || Number(row.reviewedRelationships) !== expected.reviewedRelationships;
+    })
+    || coreYearRows.some((row) => {
+      const index = targetYears.indexOf(Number(row.year));
+      return index >= 0
+        && Number(row.localResultRows) !== expectedYearRows[index].resultRows;
+    })
+  ) {
+    throw new Error(
+      "South Carolina production preflight evidence is incompatible or already contains precinct release rows",
+    );
+  }
+  const age = context.now.getTime() - Date.parse(report.capturedAtUtc);
+  if (age < 0 || age > SOUTH_CAROLINA_MAX_RELEASE_EVIDENCE_AGE_MS) {
+    throw new Error("South Carolina production preflight is outside the four-hour release window");
+  }
+  if (typeof report.database.name !== "string" || !report.database.name.trim()) {
+    throw new Error("South Carolina production preflight database name is missing");
+  }
+  return {
+    databaseName: report.database.name.trim(),
+    capturedAtUtc: report.capturedAtUtc,
+    publicRevision: Number(report.publicRevision),
+    releaseMode: "initial_hidden_load",
+  };
+}
+
+export function validateSouthCarolinaProductionBackupEvidence(manifest, context) {
+  const restore = manifest?.restoreVerification;
+  if (
+    !Number.isInteger(manifest?.manifestVersion)
+    || manifest.manifestVersion < 3
+    || manifest?.backupPurpose !== "sc-precinct-production-release-rollback"
+    || manifest?.releaseCandidate?.id !== context.releaseCandidate.id
+    || manifest?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || manifest?.sourceEndpointFingerprint !== context.endpointFingerprint
+    || !/^[a-f0-9]{64}$/.test(manifest?.dumpSha256 ?? "")
+    || manifest?.dumpFormat !== "custom"
+    || Number(manifest?.pgClientMajor) !== 17
+    || Math.trunc(Number(manifest?.sourceServerVersionNum) / 10_000) !== 17
+    || JSON.stringify(manifest?.includedSchemas) !== JSON.stringify(["public"])
+    || !Array.isArray(manifest?.excludedTableDataPatterns)
+    || manifest.excludedTableDataPatterns.length !== 0
+    || manifest?.remoteMutationPerformed !== false
+    || Number(manifest?.sourceInvalidConstraints) !== 0
+    || restore?.verified !== true
+    || restore?.defaultTransactionReadOnly !== true
+    || restore?.exactSourceTableSet !== true
+    || restore?.exactSourceRowCounts !== true
+    || Number(restore?.invalidConstraints) !== 0
+    || !validIso(manifest?.createdAtUtc)
+    || !validIso(restore?.verifiedAtUtc)
+  ) {
+    throw new Error("South Carolina production backup evidence is incomplete or incompatible");
+  }
+  const created = Date.parse(manifest.createdAtUtc);
+  const restored = Date.parse(restore.verifiedAtUtc);
+  const preflight = Date.parse(context.preflightCapturedAtUtc);
+  const now = context.now.getTime();
+  if (
+    Number.isNaN(preflight)
+    || created <= preflight
+    || restored < created
+    || now - created < 0
+    || now - created > SOUTH_CAROLINA_MAX_RELEASE_EVIDENCE_AGE_MS
+    || now - restored < 0
+    || now - restored > SOUTH_CAROLINA_MAX_RELEASE_EVIDENCE_AGE_MS
+  ) {
+    throw new Error("South Carolina backup must follow the fresh preflight and restore within four hours");
+  }
+  const sourceCounts = manifest.sourcePublicTableRowCounts;
+  const restoredCounts = restore.publicTableRowCounts;
+  const sourceTableCount = Number(manifest.sourcePublicTableCount);
+  if (
+    !sourceCounts
+    || !restoredCounts
+    || typeof sourceCounts !== "object"
+    || typeof restoredCounts !== "object"
+    || Array.isArray(sourceCounts)
+    || Array.isArray(restoredCounts)
+    || sourceTableCount !== Number(restore.publicTableCount)
+    || sourceTableCount !== Number(restore.tableDataEntryCount)
+    || Object.keys(sourceCounts).length !== sourceTableCount
+    || Object.keys(restoredCounts).length !== sourceTableCount
+    || !semanticallyEqual(sourceCounts, restoredCounts)
+  ) {
+    throw new Error("South Carolina production backup exact table or row-count proof drifted");
+  }
+  return {
+    dumpSha256: manifest.dumpSha256,
+    createdAtUtc: manifest.createdAtUtc,
+    restoredAtUtc: restore.verifiedAtUtc,
+    sourcePublicTableCount: sourceTableCount,
+  };
+}
+
+export function validateSouthCarolinaProductionAuthorization(value, context) {
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "SC"
+    || value?.decision !== "GO_PRODUCTION"
+    || typeof value?.authorizationId !== "string"
+    || !value.authorizationId.trim()
+    || value?.releaseCandidate?.id !== context.releaseCandidate.id
+    || value?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || value?.evidence?.preflightSha256 !== context.preflightSha256
+    || value?.evidence?.backupManifestSha256 !== context.backupManifestSha256
+    || !validIso(value?.authorizedAtUtc)
+    || !validIso(value?.expiresAtUtc)
+    || !normalizeIdentity(value?.approvedBy)
+    || value?.replacement !== undefined
+    || !Array.isArray(value?.scopes)
+    || !semanticallyEqual(value.scopes, expectedScopes())
+  ) {
+    throw new Error("South Carolina production authorization is incomplete or incompatible");
+  }
+  const authorized = Date.parse(value.authorizedAtUtc);
+  const expires = Date.parse(value.expiresAtUtc);
+  const now = context.now.getTime();
+  if (authorized > now || expires <= now || expires <= authorized) {
+    throw new Error("South Carolina production authorization is not active");
+  }
+  return {
+    authorizationId: value.authorizationId.trim(),
+    approvedBy: value.approvedBy.trim(),
+    authorizedAtUtc: value.authorizedAtUtc,
+    expiresAtUtc: value.expiresAtUtc,
+  };
+}

--- a/scripts/lib/sc-precinct-public-activation.mjs
+++ b/scripts/lib/sc-precinct-public-activation.mjs
@@ -1,0 +1,445 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { inspectReleaseArtifact } from "./sc-precinct-release-candidate.mjs";
+import {
+  inspectPrecinctGeometryManifest,
+  inspectPrecinctGeometryRegistry,
+} from "../../src/lib/precinct-geography.ts";
+
+export const SOUTH_CAROLINA_PUBLIC_ACTIVATION_ROOT =
+  ".etl/precinct-public-activations/SC";
+export const SOUTH_CAROLINA_PUBLIC_ACTIVATION_YEARS = Object.freeze([
+  2016,
+  2020,
+  2024,
+]);
+
+const REGISTRY_PATH = "data/precinct-geometry-manifests.json";
+const COVERAGE_PATHS = Object.freeze([
+  [2016, "data/precinct-geometry-coverage-inventory-2016.json"],
+  [2020, "data/precinct-geometry-coverage-inventory-2020.json"],
+  [2024, "data/precinct-geometry-coverage-inventory.json"],
+]);
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function serializeSouthCarolinaPublicActivationDocument(value) {
+  return Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonical(value[key])]),
+  );
+}
+
+function semanticallyEqual(left, right) {
+  return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+}
+
+function readRepositoryJson(root, relativePath) {
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  if (!existsSync(absolutePath)) {
+    throw new Error("South Carolina public activation target is missing: " + relativePath);
+  }
+  const bytes = readFileSync(absolutePath);
+  return {
+    path: relativePath,
+    absolutePath,
+    bytes,
+    byteCount: bytes.length,
+    sha256: sha256(bytes),
+    value: JSON.parse(bytes.toString("utf8")),
+  };
+}
+
+function loadReleasePackage(options) {
+  if (!/^[a-f0-9]{64}$/.test(options.packageSha256 ?? "")) {
+    throw new Error("South Carolina public activation requires the exact package SHA-256");
+  }
+  const artifact = inspectReleaseArtifact(options.root, options.packagePath, {
+    allowedRoots: [".etl/precinct-release-candidates/SC/"],
+    sha256: options.packageSha256,
+  });
+  const document = JSON.parse(artifact.bytes.toString("utf8"));
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "sc-precinct-gis-three-election-v1"
+    || document?.state !== "SC"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.safety?.canonicalManifestChanged !== false
+    || document?.safety?.publicEligibilityChanged !== false
+    || document?.totals?.elections !== 3
+    || !Array.isArray(document?.years)
+    || !semanticallyEqual(
+      document.years.map((year) => Number(year.year)),
+      SOUTH_CAROLINA_PUBLIC_ACTIVATION_YEARS,
+    )
+    || Number.isNaN(Date.parse(document?.preparedFromLocalValidationAt))
+  ) {
+    throw new Error("South Carolina public-activation package contract is incompatible");
+  }
+  return {
+    artifact,
+    document,
+    packageRoot: path.dirname(path.resolve(
+      options.root,
+      ...artifact.path.split("/"),
+    )),
+    identity: {
+      id: document.id,
+      path: options.packagePath,
+      sha256: artifact.sha256,
+    },
+  };
+}
+
+function loadDraftManifests(root, loaded) {
+  return loaded.document.years.map((year) => {
+    const draft = inspectReleaseArtifact(
+      loaded.packageRoot,
+      year.draftManifest.path,
+      {
+        allowedRoots: ["draft-manifests/"],
+        byteCount: year.draftManifest.byteCount,
+        sha256: year.draftManifest.sha256,
+      },
+    );
+    const manifest = JSON.parse(draft.bytes.toString("utf8"));
+    const inspection = inspectPrecinctGeometryManifest(manifest);
+    if (
+      inspection.errors.length
+      || inspection.publicEligibilityReasons.length
+      || manifest.state !== "SC"
+      || manifest.election?.year !== year.year
+      || manifest.id !== year.manifestId
+      || manifest.geography?.level !== "precinct"
+      || manifest.delivery?.format !== "parent_scoped_geojson"
+      || manifest.delivery?.url !== year.proposedPublicDelivery?.url
+      || manifest.delivery?.sha256 !== year.proposedPublicDelivery?.sha256
+      || manifest.delivery?.byteCount !== year.proposedPublicDelivery?.byteCount
+      || manifest.delivery?.featureCount !== year.reviewedGeometry?.featureCount
+      || manifest.delivery?.parentCount !== 46
+    ) {
+      throw new Error("South Carolina " + year.year + " draft manifest is not public-eligible");
+    }
+    const preimage = inspectReleaseArtifact(root, year.canonicalManifest.path, {
+      allowedRoots: ["data/precinct-geometry/SC/"],
+      byteCount: year.canonicalManifest.byteCount,
+      sha256: year.canonicalManifest.sha256,
+    });
+    const preimageManifest = JSON.parse(preimage.bytes.toString("utf8"));
+    if (
+      preimageManifest.id !== manifest.id
+      || preimageManifest.validation?.status !== "blocked"
+      || preimageManifest.validation?.rowLevelRenderingSafe !== true
+      || preimageManifest.delivery !== null
+    ) {
+      throw new Error("South Carolina " + year.year + " canonical source preimage is not blocked");
+    }
+    return {
+      year: year.year,
+      manifestId: manifest.id,
+      preimage: {
+        path: year.canonicalManifest.path,
+        byteCount: preimage.byteCount,
+        sha256: preimage.sha256,
+      },
+      draft: {
+        path: path.posix.join(
+          path.posix.dirname(loaded.identity.path),
+          year.draftManifest.path,
+        ),
+        byteCount: draft.byteCount,
+        sha256: draft.sha256,
+        manifest,
+      },
+    };
+  });
+}
+
+function updateRegistry(root, manifests, activatedAtUtc) {
+  const current = readRepositoryJson(root, REGISTRY_PATH);
+  if (
+    current.value?.schemaVersion !== 1
+    || !Array.isArray(current.value?.manifests)
+  ) {
+    throw new Error("South Carolina canonical manifest registry is invalid");
+  }
+  const existing = current.value.manifests.filter((row) => row?.state === "SC");
+  const drafts = manifests.map((item) => item.draft.manifest);
+  let disposition;
+  let nextRows;
+  if (existing.length === 0) {
+    disposition = "activate";
+    nextRows = [...current.value.manifests, ...drafts];
+  } else if (
+    existing.length === drafts.length
+    && drafts.every((draft) => existing.some((row) => semanticallyEqual(row, draft)))
+  ) {
+    disposition = "verified_existing";
+    nextRows = current.value.manifests;
+  } else {
+    throw new Error("South Carolina canonical registry is partially activated or drifted");
+  }
+  const value = {
+    ...current.value,
+    updatedAt: disposition === "activate" ? activatedAtUtc : current.value.updatedAt,
+    manifests: nextRows,
+  };
+  const inspection = inspectPrecinctGeometryRegistry(
+    value,
+    Math.max(Date.now(), Date.parse(activatedAtUtc) + 1),
+  );
+  if (inspection.errors.length) {
+    throw new Error(
+      "South Carolina activated registry is invalid: " + inspection.errors.join("; "),
+    );
+  }
+  const eligible = inspection.manifests.filter((item, index) =>
+    value.manifests[index]?.state === "SC"
+    && item.publicEligibilityReasons.length === 0);
+  if (eligible.length !== 3) {
+    throw new Error("South Carolina activated registry does not contain three eligible manifests");
+  }
+  return { current, value, disposition };
+}
+
+function recomputeCoverageSummary(value) {
+  const states = value.states ?? [];
+  const count = (field, choices) => Object.fromEntries(
+    choices.map((choice) => [
+      choice,
+      states.filter((row) => (row[field] ?? "undecided") === choice).length,
+    ]),
+  );
+  return {
+    totalJurisdictions: states.length,
+    programStatus: count("programStatus", ["not_started", "in_progress", "reviewed"]),
+    disposition: count("disposition", [
+      "undecided",
+      "mapped",
+      "partial",
+      "official_geometry_unavailable",
+      "blocked",
+    ]),
+    publicEligibleJurisdictions: states.filter((row) =>
+      (row.geometry?.publicEligibleManifestCount ?? 0) > 0).length,
+  };
+}
+
+function southCarolinaCoverageRow(manifest, activatedAtUtc) {
+  return {
+    state: "SC",
+    stateName: "South Carolina",
+    electionId: manifest.election.id,
+    programStatus: "reviewed",
+    wave: 8,
+    disposition: "mapped",
+    checkedAt: activatedAtUtc,
+    sourceTiers: manifest.geography.derivationMethod === "official_export"
+      ? ["tier_1_official_export_database"]
+      : ["tier_1_official_export_database", "tier_3_secondary_geometry"],
+    resultReportingGrains: ["precinct"],
+    generalOfficialSourceLeads: [
+      manifest.source.url,
+      "https://electionhistory.scvotes.gov/",
+    ],
+    geometry: {
+      manifestIds: [manifest.id],
+      officialSourceLeads: [manifest.source.url],
+      retainedArtifacts: [
+        manifest.source.artifact,
+        manifest.normalization.artifact,
+        manifest.crosswalk.artifact,
+      ],
+      levels: [manifest.geography.level],
+      vintageStatuses: [manifest.geography.vintageStatus],
+      featureCount: manifest.normalization.featureCount,
+      publicEligibleManifestCount: 1,
+    },
+    crosswalk: {
+      resultUnits: manifest.crosswalk.resultUnits,
+      colorableResultUnits: manifest.crosswalk.colorableResultUnits,
+      matchedResultUnits: manifest.crosswalk.matchedResultUnits,
+      unmatchedResultUnits: manifest.crosswalk.unmatchedResultUnits,
+      nonGeographicResultUnits: manifest.crosswalk.nonGeographicResultUnits,
+      sourceAliasResultUnits: manifest.crosswalk.sourceAliasResultUnits,
+    },
+    blockers: [],
+    nextAction:
+      "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
+    notes: [
+      "Official South Carolina Election Commission results supply every displayed value; retained secondary geometry contains no election values.",
+      "Geographic precincts use reviewed election-specific relationships. Administrative reporting buckets remain non-geographic and are never assigned to polygons.",
+      "The map is parent-scoped by South Carolina county GEOID; election values are excluded from geometry delivery.",
+      "Each election retains its own boundary vintage. Cross-election precinct comparison requires a separately reviewed common-geography crosswalk and is not inferred by this release.",
+    ],
+  };
+}
+
+function updateCoverage(root, manifest, relativePath, activatedAtUtc) {
+  const current = readRepositoryJson(root, relativePath);
+  if (!Array.isArray(current.value?.states)) {
+    throw new Error("South Carolina coverage inventory is invalid: " + relativePath);
+  }
+  const existing = current.value.states.filter((row) => row?.state === "SC");
+  let disposition;
+  let states;
+  if (existing.length === 0) {
+    const expectedRow = southCarolinaCoverageRow(manifest, activatedAtUtc);
+    disposition = "activate";
+    states = [...current.value.states, expectedRow];
+  } else if (existing.length === 1) {
+    const row = existing[0];
+    const currentEligible = Number(
+      row.geometry?.publicEligibleManifestCount,
+    );
+    if (
+      row.electionId !== manifest.election.id
+      || row.programStatus !== "reviewed"
+      || row.disposition !== "mapped"
+      || !Array.isArray(row.geometry?.manifestIds)
+      || row.geometry.manifestIds.length !== 1
+      || row.geometry.manifestIds[0] !== manifest.id
+      || row.geometry.featureCount !== manifest.normalization.featureCount
+      || !semanticallyEqual(
+        row.geometry.levels,
+        [manifest.geography.level],
+      )
+      || ![0, 1].includes(currentEligible)
+      || row.crosswalk?.resultUnits !== manifest.crosswalk.resultUnits
+      || row.crosswalk?.matchedResultUnits
+        !== manifest.crosswalk.matchedResultUnits
+      || row.crosswalk?.unmatchedResultUnits
+        !== manifest.crosswalk.unmatchedResultUnits
+    ) {
+      throw new Error(relativePath + " contains a drifted South Carolina row");
+    }
+    const expectedRow = {
+      ...row,
+      checkedAt: currentEligible === 1 ? row.checkedAt : activatedAtUtc,
+      geometry: {
+        ...row.geometry,
+        publicEligibleManifestCount: 1,
+      },
+      blockers: [],
+      nextAction:
+        "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
+    };
+    if (currentEligible === 1) {
+      if (!semanticallyEqual(row, expectedRow)) {
+        throw new Error(relativePath + " contains a partial South Carolina activation");
+      }
+      disposition = "verified_existing";
+      states = current.value.states;
+    } else {
+      disposition = "activate";
+      states = current.value.states.map((candidate) =>
+        candidate?.state === "SC" ? expectedRow : candidate);
+    }
+  } else {
+    throw new Error(relativePath + " contains a partial or drifted South Carolina row");
+  }
+  const value = {
+    ...current.value,
+    updatedAt: disposition === "activate" ? activatedAtUtc : current.value.updatedAt,
+    states,
+  };
+  value.summary = recomputeCoverageSummary(value);
+  return { current, value, disposition };
+}
+
+function outputFile(relativePath, built) {
+  const bytes = serializeSouthCarolinaPublicActivationDocument(built.value);
+  return {
+    path: relativePath,
+    absolutePath: built.current.absolutePath,
+    preimage: {
+      byteCount: built.current.byteCount,
+      sha256: built.current.sha256,
+    },
+    byteCount: bytes.length,
+    sha256: sha256(bytes),
+    disposition: built.disposition,
+    bytes,
+  };
+}
+
+export function inspectSouthCarolinaPublicActivationPlan(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const loaded = loadReleasePackage({ ...options, root });
+  const manifests = loadDraftManifests(root, loaded);
+  const activatedAtUtc = loaded.document.preparedFromLocalValidationAt;
+  const outputs = [outputFile(
+    REGISTRY_PATH,
+    updateRegistry(root, manifests, activatedAtUtc),
+  )];
+  for (const [year, relativePath] of COVERAGE_PATHS) {
+    const manifest = manifests.find((item) => item.year === year)?.draft.manifest;
+    if (!manifest) throw new Error("South Carolina activation is missing year " + year);
+    outputs.push(outputFile(
+      relativePath,
+      updateCoverage(root, manifest, relativePath, activatedAtUtc),
+    ));
+  }
+  const plan = {
+    schemaVersion: 1,
+    id: "sc-precinct-public-activation-three-election-v1",
+    state: "SC",
+    decision: "DEPLOY_GUARDED_STATIC_MANIFESTS_DATABASE_REMAINS_BLOCKED",
+    releaseCandidate: loaded.identity,
+    activatedAtUtc,
+    manifests: manifests.map((item) => ({
+      year: item.year,
+      manifestId: item.manifestId,
+      canonicalSourcePreimage: item.preimage,
+      draftManifest: {
+        path: item.draft.path,
+        byteCount: item.draft.byteCount,
+        sha256: item.draft.sha256,
+        publicManifestSha256: sha256(
+          serializeSouthCarolinaPublicActivationDocument(item.draft.manifest),
+        ),
+        delivery: item.draft.manifest.delivery,
+      },
+    })),
+    trackedOutputs: outputs.map(({
+      bytes: _bytes,
+      absolutePath: _absolutePath,
+      ...file
+    }) => file),
+    safety: {
+      productionContacted: false,
+      productionMutationPerformed: false,
+      publicFileWritten: false,
+      databasePublicationStatusChanged: false,
+      publicEndpointsRemainDatabaseGated: true,
+      gitPublicationPerformed: false,
+    },
+  };
+  const bytes = serializeSouthCarolinaPublicActivationDocument(plan);
+  const digest = sha256(bytes);
+  return {
+    root,
+    packageDocument: loaded.document,
+    plan,
+    bytes,
+    sha256: digest,
+    outputPath: path.posix.join(
+      SOUTH_CAROLINA_PUBLIC_ACTIVATION_ROOT,
+      loaded.identity.sha256.slice(0, 12) + "-" + digest.slice(0, 12),
+      "activation-candidate.json",
+    ),
+    outputs,
+  };
+}

--- a/scripts/lib/sc-precinct-publication.mjs
+++ b/scripts/lib/sc-precinct-publication.mjs
@@ -1,0 +1,653 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { inspectSouthCarolinaPrecinctBlobPublicationPlan } from "./sc-precinct-blob-publication.mjs";
+import { inspectReleaseArtifact } from "./sc-precinct-release-candidate.mjs";
+import {
+  inspectPrecinctGeometryManifest,
+  inspectPrecinctGeometryRegistry,
+} from "../../src/lib/precinct-geography.ts";
+
+export const SOUTH_CAROLINA_PUBLICATION_YEARS = Object.freeze([2016, 2020, 2024]);
+export const SOUTH_CAROLINA_PUBLICATION_SCOPES = Object.freeze([
+  "publish_sc_precinct_geography_versions",
+  "authorize_sc_precinct_results",
+  "increment_public_data_revision",
+]);
+export const SOUTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES = Object.freeze([
+  "block_sc_precinct_geography_versions",
+  "revoke_sc_precinct_results",
+  "increment_public_data_revision",
+]);
+
+const EXPECTED_TOTALS = Object.freeze({
+  reportingUnits: 7_396,
+  candidateResultRows: 20_403,
+  geometryFeatures: 6_805,
+  reviewedRelationships: 7_396,
+  zeroVoteUnits: 2,
+  sourceDocuments: 6,
+  importRuns: 3,
+});
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function serializeSouthCarolinaPublicationDocument(value) {
+  return Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonical(value[key])]),
+  );
+}
+
+export function semanticallyEqual(left, right) {
+  return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+}
+
+function safeEvidence(root, relativePath, allowedRoot, expectedSha256) {
+  if (
+    typeof relativePath !== "string"
+    || path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !relativePath.startsWith(allowedRoot + "/")
+    || !relativePath.endsWith(".json")
+    || !/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")
+  ) {
+    throw new Error("South Carolina publication evidence path is unsafe");
+  }
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...allowedRoot.split("/"));
+  if (!absolutePath.startsWith(allowed + path.sep) || !existsSync(absolutePath)) {
+    throw new Error("South Carolina publication evidence is missing");
+  }
+  const bytes = readFileSync(absolutePath);
+  const digest = sha256(bytes);
+  if (digest !== expectedSha256) {
+    throw new Error("South Carolina publication evidence SHA-256 drifted");
+  }
+  return {
+    path: relativePath,
+    absolutePath,
+    bytes,
+    sha256: digest,
+    value: JSON.parse(bytes.toString("utf8")),
+  };
+}
+
+function credentialFreeHttpsOrigin(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error("South Carolina publication delivery origin is invalid");
+  }
+  if (
+    parsed.protocol !== "https:"
+    || parsed.username
+    || parsed.password
+    || parsed.search
+    || parsed.hash
+    || parsed.pathname !== "/"
+    || parsed.origin !== value
+  ) {
+    throw new Error("South Carolina publication origin must be credential-free HTTPS");
+  }
+  return parsed.origin;
+}
+
+function loadPackage(root, packagePath, packageSha256) {
+  if (!/^[a-f0-9]{64}$/.test(packageSha256 ?? "")) {
+    throw new Error("South Carolina publication requires the exact package SHA-256");
+  }
+  const artifact = inspectReleaseArtifact(root, packagePath, {
+    allowedRoots: [".etl/precinct-release-candidates/SC/"],
+    sha256: packageSha256,
+  });
+  const document = JSON.parse(artifact.bytes.toString("utf8"));
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "sc-precinct-gis-three-election-v1"
+    || document?.state !== "SC"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.totals?.reportingUnits !== EXPECTED_TOTALS.reportingUnits
+    || document?.totals?.candidateResultRows !== EXPECTED_TOTALS.candidateResultRows
+    || document?.totals?.geometryFeatures !== EXPECTED_TOTALS.geometryFeatures
+    || document?.totals?.reviewedRelationships
+      !== EXPECTED_TOTALS.reviewedRelationships
+    || document?.totals?.zeroVoteUnits !== EXPECTED_TOTALS.zeroVoteUnits
+    || !Array.isArray(document?.years)
+    || !semanticallyEqual(
+      document.years.map((year) => Number(year.year)),
+      SOUTH_CAROLINA_PUBLICATION_YEARS,
+    )
+  ) {
+    throw new Error("South Carolina publication release package is incompatible");
+  }
+  return {
+    artifact,
+    document,
+    root: path.dirname(path.resolve(root, ...artifact.path.split("/"))),
+    identity: { id: document.id, path: packagePath, sha256: artifact.sha256 },
+  };
+}
+
+function publicManifests(root, loaded) {
+  const registryPath = "data/precinct-geometry-manifests.json";
+  const registryBytes = readFileSync(path.resolve(root, registryPath));
+  const registry = JSON.parse(registryBytes.toString("utf8"));
+  const inspection = inspectPrecinctGeometryRegistry(registry);
+  if (inspection.errors.length) {
+    throw new Error("South Carolina publication registry is invalid: " + inspection.errors.join("; "));
+  }
+  const rows = registry.manifests.filter((manifest) => manifest?.state === "SC");
+  if (rows.length !== 3) {
+    throw new Error("South Carolina publication registry does not contain three manifests");
+  }
+  return loaded.document.years.map((year) => {
+    const draftArtifact = inspectReleaseArtifact(loaded.root, year.draftManifest.path, {
+      allowedRoots: ["draft-manifests/"],
+      byteCount: year.draftManifest.byteCount,
+      sha256: year.draftManifest.sha256,
+    });
+    const draft = JSON.parse(draftArtifact.bytes.toString("utf8"));
+    const manifest = rows.find((row) => row.id === year.manifestId);
+    const manifestInspection = inspectPrecinctGeometryManifest(manifest);
+    if (
+      !manifest
+      || !semanticallyEqual(manifest, draft)
+      || manifestInspection.errors.length
+      || manifestInspection.publicEligibilityReasons.length
+      || manifest.election?.year !== year.year
+      || manifest.delivery?.format !== "parent_scoped_geojson"
+      || manifest.delivery?.featureCount !== year.reviewedGeometry.featureCount
+      || manifest.delivery?.parentCount !== 46
+    ) {
+      throw new Error("South Carolina " + year.year + " public manifest drifted from the package");
+    }
+    return {
+      year: year.year,
+      electionId: year.electionId,
+      manifestId: manifest.id,
+      publicManifestSha256: sha256(serializeSouthCarolinaPublicationDocument(manifest)),
+      delivery: manifest.delivery,
+      boundaryVintage: manifest.geography.boundaryVintage,
+      blockedManifestSha256: year.canonicalManifest.sha256,
+      featureCount: manifest.delivery.featureCount,
+      zeroVoteUnits: year.certifiedResults.zeroVoteUnits,
+      resultRows: year.certifiedResults.resultRows,
+      manifest,
+    };
+  }).map((item, _index, all) => {
+    if (new Set(all.map((row) => row.manifestId)).size !== 3) {
+      throw new Error("South Carolina publication manifest IDs are duplicated");
+    }
+    return item;
+  });
+}
+
+function validAuditArtifact(value) {
+  return typeof value?.path === "string"
+    && value.path.startsWith(".etl/")
+    && !value.path.includes("\\")
+    && !value.path.split("/").includes("..")
+    && /^[a-f0-9]{64}$/.test(value?.sha256 ?? "");
+}
+
+export function validateSouthCarolinaHiddenLoadReceipt(value, context) {
+  const audit = value?.transaction?.productionReleaseAudit;
+  const validation = value?.validation;
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "SC"
+    || value?.decision !== "COMMITTED_HIDDEN_NOT_PUBLIC"
+    || value?.releaseCandidate?.id !== context.releaseCandidate.id
+    || value?.releaseCandidate?.path !== context.releaseCandidate.path
+    || value?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || typeof value?.committedAtUtc !== "string"
+    || Number.isNaN(Date.parse(value.committedAtUtc))
+    || Date.parse(value.committedAtUtc) > context.now
+    || !/^[a-f0-9]{64}$/.test(value?.endpointFingerprint ?? "")
+    || value?.productionMutationPerformed !== true
+    || value?.canonicalManifestChanged !== false
+    || value?.publicFileWritten !== false
+    || value?.publicDeliveryAuthorized !== false
+    || value?.transaction?.productionMutationPerformed !== true
+    || value?.transaction?.publicDeliveryAuthorized !== false
+    || validation?.productionMutationPerformed !== true
+    || validation?.publicDeliveryAuthorized !== false
+    || value?.transaction?.revision !== validation?.revision
+    || !Number.isInteger(Number(value?.transaction?.revision))
+    || Number(value.transaction.revision) < 1
+    || value?.committedAtUtc !== audit?.transaction?.executedAtUtc
+    || value?.transaction?.revision !== audit?.transaction?.publicRevision
+    || value?.authorization?.id !== audit?.authorizationId
+    || value?.authorization?.path !== audit?.authorization?.path
+    || value?.authorization?.sha256 !== audit?.authorization?.sha256
+    || value?.preflight?.path !== audit?.preflight?.path
+    || value?.preflight?.sha256 !== audit?.preflight?.sha256
+    || value?.backup?.manifestSha256 !== audit?.backupManifest?.sha256
+    || value?.backup?.dumpSha256 !== audit?.backupManifest?.dumpSha256
+    || value?.endpointFingerprint !== audit?.endpointFingerprint
+    || audit?.releasePackage?.path !== context.releaseCandidate.path
+    || audit?.releasePackage?.sha256 !== context.releaseCandidate.sha256
+    || ![
+      audit?.releasePackage,
+      audit?.authorization,
+      audit?.preflight,
+    ].every(validAuditArtifact)
+    || !/^[a-f0-9]{64}$/.test(audit?.backupManifest?.sha256 ?? "")
+    || !/^[a-f0-9]{64}$/.test(audit?.backupManifest?.dumpSha256 ?? "")
+    || !semanticallyEqual(validation?.productionReleaseAudit, audit)
+    || !semanticallyEqual(validation?.releaseCandidate, {
+      id: context.releaseCandidate.id,
+      sha256: context.releaseCandidate.sha256,
+      publicDeliveryAuthorized: false,
+    })
+    || validation?.database?.name !== value?.transaction?.database?.name
+    || typeof validation?.database?.name !== "string"
+    || !validation.database.name
+    || !Array.isArray(validation?.years)
+    || validation.years.length !== 3
+    || !semanticallyEqual(
+      validation.years.map((year) => Number(year.year)),
+      SOUTH_CAROLINA_PUBLICATION_YEARS,
+    )
+  ) {
+    throw new Error("South Carolina hidden-load receipt is incomplete or incompatible");
+  }
+  const totals = {
+    reportingUnits: validation.years.reduce((sum, year) => sum + year.reportingUnits, 0),
+    candidateResultRows: validation.years.reduce((sum, year) => sum + year.resultRows, 0),
+    geometryFeatures: validation.years.reduce((sum, year) => sum + year.features, 0),
+    reviewedRelationships: validation.years.reduce(
+      (sum, year) => sum + year.exactCrosswalks,
+      0,
+    ),
+    zeroVoteUnits: validation.years.reduce((sum, year) => sum + year.zeroVoteUnits, 0),
+  };
+  for (const [key, expected] of Object.entries(EXPECTED_TOTALS)) {
+    if (key === "sourceDocuments" || key === "importRuns") continue;
+    if (Number(totals[key]) !== expected) {
+      throw new Error("South Carolina hidden-load receipt total drifted: " + key);
+    }
+  }
+  return {
+    committedAtUtc: value.committedAtUtc,
+    databaseName: validation.database.name,
+    endpointFingerprint: value.endpointFingerprint,
+    hiddenRevision: value.transaction.revision,
+    productionReleaseAudit: audit,
+    totals,
+  };
+}
+
+export function validateSouthCarolinaBlobPublicationEvidence(value, blobPlan, now = Date.now()) {
+  const origin = credentialFreeHttpsOrigin(value?.deliveryOrigin);
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "SC"
+    || value?.purpose !== "sc-precinct-parent-scoped-immutable-geometry-publication"
+    || value?.releaseCandidate?.id !== blobPlan.releaseCandidate.id
+    || value?.releaseCandidate?.path !== blobPlan.releaseCandidate.path
+    || value?.releaseCandidate?.sha256 !== blobPlan.releaseCandidate.sha256
+    || typeof value?.publishedAtUtc !== "string"
+    || Number.isNaN(Date.parse(value.publishedAtUtc))
+    || Date.parse(value.publishedAtUtc) > now
+    || value?.assetCount !== 141
+    || value?.canonicalManifestChanged !== false
+    || value?.publicEligibilityChanged !== false
+    || !Array.isArray(value?.artifacts)
+    || value.artifacts.length !== 141
+  ) {
+    throw new Error("South Carolina Blob publication evidence is incomplete or incompatible");
+  }
+  const expected = new Map(blobPlan.artifacts.map((artifact) => [artifact.pathname, artifact]));
+  const seen = new Set();
+  for (const artifact of value.artifacts) {
+    const wanted = expected.get(artifact?.pathname);
+    let remote;
+    try {
+      remote = new URL(artifact?.url);
+    } catch {
+      throw new Error("South Carolina Blob publication evidence contains an invalid URL");
+    }
+    if (
+      !wanted
+      || seen.has(artifact.pathname)
+      || artifact.kind !== wanted.kind
+      || artifact.year !== wanted.year
+      || artifact.packageRelativePath !== wanted.packageRelativePath
+      || artifact.publicUrl !== wanted.publicUrl
+      || artifact.byteCount !== wanted.byteCount
+      || artifact.sha256 !== wanted.sha256
+      || remote.origin !== origin
+      || remote.pathname !== "/" + wanted.pathname
+      || !["created", "verified_existing"].includes(artifact.disposition)
+    ) {
+      throw new Error("South Carolina Blob publication artifact set drifted");
+    }
+    seen.add(artifact.pathname);
+  }
+  if (seen.size !== expected.size) {
+    throw new Error("South Carolina Blob publication artifact set is incomplete");
+  }
+  return {
+    publishedAtUtc: value.publishedAtUtc,
+    deliveryOrigin: origin,
+    authorizationId: value.authorizationId ?? null,
+    assetCount: seen.size,
+  };
+}
+
+export function inspectSouthCarolinaPublicationPlan(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const now = options.now ?? Date.now();
+  const loaded = loadPackage(root, options.packagePath, options.packageSha256);
+  const manifests = publicManifests(root, loaded);
+  const hiddenArtifact = safeEvidence(
+    root,
+    options.hiddenReceiptPath,
+    ".etl/production-release-receipts/SC",
+    options.hiddenReceiptSha256,
+  );
+  const hidden = validateSouthCarolinaHiddenLoadReceipt(hiddenArtifact.value, {
+    now,
+    releaseCandidate: loaded.identity,
+  });
+  const blobArtifact = safeEvidence(
+    root,
+    options.blobEvidencePath,
+    ".etl/precinct-blob-publications/SC",
+    options.blobEvidenceSha256,
+  );
+  const blobPlan = inspectSouthCarolinaPrecinctBlobPublicationPlan({
+    root,
+    packagePath: loaded.identity.path,
+    packageSha256: loaded.identity.sha256,
+  });
+  const blob = validateSouthCarolinaBlobPublicationEvidence(blobArtifact.value, blobPlan, now);
+  const registryBytes = readFileSync(path.resolve(root, "data/precinct-geometry-manifests.json"));
+  const plan = {
+    schemaVersion: 1,
+    id: "sc-precinct-database-publication-v1",
+    state: "SC",
+    decision: "GO_AUTHORIZATION_AND_VERIFIED_DEPLOYMENT_REQUIRED",
+    releaseCandidate: loaded.identity,
+    hiddenLoad: {
+      path: hiddenArtifact.path,
+      sha256: hiddenArtifact.sha256,
+      ...hidden,
+    },
+    blobPublication: {
+      path: blobArtifact.path,
+      sha256: blobArtifact.sha256,
+      ...blob,
+    },
+    staticRegistry: {
+      path: "data/precinct-geometry-manifests.json",
+      byteCount: registryBytes.length,
+      sha256: sha256(registryBytes),
+    },
+    manifests: manifests.map(({ manifest: _manifest, ...manifest }) => manifest),
+    expectedTotals: EXPECTED_TOTALS,
+    safety: {
+      databaseMutationPerformed: false,
+      blobMutationPerformed: false,
+      gitMutationPerformed: false,
+      deploymentMutationPerformed: false,
+      publicCutoverIsSingleDatabaseTransaction: true,
+    },
+  };
+  const bytes = serializeSouthCarolinaPublicationDocument(plan);
+  return {
+    root,
+    packageDocument: loaded.document,
+    plan,
+    bytes,
+    sha256: sha256(bytes),
+  };
+}
+
+export function buildSouthCarolinaPublicationAuthorizationTemplate(plan, planSha256) {
+  return {
+    schemaVersion: 1,
+    state: "SC",
+    decision: "NO_GO_PUBLIC",
+    activationId: null,
+    approvedBy: null,
+    authorizedAtUtc: null,
+    expiresAtUtc: null,
+    releaseCandidate: plan.releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    scopes: [...SOUTH_CAROLINA_PUBLICATION_SCOPES],
+    productionDeployment: {
+      deploymentId: null,
+      url: null,
+      gitSha: null,
+      gitTreeSha: null,
+      readyVerified: false,
+      promotedVerified: false,
+      blockedResultGateVerified: false,
+      blockedGeometryGateVerified: false,
+      verifiedAtUtc: null,
+      deliveryOrigin: plan.blobPublication.deliveryOrigin,
+      staticRegistrySha256: plan.staticRegistry.sha256,
+    },
+    rollbackTarget: {
+      deploymentId: null,
+      url: null,
+      gitSha: null,
+      gitTreeSha: null,
+      verifiedAtUtc: null,
+      gateCapableVerified: false,
+      blockedResultGateVerified: false,
+      blockedGeometryGateVerified: false,
+    },
+    evidence: {
+      hiddenLoad: { path: plan.hiddenLoad.path, sha256: plan.hiddenLoad.sha256 },
+      blobPublication: {
+        path: plan.blobPublication.path,
+        sha256: plan.blobPublication.sha256,
+      },
+    },
+  };
+}
+
+export function validateSouthCarolinaPublicationAuthorization(value, context) {
+  const now = context.now ?? Date.now();
+  const authorizedAt = Date.parse(value?.authorizedAtUtc);
+  const expiresAt = Date.parse(value?.expiresAtUtc);
+  const deployedAt = Date.parse(value?.productionDeployment?.verifiedAtUtc);
+  const rollbackTargetAt = Date.parse(value?.rollbackTarget?.verifiedAtUtc);
+  const recovery = context.recovery === true;
+  let deploymentUrl;
+  let rollbackTargetUrl;
+  try {
+    deploymentUrl = new URL(value?.productionDeployment?.url);
+  } catch {
+    // The common fail-closed check below reports an incompatible record.
+  }
+  try {
+    rollbackTargetUrl = new URL(value?.rollbackTarget?.url);
+  } catch {
+    // The common fail-closed check below reports an incompatible record.
+  }
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "SC"
+    || value?.decision !== "GO_PUBLIC"
+    || typeof value?.activationId !== "string"
+    || !value.activationId.trim()
+    || typeof value?.approvedBy !== "string"
+    || !value.approvedBy.trim()
+    || value?.releaseCandidate?.id !== context.plan.releaseCandidate.id
+    || value?.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
+    || value?.publicationPlan?.id !== context.plan.id
+    || value?.publicationPlan?.sha256 !== context.planSha256
+    || !semanticallyEqual(value?.scopes, SOUTH_CAROLINA_PUBLICATION_SCOPES)
+    || [authorizedAt, expiresAt, deployedAt, rollbackTargetAt].some(Number.isNaN)
+    || expiresAt <= authorizedAt
+    || deployedAt > authorizedAt
+    || typeof value?.productionDeployment?.deploymentId !== "string"
+    || !value.productionDeployment.deploymentId.trim()
+    || !/^[a-f0-9]{40}$/.test(value?.productionDeployment?.gitSha ?? "")
+    || !/^[a-f0-9]{40}$/.test(value?.productionDeployment?.gitTreeSha ?? "")
+    || value?.productionDeployment?.readyVerified !== true
+    || value?.productionDeployment?.promotedVerified !== true
+    || value?.productionDeployment?.blockedResultGateVerified !== true
+    || value?.productionDeployment?.blockedGeometryGateVerified !== true
+    || value?.productionDeployment?.deliveryOrigin
+      !== context.plan.blobPublication.deliveryOrigin
+    || value?.productionDeployment?.staticRegistrySha256
+      !== context.plan.staticRegistry.sha256
+    || deploymentUrl?.protocol !== "https:"
+    || deploymentUrl?.username
+    || deploymentUrl?.password
+    || deploymentUrl?.search
+    || deploymentUrl?.hash
+    || typeof value?.rollbackTarget?.deploymentId !== "string"
+    || !value.rollbackTarget.deploymentId.trim()
+    || value.rollbackTarget.deploymentId
+      === value.productionDeployment.deploymentId
+    || !/^[a-f0-9]{40}$/.test(value?.rollbackTarget?.gitSha ?? "")
+    || !/^[a-f0-9]{40}$/.test(value?.rollbackTarget?.gitTreeSha ?? "")
+    || value.rollbackTarget.gitTreeSha
+      === value.productionDeployment.gitTreeSha
+    || value?.rollbackTarget?.gateCapableVerified !== true
+    || value?.rollbackTarget?.blockedResultGateVerified !== true
+    || value?.rollbackTarget?.blockedGeometryGateVerified !== true
+    || rollbackTargetUrl?.protocol !== "https:"
+    || rollbackTargetUrl?.username
+    || rollbackTargetUrl?.password
+    || rollbackTargetUrl?.search
+    || rollbackTargetUrl?.hash
+    || rollbackTargetAt > authorizedAt
+    || (!recovery && (
+      authorizedAt > now
+      || now > expiresAt
+      || deployedAt > now
+      || now - deployedAt > 4 * 60 * 60 * 1000
+      || rollbackTargetAt > now
+      || now - rollbackTargetAt > 4 * 60 * 60 * 1000
+    ))
+    || value?.evidence?.hiddenLoad?.path !== context.plan.hiddenLoad.path
+    || value?.evidence?.hiddenLoad?.sha256 !== context.plan.hiddenLoad.sha256
+    || value?.evidence?.blobPublication?.path
+      !== context.plan.blobPublication.path
+    || value?.evidence?.blobPublication?.sha256
+      !== context.plan.blobPublication.sha256
+  ) {
+    throw new Error("South Carolina public authorization is absent, expired, or incompatible");
+  }
+  return {
+    activationId: value.activationId.trim(),
+    approvedBy: value.approvedBy.trim(),
+    productionDeployment: value.productionDeployment,
+    rollbackTarget: value.rollbackTarget,
+  };
+}
+
+export function buildSouthCarolinaPublicRollbackAuthorizationTemplate(
+  plan,
+  planSha256,
+  publicationReceipt,
+) {
+  return {
+    schemaVersion: 1,
+    state: "SC",
+    decision: "NO_GO_ROLLBACK",
+    rollbackId: null,
+    approvedBy: null,
+    authorizedAtUtc: null,
+    expiresAtUtc: null,
+    releaseCandidate: plan.releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    publication: {
+      activationId: publicationReceipt.activationId,
+      revision: publicationReceipt.revision,
+      changedAtUtc: publicationReceipt.changedAtUtc,
+    },
+    scopes: [...SOUTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES],
+    rollbackWindow: {
+      startsAtUtc: null,
+      endsAtUtc: null,
+    },
+    applicationRollback: {
+      target: publicationReceipt.rollbackTarget,
+      databaseBlockFirstAcknowledged: false,
+      restoreAfterDatabaseRollbackAcknowledged: false,
+    },
+    evidence: {
+      publicationReceipt: {
+        path: publicationReceipt.path,
+        sha256: publicationReceipt.sha256,
+      },
+    },
+  };
+}
+
+export function validateSouthCarolinaPublicRollbackAuthorization(value, context) {
+  const now = context.now ?? Date.now();
+  const authorizedAt = Date.parse(value?.authorizedAtUtc);
+  const expiresAt = Date.parse(value?.expiresAtUtc);
+  const startsAt = Date.parse(value?.rollbackWindow?.startsAtUtc);
+  const endsAt = Date.parse(value?.rollbackWindow?.endsAtUtc);
+  const receipt = context.publicationReceipt;
+  const recovery = context.recovery === true;
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "SC"
+    || value?.decision !== "GO_ROLLBACK"
+    || typeof value?.rollbackId !== "string"
+    || !value.rollbackId.trim()
+    || typeof value?.approvedBy !== "string"
+    || !value.approvedBy.trim()
+    || value?.releaseCandidate?.id !== context.plan.releaseCandidate.id
+    || value?.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
+    || value?.publicationPlan?.id !== context.plan.id
+    || value?.publicationPlan?.sha256 !== context.planSha256
+    || value?.publication?.activationId !== receipt.activationId
+    || Number(value?.publication?.revision) !== receipt.revision
+    || value?.publication?.changedAtUtc !== receipt.changedAtUtc
+    || !semanticallyEqual(value?.scopes, SOUTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES)
+    || [authorizedAt, expiresAt, startsAt, endsAt].some(Number.isNaN)
+    || expiresAt <= authorizedAt
+    || startsAt > endsAt
+    || (!recovery && (
+      authorizedAt > now
+      || now > expiresAt
+      || startsAt > now
+      || now > endsAt
+    ))
+    || !semanticallyEqual(
+      value?.applicationRollback?.target,
+      receipt.rollbackTarget,
+    )
+    || value?.applicationRollback?.databaseBlockFirstAcknowledged !== true
+    || value?.applicationRollback?.restoreAfterDatabaseRollbackAcknowledged
+      !== true
+    || value?.evidence?.publicationReceipt?.path !== receipt.path
+    || value?.evidence?.publicationReceipt?.sha256 !== receipt.sha256
+  ) {
+    throw new Error("South Carolina rollback authorization is absent, expired, or incompatible");
+  }
+  return {
+    activationId: value.rollbackId.trim(),
+    rollbackId: value.rollbackId.trim(),
+    publicationActivationId: receipt.activationId,
+    approvedBy: value.approvedBy.trim(),
+    rollbackWindow: value.rollbackWindow,
+    applicationRollback: value.applicationRollback,
+  };
+}

--- a/scripts/lib/sc-precinct-release-candidate.mjs
+++ b/scripts/lib/sc-precinct-release-candidate.mjs
@@ -1,0 +1,618 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+import { buildPrecinctDeliveryCandidateFeatureCollection } from "./precinct-delivery-builder.mjs";
+import { buildParentScopedPrecinctDeliveryPackage } from "./precinct-parent-delivery-builder.mjs";
+import { buildSouthCarolinaPrecinctGisPlan } from "./sc-precinct-gis-plan.mjs";
+import { inspectPrecinctGeometryManifest } from "../../src/lib/precinct-geography.ts";
+
+export const SOUTH_CAROLINA_RELEASE_CANDIDATE_ID = "sc-precinct-gis-three-election-v1";
+export const SOUTH_CAROLINA_RELEASE_CANDIDATE_ROOT = ".etl/precinct-release-candidates/SC";
+export const SOUTH_CAROLINA_PRECINCT_VALIDATION_REPORT = ".etl/local-db/sc-precinct-gis-validation.json";
+export const SOUTH_CAROLINA_PUBLIC_RELEASE_YEARS = Object.freeze([
+  2016,
+  2020,
+  2024,
+]);
+export const SOUTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS = 7;
+export const SOUTH_CAROLINA_DELIVERY_SIMPLIFICATION_TOLERANCE_DEGREES = 0.000005;
+export const SOUTH_CAROLINA_MAX_PARENT_DELIVERY_BYTES = 8_000_000;
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function serializeSouthCarolinaReleaseDocument(value) {
+  return Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function safePath(root, relativePath, allowedRoots) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath
+    || path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !allowedRoots.some((prefix) => relativePath.startsWith(prefix))
+  ) {
+    throw new Error("Unsafe South Carolina release artifact path: " + relativePath);
+  }
+  const resolvedRoot = path.resolve(root);
+  const absolutePath = path.resolve(resolvedRoot, ...relativePath.split("/"));
+  if (!absolutePath.startsWith(resolvedRoot + path.sep)) {
+    throw new Error("South Carolina release artifact escapes repository root: " + relativePath);
+  }
+  return absolutePath;
+}
+
+function readArtifact(root, declaration, allowedRoots = ["data/", ".etl/"]) {
+  const absolutePath = safePath(root, declaration.path, allowedRoots);
+  if (!existsSync(absolutePath)) {
+    throw new Error("South Carolina release artifact is missing: " + declaration.path);
+  }
+  const bytes = readFileSync(absolutePath);
+  const digest = sha256(bytes);
+  if (
+    Number.isInteger(declaration.byteCount)
+    && bytes.length !== declaration.byteCount
+  ) {
+    throw new Error("South Carolina release artifact byte count drifted: " + declaration.path);
+  }
+  if (declaration.sha256 && digest !== declaration.sha256) {
+    throw new Error("South Carolina release artifact SHA-256 drifted: " + declaration.path);
+  }
+  return { path: declaration.path, byteCount: bytes.length, sha256: digest, bytes };
+}
+
+export function inspectReleaseArtifact(root, relativePath, options = {}) {
+  return readArtifact(root, {
+    path: relativePath,
+    byteCount: options.byteCount,
+    sha256: options.sha256,
+  }, options.allowedRoots ?? ["data/", ".etl/", "drizzle/", "scripts/"]);
+}
+
+function parseJsonArtifact(root, declaration, allowedRoots) {
+  const artifact = readArtifact(root, declaration, allowedRoots);
+  const payload = declaration.path.endsWith(".gz")
+    ? gunzipSync(artifact.bytes)
+    : artifact.bytes;
+  return { artifact, value: JSON.parse(payload.toString("utf8")) };
+}
+
+function validateLocalReport(report, plan) {
+  if (
+    report?.schemaVersion !== 1
+    || report?.productionMutationPerformed !== false
+    || report?.publicDeliveryAuthorized !== false
+    || report?.validation?.database?.environment !== "local"
+    || report?.validation?.database?.host !== "loopback"
+    || report?.validation?.database?.port !== 54329
+    || report?.validation?.database?.name !== "crm_clone_dev"
+    || report?.validation?.database?.readOnlySession !== true
+    || report?.validation?.invalidConstraints !== 0
+    || !Number.isInteger(report?.validation?.revision)
+    || Number.isNaN(Date.parse(report?.generatedAtUtc))
+  ) {
+    throw new Error("South Carolina precinct database validation report is not release-safe");
+  }
+  const rows = new Map(
+    (report.validation.years ?? []).map((row) => [Number(row.year), row]),
+  );
+  for (const year of plan.years) {
+    const row = rows.get(year.year);
+    const expected = {
+      reportingUnits: year.reportingUnits.length,
+      resultRows: year.resultRows.length,
+      sameYearResultRows: year.resultRows.length,
+      totalVotes: year.totals.Total,
+      zeroVoteUnits: year.zeroVoteUnits,
+      geographyVersions: 1,
+      features: year.geometry.features.length,
+      safeBlockedGeographyVersions: 1,
+      reviewedCrosswalks: year.geometry.crosswalks.length,
+      exactFeatures: year.geometry.features.length,
+      exactCrosswalks: year.geometry.crosswalks.length,
+    };
+    if (!row) throw new Error("South Carolina precinct validation is missing " + year.year);
+    for (const [key, value] of Object.entries(expected)) {
+      if (Number(row[key]) !== value) {
+        throw new Error("South Carolina " + year.year + " local validation " + key + " drifted");
+      }
+    }
+  }
+  if (rows.size !== plan.years.length) {
+    throw new Error("South Carolina precinct validation year set drifted");
+  }
+  return {
+    generatedAtUtc: report.generatedAtUtc,
+    revision: report.validation.revision,
+    invalidConstraints: report.validation.invalidConstraints,
+    database: report.validation.database,
+  };
+}
+
+function publicUrl(year, manifestId, indexSha256) {
+  return "/data/geography/sc/"
+    + year.electionDate
+    + "/precinct/"
+    + manifestId
+    + "-"
+    + indexSha256.slice(0, 12)
+    + "/index.json";
+}
+
+function squaredDistanceToSegment(point, start, end) {
+  const dx = end[0] - start[0];
+  const dy = end[1] - start[1];
+  if (dx === 0 && dy === 0) {
+    return (point[0] - start[0]) ** 2 + (point[1] - start[1]) ** 2;
+  }
+  const amount = Math.max(
+    0,
+    Math.min(
+      1,
+      ((point[0] - start[0]) * dx + (point[1] - start[1]) * dy)
+        / (dx * dx + dy * dy),
+    ),
+  );
+  const projectedX = start[0] + amount * dx;
+  const projectedY = start[1] + amount * dy;
+  return (point[0] - projectedX) ** 2 + (point[1] - projectedY) ** 2;
+}
+
+function simplifyLine(points, squaredTolerance) {
+  if (points.length <= 2) return points;
+  let maximumDistance = squaredTolerance;
+  let maximumIndex = -1;
+  const start = points[0];
+  const end = points[points.length - 1];
+  for (let index = 1; index < points.length - 1; index += 1) {
+    const distance = squaredDistanceToSegment(points[index], start, end);
+    if (distance > maximumDistance) {
+      maximumDistance = distance;
+      maximumIndex = index;
+    }
+  }
+  if (maximumIndex < 0) return [start, end];
+  const left = simplifyLine(points.slice(0, maximumIndex + 1), squaredTolerance);
+  const right = simplifyLine(points.slice(maximumIndex), squaredTolerance);
+  return [...left.slice(0, -1), ...right];
+}
+
+function samePoint(left, right) {
+  return left[0] === right[0] && left[1] === right[1];
+}
+
+function quantizeCoordinate(coordinate, scale) {
+  return coordinate.map((value) =>
+    Number.isFinite(value) ? Math.round(value * scale) / scale : value);
+}
+
+function simplifyRing(ring, scale, tolerance) {
+  const quantized = ring
+    .map((coordinate) => quantizeCoordinate(coordinate, scale))
+    .filter((coordinate, index, rows) =>
+      index === 0 || !samePoint(coordinate, rows[index - 1]));
+  if (
+    quantized.length > 1
+    && samePoint(quantized[0], quantized[quantized.length - 1])
+  ) {
+    quantized.pop();
+  }
+  if (new Set(quantized.map((coordinate) => coordinate.join(","))).size < 3) {
+    return null;
+  }
+
+  let anchorIndex = 0;
+  for (let index = 1; index < quantized.length; index += 1) {
+    if (
+      quantized[index][0] < quantized[anchorIndex][0]
+      || (
+        quantized[index][0] === quantized[anchorIndex][0]
+        && quantized[index][1] < quantized[anchorIndex][1]
+      )
+    ) {
+      anchorIndex = index;
+    }
+  }
+  const rotated = [
+    ...quantized.slice(anchorIndex),
+    ...quantized.slice(0, anchorIndex),
+  ];
+  let splitIndex = 1;
+  let splitDistance = -1;
+  for (let index = 1; index < rotated.length; index += 1) {
+    const distance = (rotated[index][0] - rotated[0][0]) ** 2
+      + (rotated[index][1] - rotated[0][1]) ** 2;
+    if (distance > splitDistance) {
+      splitDistance = distance;
+      splitIndex = index;
+    }
+  }
+  const squaredTolerance = tolerance ** 2;
+  const firstArc = simplifyLine(
+    rotated.slice(0, splitIndex + 1),
+    squaredTolerance,
+  );
+  const secondArc = simplifyLine(
+    [...rotated.slice(splitIndex), rotated[0]],
+    squaredTolerance,
+  );
+  const simplified = [...firstArc, ...secondArc.slice(1, -1)];
+  const usable = new Set(
+    simplified.map((coordinate) => coordinate.join(",")),
+  ).size >= 3 ? simplified : rotated;
+  return [...usable, usable[0]];
+}
+
+function simplifyPolygon(polygon, scale, tolerance) {
+  const outer = simplifyRing(polygon[0], scale, tolerance);
+  if (!outer) return null;
+  return [
+    outer,
+    ...polygon.slice(1)
+      .map((ring) => simplifyRing(ring, scale, tolerance))
+      .filter(Boolean),
+  ];
+}
+
+function simplifyGeometry(geometry, scale, tolerance) {
+  if (geometry.type === "Polygon") {
+    const polygon = simplifyPolygon(geometry.coordinates, scale, tolerance);
+    if (!polygon) {
+      throw new Error("South Carolina presentation simplification collapsed a polygon");
+    }
+    return {
+      type: "Polygon",
+      coordinates: polygon,
+    };
+  }
+  if (geometry.type === "MultiPolygon") {
+    const polygons = geometry.coordinates
+      .map((polygon) => simplifyPolygon(polygon, scale, tolerance))
+      .filter(Boolean);
+    if (polygons.length === 0) {
+      throw new Error("South Carolina presentation simplification collapsed a multipolygon");
+    }
+    return {
+      type: "MultiPolygon",
+      coordinates: polygons,
+    };
+  }
+  throw new Error("South Carolina delivery has an unsupported geometry type");
+}
+
+export function quantizeSouthCarolinaDeliveryCollection(collection) {
+  const scale = 10 ** SOUTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS;
+  const tolerance = SOUTH_CAROLINA_DELIVERY_SIMPLIFICATION_TOLERANCE_DEGREES;
+  return {
+    ...collection,
+    metadata: {
+      ...collection.metadata,
+      coordinatePrecisionDecimals: SOUTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS,
+      simplificationToleranceDegrees: tolerance,
+      presentationGeometry: "source-normalized geometry is rounded to seven decimals and simplified at a 0.000005-degree presentation tolerance for county-scoped web delivery; zero-area polygon parts are omitted while source artifacts, identities, and joins remain unchanged",
+    },
+    features: collection.features.map((feature) => ({
+      ...feature,
+      geometry: simplifyGeometry(feature.geometry, scale, tolerance),
+    })),
+  };
+}
+
+function buildDraftManifest(year, delivery) {
+  const geographicReportingUnits = year.reportingUnits.filter(
+    (unit) => unit.isGeographic,
+  ).length;
+  const nonGeographicReportingUnits = year.reportingUnits.length
+    - geographicReportingUnits;
+  const draft = JSON.parse(JSON.stringify(year.manifest));
+  const warnings = [
+    ...draft.validation.warnings,
+    "All " + geographicReportingUnits
+      + " displayable precinct relationships are reviewed one-to-one across all 46 South Carolina counties.",
+    "All " + nonGeographicReportingUnits
+      + " administrative reporting units remain explicitly non-geographic and are never assigned to a polygon.",
+    "The " + year.zeroVoteUnits
+      + " zero-presidential-vote precincts remain geographic reporting units.",
+    "All " + year.manifest.crosswalk.reviewedNoDataFeatures
+      + " reviewed no-data polygons remain visible without an invented result row.",
+    "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged.",
+  ];
+  draft.validation = {
+    ...draft.validation,
+    status: "reviewed",
+    rowLevelRenderingSafe: true,
+    errors: [],
+    warnings: [...new Set(warnings)],
+  };
+  draft.delivery = {
+    format: "parent_scoped_geojson",
+    url: publicUrl(year, draft.id, delivery.indexSha256),
+    sha256: delivery.indexSha256,
+    byteCount: delivery.indexByteCount,
+    featureIdProperty: "geometryFeatureId",
+    resultUnitProperty: "resultUnitCode",
+    parentGeoidProperty: "parentGeoid",
+    parentCount: delivery.parentCount,
+    featureCount: delivery.featureCount,
+  };
+  draft.caveats = [...new Set(draft.caveats)];
+  const inspection = inspectPrecinctGeometryManifest(draft);
+  if (inspection.errors.length || inspection.publicEligibilityReasons.length) {
+    throw new Error(
+      "South Carolina " + year.year + " public draft is invalid: "
+      + inspection.errors.concat(inspection.publicEligibilityReasons).join("; "),
+    );
+  }
+  return draft;
+}
+
+function buildYear(root, year) {
+  const geographicReportingUnits = year.reportingUnits.filter(
+    (unit) => unit.isGeographic,
+  ).length;
+  const nonGeographicReportingUnits = year.reportingUnits.length
+    - geographicReportingUnits;
+  const normalized = parseJsonArtifact(root, {
+    path: year.manifest.normalization.artifact,
+    byteCount: year.manifest.normalization.byteCount,
+    sha256: year.manifest.normalization.sha256,
+  }, ["data/"]);
+  const crosswalk = parseJsonArtifact(root, {
+    path: year.manifest.crosswalk.artifact,
+    byteCount: year.manifest.crosswalk.byteCount,
+    sha256: year.manifest.crosswalk.sha256,
+  }, ["data/"]);
+  const statewide = quantizeSouthCarolinaDeliveryCollection(
+    buildPrecinctDeliveryCandidateFeatureCollection(
+      year.manifest,
+      normalized.value,
+      crosswalk.value,
+    ),
+  );
+  const delivery = buildParentScopedPrecinctDeliveryPackage(statewide);
+  if (
+    delivery.parentCount !== 46
+    || delivery.featureCount !== year.geometry.features.length
+    || delivery.resultUnitCount !== year.geometry.features.length
+  ) {
+    throw new Error("South Carolina " + year.year + " parent-scoped delivery drifted");
+  }
+  const largestParentByteCount = Math.max(
+    ...delivery.parentArtifacts.map((artifact) => artifact.byteCount),
+  );
+  if (largestParentByteCount > SOUTH_CAROLINA_MAX_PARENT_DELIVERY_BYTES) {
+    throw new Error(
+      "South Carolina " + year.year + " parent delivery exceeds the web response safety limit",
+    );
+  }
+  const draft = buildDraftManifest(year, delivery);
+  const draftBytes = serializeSouthCarolinaReleaseDocument(draft);
+  const assetRoot = path.posix.join(
+    "delivery-assets",
+    draft.id + "-" + delivery.indexSha256.slice(0, 12),
+  );
+  const index = {
+    packageRelativePath: path.posix.join(assetRoot, "index.json"),
+    publicUrl: draft.delivery.url,
+    byteCount: delivery.indexByteCount,
+    sha256: delivery.indexSha256,
+  };
+  const parentArtifacts = delivery.parentArtifacts.map((artifact) => ({
+    parentGeoid: artifact.parentGeoid,
+    packageRelativePath: path.posix.join(assetRoot, artifact.path),
+    publicUrl: path.posix.join(path.posix.dirname(draft.delivery.url), artifact.path),
+    byteCount: artifact.byteCount,
+    sha256: artifact.sha256,
+    featureCount: artifact.featureCount,
+  }));
+  return {
+    summary: {
+      year: year.year,
+      electionId: year.electionId,
+      manifestId: year.manifest.id,
+      canonicalManifest: {
+        path: year.manifestPath,
+        sha256: year.manifestSha256,
+        byteCount: year.manifestByteCount,
+        validationStatus: "blocked",
+        rowLevelRenderingSafe:
+          year.manifest.validation.rowLevelRenderingSafe,
+        delivery: null,
+      },
+      certifiedResults: {
+        authority: year.resultSource.authority,
+        sourceId: year.resultSource.id,
+        sourceUrl: year.resultSource.url,
+        artifact: {
+          path: year.resultSource.artifact,
+          byteCount: year.resultSource.byteCount,
+          sha256: year.resultSource.sha256,
+        },
+        reportingUnits: year.reportingUnits.length,
+        geographicReportingUnits,
+        nonGeographicReportingUnits,
+        resultRows: year.resultRows.length,
+        zeroVoteUnits: year.zeroVoteUnits,
+        candidateDetailSuppressedUnits: year.candidateDetailSuppressedUnits,
+        totals: year.totals,
+        officialTotals: year.officialTotals,
+      },
+      reviewedGeometry: {
+        sourceAuthority: year.manifest.source.authority,
+        sourceUrl: year.manifest.source.url,
+        sourceTerms: year.manifest.source.licenseOrTerms,
+        featureCount: year.geometry.features.length,
+        parentCount: delivery.parentCount,
+        reviewedRelationships: year.geometry.crosswalks.length,
+        reviewedNoDataFeatures: year.manifest.crosswalk.reviewedNoDataFeatures,
+        publicGeographyLabel: year.year === 2024
+          ? "NYT official-boundary geometry joined only to official South Carolina Election Commission results under retained non-commercial attribution terms"
+          : "VEST election-specific geometry attributed to South Carolina Revenue and Fiscal Affairs boundaries and joined only to official South Carolina Election Commission results",
+        electionValuesInDelivery: false,
+      },
+      parentScopedDelivery: {
+        format: "parent_scoped_geojson",
+        originEnvironmentVariable: "CRM_PRECINCT_GEOGRAPHY_ORIGIN",
+        index,
+        parentCount: delivery.parentCount,
+        featureCount: delivery.featureCount,
+        deliveryIdentityCount: delivery.resultUnitCount,
+        colorableResultUnitCount: geographicReportingUnits,
+        nonGeographicResultUnitCount: nonGeographicReportingUnits,
+        candidateDetailSuppressedResultUnitCount:
+          year.candidateDetailSuppressedUnits,
+        reviewedNoDataFeatureCount:
+          year.manifest.crosswalk.reviewedNoDataFeatures,
+        parentArtifactByteCount: delivery.parentArtifactByteCount,
+        largestParentByteCount,
+        coordinatePrecisionDecimals: SOUTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS,
+        simplificationToleranceDegrees:
+          SOUTH_CAROLINA_DELIVERY_SIMPLIFICATION_TOLERANCE_DEGREES,
+        maximumParentByteCount: SOUTH_CAROLINA_MAX_PARENT_DELIVERY_BYTES,
+        parentArtifacts,
+        electionValuesInDelivery: false,
+        publicationPerformed: false,
+      },
+      proposedPublicDelivery: draft.delivery,
+      draftManifest: {
+        path: path.posix.join("draft-manifests", draft.id + ".json"),
+        byteCount: draftBytes.length,
+        sha256: sha256(draftBytes),
+        canonicalMutationPerformed: false,
+        reviewRequired: true,
+      },
+    },
+    draft: { path: path.posix.join("draft-manifests", draft.id + ".json"), bytes: draftBytes },
+    assets: [
+      { path: index.packageRelativePath, bytes: delivery.indexBytes },
+      ...delivery.parentArtifacts.map((artifact) => ({
+        path: path.posix.join(assetRoot, artifact.path),
+        bytes: artifact.bytes,
+      })),
+    ],
+  };
+}
+
+function sum(years, selector) {
+  return years.reduce((total, year) => total + selector(year), 0);
+}
+
+export async function buildSouthCarolinaPrecinctReleaseCandidate(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const plan = await buildSouthCarolinaPrecinctGisPlan({
+    root,
+    years: [...SOUTH_CAROLINA_PUBLIC_RELEASE_YEARS],
+  });
+  const validationPath = options.validationReportPath
+    ?? SOUTH_CAROLINA_PRECINCT_VALIDATION_REPORT;
+  const validationArtifact = readArtifact(root, { path: validationPath }, [".etl/"]);
+  const validationValue = JSON.parse(validationArtifact.bytes.toString("utf8"));
+  const localValidation = validateLocalReport(validationValue, plan);
+  const migration0008Artifact = readArtifact(root, {
+    path: "drizzle/0008_typical_thunderbolts.sql",
+  }, ["drizzle/"]);
+  const migration0009Artifact = readArtifact(root, {
+    path: "drizzle/0009_public_wolfpack.sql",
+  }, ["drizzle/"]);
+  const yearBuilds = plan.years.map((year) => buildYear(root, year));
+  const years = yearBuilds.map((year) => year.summary);
+  const packageDocument = {
+    schemaVersion: 1,
+    id: SOUTH_CAROLINA_RELEASE_CANDIDATE_ID,
+    state: "SC",
+    stateName: "South Carolina",
+    scope: "reviewed 2016, 2020, and 2024 South Carolina presidential precinct GIS release preparation; 2012 remains blocked and excluded",
+    preparedFromLocalValidationAt: localValidation.generatedAtUtc,
+    disposition: "prepared_awaiting_explicit_production_authorization",
+    decision: "NO_GO_PRODUCTION",
+    safety: {
+      productionMutationPerformed: false,
+      publicFileWritten: false,
+      canonicalManifestChanged: false,
+      canonicalRegistryChanged: false,
+      publicEligibilityChanged: false,
+      gitPublicationPerformed: false,
+      explicitProductionAuthorizationRequired: true,
+    },
+    totals: {
+      elections: years.length,
+      countyParentsPerElection: 46,
+      reportingUnits: sum(years, (year) => year.certifiedResults.reportingUnits),
+      candidateResultRows: sum(years, (year) => year.certifiedResults.resultRows),
+      zeroVoteUnits: sum(years, (year) => year.certifiedResults.zeroVoteUnits),
+      geometryFeatures: sum(years, (year) => year.reviewedGeometry.featureCount),
+      reviewedRelationships: sum(years, (year) => year.reviewedGeometry.reviewedRelationships),
+      deliveryIndexes: years.length,
+      parentDeliveryArtifacts: years.length * 46,
+    },
+    years,
+    localValidation: {
+      path: validationPath,
+      byteCount: validationArtifact.byteCount,
+      sha256: validationArtifact.sha256,
+      ...localValidation,
+    },
+    databaseActivationContract: {
+      migrations: [migration0008Artifact, migration0009Artifact].map((artifact) => ({
+        path: artifact.path,
+        byteCount: artifact.byteCount,
+        sha256: artifact.sha256,
+      })),
+      productionWriterImplemented: true,
+      productionWriterEnabled: false,
+      expectedPostLoad: {
+        reportingUnits: sum(years, (year) => year.certifiedResults.reportingUnits),
+        candidateResultRows: sum(years, (year) => year.certifiedResults.resultRows),
+        geographyVersions: 3,
+        geometryFeatures: sum(years, (year) => year.reviewedGeometry.featureCount),
+        reviewedRelationships: sum(years, (year) => year.reviewedGeometry.reviewedRelationships),
+        reviewedNoDataFeatures: sum(
+          years,
+          (year) => year.reviewedGeometry.reviewedNoDataFeatures,
+        ),
+        zeroVoteUnits: sum(years, (year) => year.certifiedResults.zeroVoteUnits),
+        invalidConstraints: 0,
+      },
+    },
+    releasePolicy: {
+      officialResultsScope: "Official South Carolina Election Commission presidential rows for every precinct and separately reported administrative bucket. Only geographic precinct rows are displayed; all official totals and non-geographic exclusions remain reconciled in the source package.",
+      certifiedCanvassBoundary: "Administrative reporting buckets such as absentee, failsafe, failsafe provisional, and provisional are not assigned or estimated onto precinct polygons. The map therefore does not purport to sum to the statewide certified total.",
+      publicLabel: "South Carolina precinct results with reviewed election-specific geometry",
+      hiddenLoadRequired: true,
+      immutableBlobPublicationRequired: true,
+      protectedPreviewRequired: true,
+      databasePublicationGateRequired: true,
+    },
+    goNoGoGates: [
+      { id: "official_sources_hash_pinned", status: "passed" },
+      { id: "three_year_exact_result_geometry_join", status: "passed" },
+      { id: "2012_excluded_until_safe_geometry_join_exists", status: "passed" },
+      { id: "non_geographic_vote_buckets_retained_without_polygon_assignment", status: "passed" },
+      { id: "local_database_exact_validation", status: "passed", evidence: validationPath },
+      { id: "immutable_parent_scoped_delivery", status: "passed" },
+      { id: "production_hidden_load", status: "pending" },
+      { id: "blob_publication", status: "pending" },
+      { id: "protected_preview_and_public_activation", status: "pending" },
+    ],
+  };
+  return {
+    packageDocument,
+    packageBytes: serializeSouthCarolinaReleaseDocument(packageDocument),
+    draftManifests: yearBuilds.map((year) => year.draft),
+    deliveryAssets: yearBuilds.flatMap((year) => year.assets),
+  };
+}
+
+export function southCarolinaReleaseCandidateOutputRoot(packageSha256) {
+  if (!/^[a-f0-9]{64}$/.test(packageSha256)) {
+    throw new Error("South Carolina release package hash must be SHA-256");
+  }
+  return path.posix.join(
+    SOUTH_CAROLINA_RELEASE_CANDIDATE_ROOT,
+    SOUTH_CAROLINA_RELEASE_CANDIDATE_ID + "-" + packageSha256.slice(0, 12),
+  );
+}

--- a/scripts/prepare-sc-precinct-public-activation.mjs
+++ b/scripts/prepare-sc-precinct-public-activation.mjs
@@ -1,0 +1,144 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  inspectSouthCarolinaPublicActivationPlan,
+} from "./lib/sc-precinct-public-activation.mjs";
+
+function parseArguments(args) {
+  const packagePath = args.find((arg) => arg.startsWith("--package="))
+    ?.slice("--package=".length);
+  const packageSha256 = args.find((arg) => arg.startsWith("--package-sha256="))
+    ?.slice("--package-sha256=".length);
+  const write = args.includes("--write");
+  for (const arg of args) {
+    if (
+      arg !== "--write"
+      && !arg.startsWith("--package=")
+      && !arg.startsWith("--package-sha256=")
+    ) {
+      throw new Error("Unknown South Carolina public-activation option: " + arg);
+    }
+  }
+  if (!packagePath || !packageSha256) {
+    throw new Error(
+      "South Carolina public activation requires --package and --package-sha256",
+    );
+  }
+  return { packagePath, packageSha256, write };
+}
+
+function immutableWrite(root, relativePath, bytes) {
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ".etl", "precinct-public-activations", "SC");
+  if (!absolutePath.startsWith(allowed + path.sep)) {
+    throw new Error("South Carolina activation evidence escapes its fixed .etl root");
+  }
+  if (existsSync(absolutePath)) {
+    if (!readFileSync(absolutePath).equals(bytes)) {
+      throw new Error("Refusing to overwrite different South Carolina activation evidence");
+    }
+    return "verified_existing";
+  }
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, bytes, { mode: 0o600, flag: "wx" });
+  return "created";
+}
+
+export function writeSouthCarolinaActivationTrackedOutputs(outputs) {
+  if (outputs.length !== 4 || new Set(outputs.map((item) => item.path)).size !== 4) {
+    throw new Error("South Carolina activation requires exactly four unique tracked outputs");
+  }
+  const staged = [];
+  const committed = [];
+  try {
+    for (const output of outputs) {
+      const before = readFileSync(output.absolutePath);
+      if (before.length !== output.preimage.byteCount) {
+        throw new Error("South Carolina activation target changed after plan: " + output.path);
+      }
+      const currentHash = createHash("sha256").update(before).digest("hex");
+      if (currentHash !== output.preimage.sha256) {
+        throw new Error("South Carolina activation target preimage drifted: " + output.path);
+      }
+      const temporaryPath = output.absolutePath
+        + ".crm-sc-activation-" + randomUUID() + ".tmp";
+      writeFileSync(temporaryPath, output.bytes, { flag: "wx" });
+      staged.push({ output, before, temporaryPath });
+    }
+    for (const item of staged) {
+      renameSync(item.temporaryPath, item.output.absolutePath);
+      committed.push(item);
+    }
+  } catch (error) {
+    for (const item of staged) {
+      if (existsSync(item.temporaryPath)) unlinkSync(item.temporaryPath);
+    }
+    for (const item of committed.reverse()) {
+      const rollbackPath = item.output.absolutePath
+        + ".crm-sc-rollback-" + randomUUID() + ".tmp";
+      writeFileSync(rollbackPath, item.before, { flag: "wx" });
+      renameSync(rollbackPath, item.output.absolutePath);
+    }
+    throw error;
+  }
+  return outputs.map((output) => ({
+    path: output.path,
+    sha256: output.sha256,
+    byteCount: output.byteCount,
+  }));
+}
+
+export async function prepareSouthCarolinaPublicActivation(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const built = inspectSouthCarolinaPublicActivationPlan({ ...options, root });
+  if (!options.write) {
+    return {
+      mode: "plan",
+      decision: built.plan.decision,
+      releaseCandidate: built.plan.releaseCandidate,
+      activationCandidate: {
+        path: built.outputPath,
+        sha256: built.sha256,
+        byteCount: built.bytes.length,
+      },
+      trackedOutputs: built.plan.trackedOutputs,
+      productionMutationPerformed: false,
+      publicEndpointsRemainDatabaseGated: true,
+    };
+  }
+  const trackedOutputs = writeSouthCarolinaActivationTrackedOutputs(built.outputs);
+  const evidenceDisposition = immutableWrite(root, built.outputPath, built.bytes);
+  return {
+    mode: "write",
+    decision: built.plan.decision,
+    releaseCandidate: built.plan.releaseCandidate,
+    activationCandidate: {
+      path: built.outputPath,
+      sha256: built.sha256,
+      byteCount: built.bytes.length,
+      disposition: evidenceDisposition,
+    },
+    trackedOutputs,
+    productionMutationPerformed: false,
+    publicEndpointsRemainDatabaseGated: true,
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  prepareSouthCarolinaPublicActivation(parseArguments(process.argv.slice(2))).then(
+    (result) => console.log(JSON.stringify(result, null, 2)),
+    (error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/prepare-sc-precinct-release-candidate.mjs
+++ b/scripts/prepare-sc-precinct-release-candidate.mjs
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildSouthCarolinaPrecinctReleaseCandidate,
+  southCarolinaReleaseCandidateOutputRoot,
+} from "./lib/sc-precinct-release-candidate.mjs";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function immutableWrite(root, relativePath, bytes) {
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  const expectedRoot = path.resolve(root, ".etl", "precinct-release-candidates", "SC");
+  if (!absolutePath.startsWith(expectedRoot + path.sep)) {
+    throw new Error("South Carolina release output escapes its content-addressed root");
+  }
+  if (existsSync(absolutePath)) {
+    if (!readFileSync(absolutePath).equals(bytes)) {
+      throw new Error("Refusing to overwrite different South Carolina release bytes: " + relativePath);
+    }
+    return "verified_existing";
+  }
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, bytes);
+  return "created";
+}
+
+export async function prepareSouthCarolinaPrecinctReleaseCandidate(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const built = await buildSouthCarolinaPrecinctReleaseCandidate({
+    root,
+    validationReportPath: options.validationReportPath,
+  });
+  const packageSha256 = sha256(built.packageBytes);
+  const outputRoot = southCarolinaReleaseCandidateOutputRoot(packageSha256);
+  const files = [
+    { path: "release-candidate.json", bytes: built.packageBytes },
+    ...built.draftManifests,
+    ...built.deliveryAssets,
+  ];
+  const disposition = options.write
+    ? files.map((file) => immutableWrite(
+      root,
+      path.posix.join(outputRoot, file.path),
+      file.bytes,
+    ))
+    : [];
+  return {
+    mode: options.write ? "write" : "plan",
+    decision: "NO_GO_PRODUCTION",
+    state: "SC",
+    releaseCandidate: {
+      id: built.packageDocument.id,
+      path: path.posix.join(outputRoot, "release-candidate.json"),
+      sha256: packageSha256,
+      byteCount: built.packageBytes.length,
+    },
+    totals: built.packageDocument.totals,
+    fileCount: files.length,
+    createdCount: disposition.filter((value) => value === "created").length,
+    verifiedExistingCount: disposition.filter((value) => value === "verified_existing").length,
+    productionMutationPerformed: false,
+    publicFileWritten: false,
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const unknown = args.filter((arg) => arg !== "--write" && !arg.startsWith("--validation-report="));
+  if (unknown.length) throw new Error("Unknown South Carolina release-candidate option: " + unknown[0]);
+  const validationReportPath = args.find((arg) => arg.startsWith("--validation-report="))
+    ?.slice("--validation-report=".length);
+  console.log(JSON.stringify(await prepareSouthCarolinaPrecinctReleaseCandidate({
+    write: args.includes("--write"),
+    validationReportPath,
+  }), null, 2));
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/publish-sc-precinct-delivery-assets.mjs
+++ b/scripts/publish-sc-precinct-delivery-assets.mjs
@@ -1,0 +1,264 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  inspectSouthCarolinaPrecinctBlobPublicationPlan,
+  validateSouthCarolinaBlobPublicationAuthorization,
+} from "./lib/sc-precinct-blob-publication.mjs";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function parseArguments(args) {
+  const write = args.includes("--write");
+  const packagePath = args.find((argument) =>
+    argument.startsWith("--package="))?.slice("--package=".length);
+  const packageSha256 = args.find((argument) =>
+    argument.startsWith("--package-sha256="))
+    ?.slice("--package-sha256=".length);
+  const concurrencyValue = args.find((argument) =>
+    argument.startsWith("--concurrency="))?.slice("--concurrency=".length);
+  const concurrency = concurrencyValue ? Number(concurrencyValue) : 4;
+  for (const argument of args) {
+    if (
+      argument !== "--write"
+      && !argument.startsWith("--package=")
+      && !argument.startsWith("--package-sha256=")
+      && !argument.startsWith("--concurrency=")
+    ) {
+      throw new Error("Unknown South Carolina Blob publication option: " + argument);
+    }
+  }
+  if (!packagePath || !packageSha256) {
+    throw new Error(
+      "usage: npm run local-gis:delivery-publish:me -- "
+      + "--package=<release-candidate.json> --package-sha256=<sha256> "
+      + "[--concurrency=4] [--write]",
+    );
+  }
+  if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 8) {
+    throw new Error("South Carolina Blob publication concurrency must be 1 through 8");
+  }
+  return { write, packagePath, packageSha256, concurrency };
+}
+
+function publicPlan(plan) {
+  return {
+    schemaVersion: plan.schemaVersion,
+    state: plan.state,
+    releaseCandidate: plan.releaseCandidate,
+    decision: plan.decision,
+    assetCount: plan.assetCount,
+    indexCount: plan.indexCount,
+    parentArtifactCount: plan.parentArtifactCount,
+    totalByteCount: plan.totalByteCount,
+    uploadOrder: plan.uploadOrder,
+    canonicalManifestChanged: plan.canonicalManifestChanged,
+    publicEligibilityChanged: plan.publicEligibilityChanged,
+    artifacts: plan.artifacts.map(({ absolutePath: _absolutePath, ...artifact }) =>
+      artifact),
+  };
+}
+
+async function verifyPublicBlob(url, artifact) {
+  const response = await fetch(url, {
+    cache: "no-store",
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!response.ok) {
+    throw new Error(
+      "Published South Carolina geometry returned HTTP " + response.status,
+    );
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.length !== artifact.byteCount || sha256(bytes) !== artifact.sha256) {
+    throw new Error("Published South Carolina geometry failed byte/hash verification");
+  }
+}
+
+async function publishArtifact(artifact, sdk) {
+  let existing = null;
+  try {
+    existing = await sdk.head(artifact.pathname);
+  } catch (error) {
+    if (!(error instanceof sdk.BlobNotFoundError)) throw error;
+  }
+  if (existing) {
+    if (existing.size !== artifact.byteCount) {
+      throw new Error(
+        "Existing immutable South Carolina geometry has a different byte count",
+      );
+    }
+    await verifyPublicBlob(existing.url, artifact);
+    return {
+      ...artifact,
+      disposition: "verified_existing",
+      url: existing.url,
+      remoteMutationPerformed: false,
+    };
+  }
+
+  const bytes = readFileSync(artifact.absolutePath);
+  const uploaded = await sdk.put(artifact.pathname, bytes, {
+    access: "public",
+    addRandomSuffix: false,
+    allowOverwrite: false,
+    cacheControlMaxAge: 31_536_000,
+    contentType: artifact.kind === "index"
+      ? "application/json"
+      : "application/geo+json",
+    multipart: bytes.length >= 4 * 1024 * 1024,
+  });
+  if (
+    uploaded.pathname !== artifact.pathname
+    || new URL(uploaded.url).pathname !== "/" + artifact.pathname
+  ) {
+    throw new Error("Published South Carolina geometry URL/pathname drifted");
+  }
+  await verifyPublicBlob(uploaded.url, artifact);
+  return {
+    ...artifact,
+    disposition: "created",
+    url: uploaded.url,
+    remoteMutationPerformed: true,
+  };
+}
+
+async function publishBatch(artifacts, concurrency, sdk) {
+  const results = new Array(artifacts.length);
+  let nextIndex = 0;
+  async function worker() {
+    while (nextIndex < artifacts.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await publishArtifact(artifacts[index], sdk);
+    }
+  }
+  await Promise.all(
+    Array.from(
+      { length: Math.min(concurrency, artifacts.length) },
+      () => worker(),
+    ),
+  );
+  return results;
+}
+
+function writeEvidence(root, evidence) {
+  const bytes = Buffer.from(JSON.stringify(evidence, null, 2) + "\n", "utf8");
+  const digest = sha256(bytes);
+  const relativePath = path.posix.join(
+    ".etl",
+    "precinct-blob-publications",
+    "SC",
+    "sc-precinct-blob-publication-"
+      + evidence.releaseCandidate.sha256.slice(0, 12)
+      + "-"
+      + digest.slice(0, 12)
+      + ".json",
+  );
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  if (existsSync(absolutePath)) {
+    if (!readFileSync(absolutePath).equals(bytes)) {
+      throw new Error("Refusing to overwrite different Blob publication evidence");
+    }
+  } else {
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, bytes, { mode: 0o600 });
+  }
+  return { path: relativePath, byteCount: bytes.length, sha256: digest };
+}
+
+export async function publishSouthCarolinaPrecinctDeliveryAssets(options) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const plan = inspectSouthCarolinaPrecinctBlobPublicationPlan({
+    root,
+    packagePath: options.packagePath,
+    packageSha256: options.packageSha256,
+  });
+  if (!options.write) {
+    return {
+      mode: "plan",
+      ...publicPlan(plan),
+      remoteMutationPerformed: false,
+      evidence: null,
+    };
+  }
+  const authorization = validateSouthCarolinaBlobPublicationAuthorization(plan);
+  const sdk = await import("@vercel/blob");
+  const parentResults = await publishBatch(
+    plan.artifacts.filter((artifact) => artifact.kind === "parent"),
+    options.concurrency ?? 4,
+    sdk,
+  );
+  const indexResults = await publishBatch(
+    plan.artifacts.filter((artifact) => artifact.kind === "index"),
+    options.concurrency ?? 4,
+    sdk,
+  );
+  const results = [...parentResults, ...indexResults];
+  const origins = new Set(results.map((result) => new URL(result.url).origin));
+  if (origins.size !== 1) {
+    throw new Error("South Carolina geometry assets were not published to one origin");
+  }
+  const evidenceDocument = {
+    schemaVersion: 1,
+    state: "SC",
+    purpose: "sc-precinct-parent-scoped-immutable-geometry-publication",
+    publishedAtUtc: new Date().toISOString(),
+    authorizationId: authorization.authorizationId,
+    releaseCandidate: plan.releaseCandidate,
+    deliveryOrigin: [...origins][0],
+    assetCount: results.length,
+    createdCount: results.filter((result) => result.disposition === "created").length,
+    verifiedExistingCount: results.filter(
+      (result) => result.disposition === "verified_existing",
+    ).length,
+    remoteMutationPerformed: results.some(
+      (result) => result.remoteMutationPerformed,
+    ),
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+    nextRequiredStep:
+      "Configure CRM_PRECINCT_GEOGRAPHY_ORIGIN to deliveryOrigin in a protected preview and verify every election and county before canonical manifest activation.",
+    artifacts: results.map(({
+      absolutePath: _absolutePath,
+      remoteMutationPerformed: _remoteMutationPerformed,
+      ...result
+    }) => result),
+  };
+  const evidence = writeEvidence(root, evidenceDocument);
+  return {
+    mode: "write",
+    decision: "ASSETS_PUBLISHED_MANIFESTS_STILL_BLOCKED",
+    releaseCandidate: plan.releaseCandidate,
+    deliveryOrigin: evidenceDocument.deliveryOrigin,
+    assetCount: evidenceDocument.assetCount,
+    createdCount: evidenceDocument.createdCount,
+    verifiedExistingCount: evidenceDocument.verifiedExistingCount,
+    remoteMutationPerformed: evidenceDocument.remoteMutationPerformed,
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+    evidence,
+  };
+}
+
+async function main() {
+  const args = parseArguments(process.argv.slice(2));
+  const result = await publishSouthCarolinaPrecinctDeliveryAssets(args);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/publish-sc-precinct-geography-status.mjs
+++ b/scripts/publish-sc-precinct-geography-status.mjs
@@ -1,0 +1,1214 @@
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import postgres from "postgres";
+import {
+  buildSouthCarolinaPrecinctExecutionContext,
+  validateSouthCarolinaPrecinctGisClient,
+} from "./lib/sc-precinct-gis-db.mjs";
+import { buildSouthCarolinaPrecinctGisPlan } from "./lib/sc-precinct-gis-plan.mjs";
+import { productionEndpointFingerprint } from "./lib/sc-precinct-production-preflight.mjs";
+import {
+  SOUTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES,
+  buildSouthCarolinaPublicRollbackAuthorizationTemplate,
+  buildSouthCarolinaPublicationAuthorizationTemplate,
+  inspectSouthCarolinaPublicationPlan,
+  semanticallyEqual,
+  serializeSouthCarolinaPublicationDocument,
+  sha256,
+  validateSouthCarolinaPublicRollbackAuthorization,
+  validateSouthCarolinaPublicationAuthorization,
+} from "./lib/sc-precinct-publication.mjs";
+
+function parseArguments(args) {
+  const read = (name) => args.find((arg) => arg.startsWith(name + "="))
+    ?.slice(name.length + 1);
+  const parsed = {
+    packagePath: read("--package"),
+    packageSha256: read("--package-sha256"),
+    hiddenReceiptPath: read("--hidden-receipt"),
+    hiddenReceiptSha256: read("--hidden-receipt-sha256"),
+    blobEvidencePath: read("--blob-evidence"),
+    blobEvidenceSha256: read("--blob-evidence-sha256"),
+    planSha256: read("--plan-sha256"),
+    authorizationPath: read("--authorization"),
+    authorizationSha256: read("--authorization-sha256"),
+    publicationReceiptPath: read("--publication-receipt"),
+    publicationReceiptSha256: read("--publication-receipt-sha256"),
+    outputPath: read("--output"),
+    writePlan: args.includes("--write-plan"),
+    writeAuthorizationTemplate: args.includes("--write-authorization-template"),
+    apply: args.includes("--apply"),
+    recoverReceipt: args.includes("--recover-receipt"),
+    rollback: args.includes("--rollback"),
+  };
+  const allowed = new Set([
+    "--package",
+    "--package-sha256",
+    "--hidden-receipt",
+    "--hidden-receipt-sha256",
+    "--blob-evidence",
+    "--blob-evidence-sha256",
+    "--plan-sha256",
+    "--authorization",
+    "--authorization-sha256",
+    "--publication-receipt",
+    "--publication-receipt-sha256",
+    "--output",
+  ]);
+  for (const arg of args) {
+    if (
+      ![
+        "--write-plan",
+        "--write-authorization-template",
+        "--apply",
+        "--recover-receipt",
+        "--rollback",
+      ].includes(arg)
+      && ![...allowed].some((name) => arg.startsWith(name + "="))
+    ) {
+      throw new Error("Unknown South Carolina publication-status option: " + arg);
+    }
+  }
+  const modes = [
+    parsed.writePlan,
+    parsed.writeAuthorizationTemplate,
+    parsed.apply,
+    parsed.recoverReceipt,
+  ]
+    .filter(Boolean).length;
+  if (modes > 1) throw new Error("South Carolina publication-status modes are mutually exclusive");
+  for (const field of [
+    "packagePath",
+    "packageSha256",
+    "hiddenReceiptPath",
+    "hiddenReceiptSha256",
+    "blobEvidencePath",
+    "blobEvidenceSha256",
+  ]) {
+    if (!parsed[field]) throw new Error("South Carolina publication-status requires " + field);
+  }
+  if (
+    parsed.rollback
+    && (!parsed.publicationReceiptPath || !parsed.publicationReceiptSha256)
+  ) {
+    throw new Error("South Carolina rollback requires the exact publication receipt and SHA-256");
+  }
+  return parsed;
+}
+
+function safeJson(root, relativePath, expectedSha256, allowedRoot) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith(allowedRoot + "/")
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+    || !relativePath.endsWith(".json")
+    || !/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")
+  ) {
+    throw new Error("South Carolina publication-status JSON path is unsafe");
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...allowedRoot.split("/"));
+  if (!absolute.startsWith(allowed + path.sep) || !existsSync(absolute)) {
+    throw new Error("South Carolina publication-status JSON is missing");
+  }
+  const bytes = readFileSync(absolute);
+  if (sha256(bytes) !== expectedSha256) {
+    throw new Error("South Carolina publication-status JSON SHA-256 drifted");
+  }
+  return {
+    path: relativePath,
+    absolute,
+    bytes,
+    sha256: expectedSha256,
+    value: JSON.parse(bytes.toString("utf8")),
+  };
+}
+
+function immutableJson(root, relativePath, value, allowedRoot) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith(allowedRoot + "/")
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+    || !relativePath.endsWith(".json")
+  ) {
+    throw new Error("South Carolina publication-status output path is unsafe");
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...allowedRoot.split("/"));
+  if (!absolute.startsWith(allowed + path.sep)) {
+    throw new Error("South Carolina publication-status output escapes its fixed root");
+  }
+  const bytes = serializeSouthCarolinaPublicationDocument(value);
+  if (existsSync(absolute)) {
+    if (!readFileSync(absolute).equals(bytes)) {
+      throw new Error("Refusing to overwrite different South Carolina publication evidence");
+    }
+    return { path: relativePath, sha256: sha256(bytes), byteCount: bytes.length };
+  }
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, bytes, { flag: "wx", mode: 0o600 });
+  return { path: relativePath, sha256: sha256(bytes), byteCount: bytes.length };
+}
+
+function productionUrl(environment = process.env) {
+  const first = environment.POSTGRES_URL_NON_POOLING;
+  const second = environment.POSTGRES_DATABASE_URL_UNPOOLED;
+  if (first && second && first !== second) {
+    throw new Error("Production unpooled URL variables disagree");
+  }
+  const value = first ?? second;
+  if (!value) throw new Error("Production unpooled database URL is unavailable");
+  return value;
+}
+
+function runGit(root, args, runner = execFileSync) {
+  return runner("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    windowsHide: true,
+  }).trim();
+}
+
+export function verifySouthCarolinaPublicationGitCandidate(
+  root,
+  publicAuthorization,
+  runner = execFileSync,
+) {
+  let head;
+  let headTree;
+  let productionTree;
+  let rollbackTree;
+  let trackedStatus;
+  try {
+    head = runGit(root, ["rev-parse", "HEAD"], runner);
+    headTree = runGit(root, ["rev-parse", "HEAD^{tree}"], runner);
+    productionTree = runGit(
+      root,
+      ["rev-parse", `${publicAuthorization.productionDeployment.gitSha}^{tree}`],
+      runner,
+    );
+    rollbackTree = runGit(
+      root,
+      ["rev-parse", `${publicAuthorization.rollbackTarget.gitSha}^{tree}`],
+      runner,
+    );
+    trackedStatus = runGit(
+      root,
+      ["status", "--porcelain", "--untracked-files=no"],
+      runner,
+    );
+  } catch {
+    throw new Error("South Carolina publication Git evidence could not be resolved locally");
+  }
+  if (
+    head !== publicAuthorization.productionDeployment.gitSha
+    || headTree !== publicAuthorization.productionDeployment.gitTreeSha
+    || productionTree !== publicAuthorization.productionDeployment.gitTreeSha
+    || rollbackTree !== publicAuthorization.rollbackTarget.gitTreeSha
+    || trackedStatus
+  ) {
+    throw new Error("South Carolina publication checkout or deployment Git evidence drifted");
+  }
+  return {
+    gitSha: head,
+    gitTreeSha: headTree,
+    rollbackTarget: {
+      gitSha: publicAuthorization.rollbackTarget.gitSha,
+      gitTreeSha: rollbackTree,
+    },
+    trackedWorktreeClean: true,
+  };
+}
+
+export function assertSouthCarolinaPublicationRecoveryVersionSet(versions) {
+  if (!Array.isArray(versions) || versions.length !== 3) {
+    throw new Error("South Carolina publication receipt recovery found an incomplete version set");
+  }
+  return versions;
+}
+
+function expectedActivationMetadata(
+  context,
+  manifest,
+  previousCaveat,
+  revision,
+  changedAtUtc = context.changedAtUtc,
+) {
+  const publication = context.publicationReceipt ?? {
+    activationId: context.authorization.activationId,
+    authorizationSha256: context.authorizationSha256,
+    rollbackTarget: context.authorization.rollbackTarget,
+  };
+  return {
+    activationId: publication.activationId,
+    activationCandidateSha256: context.planSha256,
+    releasePackageSha256: context.plan.releaseCandidate.sha256,
+    blobPublicationSha256: context.plan.blobPublication.sha256,
+    deliveryOrigin: context.plan.blobPublication.deliveryOrigin,
+    authorizationSha256: publication.authorizationSha256,
+    rollbackTarget: publication.rollbackTarget,
+    mode: "publish",
+    year: manifest.year,
+    manifestId: manifest.manifestId,
+    publicManifestSha256: manifest.publicManifestSha256,
+    delivery: manifest.delivery,
+    previousCaveat,
+    changedAtUtc,
+    revision,
+  };
+}
+
+function expectedRollbackMetadata(context, revision) {
+  return {
+    rollbackId: context.authorization.rollbackId,
+    publicationActivationId: context.publicationReceipt.activationId,
+    activationCandidateSha256: context.planSha256,
+    releasePackageSha256: context.plan.releaseCandidate.sha256,
+    blobPublicationSha256: context.plan.blobPublication.sha256,
+    authorizationSha256: context.authorizationSha256,
+    publicationReceiptSha256: context.publicationReceipt.sha256,
+    rollbackTarget: context.authorization.applicationRollback.target,
+    changedAtUtc: context.changedAtUtc,
+    revision,
+    mode: "rollback",
+  };
+}
+
+async function verifyPostconditions(
+  nv,
+  context,
+  revision,
+  mode = context.mode ?? "publish",
+) {
+  const publicAuthorized = mode === "publish";
+  const wantedStatus = publicAuthorized ? "published" : "blocked";
+  const versions = await nv.unsafe([
+    "select e.year,gv.status,gv.caveat,gv.metadata",
+    "from geography_versions gv join elections e on e.id=gv.election_id",
+    "where gv.state_code='SC' and gv.geography_type='precinct'",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+    "order by e.year",
+  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  if (versions.length !== 3) {
+    throw new Error("South Carolina publication postcondition has an incomplete version set");
+  }
+  for (const [index, row] of versions.entries()) {
+    const manifest = context.plan.manifests[index];
+    const previousCaveat = context.gisPlan.years[index].manifest.validation.errors
+      .join(" ");
+    const metadata = row.metadata ?? {};
+    const publicationRevision = context.publicationReceipt?.revision ?? revision;
+    const publicationChangedAt = context.publicationReceipt?.changedAtUtc
+      ?? context.changedAtUtc;
+    const originalActivation = expectedActivationMetadata(
+      context,
+      manifest,
+      previousCaveat,
+      publicationRevision,
+      publicationChangedAt,
+    );
+    const expectedActivation = publicAuthorized
+      ? originalActivation
+      : {
+        ...originalActivation,
+        rollback: expectedRollbackMetadata(context, revision),
+      };
+    const expectedCaveat = publicAuthorized
+      ? "Reviewed South Carolina election-specific precinct geometry is publicly authorized under activation "
+        + originalActivation.activationId + "."
+      : previousCaveat;
+    if (
+      Number(row.year) !== manifest.year
+      || row.status !== wantedStatus
+      || String(row.caveat ?? "") !== expectedCaveat
+      || metadata.manifestId !== manifest.manifestId
+      || metadata.publicDeliveryAuthorized !== publicAuthorized
+      || metadata.releaseCandidate?.publicDeliveryAuthorized !== publicAuthorized
+      || metadata.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
+      || !semanticallyEqual(metadata.publicActivation, expectedActivation)
+    ) {
+      throw new Error("South Carolina " + manifest.year + " geography publication drifted");
+    }
+  }
+  const linked = await nv.unsafe([
+    "select count(*)::int total,",
+    " count(*) filter (where ((x.relationship_type='one_to_one'",
+    "   and x.match_method in ('exact_official_id','official_crosswalk','reviewed_name')",
+    "   and x.geography_feature_id is not null)",
+    "  or (x.relationship_type='non_geographic'",
+    "   and x.match_method='exact_official_id'",
+    "   and x.geography_feature_id is null))",
+    "  and x.review_status='reviewed'",
+    "  and x.confidence='high' and x.metadata->>'publicDeliveryAuthorized'=$2",
+    "  and x.metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from reporting_unit_geometry_crosswalks x",
+    "join geography_versions gv on gv.id=x.geometry_version_id",
+    "where gv.state_code='SC' and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (Number(linked[0]?.total) !== 7_396 || Number(linked[0]?.exact) !== 7_396) {
+    throw new Error("South Carolina publication crosswalk postcondition failed");
+  }
+  const units = await nv.unsafe([
+    "select count(*)::int total, count(*) filter (where",
+    " metadata->>'publicDeliveryAuthorized'=$2 and",
+    " metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from reporting_units where state_code='SC'",
+    " and reporting_grain in ('precinct','administrative_reporting_unit')",
+    " and metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (Number(units[0]?.total) !== 7_396 || Number(units[0]?.exact) !== 7_396) {
+    throw new Error("South Carolina publication reporting-unit postcondition failed");
+  }
+  const sources = await nv.unsafe([
+    "select count(*)::int total, count(*) filter (where",
+    " metadata->>'publicDeliveryAuthorized'=$2 and",
+    " metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from source_documents where state_code='SC'",
+    " and metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (Number(sources[0]?.total) !== 6 || Number(sources[0]?.exact) !== 6) {
+    throw new Error("South Carolina publication source-document postcondition failed");
+  }
+  const runs = await nv.unsafe([
+    "select count(*)::int total, count(*) filter (where",
+    " summary->>'publicDeliveryAuthorized'=$2 and",
+    " summary->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from import_runs where state_code='SC'",
+    " and summary->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (Number(runs[0]?.total) !== 3 || Number(runs[0]?.exact) !== 3) {
+    throw new Error("South Carolina publication import-run postcondition failed");
+  }
+  const results = await nv.unsafe([
+    "select count(*)::int total from result_rows rr",
+    "join reporting_units ru on ru.id=rr.reporting_unit_id",
+    "where rr.state_code='SC' and rr.level='precinct'",
+    " and ru.metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  if (Number(results[0]?.total) !== 20_403) {
+    throw new Error("South Carolina publication result-row postcondition failed");
+  }
+  const invalid = await nv.unsafe(
+    "select count(*)::int count from pg_constraint where connamespace='public'::regnamespace and not convalidated",
+  );
+  if (Number(invalid[0]?.count) !== 0) {
+    throw new Error("South Carolina publication left invalid public constraints");
+  }
+  const revisionRows = await nv.unsafe([
+    "select revision::int revision,reason from public_data_revisions",
+    "where scope='public'",
+  ].join("\n"));
+  const expectedReason = "South Carolina precinct unit geometry " + mode + " "
+    + (publicAuthorized
+      ? context.authorization.activationId
+      : context.authorization.rollbackId);
+  if (
+    Number(revisionRows[0]?.revision) !== revision
+    || String(revisionRows[0]?.reason) !== expectedReason
+  ) {
+    throw new Error("South Carolina publication revision postcondition failed");
+  }
+  return {
+    mode,
+    status: wantedStatus,
+    publicDeliveryAuthorized: publicAuthorized,
+    geographyVersions: 3,
+    crosswalks: 7_396,
+    reportingUnits: 7_396,
+    sourceDocuments: 6,
+    importRuns: 3,
+    resultRows: 20_403,
+    invalidConstraints: 0,
+  };
+}
+
+export async function applySouthCarolinaGeographyPublicationTransaction(nv, context) {
+  const mode = context.mode ?? "publish";
+  if (!new Set(["publish", "rollback"]).has(mode)) {
+    throw new Error("South Carolina publication transaction mode is invalid");
+  }
+  const publicAuthorized = mode === "publish";
+  if (mode === "rollback" && !context.publicationReceipt) {
+    throw new Error("South Carolina rollback requires the exact publication receipt");
+  }
+  if (mode === "rollback" && (
+    context.authorization.publicationActivationId
+      !== context.publicationReceipt.activationId
+    || !semanticallyEqual(
+      context.authorization.applicationRollback?.target,
+      context.publicationReceipt.rollbackTarget,
+    )
+  )) {
+    throw new Error("South Carolina rollback authorization drifted from the publication receipt");
+  }
+  const identity = await nv.unsafe([
+    "select current_database() database_name,",
+    " current_setting('transaction_read_only') transaction_read_only",
+  ].join("\n"));
+  if (
+    identity.length !== 1
+    || String(identity[0].database_name) !== context.plan.hiddenLoad.databaseName
+    || String(identity[0].transaction_read_only) !== "off"
+  ) {
+    throw new Error("South Carolina publication transaction database identity drifted");
+  }
+  await nv.unsafe("select set_config('lock_timeout','30s',true)");
+  await nv.unsafe(
+    "select pg_advisory_xact_lock(hashtextextended('crm-sc-precinct-gis-release-v1',0))",
+  );
+  const revisions = await nv.unsafe(
+    "select revision::int revision from public_data_revisions where scope='public' for update",
+  );
+  const currentRevision = Number(revisions[0]?.revision);
+  if (
+    revisions.length !== 1
+    || !Number.isInteger(currentRevision)
+    || currentRevision < 0
+  ) {
+    throw new Error("South Carolina public revision is missing or invalid");
+  }
+  const revision = currentRevision + 1;
+  const gisPlan = context.gisPlan;
+  if (mode === "publish") {
+    await (context.validateCurrentDatabase ?? validateSouthCarolinaPrecinctGisClient)(nv, gisPlan, {
+      executionContext: context.executionContext,
+      readOnlySession: false,
+    });
+  }
+  const versions = await nv.unsafe([
+    "select gv.id,e.year,gv.status,gv.caveat,gv.metadata",
+    "from geography_versions gv join elections e on e.id=gv.election_id",
+    "where gv.state_code='SC' and gv.geography_type='precinct'",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+    "order by e.year for update of gv",
+  ].join("\n"), [context.plan.releaseCandidate.sha256]);
+  if (versions.length !== 3) {
+    throw new Error("South Carolina publication requires three exact geography versions");
+  }
+  for (const [index, version] of versions.entries()) {
+    const manifest = context.plan.manifests[index];
+    const expectedBlockedCaveat = gisPlan.years[index].manifest.validation.errors
+      .join(" ");
+    const commonDrift = Number(version.year) !== manifest.year
+      || version.metadata?.manifestId !== manifest.manifestId
+      || version.metadata?.releaseCandidate?.sha256
+        !== context.plan.releaseCandidate.sha256;
+    const originalActivation = mode === "rollback"
+      ? expectedActivationMetadata(
+        context,
+        manifest,
+        expectedBlockedCaveat,
+        context.publicationReceipt.revision,
+        context.publicationReceipt.changedAtUtc,
+      )
+      : null;
+    if (mode === "publish" && (
+      commonDrift
+      || version.status !== "blocked"
+      || version.metadata?.manifestSha256 !== manifest.blockedManifestSha256
+      || version.metadata?.publicDeliveryAuthorized !== false
+      || version.metadata?.releaseCandidate?.publicDeliveryAuthorized !== false
+      || String(version.caveat ?? "") !== expectedBlockedCaveat
+      || Object.hasOwn(version.metadata ?? {}, "publicActivation")
+    )) {
+      throw new Error("South Carolina " + manifest.year + " publication precondition drifted");
+    }
+    if (mode === "rollback" && (
+      commonDrift
+      || version.status !== "published"
+      || String(version.caveat ?? "")
+        !== "Reviewed South Carolina election-specific precinct geometry is publicly authorized under activation "
+          + context.publicationReceipt.activationId + "."
+      || version.metadata?.publicDeliveryAuthorized !== true
+      || version.metadata?.releaseCandidate?.publicDeliveryAuthorized !== true
+      || !semanticallyEqual(version.metadata?.publicActivation, originalActivation)
+    )) {
+      throw new Error(
+        "South Carolina " + manifest.year
+          + " rollback does not match the publication being reversed",
+      );
+    }
+    const activation = mode === "publish"
+      ? expectedActivationMetadata(
+        context,
+        manifest,
+        expectedBlockedCaveat,
+        revision,
+      )
+      : {
+        ...originalActivation,
+        rollback: expectedRollbackMetadata(context, revision),
+      };
+    const wantedStatus = publicAuthorized ? "published" : "blocked";
+    const wantedCaveat = publicAuthorized
+      ? "Reviewed South Carolina election-specific precinct geometry is publicly authorized under activation "
+        + context.authorization.activationId + "."
+      : originalActivation.previousCaveat;
+    const currentStatus = publicAuthorized ? "blocked" : "published";
+    const updated = await nv.unsafe([
+      "update geography_versions set status=$2,",
+      " caveat=$3,",
+      " metadata=jsonb_set(jsonb_set(jsonb_set(metadata,",
+      "  '{publicDeliveryAuthorized}',$4::text::jsonb,true),",
+      "  '{releaseCandidate,publicDeliveryAuthorized}',$4::text::jsonb,true),",
+      "  '{publicActivation}',$5::text::jsonb,true),",
+      " updated_at=now() where id=$1::uuid and status=$6 returning id",
+    ].join("\n"), [
+      version.id,
+      wantedStatus,
+      wantedCaveat,
+      JSON.stringify(publicAuthorized),
+      JSON.stringify(activation),
+      currentStatus,
+    ]);
+    if (updated.length !== 1) {
+      throw new Error("South Carolina " + manifest.year + " publication update lost its lock");
+    }
+  }
+  const crosswalks = await nv.unsafe([
+    "update reporting_unit_geometry_crosswalks x set metadata=",
+    " jsonb_set(jsonb_set(x.metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "from geography_versions gv where gv.id=x.geometry_version_id",
+    " and gv.state_code='SC' and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+    "returning x.id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (crosswalks.length !== 7_396) {
+    throw new Error("South Carolina publication crosswalk update count drifted");
+  }
+  const units = await nv.unsafe([
+    "update reporting_units set metadata=",
+    " jsonb_set(jsonb_set(metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "where state_code='SC'",
+    " and reporting_grain in ('precinct','administrative_reporting_unit')",
+    " and metadata->'releaseCandidate'->>'sha256'=$1 returning id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (units.length !== 7_396) {
+    throw new Error("South Carolina publication reporting-unit update count drifted");
+  }
+  const sources = await nv.unsafe([
+    "update source_documents set metadata=",
+    " jsonb_set(jsonb_set(metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "where state_code='SC' and metadata->'releaseCandidate'->>'sha256'=$1 returning id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (sources.length !== 6) {
+    throw new Error("South Carolina publication source-document update count drifted");
+  }
+  const runs = await nv.unsafe([
+    "update import_runs set summary=",
+    " jsonb_set(jsonb_set(summary,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "where state_code='SC' and summary->'releaseCandidate'->>'sha256'=$1 returning id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (runs.length !== 3) {
+    throw new Error("South Carolina publication import-run update count drifted");
+  }
+  const revisionRows = await nv.unsafe([
+    "update public_data_revisions set revision=revision+1,updated_at=now(),reason=$1",
+    "where scope='public' returning revision::int revision,updated_at",
+  ].join("\n"), [
+    "South Carolina precinct unit geometry " + mode + " "
+      + (publicAuthorized
+        ? context.authorization.activationId
+        : context.authorization.rollbackId),
+  ]);
+  if (Number(revisionRows[0]?.revision) !== revision) {
+    throw new Error("South Carolina publication revision increment drifted");
+  }
+  const postconditions = await verifyPostconditions(nv, context, revision, mode);
+  return {
+    result: publicAuthorized ? "PUBLISHED" : "ROLLED_BACK",
+    mode,
+    revision,
+    changedAtUtc: context.changedAtUtc,
+    postconditions,
+    publicDeliveryAuthorized: publicAuthorized,
+  };
+}
+
+function defaultPlanPath(planSha256) {
+  return ".etl/precinct-publication-plans/SC/sc-precinct-publication-plan-"
+    + planSha256.slice(0, 12) + ".json";
+}
+
+function defaultAuthorizationPath(planSha256, mode = "publish") {
+  return ".etl/production-authorizations/SC/sc-precinct-" + mode + "-authorization-template-"
+    + planSha256.slice(0, 12) + ".json";
+}
+
+export function inspectSouthCarolinaPublicationReceipt(root, options, built) {
+  const artifact = safeJson(
+    root,
+    options.publicationReceiptPath,
+    options.publicationReceiptSha256,
+    ".etl/production-publication-receipts/SC",
+  );
+  const value = artifact.value;
+  const publicAuthorizationArtifact = safeJson(
+    root,
+    value?.authorization?.path,
+    value?.authorization?.sha256,
+    ".etl/production-authorizations/SC",
+  );
+  const publicAuthorization = validateSouthCarolinaPublicationAuthorization(
+    publicAuthorizationArtifact.value,
+    {
+      plan: built.plan,
+      planSha256: built.sha256,
+      now: options.now ?? Date.now(),
+      recovery: true,
+    },
+  );
+  const changedAt = Date.parse(value?.changedAtUtc);
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "SC"
+    || value?.mode !== "publish"
+    || value?.decision !== "PUBLISHED"
+    || value?.activationId !== publicAuthorization.activationId
+    || value?.approvedBy !== publicAuthorization.approvedBy
+    || !semanticallyEqual(value?.releaseCandidate, built.plan.releaseCandidate)
+    || value?.publicationPlan?.id !== built.plan.id
+    || value?.publicationPlan?.sha256 !== built.sha256
+    || value?.authorization?.path !== publicAuthorizationArtifact.path
+    || value?.authorization?.sha256 !== publicAuthorizationArtifact.sha256
+    || value?.hiddenLoad?.path !== built.plan.hiddenLoad.path
+    || value?.hiddenLoad?.sha256 !== built.plan.hiddenLoad.sha256
+    || value?.blobPublication?.path !== built.plan.blobPublication.path
+    || value?.blobPublication?.sha256 !== built.plan.blobPublication.sha256
+    || value?.blobPublication?.deliveryOrigin
+      !== built.plan.blobPublication.deliveryOrigin
+    || !semanticallyEqual(
+      value?.productionDeployment,
+      publicAuthorization.productionDeployment,
+    )
+    || !semanticallyEqual(value?.rollbackTarget, publicAuthorization.rollbackTarget)
+    || Number.isNaN(changedAt)
+    || changedAt > (options.now ?? Date.now())
+    || Date.parse(publicAuthorization.rollbackTarget.verifiedAtUtc) > changedAt
+    || !Number.isInteger(Number(value?.revision))
+    || Number(value.revision) < 1
+    || value?.postconditions?.mode !== "publish"
+    || value?.postconditions?.status !== "published"
+    || value?.postconditions?.publicDeliveryAuthorized !== true
+    || value?.postconditions?.geographyVersions !== 3
+    || value?.postconditions?.crosswalks !== 7_396
+    || value?.postconditions?.reportingUnits !== 7_396
+    || value?.postconditions?.sourceDocuments !== 6
+    || value?.postconditions?.importRuns !== 3
+    || value?.postconditions?.resultRows !== 20_403
+    || value?.postconditions?.invalidConstraints !== 0
+    || value?.productionMutationPerformed !== true
+    || value?.publicDeliveryAuthorized !== true
+  ) {
+    throw new Error("South Carolina publication receipt is incomplete or incompatible");
+  }
+  return {
+    artifact,
+    publicAuthorization,
+    summary: {
+      path: artifact.path,
+      sha256: artifact.sha256,
+      activationId: value.activationId,
+      authorizationSha256: publicAuthorizationArtifact.sha256,
+      revision: Number(value.revision),
+      changedAtUtc: value.changedAtUtc,
+      rollbackTarget: value.rollbackTarget,
+      productionDeployment: value.productionDeployment,
+    },
+  };
+}
+
+function defaultReceiptPath(planSha256, activationId, mode = "publish") {
+  const safeId = activationId.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 80);
+  return ".etl/production-publication-receipts/SC/sc-precinct-" + mode + "-"
+    + planSha256.slice(0, 12) + "-" + safeId + ".json";
+}
+
+function reserveReceipt(
+  root,
+  relativePath,
+  planSha256,
+  authorizationSha256,
+  mode,
+  publicationReceiptSha256 = null,
+  options = {},
+) {
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ".etl", "production-publication-receipts", "SC");
+  if (!absolute.startsWith(allowed + path.sep) || !relativePath.endsWith(".json")) {
+    throw new Error("South Carolina publication receipt path is unsafe");
+  }
+  if (existsSync(absolute)) throw new Error("South Carolina publication receipt already exists");
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  const pending = absolute + ".pending";
+  const pendingDocument = {
+    schemaVersion: 1,
+    state: "SC",
+    purpose: "ambiguous-commit recovery marker",
+    mode,
+    planSha256,
+    authorizationSha256,
+    publicationReceiptSha256,
+  };
+  const pendingBytes = serializeSouthCarolinaPublicationDocument(pendingDocument);
+  if (existsSync(pending)) {
+    if (
+      options.allowExisting === true
+      && readFileSync(pending).equals(pendingBytes)
+    ) {
+      return { absolute, pending, pendingBytes, disposition: "reused" };
+    }
+    throw new Error("A South Carolina publication recovery marker already exists; reconcile it before retrying");
+  }
+  writeFileSync(pending, pendingBytes, { flag: "wx", mode: 0o600 });
+  return { absolute, pending, pendingBytes, disposition: "created" };
+}
+
+function finishPublicationReceipt(reservation, receipt) {
+  const receiptBytes = serializeSouthCarolinaPublicationDocument(receipt);
+  const temporary = reservation.absolute + ".write-"
+    + sha256(receiptBytes).slice(0, 12) + ".tmp";
+  if (existsSync(temporary)) {
+    if (!readFileSync(temporary).equals(receiptBytes)) {
+      throw new Error("South Carolina publication receipt temporary file drifted");
+    }
+  } else {
+    writeFileSync(temporary, receiptBytes, { flag: "wx", mode: 0o600 });
+  }
+  renameSync(temporary, reservation.absolute);
+  if (readFileSync(reservation.pending).equals(reservation.pendingBytes)) {
+    unlinkSync(reservation.pending);
+  }
+  return receiptBytes;
+}
+
+export async function runSouthCarolinaGeographyPublication(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const parsed = options.packagePath ? options : parseArguments(process.argv.slice(2));
+  const mode = parsed.rollback ? "rollback" : "publish";
+  const environment = options.environment ?? process.env;
+  const clock = options.nowFactory ?? (() => options.now ?? new Date());
+  const currentTime = () => {
+    const value = clock();
+    const result = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    if (Number.isNaN(result.getTime())) {
+      throw new Error("South Carolina publication clock returned an invalid time");
+    }
+    return result;
+  };
+  const built = inspectSouthCarolinaPublicationPlan({ ...parsed, root });
+  if (parsed.planSha256 && parsed.planSha256 !== built.sha256) {
+    throw new Error("South Carolina publication plan SHA-256 drifted");
+  }
+  const publicationReceipt = mode === "rollback"
+    ? inspectSouthCarolinaPublicationReceipt(root, {
+      ...parsed,
+      now: currentTime().getTime(),
+    }, built)
+    : null;
+  if (parsed.writePlan) {
+    if (mode === "rollback") {
+      throw new Error("South Carolina rollback reuses the exact hash-pinned publication plan");
+    }
+    const artifact = immutableJson(
+      root,
+      parsed.outputPath ?? defaultPlanPath(built.sha256),
+      built.plan,
+      ".etl/precinct-publication-plans/SC",
+    );
+    return {
+      mode: "write_plan",
+      decision: built.plan.decision,
+      publicationPlan: artifact,
+      productionMutationPerformed: false,
+    };
+  }
+  if (parsed.writeAuthorizationTemplate) {
+    const template = mode === "rollback"
+      ? buildSouthCarolinaPublicRollbackAuthorizationTemplate(
+        built.plan,
+        built.sha256,
+        publicationReceipt.summary,
+      )
+      : buildSouthCarolinaPublicationAuthorizationTemplate(built.plan, built.sha256);
+    const artifact = immutableJson(
+      root,
+      parsed.outputPath ?? defaultAuthorizationPath(built.sha256, mode),
+      template,
+      ".etl/production-authorizations/SC",
+    );
+    return {
+      mode: "write_authorization_template",
+      operation: mode,
+      decision: mode === "rollback" ? "NO_GO_ROLLBACK" : "NO_GO_PUBLIC",
+      publicationPlanSha256: built.sha256,
+      authorizationTemplate: artifact,
+      productionMutationPerformed: false,
+    };
+  }
+  if (!parsed.apply && !parsed.recoverReceipt) {
+    return {
+      mode: "plan",
+      operation: mode,
+      decision: mode === "rollback"
+        ? "GO_ROLLBACK_AUTHORIZATION_REQUIRED"
+        : built.plan.decision,
+      publicationPlanSha256: built.sha256,
+      requiredScopes: mode === "rollback"
+        ? [...SOUTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES]
+        : undefined,
+      productionMutationPerformed: false,
+      expectedTotals: built.plan.expectedTotals,
+    };
+  }
+  const authorizationArtifact = safeJson(
+    root,
+    parsed.authorizationPath,
+    parsed.authorizationSha256,
+    ".etl/production-authorizations/SC",
+  );
+  const validateAuthorizationAt = (now, recovery = false) => mode === "rollback"
+    ? validateSouthCarolinaPublicRollbackAuthorization(authorizationArtifact.value, {
+      plan: built.plan,
+      planSha256: built.sha256,
+      publicationReceipt: publicationReceipt.summary,
+      now: now.getTime(),
+      recovery,
+    })
+    : validateSouthCarolinaPublicationAuthorization(authorizationArtifact.value, {
+      plan: built.plan,
+      planSha256: built.sha256,
+      now: now.getTime(),
+      recovery,
+    });
+  const databaseUrl = productionUrl(environment);
+  const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
+  if (endpointFingerprint !== built.plan.hiddenLoad.endpointFingerprint) {
+    throw new Error("South Carolina publication database endpoint drifted from the hidden load");
+  }
+  const gisPlan = await buildSouthCarolinaPrecinctGisPlan({
+    root,
+    years: [2016, 2020, 2024],
+  });
+  const executionContext = {
+    mode: "production_release",
+    releasePackageSha256: built.plan.releaseCandidate.sha256,
+    releaseCandidateId: built.plan.releaseCandidate.id,
+    databaseName: built.plan.hiddenLoad.databaseName,
+    productionReleaseAudit: built.plan.hiddenLoad.productionReleaseAudit,
+  };
+  buildSouthCarolinaPrecinctExecutionContext(executionContext);
+  const rawOperationId = mode === "rollback"
+    ? authorizationArtifact.value?.rollbackId
+    : authorizationArtifact.value?.activationId;
+  const operationId = typeof rawOperationId === "string"
+    ? rawOperationId.trim()
+    : "";
+  const receiptPath = parsed.outputPath ?? defaultReceiptPath(
+    built.sha256,
+    operationId || "invalid-authorization",
+    mode,
+  );
+  const publicAuthorization = mode === "publish"
+    ? null
+    : publicationReceipt.publicAuthorization;
+
+  const receiptDocument = (authorization, committed, recovery = null) => {
+    const originalPublicAuthorization = mode === "publish"
+      ? authorization
+      : publicAuthorization;
+    return {
+      schemaVersion: 1,
+      state: "SC",
+      mode,
+      decision: mode === "publish" ? "PUBLISHED" : "ROLLED_BACK",
+      activationId: mode === "publish"
+        ? authorization.activationId
+        : publicationReceipt.summary.activationId,
+      ...(mode === "rollback" ? { rollbackId: authorization.rollbackId } : {}),
+      approvedBy: authorization.approvedBy,
+      releaseCandidate: built.plan.releaseCandidate,
+      publicationPlan: { id: built.plan.id, sha256: built.sha256 },
+      authorization: {
+        path: authorizationArtifact.path,
+        sha256: authorizationArtifact.sha256,
+      },
+      hiddenLoad: {
+        path: built.plan.hiddenLoad.path,
+        sha256: built.plan.hiddenLoad.sha256,
+      },
+      blobPublication: {
+        path: built.plan.blobPublication.path,
+        sha256: built.plan.blobPublication.sha256,
+        deliveryOrigin: built.plan.blobPublication.deliveryOrigin,
+      },
+      productionDeployment: originalPublicAuthorization.productionDeployment,
+      rollbackTarget: originalPublicAuthorization.rollbackTarget,
+      ...(mode === "rollback"
+        ? { publicationReceipt: publicationReceipt.summary }
+        : {}),
+      changedAtUtc: committed.changedAtUtc,
+      revision: committed.revision,
+      postconditions: committed.postconditions,
+      ...(recovery ? { recovery } : {}),
+      productionMutationPerformed: true,
+      publicDeliveryAuthorized: mode === "publish",
+    };
+  };
+
+  if (parsed.recoverReceipt) {
+    if (
+      environment.CRM_DATABASE_ENVIRONMENT !== "production-read-only"
+      || environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_RECEIPT_RECOVERY !== built.sha256
+      || environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_AUTHORIZATION_SHA256
+        !== authorizationArtifact.sha256
+      || (mode === "rollback"
+        && environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_RECEIPT_SHA256
+          !== publicationReceipt.summary.sha256)
+    ) {
+      throw new Error(
+        "South Carolina publication receipt recovery is not explicitly read-only and hash-authorized",
+      );
+    }
+    const reservation = reserveReceipt(
+      root,
+      receiptPath,
+      built.sha256,
+      authorizationArtifact.sha256,
+      mode,
+      publicationReceipt?.summary.sha256 ?? null,
+      { allowExisting: true },
+    );
+    let sql;
+    try {
+      sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+        max: 1,
+        connect_timeout: 10,
+        idle_timeout: 20,
+        connection: {
+          application_name: "civicresultmaps-sc-precinct-publication-receipt-recovery",
+          default_transaction_read_only: true,
+        },
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    }
+    let recovered;
+    try {
+      recovered = await sql.begin("read only", async (nv) => {
+        const identity = await nv.unsafe([
+          "select current_database() database_name,",
+          " current_setting('transaction_read_only') transaction_read_only",
+        ].join("\n"));
+        if (
+          identity.length !== 1
+          || String(identity[0].database_name) !== built.plan.hiddenLoad.databaseName
+          || String(identity[0].transaction_read_only) !== "on"
+        ) {
+          throw new Error("South Carolina publication receipt recovery database identity drifted");
+        }
+        const versions = await nv.unsafe([
+          "select e.year,gv.status,gv.caveat,gv.metadata from geography_versions gv",
+          "join elections e on e.id=gv.election_id",
+          "where gv.state_code='SC' and gv.geography_type='precinct'",
+          " and gv.metadata->'releaseCandidate'->>'sha256'=$1 order by e.year",
+        ].join("\n"), [built.plan.releaseCandidate.sha256]);
+        assertSouthCarolinaPublicationRecoveryVersionSet(versions);
+        const operationAudit = mode === "publish"
+          ? versions[0]?.metadata?.publicActivation
+          : versions[0]?.metadata?.publicActivation?.rollback;
+        const changedAtUtc = operationAudit?.changedAtUtc;
+        const revision = Number(operationAudit?.revision);
+        const recoveryNow = currentTime();
+        if (
+          typeof changedAtUtc !== "string"
+          || Number.isNaN(Date.parse(changedAtUtc))
+          || Date.parse(changedAtUtc) > recoveryNow.getTime()
+          || !Number.isInteger(revision)
+          || revision < 1
+        ) {
+          throw new Error("South Carolina publication receipt recovery audit is incomplete");
+        }
+        const authorization = validateAuthorizationAt(
+          new Date(changedAtUtc),
+          true,
+        );
+        const context = {
+          mode,
+          plan: built.plan,
+          planSha256: built.sha256,
+          authorization,
+          authorizationSha256: authorizationArtifact.sha256,
+          publicationReceipt: publicationReceipt?.summary ?? null,
+          changedAtUtc,
+          gisPlan,
+          executionContext,
+        };
+        const postconditions = await verifyPostconditions(
+          nv,
+          context,
+          revision,
+          mode,
+        );
+        return { authorization, changedAtUtc, revision, postconditions };
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+    const receipt = receiptDocument(recovered.authorization, recovered, {
+      recoveredAtUtc: currentTime().toISOString(),
+      productionMutationPerformed: false,
+    });
+    const receiptBytes = finishPublicationReceipt(reservation, receipt);
+    return {
+      mode: "recover_receipt",
+      operation: mode,
+      decision: mode === "publish"
+        ? "RECOVERED_PUBLICATION_RECEIPT"
+        : "RECOVERED_ROLLBACK_RECEIPT",
+      activationId: recovered.authorization.activationId,
+      revision: recovered.revision,
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: mode === "publish",
+      receipt: {
+        path: receiptPath,
+        sha256: sha256(receiptBytes),
+        byteCount: receiptBytes.length,
+      },
+    };
+  }
+
+  const initialNow = currentTime();
+  const authorization = validateAuthorizationAt(initialNow);
+  const writeAuthorized = mode === "publish"
+    ? environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_WRITES
+        === "I_ACKNOWLEDGE_ATOMIC_SOUTH_CAROLINA_PRECINCT_PUBLIC_CUTOVER"
+      && environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_ACTIVATION_ID
+        === authorization.activationId
+    : environment.CRM_SC_PRECINCT_GEOGRAPHY_ROLLBACK_WRITES
+        === "I_ACKNOWLEDGE_DATABASE_FIRST_SOUTH_CAROLINA_PRECINCT_PUBLIC_ROLLBACK"
+      && environment.CRM_SC_PRECINCT_GEOGRAPHY_ROLLBACK_ID === authorization.rollbackId
+      && environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_RECEIPT_SHA256
+        === publicationReceipt.summary.sha256;
+  if (
+    environment.CRM_DATABASE_ENVIRONMENT !== "production"
+    || !writeAuthorized
+    || environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_PACKAGE_SHA256
+      !== built.plan.releaseCandidate.sha256
+    || environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_PLAN_SHA256 !== built.sha256
+    || environment.CRM_SC_PRECINCT_GEOGRAPHY_PUBLICATION_AUTHORIZATION_SHA256
+      !== authorizationArtifact.sha256
+  ) {
+    throw new Error("South Carolina public " + mode + " is not explicitly hash-authorized");
+  }
+  const activePublicAuthorization = mode === "publish"
+    ? authorization
+    : publicAuthorization;
+  verifySouthCarolinaPublicationGitCandidate(root, activePublicAuthorization, options.gitRunner);
+  const reservation = reserveReceipt(
+    root,
+    receiptPath,
+    built.sha256,
+    authorizationArtifact.sha256,
+    mode,
+    publicationReceipt?.summary.sha256 ?? null,
+  );
+  let sql;
+  try {
+    sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+      max: 1,
+      connect_timeout: 10,
+      idle_timeout: 20,
+      connection: { application_name: "civicresultmaps-sc-precinct-publication-status" },
+    });
+  } catch (error) {
+    if (existsSync(reservation.pending)) unlinkSync(reservation.pending);
+    throw error;
+  }
+  let transactionBodyCompleted = false;
+  let committed;
+  try {
+    committed = await sql.begin(async (nv) => {
+      const transactionNow = currentTime();
+      const finalAuthorization = validateAuthorizationAt(transactionNow);
+      if (finalAuthorization.activationId !== authorization.activationId) {
+        throw new Error("South Carolina publication authorization drifted before the transaction");
+      }
+      verifySouthCarolinaPublicationGitCandidate(
+        root,
+        activePublicAuthorization,
+        options.gitRunner,
+      );
+      const result = await applySouthCarolinaGeographyPublicationTransaction(nv, {
+        mode,
+        plan: built.plan,
+        planSha256: built.sha256,
+        authorization: finalAuthorization,
+        authorizationSha256: authorizationArtifact.sha256,
+        publicationReceipt: publicationReceipt?.summary ?? null,
+        changedAtUtc: transactionNow.toISOString(),
+        gisPlan,
+        executionContext,
+      });
+      transactionBodyCompleted = true;
+      return result;
+    });
+  } catch (error) {
+    if (!transactionBodyCompleted && existsSync(reservation.pending)) {
+      unlinkSync(reservation.pending);
+    }
+    throw error;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+  const receipt = receiptDocument(authorization, committed);
+  const receiptBytes = finishPublicationReceipt(reservation, receipt);
+  return {
+    mode: "apply",
+    operation: mode,
+    decision: mode === "publish" ? "PUBLISHED" : "ROLLED_BACK",
+    activationId: authorization.activationId,
+    revision: committed.revision,
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: mode === "publish",
+    receipt: {
+      path: receiptPath,
+      sha256: sha256(receiptBytes),
+      byteCount: receiptBytes.length,
+    },
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runSouthCarolinaGeographyPublication().then(
+    (result) => console.log(JSON.stringify(result, null, 2)),
+    (error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/report-sc-precinct-production-preflight.mjs
+++ b/scripts/report-sc-precinct-production-preflight.mjs
@@ -1,0 +1,202 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import postgres from "postgres";
+import { inspectReleaseArtifact } from "./lib/sc-precinct-release-candidate.mjs";
+import {
+  assertSouthCarolinaReleaseCandidateDocument,
+  collectSouthCarolinaProductionPreflight,
+  productionEndpointFingerprint,
+  sha256,
+} from "./lib/sc-precinct-production-preflight.mjs";
+
+// Deliberately do not load .env.local. A production read is opt-in and must use
+// one explicitly supplied unpooled URL plus the exact release-package hash.
+
+function parseArguments(args) {
+  const packageArgument = args.find((arg) => arg.startsWith("--package="));
+  const reportArgument = args.find((arg) => arg.startsWith("--report="));
+  const connectReadOnly = args.includes("--connect-read-only");
+  for (const arg of args) {
+    if (
+      arg !== "--connect-read-only"
+      && !arg.startsWith("--package=")
+      && !arg.startsWith("--report=")
+    ) {
+      throw new Error("Unknown South Carolina production-preflight option: " + arg);
+    }
+  }
+  const packagePath = packageArgument?.slice("--package=".length);
+  if (!packagePath) {
+    throw new Error("--package is required for South Carolina production preflight");
+  }
+  return {
+    packagePath,
+    reportPath: reportArgument?.slice("--report=".length),
+    connectReadOnly,
+  };
+}
+
+function productionUrl() {
+  const first = process.env.POSTGRES_URL_NON_POOLING;
+  const second = process.env.POSTGRES_DATABASE_URL_UNPOOLED;
+  if (first && second && first !== second) {
+    throw new Error("Production unpooled URL variables disagree");
+  }
+  const value = first ?? second;
+  if (!value) throw new Error("Production unpooled database URL is unavailable");
+  return value;
+}
+
+function safeReportPath(root, requested, packageSha256, reportSha256) {
+  const relativePath = requested ?? path.posix.join(
+    ".etl",
+    "production-preflight-candidates",
+    "SC",
+    "sc-precinct-production-preflight-"
+      + packageSha256.slice(0, 12)
+      + "-"
+      + reportSha256.slice(0, 12)
+      + ".json",
+  );
+  if (
+    path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !relativePath.startsWith(".etl/production-preflight-candidates/SC/")
+  ) {
+    throw new Error("South Carolina production preflight report must remain in its .etl root");
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ".etl", "production-preflight-candidates", "SC");
+  if (!absolute.startsWith(allowed + path.sep)) {
+    throw new Error("South Carolina production preflight report escapes its .etl root");
+  }
+  return { relativePath, absolute };
+}
+
+function loadReleaseCandidate(root, relativePath) {
+  if (
+    path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !relativePath.startsWith(".etl/precinct-release-candidates/SC/")
+    || !relativePath.endsWith("/release-candidate.json")
+  ) {
+    throw new Error("South Carolina production preflight package path is unsafe");
+  }
+  const artifact = inspectReleaseArtifact(root, relativePath, {
+    allowedRoots: [".etl/precinct-release-candidates/SC/"],
+  });
+  const document = JSON.parse(artifact.bytes.toString("utf8"));
+  const releaseCandidate = assertSouthCarolinaReleaseCandidateDocument(
+    document,
+    artifact.sha256,
+  );
+  for (const manifest of releaseCandidate.canonicalManifestPreimages) {
+    const current = inspectReleaseArtifact(root, manifest.path, {
+      allowedRoots: ["data/precinct-geometry/SC/"],
+      byteCount: manifest.byteCount,
+      sha256: manifest.sha256,
+    });
+    if (!current.bytes.length) throw new Error("Canonical manifest is empty");
+  }
+  return { artifact, document, releaseCandidate };
+}
+
+export async function runSouthCarolinaProductionPreflight(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const parsed = options.packagePath
+    ? options
+    : parseArguments(process.argv.slice(2));
+  const loaded = loadReleaseCandidate(root, parsed.packagePath);
+  if (!parsed.connectReadOnly) {
+    return {
+      mode: "plan",
+      state: "SC",
+      releasePackageSha256: loaded.artifact.sha256,
+      connectionOpened: false,
+      productionMutationPerformed: false,
+      requiredEnvironment: {
+        CRM_DATABASE_ENVIRONMENT: "production-read-only",
+        CRM_SC_PRECINCT_GEOGRAPHY_PRODUCTION_PREFLIGHT_ACK: loaded.artifact.sha256,
+        unpooledUrl: "POSTGRES_URL_NON_POOLING or POSTGRES_DATABASE_URL_UNPOOLED",
+      },
+    };
+  }
+  if (process.env.CRM_DATABASE_ENVIRONMENT !== "production-read-only") {
+    throw new Error("South Carolina production preflight requires production-read-only environment");
+  }
+  if (
+    process.env.CRM_SC_PRECINCT_GEOGRAPHY_PRODUCTION_PREFLIGHT_ACK
+      !== loaded.artifact.sha256
+  ) {
+    throw new Error("South Carolina production preflight acknowledgement must equal the package SHA-256");
+  }
+  const databaseUrl = productionUrl();
+  const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
+  const sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+    max: 1,
+    connect_timeout: 10,
+    idle_timeout: 20,
+    connection: {
+      application_name: "civicresultmaps-sc-precinct-production-preflight",
+      default_transaction_read_only: true,
+    },
+  });
+  let report;
+  try {
+    report = await sql.begin("read only", (nv) =>
+      collectSouthCarolinaProductionPreflight(nv, {
+        capturedAtUtc: new Date().toISOString(),
+        endpointFingerprint,
+        releaseCandidate: loaded.releaseCandidate,
+      }));
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+  const bytes = Buffer.from(JSON.stringify(report, null, 2) + "\n", "utf8");
+  const reportSha256 = sha256(bytes);
+  const output = safeReportPath(
+    root,
+    parsed.reportPath,
+    loaded.artifact.sha256,
+    reportSha256,
+  );
+  if (existsSync(output.absolute)) {
+    if (!readFileSync(output.absolute).equals(bytes)) {
+      throw new Error("Refusing to overwrite different South Carolina preflight evidence");
+    }
+  } else {
+    mkdirSync(path.dirname(output.absolute), { recursive: true });
+    writeFileSync(output.absolute, bytes);
+  }
+  return {
+    mode: "read_only_production_preflight",
+    state: "SC",
+    releasePackageSha256: loaded.artifact.sha256,
+    endpointFingerprint,
+    connectionOpened: true,
+    productionMutationPerformed: false,
+    reportPath: output.relativePath,
+    reportByteCount: bytes.length,
+    reportSha256,
+    migration0008Status: report.migration0008.status,
+    migration0009Status: report.migration0009.status,
+    invalidConstraints: report.invalidConstraints,
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    console.log(JSON.stringify(await runSouthCarolinaProductionPreflight(), null, 2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}

--- a/scripts/setup-sc-precinct-gis-local.mjs
+++ b/scripts/setup-sc-precinct-gis-local.mjs
@@ -1,0 +1,79 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+// This command intentionally does not load .env.local. The database guard accepts
+// only an explicitly supplied loopback crm_clone_dev URL and local-write opt-in.
+process.env.CRM_DATABASE_DRIVER = "postgres";
+
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const yearsArgument = args.find((arg) => arg.startsWith("--years="));
+const reportArgument = args.find((arg) => arg.startsWith("--report="));
+const allowed = new Set(["--apply"]);
+for (const arg of args) {
+  if (
+    !allowed.has(arg)
+    && !arg.startsWith("--years=")
+    && !arg.startsWith("--report=")
+  ) {
+    throw new Error("Unknown South Carolina GIS setup option: " + arg);
+  }
+}
+const years = yearsArgument
+  ? yearsArgument.slice("--years=".length).split(",").map((value) => Number(value.trim()))
+  : undefined;
+
+function writeReport(relativePath, value) {
+  const etlRoot = path.resolve(".etl");
+  const target = path.resolve(relativePath);
+  if (target !== etlRoot && !target.startsWith(etlRoot + path.sep)) {
+    throw new Error("South Carolina GIS reports must remain under .etl");
+  }
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, JSON.stringify(value, null, 2) + "\n", "utf8");
+  return path.relative(process.cwd(), target).replaceAll("\\", "/");
+}
+
+try {
+  const {
+    buildSouthCarolinaPrecinctGisPlan,
+    summarizeSouthCarolinaPrecinctGisPlan,
+  } = await import("./lib/sc-precinct-gis-plan.mjs");
+  const plan = await buildSouthCarolinaPrecinctGisPlan({ years });
+  const summary = summarizeSouthCarolinaPrecinctGisPlan(plan);
+  if (!apply) {
+    console.log(JSON.stringify({
+      mode: "plan",
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      ...summary,
+    }, null, 2));
+  } else {
+    const {
+      applySouthCarolinaPrecinctGisPlan,
+      validateSouthCarolinaPrecinctGisDatabase,
+    } = await import("./lib/sc-precinct-gis-db.mjs");
+    const applied = await applySouthCarolinaPrecinctGisPlan(plan);
+    const validation = await validateSouthCarolinaPrecinctGisDatabase(plan);
+    const report = {
+      schemaVersion: 1,
+      generatedAtUtc: new Date().toISOString(),
+      scope: "local-only South Carolina precinct GIS setup",
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      plan: summary,
+      applied,
+      validation,
+    };
+    const reportPath = writeReport(
+      reportArgument
+        ? reportArgument.slice("--report=".length)
+        : ".etl/local-db/sc-precinct-gis-setup-report.json",
+      report,
+    );
+    console.log(JSON.stringify({ ...report, reportPath }, null, 2));
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/scripts/validate-sc-precinct-gis-local.mjs
+++ b/scripts/validate-sc-precinct-gis-local.mjs
@@ -1,0 +1,58 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+// Validation is local-only and uses a read-only startup session.
+process.env.CRM_DATABASE_DRIVER = "postgres";
+
+const args = process.argv.slice(2);
+const yearsArgument = args.find((arg) => arg.startsWith("--years="));
+const reportArgument = args.find((arg) => arg.startsWith("--report="));
+for (const arg of args) {
+  if (!arg.startsWith("--years=") && !arg.startsWith("--report=")) {
+    throw new Error("Unknown South Carolina GIS validation option: " + arg);
+  }
+}
+const years = yearsArgument
+  ? yearsArgument.slice("--years=".length).split(",").map((value) => Number(value.trim()))
+  : undefined;
+
+function writeReport(relativePath, value) {
+  const etlRoot = path.resolve(".etl");
+  const target = path.resolve(relativePath);
+  if (target !== etlRoot && !target.startsWith(etlRoot + path.sep)) {
+    throw new Error("South Carolina GIS reports must remain under .etl");
+  }
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, JSON.stringify(value, null, 2) + "\n", "utf8");
+  return path.relative(process.cwd(), target).replaceAll("\\", "/");
+}
+
+try {
+  const {
+    buildSouthCarolinaPrecinctGisPlan,
+    summarizeSouthCarolinaPrecinctGisPlan,
+  } = await import("./lib/sc-precinct-gis-plan.mjs");
+  const { validateSouthCarolinaPrecinctGisDatabase } =
+    await import("./lib/sc-precinct-gis-db.mjs");
+  const plan = await buildSouthCarolinaPrecinctGisPlan({ years });
+  const validation = await validateSouthCarolinaPrecinctGisDatabase(plan);
+  const report = {
+    schemaVersion: 1,
+    generatedAtUtc: new Date().toISOString(),
+    scope: "local-only South Carolina precinct GIS validation",
+    productionMutationPerformed: false,
+    publicDeliveryAuthorized: false,
+    plan: summarizeSouthCarolinaPrecinctGisPlan(plan),
+    validation,
+  };
+  const reportPath = writeReport(
+    reportArgument
+      ? reportArgument.slice("--report=".length)
+      : ".etl/local-db/sc-precinct-gis-validation.json",
+    report,
+  );
+  console.log(JSON.stringify({ ...report, reportPath }, null, 2));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/src/lib/data-access.ts
+++ b/src/lib/data-access.ts
@@ -1,6 +1,7 @@
 import { getReadSql, hasReadableDatabase, rethrowReadErrorIfStrict } from "@/db/read-sql";
 import { readPublicDataRevision } from "@/db/public-data-revision";
 import {
+  guardedLocalGeographyMatchMethods,
   matchesPrecinctGeometryPublicationMetadata,
   precinctGeometryPublicManifestSha256,
   requiresPrecinctGeometryPublicationGate,
@@ -316,6 +317,9 @@ export async function isPrecinctGeometryManifestPublished(
   const expectedNoDataFeatureCount = manifest.crosswalk.reviewedNoDataFeatures
     ?? expectedFeatureCount - expectedLinkedRelationshipCount;
   const expectedReportingUnitCount = manifest.crosswalk.resultUnits;
+  const reviewedMatchMethods = guardedLocalGeographyMatchMethods(
+    manifest.state,
+  );
   const publicManifestSha256 = precinctGeometryPublicManifestSha256(manifest);
   let rows: Array<{
     metadata: unknown;
@@ -354,10 +358,8 @@ export async function isPrecinctGeometryManifestPublished(
             and result_sources.metadata->'releaseCandidate'->>'sha256'
               = geography_versions.metadata->'releaseCandidate'->>'sha256'
             and reporting_unit_geometry_crosswalks.relationship_type = 'one_to_one'
-            and reporting_unit_geometry_crosswalks.match_method in (
-              'exact_official_id',
-              'official_crosswalk'
-            )
+            and reporting_unit_geometry_crosswalks.match_method
+              = any(${reviewedMatchMethods})
             and reporting_unit_geometry_crosswalks.review_status = 'reviewed'
             and reporting_unit_geometry_crosswalks.confidence = 'high'
             and reporting_unit_geometry_crosswalks.metadata->>'manifestId'
@@ -576,6 +578,7 @@ export async function listResults(input: {
     : { enabled: false } as const;
   const requiresPublicationGate = requiresPrecinctResultPublicationGate(input)
     && !minnesotaRehearsal.enabled;
+  const reviewedMatchMethods = guardedLocalGeographyMatchMethods(input.state);
   if (parentGeoid && !isValidLocalGeographyParentId({
     state: input.state,
     geographyLevel: input.level,
@@ -692,10 +695,7 @@ export async function listResults(input: {
                   and gate_version.metadata->>'manifestId'
                     = gate_crosswalk.metadata->>'manifestId'
                   and gate_crosswalk.relationship_type = 'one_to_one'
-                  and gate_crosswalk.match_method in (
-                    'exact_official_id',
-                    'official_crosswalk'
-                  )
+                  and gate_crosswalk.match_method = any(${reviewedMatchMethods})
                   and gate_crosswalk.review_status = 'reviewed'
                   and gate_crosswalk.confidence = 'high'
                   and gate_crosswalk.metadata->>'publicDeliveryAuthorized' = 'true'
@@ -796,10 +796,7 @@ export async function listResults(input: {
                 and gate_version.metadata->>'manifestId'
                   = gate_crosswalk.metadata->>'manifestId'
                 and gate_crosswalk.relationship_type = 'one_to_one'
-                and gate_crosswalk.match_method in (
-                  'exact_official_id',
-                  'official_crosswalk'
-                )
+                and gate_crosswalk.match_method = any(${reviewedMatchMethods})
                 and gate_crosswalk.review_status = 'reviewed'
                 and gate_crosswalk.confidence = 'high'
                 and gate_crosswalk.metadata->>'publicDeliveryAuthorized' = 'true'

--- a/src/lib/precinct-result-publication.ts
+++ b/src/lib/precinct-result-publication.ts
@@ -22,6 +22,15 @@ const GUARDED_LOCAL_GEOGRAPHY_RELEASES = Object.freeze({
     geographyLevel: "precinct",
     releaseCandidatePattern: /^nv-precinct-gis-three-election-v\d+$/,
   },
+  SC: {
+    geographyLevel: "precinct",
+    releaseCandidatePattern: /^sc-precinct-gis-three-election-v\d+$/,
+    reviewedMatchMethods: Object.freeze([
+      "exact_official_id",
+      "official_crosswalk",
+      "reviewed_name",
+    ]),
+  },
   TX: {
     geographyLevel: "precinct",
     releaseCandidatePattern: /^tx-precinct-gis-four-election-v\d+$/,
@@ -29,7 +38,13 @@ const GUARDED_LOCAL_GEOGRAPHY_RELEASES = Object.freeze({
 } satisfies Record<string, {
   geographyLevel: string;
   releaseCandidatePattern: RegExp;
+  reviewedMatchMethods?: readonly string[];
 }>);
+
+const DEFAULT_REVIEWED_MATCH_METHODS = Object.freeze([
+  "exact_official_id",
+  "official_crosswalk",
+]);
 
 type GuardedLocalGeographyState = keyof typeof GUARDED_LOCAL_GEOGRAPHY_RELEASES;
 
@@ -44,6 +59,13 @@ function guardedReleaseContract(state: string) {
 
 export function guardedLocalGeographyLevel(state: string) {
   return guardedReleaseContract(state)?.geographyLevel ?? null;
+}
+
+export function guardedLocalGeographyMatchMethods(state: string) {
+  const contract = guardedReleaseContract(state);
+  return contract && "reviewedMatchMethods" in contract
+    ? contract.reviewedMatchMethods
+    : DEFAULT_REVIEWED_MATCH_METHODS;
 }
 
 export function requiresPrecinctResultPublicationGate(input: {

--- a/tests/api/sc-precinct-blob-publication.test.mjs
+++ b/tests/api/sc-precinct-blob-publication.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { inspectSouthCarolinaPrecinctBlobPublicationPlan } from "../../scripts/lib/sc-precinct-blob-publication.mjs";
+import { buildSouthCarolinaTestReleaseFixture } from "./sc-precinct-release-fixture.mjs";
+
+const { prepared } = await buildSouthCarolinaTestReleaseFixture({ write: true });
+const plan = inspectSouthCarolinaPrecinctBlobPublicationPlan({
+  packagePath: prepared.releaseCandidate.path,
+  packageSha256: prepared.releaseCandidate.sha256,
+});
+
+test("South Carolina Blob plan pins all 138 county assets before three indexes", () => {
+  assert.equal(plan.artifacts.length, 141);
+  assert.equal(plan.artifacts.filter((artifact) => artifact.kind === "parent").length, 138);
+  assert.equal(plan.artifacts.filter((artifact) => artifact.kind === "index").length, 3);
+  assert.ok(plan.artifacts.slice(0, 138).every((artifact) => artifact.kind === "parent"));
+  assert.ok(plan.artifacts.slice(138).every((artifact) => artifact.kind === "index"));
+  assert.ok(plan.artifacts.every((artifact) => artifact.pathname.startsWith("data/geography/sc/")));
+  assert.equal(plan.decision, "NO_GO_PUBLICATION");
+  assert.equal(plan.canonicalManifestChanged, false);
+  assert.equal(plan.publicEligibilityChanged, false);
+});

--- a/tests/api/sc-precinct-gis-local.test.mjs
+++ b/tests/api/sc-precinct-gis-local.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  assertSouthCarolinaGeometryVersionPrecondition,
+  canonicalJson,
+} from "../../scripts/lib/sc-precinct-gis-db.mjs";
+import {
+  requiresPrecinctGeometryPublicationGate,
+  requiresPrecinctResultPublicationGate,
+} from "../../src/lib/precinct-result-publication.ts";
+
+test("South Carolina precinct GIS commands remain loopback-only and public-fail-closed", () => {
+  const setup = readFileSync("scripts/setup-sc-precinct-gis-local.mjs", "utf8");
+  const validate = readFileSync("scripts/validate-sc-precinct-gis-local.mjs", "utf8");
+  const database = readFileSync("scripts/lib/sc-precinct-gis-db.mjs", "utf8");
+  const packageJson = JSON.parse(readFileSync("package.json"));
+  assert.match(setup, /CRM_DATABASE_DRIVER = "postgres"/);
+  assert.match(validate, /CRM_DATABASE_DRIVER = "postgres"/);
+  assert.doesNotMatch(setup + validate, /--env-file|dotenv/);
+  assert.match(database, /getLocalCloneDatabaseUrl\(\{ requireWriteOptIn: true \}\)/);
+  assert.match(database, /reporting_grain='precinct'/);
+  assert.match(database, /status='blocked'| 'blocked'/);
+  assert.match(database, /publicDeliveryAuthorized: false/);
+  assert.doesNotMatch(database, /runNeonTransaction|@neondatabase/);
+  assert.equal(packageJson.scripts["precinct-gis:plan:sc"], "node --experimental-strip-types scripts/setup-sc-precinct-gis-local.mjs");
+  assert.equal(packageJson.scripts["precinct-gis:setup:sc:local"], "node --experimental-strip-types scripts/setup-sc-precinct-gis-local.mjs --apply");
+});
+
+test("South Carolina results and geometry require exact publication evidence", () => {
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "SC", level: "precinct" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ME", level: "precinct" }), false);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ia", level: "precinct" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "SC", level: "county" }), false);
+  assert.equal(requiresPrecinctGeometryPublicationGate({
+    state: "SC",
+    geography: { level: "precinct" },
+  }), true);
+});
+
+test("South Carolina release precondition rejects duplicate or boundary-drifted versions", () => {
+  const yearPlan = {
+    year: 2024,
+    manifest: {
+      id: "sc-2024-11-05-general-precinct-geometry-candidate-v1",
+      geography: { boundaryVintage: "reviewed South Carolina 2024 precinct boundaries" },
+    },
+  };
+  assert.doesNotThrow(() => assertSouthCarolinaGeometryVersionPrecondition([], yearPlan));
+  assert.doesNotThrow(() => assertSouthCarolinaGeometryVersionPrecondition([{
+    manifest_id: yearPlan.manifest.id,
+    boundary_vintage: yearPlan.manifest.geography.boundaryVintage,
+  }], yearPlan));
+  assert.throws(() => assertSouthCarolinaGeometryVersionPrecondition([{
+    manifest_id: yearPlan.manifest.id,
+    boundary_vintage: "drifted",
+  }], yearPlan), /boundary-drifted geography versions/);
+});
+
+test("South Carolina database validation compares nested JSON independent of key order", () => {
+  const left = {
+    z: [{ beta: 2, alpha: 1 }],
+    a: { delta: 4, gamma: 3 },
+  };
+  const right = {
+    a: { gamma: 3, delta: 4 },
+    z: [{ alpha: 1, beta: 2 }],
+  };
+  assert.deepEqual(canonicalJson(left), canonicalJson(right));
+});

--- a/tests/api/sc-precinct-gis-plan.test.mjs
+++ b/tests/api/sc-precinct-gis-plan.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildSouthCarolinaPrecinctGisPlan,
+  summarizeSouthCarolinaPrecinctGisPlan,
+} from "../../scripts/lib/sc-precinct-gis-plan.mjs";
+
+const plan = await buildSouthCarolinaPrecinctGisPlan();
+const summary = summarizeSouthCarolinaPrecinctGisPlan(plan);
+
+test("South Carolina plan preserves three exact election-specific source universes", () => {
+  assert.deepEqual(summary.years.map((year) => ({
+    year: year.year,
+    units: year.reportingUnits,
+    rows: year.resultRows,
+    features: year.geometryFeatures,
+    relationships: year.reviewedCrosswalks,
+    mappedVotes: year.totals.Total,
+    officialVotes: year.officialTotals.Total,
+    sourceGatePassed: year.sourceGatePassed,
+  })), [
+    { year: 2016, units: 2551, rows: 6696, features: 2234, relationships: 2551, mappedVotes: 1589961, officialVotes: 2103027, sourceGatePassed: true },
+    { year: 2020, units: 2399, rows: 6783, features: 2263, relationships: 2399, mappedVotes: 2504220, officialVotes: 2513329, sourceGatePassed: true },
+    { year: 2024, units: 2446, rows: 6924, features: 2308, relationships: 2446, mappedVotes: 2541877, officialVotes: 2548140, sourceGatePassed: true },
+  ]);
+});
+
+test("South Carolina uses county parents and never maps administrative buckets", () => {
+  for (const year of plan.years) {
+    assert.equal(new Set(year.geometry.features.map((feature) => feature.parentGeoid)).size, 46);
+    const geographic = year.reportingUnits.filter((unit) => unit.isGeographic);
+    const nonGeographic = year.reportingUnits.filter((unit) => !unit.isGeographic);
+    assert.equal(
+      year.geometry.features.length - geographic.length,
+      year.manifest.crosswalk.reviewedNoDataFeatures,
+    );
+    assert.ok(geographic.every((unit) =>
+      unit.reportingGrain === "precinct"
+      && /^45\d{3}$/.test(unit.parentGeoid)));
+    assert.ok(nonGeographic.every((unit) =>
+      unit.reportingGrain === "administrative_reporting_unit"
+      && /^45\d{3}$/.test(unit.parentGeoid)));
+    assert.ok(year.geometry.crosswalks.every((relationship) =>
+      relationship.reviewStatus === "reviewed"
+      && relationship.confidence === "high"
+      && (relationship.sourceFeatureId === null
+        ? relationship.relationshipType === "non_geographic"
+        : relationship.relationshipType === "one_to_one")));
+    assert.ok(year.resultRows.every((row) =>
+      geographic.some((unit) => unit.code === row.jurisdictionCode)));
+  }
+});
+
+test("South Carolina plan excludes blocked 2012 and rejects unsupported years", async () => {
+  await assert.rejects(
+    buildSouthCarolinaPrecinctGisPlan({ years: [2012] }),
+    /2012 remains separately blocked/,
+  );
+  await assert.rejects(
+    buildSouthCarolinaPrecinctGisPlan({ years: [2008] }),
+    /Supported South Carolina public-release years/,
+  );
+});

--- a/tests/api/sc-precinct-production-release.test.mjs
+++ b/tests/api/sc-precinct-production-release.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  assertSouthCarolinaReleaseCandidateDocument,
+  sha256,
+} from "../../scripts/lib/sc-precinct-production-preflight.mjs";
+import {
+  SOUTH_CAROLINA_PRODUCTION_RELEASE_SCOPES,
+  buildSouthCarolinaProductionAuthorizationTemplate,
+  validateSouthCarolinaProductionAuthorization,
+  validateSouthCarolinaProductionBackupEvidence,
+  validateSouthCarolinaProductionPreflightEvidence,
+} from "../../scripts/lib/sc-precinct-production-release.mjs";
+import { buildSouthCarolinaTestReleaseFixture } from "./sc-precinct-release-fixture.mjs";
+
+const { built } = await buildSouthCarolinaTestReleaseFixture();
+const packageSha256 = sha256(built.packageBytes);
+const candidate = assertSouthCarolinaReleaseCandidateDocument(built.packageDocument, packageSha256);
+const now = new Date("2026-08-13T00:30:00.000Z");
+const endpointFingerprint = "a".repeat(64);
+
+test("South Carolina release candidate and authorization scopes are state-specific", () => {
+  assert.deepEqual(SOUTH_CAROLINA_PRODUCTION_RELEASE_SCOPES, [
+    "apply_migration_0009",
+    "load_sc_precinct_results_and_geometry_hidden",
+    "increment_public_data_revision",
+  ]);
+  const template = buildSouthCarolinaProductionAuthorizationTemplate({
+    releaseCandidate: candidate,
+    preflightSha256: "b".repeat(64),
+    backupManifestSha256: "c".repeat(64),
+  });
+  assert.equal(template.decision, "NO_GO_PRODUCTION");
+  assert.deepEqual(template.scopes, SOUTH_CAROLINA_PRODUCTION_RELEASE_SCOPES);
+  assert.equal(template.replacement, undefined);
+});
+
+test("South Carolina fresh empty production evidence validates and preexisting rows fail", () => {
+  const report = {
+    schemaVersion: 1,
+    state: "SC",
+    productionMutationPerformed: false,
+    database: { transactionReadOnly: true, name: "production" },
+    invalidConstraints: 0,
+    migration0008: { status: "complete" },
+    migration0009: { status: "absent" },
+    releaseCandidate: { id: candidate.id, sha256: candidate.sha256 },
+    endpointFingerprint,
+    publicRevision: 10,
+    capturedAtUtc: "2026-08-13T00:00:00.000Z",
+    southCarolina: {
+      localYearRows: [2016, 2020, 2024].map((year) => ({
+        year,
+        reportingUnits: 0,
+        linkedLocalResultRows: 0,
+        geographyVersions: 0,
+        geometryFeatures: 0,
+        reviewedRelationships: 0,
+      })),
+      coreYearRows: [2016, 2020, 2024].map((year) => ({ year, localResultRows: 0 })),
+    },
+  };
+  assert.doesNotThrow(() => validateSouthCarolinaProductionPreflightEvidence(report, {
+    releaseCandidate: candidate,
+    endpointFingerprint,
+    now,
+  }));
+  report.southCarolina.localYearRows[0].reportingUnits = 1;
+  assert.throws(() => validateSouthCarolinaProductionPreflightEvidence(report, {
+    releaseCandidate: candidate,
+    endpointFingerprint,
+    now,
+  }), /already contains precinct release rows/);
+});
+
+test("South Carolina backup and authorization require exact fresh hashes", () => {
+  const preflightCapturedAtUtc = "2026-08-13T00:00:00.000Z";
+  const backup = {
+    manifestVersion: 3,
+    backupPurpose: "sc-precinct-production-release-rollback",
+    releaseCandidate: { id: candidate.id, sha256: candidate.sha256 },
+    sourceEndpointFingerprint: endpointFingerprint,
+    dumpSha256: "d".repeat(64),
+    dumpFormat: "custom",
+    pgClientMajor: 17,
+    sourceServerVersionNum: 170000,
+    includedSchemas: ["public"],
+    excludedTableDataPatterns: [],
+    remoteMutationPerformed: false,
+    sourceInvalidConstraints: 0,
+    createdAtUtc: "2026-08-13T00:05:00.000Z",
+    sourcePublicTableCount: 2,
+    sourcePublicTableRowCounts: { elections: 4, contests: 8 },
+    restoreVerification: {
+      verified: true,
+      defaultTransactionReadOnly: true,
+      exactSourceTableSet: true,
+      exactSourceRowCounts: true,
+      invalidConstraints: 0,
+      verifiedAtUtc: "2026-08-13T00:10:00.000Z",
+      publicTableCount: 2,
+      tableDataEntryCount: 2,
+      publicTableRowCounts: { elections: 4, contests: 8 },
+    },
+  };
+  assert.doesNotThrow(() => validateSouthCarolinaProductionBackupEvidence(backup, {
+    releaseCandidate: candidate,
+    endpointFingerprint,
+    preflightCapturedAtUtc,
+    now,
+  }));
+  const authorization = {
+    ...buildSouthCarolinaProductionAuthorizationTemplate({
+      releaseCandidate: candidate,
+      preflightSha256: "b".repeat(64),
+      backupManifestSha256: "c".repeat(64),
+    }),
+    decision: "GO_PRODUCTION",
+    authorizationId: "sc-release-1",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T00:15:00.000Z",
+    expiresAtUtc: "2026-08-13T01:15:00.000Z",
+  };
+  assert.doesNotThrow(() => validateSouthCarolinaProductionAuthorization(authorization, {
+    releaseCandidate: candidate,
+    preflightSha256: "b".repeat(64),
+    backupManifestSha256: "c".repeat(64),
+    now,
+  }));
+  authorization.scopes[1] = "load_nv_precinct_results_and_geometry_hidden";
+  assert.throws(() => validateSouthCarolinaProductionAuthorization(authorization, {
+    releaseCandidate: candidate,
+    preflightSha256: "b".repeat(64),
+    backupManifestSha256: "c".repeat(64),
+    now,
+  }), /incomplete or incompatible/);
+});
+
+test("South Carolina production runners use the correctly spelled environment guard", () => {
+  const files = [
+    "scripts/apply-sc-precinct-release.mjs",
+    "scripts/report-sc-precinct-production-preflight.mjs",
+    "scripts/publish-sc-precinct-geography-status.mjs",
+  ].map((file) => readFileSync(file, "utf8")).join("\n");
+  assert.match(files, /CRM_DATABASE_ENVIRONMENT/);
+  assert.doesNotMatch(files, /CRM_DATABASE_EIAIRONMENT|NODE_EIA/);
+  assert.doesNotMatch(files, /replacement-publication-receipt|GO_PRODUCTION_UPGRADE/);
+});
+
+test("South Carolina backup guard accepts only the three-election release package", () => {
+  const backupScript = readFileSync(
+    "scripts/backup-sc-precinct-production.ps1",
+    "utf8",
+  );
+  assert.equal(built.packageDocument.totals.elections, 3);
+  assert.match(backupScript, /\$document\.totals\.elections -ne 3/);
+  assert.doesNotMatch(backupScript, /\$document\.totals\.elections -ne 4/);
+});

--- a/tests/api/sc-precinct-public-activation.test.mjs
+++ b/tests/api/sc-precinct-public-activation.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { inspectSouthCarolinaPublicActivationPlan } from "../../scripts/lib/sc-precinct-public-activation.mjs";
+import { writeSouthCarolinaActivationTrackedOutputs } from "../../scripts/prepare-sc-precinct-public-activation.mjs";
+import { buildSouthCarolinaTestReleaseFixture } from "./sc-precinct-release-fixture.mjs";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+const coverage = JSON.parse(readFileSync(
+  "data/precinct-geometry-coverage-inventory-2016.json",
+  "utf8",
+));
+const existingSouthCarolinaRow = coverage.states.find((row) => row.state === "SC");
+const { prepared } = await buildSouthCarolinaTestReleaseFixture({
+  write: true,
+  generatedAtUtc: existingSouthCarolinaRow?.checkedAt,
+});
+const inspected = inspectSouthCarolinaPublicActivationPlan({
+  packagePath: prepared.releaseCandidate.path,
+  packageSha256: prepared.releaseCandidate.sha256,
+});
+
+test("South Carolina static activation adds or verifies exactly three guarded manifests", () => {
+  assert.equal(inspected.plan.manifests.length, 3);
+  assert.deepEqual(inspected.plan.manifests.map((item) => item.year), [2016, 2020, 2024]);
+  assert.equal(inspected.plan.trackedOutputs.length, 4);
+  const dispositions = new Set(
+    inspected.plan.trackedOutputs.map((output) => output.disposition),
+  );
+  assert.equal(dispositions.size, 1);
+  assert.ok(["activate", "verified_existing"].includes([...dispositions][0]));
+  assert.equal(inspected.plan.safety.productionMutationPerformed, false);
+  assert.equal(inspected.plan.safety.publicEndpointsRemainDatabaseGated, true);
+});
+
+test("South Carolina activation atomically writes its registry and three inventories", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "crm-sc-activation-"));
+  try {
+    const outputs = Array.from({ length: 4 }, (_, index) => {
+      const absolutePath = path.join(root, `target-${index}.json`);
+      const before = Buffer.from(`before-${index}\n`, "utf8");
+      const bytes = Buffer.from(`after-${index}\n`, "utf8");
+      writeFileSync(absolutePath, before);
+      return {
+        path: `data/target-${index}.json`,
+        absolutePath,
+        preimage: { byteCount: before.length, sha256: sha256(before) },
+        byteCount: bytes.length,
+        sha256: sha256(bytes),
+        bytes,
+      };
+    });
+    assert.equal(writeSouthCarolinaActivationTrackedOutputs(outputs).length, 4);
+    for (const output of outputs) {
+      assert.deepEqual(readFileSync(output.absolutePath), output.bytes);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/api/sc-precinct-publication-gate.test.mjs
+++ b/tests/api/sc-precinct-publication-gate.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  guardedLocalGeographyMatchMethods,
+  matchesPrecinctGeometryPublicationMetadata,
+  precinctGeometryPublicManifestSha256,
+  requiresPrecinctGeometryPublicationGate,
+  requiresPrecinctResultPublicationGate,
+} from "../../src/lib/precinct-result-publication.ts";
+
+function manifest() {
+  return {
+    schemaVersion: 1,
+    id: "sc-2024-11-05-reviewed-precinct-geometry-v1",
+    state: "SC",
+    election: { id: "2024-11-05-general", date: "2024-11-05", year: 2024, type: "general", office: "president" },
+    geography: { level: "precinct", parentLevel: "county", boundaryVintage: "reviewed", vintageStatus: "election_date_confirmed", derivationMethod: "secondary_reconstruction" },
+    source: {},
+    normalization: { featureCount: 2 },
+    crosswalk: {},
+    validation: {},
+    delivery: {
+      format: "parent_scoped_geojson",
+      url: "/data/geography/sc/2024-11-05/precinct/candidate/index.json",
+      sha256: "1".repeat(64),
+      byteCount: 123,
+      featureIdProperty: "geometryFeatureId",
+      resultUnitProperty: "resultUnitCode",
+      parentGeoidProperty: "parentGeoid",
+      parentCount: 1,
+      featureCount: 2,
+    },
+    caveats: [],
+  };
+}
+
+function metadata(value) {
+  const releaseSha256 = "2".repeat(64);
+  return {
+    manifestId: value.id,
+    publicDeliveryAuthorized: true,
+    normalization: { featureCount: 2 },
+    crosswalk: { reviewedRelationships: 2 },
+    releaseCandidate: { id: "sc-precinct-gis-three-election-v1", sha256: releaseSha256, publicDeliveryAuthorized: true },
+    publicActivation: {
+      activationId: "sc-precinct-public-2024",
+      activationCandidateSha256: "3".repeat(64),
+      releasePackageSha256: releaseSha256,
+      blobPublicationSha256: "4".repeat(64),
+      deliveryOrigin: "https://example.public.blob.vercel-storage.com",
+      authorizationSha256: "5".repeat(64),
+      changedAtUtc: "2026-08-12T23:59:00.000Z",
+      revision: 50,
+      mode: "publish",
+      year: 2024,
+      manifestId: value.id,
+      publicManifestSha256: precinctGeometryPublicManifestSha256(value),
+      delivery: value.delivery,
+      previousCaveat: "blocked pending release",
+    },
+  };
+}
+
+test("South Carolina precinct unit results and geometry use the guarded publication path", () => {
+  const value = manifest();
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "SC", level: "precinct" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ME", level: "precinct" }), false);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "SC", level: "county" }), false);
+  assert.equal(requiresPrecinctGeometryPublicationGate(value), true);
+  assert.deepEqual(guardedLocalGeographyMatchMethods("SC"), [
+    "exact_official_id",
+    "official_crosswalk",
+    "reviewed_name",
+  ]);
+  assert.deepEqual(guardedLocalGeographyMatchMethods("AK"), [
+    "exact_official_id",
+    "official_crosswalk",
+  ]);
+  assert.equal(matchesPrecinctGeometryPublicationMetadata(value, metadata(value)), true);
+  const foreign = metadata(value);
+  foreign.releaseCandidate.id = "nv-precinct-gis-three-election-v2";
+  assert.equal(matchesPrecinctGeometryPublicationMetadata(value, foreign), false);
+});
+
+test("Minnesota rehearsal cannot bypass the South Carolina publication gate", () => {
+  const source = readFileSync("src/lib/data-access.ts", "utf8");
+  assert.match(source, /input\.state\.toUpperCase\(\) === "MN"\s*\? resolveMinnesotaPrecinctRehearsal\(\)/);
+  assert.doesNotMatch(source, /requiresPrecinctResultPublicationGate\(input\)\s*&&\s*!resolveMinnesotaPrecinctRehearsal\(\)\.enabled/);
+});

--- a/tests/api/sc-precinct-publication.test.mjs
+++ b/tests/api/sc-precinct-publication.test.mjs
@@ -1,0 +1,609 @@
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  SOUTH_CAROLINA_PUBLICATION_SCOPES,
+  SOUTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES,
+  buildSouthCarolinaPublicRollbackAuthorizationTemplate,
+  buildSouthCarolinaPublicationAuthorizationTemplate,
+  serializeSouthCarolinaPublicationDocument,
+  sha256,
+  validateSouthCarolinaBlobPublicationEvidence,
+  validateSouthCarolinaPublicRollbackAuthorization,
+  validateSouthCarolinaPublicationAuthorization,
+} from "../../scripts/lib/sc-precinct-publication.mjs";
+import {
+  applySouthCarolinaGeographyPublicationTransaction,
+  assertSouthCarolinaPublicationRecoveryVersionSet,
+  inspectSouthCarolinaPublicationReceipt,
+  verifySouthCarolinaPublicationGitCandidate,
+} from "../../scripts/publish-sc-precinct-geography-status.mjs";
+const deliveryOrigin = "https://example.public.blob.vercel-storage.com";
+const blobReleaseCandidate = {
+  id: "sc-precinct-gis-three-election-v1",
+  path: ".etl/precinct-release-candidates/SC/example/release-candidate.json",
+  sha256: "d".repeat(64),
+};
+const blobArtifacts = Array.from({ length: 141 }, (_, index) => {
+  const year = [2016, 2020, 2024][Math.min(2, Math.floor(index / 47))];
+  const kind = index % 47 === 46 ? "index" : "parent";
+  return {
+    kind,
+    year,
+    packageRelativePath: `delivery-assets/${year}/file-${index}.json`,
+    publicUrl: `/data/geography/sc/${year}/precinct/file-${index}.json`,
+    pathname: `data/geography/sc/${year}/precinct/file-${index}.json`,
+    byteCount: 100 + index,
+    sha256: index.toString(16).padStart(64, "0"),
+  };
+});
+const blobPlan = {
+  releaseCandidate: blobReleaseCandidate,
+  artifacts: blobArtifacts,
+};
+const evidence = {
+  schemaVersion: 1,
+  state: "SC",
+  purpose: "sc-precinct-parent-scoped-immutable-geometry-publication",
+  releaseCandidate: blobReleaseCandidate,
+  authorizationId: "sc-blob-publication-1",
+  publishedAtUtc: "2026-08-13T00:00:00.000Z",
+  deliveryOrigin,
+  assetCount: blobPlan.artifacts.length,
+  canonicalManifestChanged: false,
+  publicEligibilityChanged: false,
+  artifacts: blobPlan.artifacts.map((artifact) => ({
+    ...artifact,
+    url: `${deliveryOrigin}/${artifact.pathname}`,
+    disposition: "created",
+  })),
+};
+
+const releaseCandidate = {
+  id: "sc-precinct-gis-three-election-v1",
+  path: ".etl/precinct-release-candidates/SC/example/release-candidate.json",
+  sha256: "1".repeat(64),
+};
+const planSha256 = "2".repeat(64);
+const rollbackTarget = {
+  deploymentId: "dpl_southCarolina_previous",
+  url: "https://previous.civicresultmaps.org",
+  gitSha: "3".repeat(40),
+  gitTreeSha: "4".repeat(40),
+  verifiedAtUtc: "2026-08-13T00:30:00.000Z",
+  gateCapableVerified: true,
+  blockedResultGateVerified: true,
+  blockedGeometryGateVerified: true,
+};
+const authorizationPlan = {
+  id: "sc-precinct-database-publication-v1",
+  releaseCandidate,
+  hiddenLoad: { path: "hidden.json", sha256: "5".repeat(64) },
+  blobPublication: {
+    path: "blob.json",
+    sha256: "6".repeat(64),
+    deliveryOrigin,
+  },
+  staticRegistry: { sha256: "7".repeat(64) },
+};
+
+function publicAuthorization() {
+  const value = buildSouthCarolinaPublicationAuthorizationTemplate(
+    authorizationPlan,
+    planSha256,
+  );
+  Object.assign(value, {
+    decision: "GO_PUBLIC",
+    activationId: "sc-precinct-public-camreyn",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T00:50:00.000Z",
+    expiresAtUtc: "2026-08-13T02:00:00.000Z",
+  });
+  Object.assign(value.productionDeployment, {
+    deploymentId: "dpl_southCarolina_public",
+    url: "https://civicresultmaps.org",
+    gitSha: "8".repeat(40),
+    gitTreeSha: "9".repeat(40),
+    readyVerified: true,
+    promotedVerified: true,
+    blockedResultGateVerified: true,
+    blockedGeometryGateVerified: true,
+    verifiedAtUtc: "2026-08-13T00:45:00.000Z",
+  });
+  Object.assign(value.rollbackTarget, rollbackTarget);
+  return value;
+}
+
+function publicationSummary() {
+  return {
+    path: ".etl/production-publication-receipts/SC/sc-precinct-publish.json",
+    sha256: "a".repeat(64),
+    activationId: "sc-precinct-public-camreyn",
+    authorizationSha256: "b".repeat(64),
+    revision: 41,
+    changedAtUtc: "2026-08-13T01:00:00.000Z",
+    rollbackTarget,
+    productionDeployment: publicAuthorization().productionDeployment,
+  };
+}
+
+test("South Carolina Blob evidence requires all 141 immutable artifacts", () => {
+  const result = validateSouthCarolinaBlobPublicationEvidence(
+    evidence,
+    blobPlan,
+    Date.parse("2026-08-13T00:01:00.000Z"),
+  );
+  assert.equal(result.assetCount, 141);
+  assert.equal(result.deliveryOrigin, deliveryOrigin);
+  const incomplete = { ...evidence, assetCount: 140 };
+  assert.throws(
+    () => validateSouthCarolinaBlobPublicationEvidence(incomplete, blobPlan),
+    /incomplete or incompatible/,
+  );
+});
+
+test("South Carolina public authorization pins production and rollback deployment trees", () => {
+  const value = publicAuthorization();
+  const checked = validateSouthCarolinaPublicationAuthorization(value, {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  assert.equal(checked.approvedBy, "Camreyn");
+  assert.deepEqual(value.scopes, SOUTH_CAROLINA_PUBLICATION_SCOPES);
+  assert.deepEqual(checked.rollbackTarget, rollbackTarget);
+
+  const sameTree = structuredClone(value);
+  sameTree.rollbackTarget.gitTreeSha = value.productionDeployment.gitTreeSha;
+  assert.throws(
+    () => validateSouthCarolinaPublicationAuthorization(sameTree, {
+      plan: authorizationPlan,
+      planSha256,
+      now: Date.parse("2026-08-13T01:01:00.000Z"),
+    }),
+    /incompatible/,
+  );
+});
+
+test("South Carolina rollback authorization is bound to the exact publication receipt", () => {
+  const receipt = publicationSummary();
+  const value = buildSouthCarolinaPublicRollbackAuthorizationTemplate(
+    authorizationPlan,
+    planSha256,
+    receipt,
+  );
+  Object.assign(value, {
+    decision: "GO_ROLLBACK",
+    rollbackId: "sc-rollback-camreyn",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T01:10:00.000Z",
+    expiresAtUtc: "2026-08-13T02:00:00.000Z",
+  });
+  Object.assign(value.rollbackWindow, {
+    startsAtUtc: "2026-08-13T01:10:00.000Z",
+    endsAtUtc: "2026-08-13T01:50:00.000Z",
+  });
+  value.applicationRollback.databaseBlockFirstAcknowledged = true;
+  value.applicationRollback.restoreAfterDatabaseRollbackAcknowledged = true;
+  const checked = validateSouthCarolinaPublicRollbackAuthorization(value, {
+    plan: authorizationPlan,
+    planSha256,
+    publicationReceipt: receipt,
+    now: Date.parse("2026-08-13T01:20:00.000Z"),
+  });
+  assert.equal(checked.rollbackId, "sc-rollback-camreyn");
+  assert.deepEqual(value.scopes, SOUTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES);
+
+  const substituted = structuredClone(value);
+  substituted.applicationRollback.target.deploymentId = "dpl_substituted";
+  assert.throws(
+    () => validateSouthCarolinaPublicRollbackAuthorization(substituted, {
+      plan: authorizationPlan,
+      planSha256,
+      publicationReceipt: receipt,
+      now: Date.parse("2026-08-13T01:20:00.000Z"),
+    }),
+    /incompatible/,
+  );
+});
+
+test("South Carolina publication receipt reloads its exact original public authorization", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "crm-sc-precinct-publication-"));
+  const authorizationPath =
+    ".etl/production-authorizations/SC/sc-precinct-public-authorization.json";
+  const receiptPath =
+    ".etl/production-publication-receipts/SC/sc-precinct-publish-receipt.json";
+  const authorization = publicAuthorization();
+  const authorizationBytes = serializeSouthCarolinaPublicationDocument(authorization);
+  const authorizationSha256 = sha256(authorizationBytes);
+  const plan = {
+    ...authorizationPlan,
+    hiddenLoad: authorizationPlan.hiddenLoad,
+    blobPublication: authorizationPlan.blobPublication,
+  };
+  const receipt = {
+    schemaVersion: 1,
+    state: "SC",
+    mode: "publish",
+    decision: "PUBLISHED",
+    activationId: authorization.activationId,
+    approvedBy: authorization.approvedBy,
+    releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    authorization: { path: authorizationPath, sha256: authorizationSha256 },
+    hiddenLoad: plan.hiddenLoad,
+    blobPublication: {
+      ...plan.blobPublication,
+      deliveryOrigin,
+    },
+    productionDeployment: authorization.productionDeployment,
+    rollbackTarget,
+    changedAtUtc: "2026-08-13T01:00:00.000Z",
+    revision: 41,
+    postconditions: {
+      mode: "publish",
+      status: "published",
+      publicDeliveryAuthorized: true,
+      geographyVersions: 3,
+      crosswalks: 7_396,
+      reportingUnits: 7_396,
+      sourceDocuments: 6,
+      importRuns: 3,
+      resultRows: 20_403,
+      invalidConstraints: 0,
+    },
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: true,
+  };
+  for (const [relative, bytes] of [
+    [authorizationPath, authorizationBytes],
+    [receiptPath, serializeSouthCarolinaPublicationDocument(receipt)],
+  ]) {
+    const absolute = path.resolve(root, ...relative.split("/"));
+    mkdirSync(path.dirname(absolute), { recursive: true });
+    writeFileSync(absolute, bytes);
+  }
+  const receiptBytes = readFileSync(path.resolve(root, ...receiptPath.split("/")));
+  const inspected = inspectSouthCarolinaPublicationReceipt(root, {
+    publicationReceiptPath: receiptPath,
+    publicationReceiptSha256: sha256(receiptBytes),
+    now: Date.parse("2026-08-13T01:10:00.000Z"),
+  }, { plan, sha256: planSha256 });
+  assert.equal(inspected.summary.activationId, authorization.activationId);
+
+  const substituted = structuredClone(receipt);
+  substituted.rollbackTarget.deploymentId = "dpl_substituted";
+  const substitutedPath =
+    ".etl/production-publication-receipts/SC/sc-precinct-substituted-receipt.json";
+  const substitutedBytes = serializeSouthCarolinaPublicationDocument(substituted);
+  writeFileSync(
+    path.resolve(root, ...substitutedPath.split("/")),
+    substitutedBytes,
+  );
+  assert.throws(
+    () => inspectSouthCarolinaPublicationReceipt(root, {
+      publicationReceiptPath: substitutedPath,
+      publicationReceiptSha256: sha256(substitutedBytes),
+      now: Date.parse("2026-08-13T01:10:00.000Z"),
+    }, { plan, sha256: planSha256 }),
+    /incomplete or incompatible/,
+  );
+});
+
+test("South Carolina Git verifier resolves both the live and rollback deployment trees", () => {
+  const authorization = validateSouthCarolinaPublicationAuthorization(publicAuthorization(), {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  const outputs = new Map([
+    ["rev-parse HEAD", authorization.productionDeployment.gitSha],
+    ["rev-parse HEAD^{tree}", authorization.productionDeployment.gitTreeSha],
+    [
+      `rev-parse ${authorization.productionDeployment.gitSha}^{tree}`,
+      authorization.productionDeployment.gitTreeSha,
+    ],
+    [
+      `rev-parse ${authorization.rollbackTarget.gitSha}^{tree}`,
+      authorization.rollbackTarget.gitTreeSha,
+    ],
+    ["status --porcelain --untracked-files=no", ""],
+  ]);
+  const runner = (_command, args) => outputs.get(args.join(" ")) + "\n";
+  assert.equal(
+    verifySouthCarolinaPublicationGitCandidate(process.cwd(), authorization, runner)
+      .trackedWorktreeClean,
+    true,
+  );
+  outputs.set(
+    `rev-parse ${authorization.rollbackTarget.gitSha}^{tree}`,
+    "f".repeat(40),
+  );
+  assert.throws(
+    () => verifySouthCarolinaPublicationGitCandidate(process.cwd(), authorization, runner),
+    /drifted/,
+  );
+});
+
+function rollbackTransactionFixture() {
+  const manifests = [2016, 2020, 2024].map((year, index) => ({
+    year,
+    manifestId: `sc-${year}-manifest`,
+    publicManifestSha256: String(index + 3).repeat(64).slice(0, 64),
+    blockedManifestSha256: String(index + 6).repeat(64).slice(0, 64),
+    delivery: {
+      format: "parent_scoped_geojson",
+      featureCount: [2234, 2263, 2308][index],
+      parentCount: 46,
+      indexPath: `/data/geography/sc/${year}/precinct/index.json`,
+    },
+  }));
+  const plan = {
+    id: authorizationPlan.id,
+    releaseCandidate,
+    hiddenLoad: { databaseName: "neondb" },
+    blobPublication: {
+      sha256: "6".repeat(64),
+      deliveryOrigin,
+    },
+    manifests,
+  };
+  const publicationReceipt = publicationSummary();
+  const gisPlan = {
+    years: manifests.map((manifest) => ({
+      manifest: { validation: { errors: [`blocked ${manifest.year}`] } },
+    })),
+  };
+  const versions = manifests.map((manifest, index) => {
+    const previousCaveat = gisPlan.years[index].manifest.validation.errors.join(" ");
+    return {
+      id: `00000000-0000-0000-0000-00000000${index + 1}`,
+      year: manifest.year,
+      status: "published",
+      caveat: "Reviewed South Carolina election-specific precinct geometry is publicly authorized under activation "
+        + publicationReceipt.activationId + ".",
+      metadata: {
+        manifestId: manifest.manifestId,
+        publicDeliveryAuthorized: true,
+        releaseCandidate: {
+          sha256: releaseCandidate.sha256,
+          publicDeliveryAuthorized: true,
+        },
+        publicActivation: {
+          activationId: publicationReceipt.activationId,
+          activationCandidateSha256: planSha256,
+          releasePackageSha256: releaseCandidate.sha256,
+          blobPublicationSha256: plan.blobPublication.sha256,
+          deliveryOrigin,
+          authorizationSha256: publicationReceipt.authorizationSha256,
+          rollbackTarget,
+          mode: "publish",
+          year: manifest.year,
+          manifestId: manifest.manifestId,
+          publicManifestSha256: manifest.publicManifestSha256,
+          delivery: manifest.delivery,
+          previousCaveat,
+          changedAtUtc: publicationReceipt.changedAtUtc,
+          revision: publicationReceipt.revision,
+        },
+      },
+    };
+  });
+  const authorization = {
+    activationId: "sc-rollback-camreyn",
+    rollbackId: "sc-rollback-camreyn",
+    publicationActivationId: publicationReceipt.activationId,
+    approvedBy: "Camreyn",
+    applicationRollback: { target: rollbackTarget },
+  };
+  return { plan, publicationReceipt, gisPlan, versions, authorization };
+}
+
+function rollbackClient(fixture) {
+  let revision = 41;
+  let reason = "South Carolina precinct unit geometry publish sc-precinct-public-camreyn";
+  let versionUpdateCount = 0;
+  const unsafe = async (statement, parameters = []) => {
+    const sql = String(statement);
+    if (sql.includes("current_database()")) {
+      return [{ database_name: "neondb", transaction_read_only: "off" }];
+    }
+    if (sql.includes("set_config") || sql.includes("pg_advisory_xact_lock")) {
+      return [];
+    }
+    if (sql.includes("for update") && sql.includes("public_data_revisions")) {
+      return [{ revision }];
+    }
+    if (sql.includes("for update of gv")) return fixture.versions;
+    if (sql.startsWith("update geography_versions")) {
+      const row = fixture.versions.find((item) => item.id === parameters[0]);
+      row.status = parameters[1];
+      row.caveat = parameters[2];
+      row.metadata.publicDeliveryAuthorized = JSON.parse(parameters[3]);
+      row.metadata.releaseCandidate.publicDeliveryAuthorized = JSON.parse(parameters[3]);
+      row.metadata.publicActivation = JSON.parse(parameters[4]);
+      versionUpdateCount += 1;
+      return [{ id: row.id }];
+    }
+    if (sql.startsWith("update reporting_unit_geometry_crosswalks")) {
+      return Array.from({ length: 7_396 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update reporting_units")) {
+      return Array.from({ length: 7_396 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update source_documents")) {
+      return Array.from({ length: 6 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update import_runs")) {
+      return Array.from({ length: 3 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update public_data_revisions")) {
+      revision += 1;
+      reason = parameters[0];
+      return [{ revision }];
+    }
+    if (sql.includes("select e.year,gv.status")) return fixture.versions;
+    if (sql.includes("from reporting_unit_geometry_crosswalks")) {
+      assert.match(sql, /'reviewed_name'/);
+      assert.match(sql, /x\.match_method='exact_official_id'/);
+      assert.match(sql, /x\.geography_feature_id is not null/);
+      assert.doesNotMatch(sql, /x\.geometry_feature_id/);
+      return [{ total: 7_396, exact: 7_396 }];
+    }
+    if (sql.includes("from reporting_units where")) {
+      return [{ total: 7_396, exact: 7_396 }];
+    }
+    if (sql.includes("from source_documents where")) {
+      return [{ total: 6, exact: 6 }];
+    }
+    if (sql.includes("from import_runs where")) {
+      return [{ total: 3, exact: 3 }];
+    }
+    if (sql.includes("from result_rows rr")) return [{ total: 20_403 }];
+    if (sql.includes("from pg_constraint")) return [{ count: 0 }];
+    if (sql.includes("from public_data_revisions")) return [{ revision, reason }];
+    throw new Error("Unexpected South Carolina publication SQL: " + sql);
+  };
+  return { unsafe, get versionUpdateCount() { return versionUpdateCount; } };
+}
+
+test("South Carolina rollback atomically blocks database delivery and preserves publish audit", async () => {
+  const fixture = rollbackTransactionFixture();
+  const client = rollbackClient(fixture);
+  const result = await applySouthCarolinaGeographyPublicationTransaction(client, {
+    mode: "rollback",
+    plan: fixture.plan,
+    planSha256,
+    authorization: fixture.authorization,
+    authorizationSha256: "c".repeat(64),
+    publicationReceipt: fixture.publicationReceipt,
+    changedAtUtc: "2026-08-13T01:30:00.000Z",
+    gisPlan: fixture.gisPlan,
+  });
+  assert.equal(result.result, "ROLLED_BACK");
+  assert.equal(result.publicDeliveryAuthorized, false);
+  assert.equal(client.versionUpdateCount, 3);
+  for (const [index, version] of fixture.versions.entries()) {
+    assert.equal(version.status, "blocked");
+    assert.equal(version.caveat, `blocked ${[2016, 2020, 2024][index]}`);
+    assert.equal(version.metadata.publicDeliveryAuthorized, false);
+    assert.equal(version.metadata.publicActivation.activationId, "sc-precinct-public-camreyn");
+    assert.equal(
+      version.metadata.publicActivation.rollback.rollbackId,
+      "sc-rollback-camreyn",
+    );
+    assert.equal(
+      version.metadata.publicActivation.rollback.publicationReceiptSha256,
+      fixture.publicationReceipt.sha256,
+    );
+  }
+});
+
+test("South Carolina publication atomically records the pinned rollback target", async () => {
+  const fixture = rollbackTransactionFixture();
+  for (const [index, version] of fixture.versions.entries()) {
+    version.status = "blocked";
+    version.caveat = `blocked ${version.year}`;
+    version.metadata = {
+      manifestId: fixture.plan.manifests[index].manifestId,
+      manifestSha256: fixture.plan.manifests[index].blockedManifestSha256,
+      publicDeliveryAuthorized: false,
+      releaseCandidate: {
+        sha256: releaseCandidate.sha256,
+        publicDeliveryAuthorized: false,
+      },
+    };
+  }
+  const authorization = validateSouthCarolinaPublicationAuthorization(publicAuthorization(), {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  const client = rollbackClient(fixture);
+  const result = await applySouthCarolinaGeographyPublicationTransaction(client, {
+    mode: "publish",
+    plan: fixture.plan,
+    planSha256,
+    authorization,
+    authorizationSha256: "b".repeat(64),
+    changedAtUtc: "2026-08-13T01:02:00.000Z",
+    gisPlan: fixture.gisPlan,
+    executionContext: {},
+    validateCurrentDatabase: async () => ({ validated: true }),
+  });
+  assert.equal(result.result, "PUBLISHED");
+  assert.equal(result.publicDeliveryAuthorized, true);
+  assert.equal(client.versionUpdateCount, 3);
+  for (const version of fixture.versions) {
+    assert.equal(version.status, "published");
+    assert.equal(version.metadata.publicDeliveryAuthorized, true);
+    assert.equal(
+      version.metadata.publicActivation.activationId,
+      authorization.activationId,
+    );
+    assert.deepEqual(
+      version.metadata.publicActivation.rollbackTarget,
+      rollbackTarget,
+    );
+    assert.equal(
+      Object.hasOwn(version.metadata.publicActivation, "rollback"),
+      false,
+    );
+  }
+});
+
+test("South Carolina rollback transaction rejects a substituted live rollback target", async () => {
+  const fixture = rollbackTransactionFixture();
+  fixture.authorization.applicationRollback.target = {
+    ...rollbackTarget,
+    deploymentId: "dpl_substituted",
+  };
+  const client = rollbackClient(fixture);
+  await assert.rejects(
+    () => applySouthCarolinaGeographyPublicationTransaction(client, {
+      mode: "rollback",
+      plan: fixture.plan,
+      planSha256,
+      authorization: fixture.authorization,
+      authorizationSha256: "c".repeat(64),
+      publicationReceipt: fixture.publicationReceipt,
+      changedAtUtc: "2026-08-13T01:30:00.000Z",
+      gisPlan: fixture.gisPlan,
+    }),
+    /drifted from the publication receipt/,
+  );
+  assert.equal(client.versionUpdateCount, 0);
+});
+
+test("South Carolina publication runner contains database-first rollback and read-only recovery guards", () => {
+  const source = readFileSync(
+    "scripts/publish-sc-precinct-geography-status.mjs",
+    "utf8",
+  );
+  assert.match(source, /--rollback/);
+  assert.match(source, /--publication-receipt-sha256/);
+  assert.match(
+    source,
+    /I_ACKNOWLEDGE_DATABASE_FIRST_SOUTH_CAROLINA_PRECINCT_PUBLIC_ROLLBACK/,
+  );
+  assert.match(source, /sql\.begin\("read only"/);
+  assert.match(source, /publicationReceiptSha256/);
+  assert.match(source, /transactionBodyCompleted/);
+  assert.match(source, /disposition === "created"/);
+});
+
+test("South Carolina publication receipt recovery requires all three geography versions", () => {
+  const versions = [2016, 2020, 2024].map((year) => ({ year }));
+  assert.equal(assertSouthCarolinaPublicationRecoveryVersionSet(versions), versions);
+  assert.throws(
+    () => assertSouthCarolinaPublicationRecoveryVersionSet(versions.slice(0, 2)),
+    /incomplete version set/,
+  );
+});

--- a/tests/api/sc-precinct-release-candidate.test.mjs
+++ b/tests/api/sc-precinct-release-candidate.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { inspectPrecinctGeometryManifest } from "../../src/lib/precinct-geography.ts";
+import {
+  SOUTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS,
+  SOUTH_CAROLINA_MAX_PARENT_DELIVERY_BYTES,
+} from "../../scripts/lib/sc-precinct-release-candidate.mjs";
+import { buildSouthCarolinaTestReleaseFixture } from "./sc-precinct-release-fixture.mjs";
+
+const { built } = await buildSouthCarolinaTestReleaseFixture();
+
+test("South Carolina release candidate freezes three complete county-scoped deliveries", () => {
+  const document = built.packageDocument;
+  assert.equal(document.id, "sc-precinct-gis-three-election-v1");
+  assert.equal(document.decision, "NO_GO_PRODUCTION");
+  assert.deepEqual(document.totals, {
+    elections: 3,
+    countyParentsPerElection: 46,
+    reportingUnits: 7396,
+    candidateResultRows: 20403,
+    zeroVoteUnits: 2,
+    geometryFeatures: 6805,
+    reviewedRelationships: 7396,
+    deliveryIndexes: 3,
+    parentDeliveryArtifacts: 138,
+  });
+  assert.equal(built.deliveryAssets.length, 141);
+  for (const year of document.years) {
+    assert.equal(year.parentScopedDelivery.parentCount, 46);
+    assert.equal(year.parentScopedDelivery.parentArtifacts.length, 46);
+    assert.equal(year.parentScopedDelivery.coordinatePrecisionDecimals, SOUTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS);
+    assert.ok(year.parentScopedDelivery.largestParentByteCount <= SOUTH_CAROLINA_MAX_PARENT_DELIVERY_BYTES);
+    assert.equal(year.parentScopedDelivery.electionValuesInDelivery, false);
+    assert.equal(year.canonicalManifest.validationStatus, "blocked");
+    assert.equal(year.canonicalManifest.delivery, null);
+  }
+});
+
+test("South Carolina draft manifests are eligible without changing canonical manifests", () => {
+  assert.equal(built.draftManifests.length, 3);
+  for (const draft of built.draftManifests) {
+    const value = JSON.parse(draft.bytes);
+    const inspection = inspectPrecinctGeometryManifest(value);
+    assert.deepEqual(inspection.errors, []);
+    assert.deepEqual(inspection.publicEligibilityReasons, []);
+    assert.equal(value.delivery.format, "parent_scoped_geojson");
+    assert.equal(value.delivery.parentCount, 46);
+    assert.equal(value.geography.level, "precinct");
+    assert.ok([0, 2].includes(value.crosswalk.reviewedNoDataFeatures));
+  }
+});
+
+test("South Carolina delivery preserves reviewed no-data shapes without election values", () => {
+  const parentCollections = built.deliveryAssets
+    .filter((artifact) => artifact.path.includes("/parents/"))
+    .map((artifact) => JSON.parse(artifact.bytes.toString("utf8")));
+  const noDataFeatures = parentCollections.flatMap((collection) =>
+    collection.features.filter((feature) =>
+      feature.properties.relationshipType === "no_data"));
+  assert.equal(noDataFeatures.length, 4);
+  assert.ok(noDataFeatures.every((feature) =>
+    feature.properties.resultUnitCode.startsWith("no-data:")
+    && !Object.keys(feature.properties).some((key) =>
+      /candidate|party|vote/i.test(key))));
+  assert.deepEqual(
+    built.packageDocument.years.map((year) =>
+      year.parentScopedDelivery.colorableResultUnitCount),
+    [2232, 2261, 2308],
+  );
+});

--- a/tests/api/sc-precinct-release-fixture.mjs
+++ b/tests/api/sc-precinct-release-fixture.mjs
@@ -1,0 +1,69 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { buildSouthCarolinaPrecinctGisPlan } from "../../scripts/lib/sc-precinct-gis-plan.mjs";
+import { buildSouthCarolinaPrecinctReleaseCandidate } from "../../scripts/lib/sc-precinct-release-candidate.mjs";
+import { prepareSouthCarolinaPrecinctReleaseCandidate } from "../../scripts/prepare-sc-precinct-release-candidate.mjs";
+
+export const SOUTH_CAROLINA_TEST_VALIDATION_PATH =
+  `.etl/test-artifacts/SC/${process.pid}-sc-precinct-public-local-gis-validation.json`;
+
+async function writeSyntheticValidationReport(
+  root,
+  generatedAtUtc = "2026-08-12T23:58:58.000Z",
+) {
+  const plan = await buildSouthCarolinaPrecinctGisPlan({
+    root,
+    years: [2016, 2020, 2024],
+  });
+  const report = {
+    schemaVersion: 1,
+    generatedAtUtc,
+    productionMutationPerformed: false,
+    publicDeliveryAuthorized: false,
+    validation: {
+      database: {
+        environment: "local",
+        host: "loopback",
+        port: 54329,
+        name: "crm_clone_dev",
+        readOnlySession: true,
+      },
+      invalidConstraints: 0,
+      revision: 1,
+      years: plan.years.map((year) => ({
+        year: year.year,
+        reportingUnits: year.reportingUnits.length,
+        resultRows: year.resultRows.length,
+        sameYearResultRows: year.resultRows.length,
+        totalVotes: year.totals.Total,
+        zeroVoteUnits: year.zeroVoteUnits,
+        geographyVersions: 1,
+        features: year.geometry.features.length,
+        safeBlockedGeographyVersions: 1,
+        reviewedCrosswalks: year.geometry.crosswalks.length,
+        exactFeatures: year.geometry.features.length,
+        exactCrosswalks: year.geometry.crosswalks.length,
+      })),
+    },
+  };
+  const absolute = path.resolve(root, ...SOUTH_CAROLINA_TEST_VALIDATION_PATH.split("/"));
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, JSON.stringify(report, null, 2) + "\n");
+}
+
+export async function buildSouthCarolinaTestReleaseFixture(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  await writeSyntheticValidationReport(root, options.generatedAtUtc);
+  const built = await buildSouthCarolinaPrecinctReleaseCandidate({
+    root,
+    validationReportPath: SOUTH_CAROLINA_TEST_VALIDATION_PATH,
+  });
+  const prepared = options.write
+    ? await prepareSouthCarolinaPrecinctReleaseCandidate({
+      root,
+      validationReportPath: SOUTH_CAROLINA_TEST_VALIDATION_PATH,
+      write: true,
+    })
+    : null;
+  return { built, prepared };
+}


### PR DESCRIPTION
## Summary

Adds the guarded South Carolina precinct GIS release path for the reviewed 2016, 2020, and 2024 presidential elections while keeping 2012 explicitly blocked and absent from public activation.

## What changed

- adds an exact three-election GIS plan and guarded local PostgreSQL setup/validation
- seals county-scoped delivery candidates with 138 GeoJSON parent files and 3 indexes
- adds production read-only preflight, restore-verified backup, hidden load, immutable Blob publication, static activation, atomic publication, rollback, and read-only receipt recovery tooling
- adds South Carolina to the shared fail-closed API publication contract
- permits `reviewed_name` crosswalks only for South Carolina; existing guarded states retain their prior stricter match-method set
- adds a complete operator runbook and implementation ledger entry
- adds focused tests for plan, local DB, candidate, Blob, production evidence, activation, API gates, publication, rollback, and recovery

## Reviewed data scope

- 2016/2020/2024 only
- 7,396 reporting units
- 20,403 official candidate result rows
- 6,805 geometry features
- 7,396 reviewed relationships
- 595 administrative/non-geographic units retained for reconciliation but never mapped
- 4 reviewed no-data shapes retained without inventing votes
- official South Carolina Election Commission exports remain the sole displayed vote authority
- VEST 2016/2020 and NYT 2024 geometry remain explicitly attributed secondary boundary sources

The 2012 package remains blocked due to unresolved election-date boundary provenance, crosswalk, and redistribution conditions.

## Website and API behavior

Local strict-database rehearsal verified:

- blocked SC precinct results return an empty database-backed response
- blocked SC geometry returns 404
- county results remain available
- the new PostgreSQL guarded match-method query executes successfully
- static activation remains database-gated until the atomic publication transaction

The production merge API gate remains the required `Public API integration` check.

## Validation

- `npm.cmd run test:precinct-geometry:sc` — 34/34 passed
- `npm.cmd run typecheck` — passed
- `npm.cmd run build` — passed
- `npm.cmd run test:e2e:api` — 2/2 passed
- `npm.cmd test` — passed; Python ETL 183 passed, 1 expected skip
- `npm.cmd run validate:source-packages` — no failures
- `npm.cmd run validate:maps` — no errors
- `npm.cmd run validate:provenance` — no failures
- Blob, production preflight, backup, and activation dry-run plans — passed
- `git diff --check` — clean

## Safety and remaining work

This PR performs no production database, Blob, Vercel, canonical registry, public eligibility, or Git merge mutation beyond publishing this branch. After merge, the release package must be resealed from the exact clean merged commit before fresh production evidence and cutover work begin.

Final scoped self-review found no release blocker or unrelated file change.