### PR TITLE
Activate guarded South Carolina precinct manifests

### DIFF
--- a/data/precinct-geometry-coverage-inventory-2016.json
+++ b/data/precinct-geometry-coverage-inventory-2016.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-15T04:00:00.000Z",
+  "updatedAt": "2026-08-15T15:16:03.574Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2016-11-08-general",
@@ -39,7 +39,7 @@
       "official_geometry_unavailable": 0,
       "blocked": 1
     },
-    "publicEligibleJurisdictions": 6
+    "publicEligibleJurisdictions": 7
   },
   "states": [
     {
@@ -441,7 +441,7 @@
       "programStatus": "reviewed",
       "wave": 10,
       "disposition": "mapped",
-      "checkedAt": "2026-08-15T04:00:00.000Z",
+      "checkedAt": "2026-08-15T15:16:03.574Z",
       "sourceTiers": [
         "tier_1_official_export_database"
       ],
@@ -471,7 +471,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 2234,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 2551,
@@ -481,10 +481,8 @@
         "nonGeographicResultUnits": 319,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Immutable parent-scoped delivery and the guarded production release have not been completed."
-      ],
-      "nextAction": "Build the guarded local database, immutable county-scoped delivery, and production activation path while preserving all administrative and no-data records.",
+      "blockers": [],
+      "nextAction": "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
       "notes": [
         "The two Laurens 6 source polygons are retained as one reviewed multipart precinct, and 2,232 official geographic rows map one-to-one without vote allocation.",
         "The zero-vote Hall's Store source row has no reviewed geometry and remains an explicit no-geometry reconciliation row.",

--- a/data/precinct-geometry-coverage-inventory-2020.json
+++ b/data/precinct-geometry-coverage-inventory-2020.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-15T04:00:00.000Z",
+  "updatedAt": "2026-08-15T15:16:03.574Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2020-11-03-general",
@@ -39,7 +39,7 @@
       "official_geometry_unavailable": 0,
       "blocked": 1
     },
-    "publicEligibleJurisdictions": 6
+    "publicEligibleJurisdictions": 7
   },
   "states": [
     {
@@ -442,7 +442,7 @@
       "programStatus": "reviewed",
       "wave": 10,
       "disposition": "mapped",
-      "checkedAt": "2026-08-15T04:00:00.000Z",
+      "checkedAt": "2026-08-15T15:16:03.574Z",
       "sourceTiers": [
         "tier_1_official_export_database"
       ],
@@ -472,7 +472,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 2263,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 2399,
@@ -482,10 +482,8 @@
         "nonGeographicResultUnits": 138,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Immutable parent-scoped delivery and the guarded production release have not been completed."
-      ],
-      "nextAction": "Build the guarded local database, immutable county-scoped delivery, and production activation path while preserving all administrative and no-data geometry records.",
+      "blockers": [],
+      "nextAction": "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
       "notes": [
         "All 2,261 geographic official result rows map one-to-one to election-specific VEST geometry attributed to South Carolina RFA.",
         "All displayed values will come only from the official South Carolina Election Commission CSV; VEST vote fields, including allocated provisional/failsafe values, are stripped.",

--- a/data/precinct-geometry-coverage-inventory.json
+++ b/data/precinct-geometry-coverage-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-15T04:00:00.000Z",
+  "updatedAt": "2026-08-15T15:16:03.574Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2024-11-05-general",
@@ -39,7 +39,7 @@
       "official_geometry_unavailable": 0,
       "blocked": 0
     },
-    "publicEligibleJurisdictions": 6
+    "publicEligibleJurisdictions": 7
   },
   "states": [
     {
@@ -446,7 +446,7 @@
       "programStatus": "reviewed",
       "wave": 10,
       "disposition": "mapped",
-      "checkedAt": "2026-08-15T04:00:00.000Z",
+      "checkedAt": "2026-08-15T15:16:03.574Z",
       "sourceTiers": [
         "tier_1_official_export_database"
       ],
@@ -476,7 +476,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 2308,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 2446,
@@ -486,10 +486,8 @@
         "nonGeographicResultUnits": 138,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Immutable parent-scoped delivery and the guarded production release have not been completed."
-      ],
-      "nextAction": "Build the guarded local database, immutable county-scoped delivery, and production activation path while preserving all administrative rows as no-geometry reconciliation records.",
+      "blockers": [],
+      "nextAction": "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
       "notes": [
         "All 2,308 geographic official result rows match exactly one official-boundary feature by county and a unique complete presidential vote signature.",
         "All displayed values will come only from the official South Carolina Election Commission CSV; NYT vote fields are stripped.",

--- a/data/precinct-geometry-manifests.json
+++ b/data/precinct-geometry-manifests.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-14T14:40:03.296Z",
+  "updatedAt": "2026-08-15T15:16:03.574Z",
   "manifests": [
     {
       "schemaVersion": 1,
@@ -2167,6 +2167,333 @@
         "The map is parent-scoped by Alaska House District, not by county or county equivalent. No precinct is centroid-assigned or proportionally allocated to a borough or census area.",
         "Each election retains its own boundary vintage. Precinct IDs and shapes are not assumed comparable across elections; cross-year trend comparison requires a separate reviewed common-geography crosswalk.",
         "The 2024 ENR precinct CSV fully reconciles presidential votes. Its U.S. House rows omit 750 statewide write-in votes, so the House comparison is retained as named-candidate context only and is not represented as a complete contest total."
+      ]
+    },
+    {
+      "schemaVersion": 1,
+      "id": "sc-2016-11-08-reviewed-precinct-geometry-v1",
+      "state": "SC",
+      "election": {
+        "id": "2016-11-08-general",
+        "date": "2016-11-08",
+        "year": 2016,
+        "type": "general",
+        "office": "president"
+      },
+      "geography": {
+        "level": "precinct",
+        "parentLevel": "county",
+        "boundaryVintage": "VEST 2016 election-specific precinct geometry sourced from the South Carolina Revenue and Fiscal Affairs Office, Harvard Dataverse version 78.0",
+        "vintageStatus": "election_date_confirmed",
+        "derivationMethod": "secondary_reconstruction"
+      },
+      "source": {
+        "authority": "South Carolina Election Commission results with VEST election-specific geometry attributed to the South Carolina Revenue and Fiscal Affairs Office",
+        "url": "https://dataverse.harvard.edu/file.xhtml?persistentId=doi:10.7910/DVN/NH5S2I/Y3OFQZ&version=78.0",
+        "retrievedAt": "2026-08-15T04:00:00.000Z",
+        "artifact": "data/precinct-geometry/SC/2016-11-08-general/source-evidence.json",
+        "sha256": "8f844e28c9d10d07947de95e81bdfc78303be843289612ff4b24f9e5b55ba6cf",
+        "byteCount": 6566,
+        "format": "precinct-source-evidence+json",
+        "licenseOrTerms": "VEST geometry is Creative Commons Attribution 4.0 under the retained Harvard Dataverse version-78 terms; official South Carolina result values remain the sole displayed vote source."
+      },
+      "normalization": {
+        "script": "scripts/build-sc-reviewed-precincts.mjs",
+        "sourceCrs": "source-defined and normalized by shpjs",
+        "servedCrs": "EPSG:4326",
+        "artifact": "data/precinct-geometry/SC/2016-11-08-general/normalized/sc-2016-reviewed-precinct-geometry.geojson.gz",
+        "sha256": "60273bd2195a2daf7fcdacf8aec00c101dfe21bfd593db44ceb074da49a3ef16",
+        "byteCount": 15662362,
+        "featureCount": 2234,
+        "sourceFeatureIdFields": [
+          "CRM_FEATURE_ID"
+        ],
+        "parentIdFields": [
+          "CRM_PARENT_GEOID"
+        ]
+      },
+      "crosswalk": {
+        "status": "reviewed",
+        "resultSourceId": "sc-election-commission-2016-president-5292",
+        "artifact": "data/precinct-geometry/SC/2016-11-08-general/crosswalk/sc-2016-result-to-geometry-review.json",
+        "sha256": "0aa2858f5d5d075c7392df120d537ad1c634f06c03201c4eaa7b030ba129077c",
+        "byteCount": 1748197,
+        "resultUnits": 2551,
+        "colorableResultUnits": 2232,
+        "matchedResultUnits": 2232,
+        "unmatchedResultUnits": 0,
+        "nonGeographicResultUnits": 319,
+        "sourceAliasResultUnits": 0,
+        "relationships": {
+          "oneToOne": 2232,
+          "oneToMany": 0,
+          "manyToOne": 0,
+          "unmatched": 0,
+          "nonGeographic": 319,
+          "sourceAlias": 0,
+          "pendingReview": 0
+        },
+        "reviewedRelationshipRecords": 2551,
+        "reviewedNoDataFeatures": 2,
+        "methods": [
+          "reviewed_name"
+        ]
+      },
+      "validation": {
+        "status": "reviewed",
+        "geometryValid": true,
+        "rowLevelRenderingSafe": true,
+        "parentTotalsReconciled": true,
+        "resultTotalsReconciled": true,
+        "errors": [],
+        "warnings": [
+          "318 plus one zero-vote no-geometry official no-geometry result units remain reconciliation-only and are never allocated to polygons.",
+          "Every displayed candidate value, when authorized, comes only from the retained South Carolina Election Commission CSV.",
+          "VEST vote fields include allocated countywide categories and are deliberately removed before normalized geometry is written.",
+          "2 reviewed geometry features have no official geographic result row and are retained as explicit no-data shapes.",
+          "All 2232 displayable precinct relationships are reviewed one-to-one across all 46 South Carolina counties.",
+          "All 319 administrative reporting units remain explicitly non-geographic and are never assigned to a polygon.",
+          "The 0 zero-presidential-vote precincts remain geographic reporting units.",
+          "All 2 reviewed no-data polygons remain visible without an invented result row.",
+          "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged."
+        ]
+      },
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/sc/2016-11-08/precinct/sc-2016-11-08-reviewed-precinct-geometry-v1-aa46d43be1ff/index.json",
+        "sha256": "aa46d43be1ffe7e2fa897ab7cc5f6d1d071cbc2127da365c7ae569df01ac5782",
+        "byteCount": 9671,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 46,
+        "featureCount": 2234
+      },
+      "caveats": [
+        "No result value from VEST, NYT, Census, or any geometry source is used as a displayed election result.",
+        "318 plus one zero-vote no-geometry official no-geometry result units remain reconciliation-only and are never allocated to polygons.",
+        "Every displayed candidate value, when authorized, comes only from the retained South Carolina Election Commission CSV.",
+        "VEST vote fields include allocated countywide categories and are deliberately removed before normalized geometry is written.",
+        "2 reviewed geometry features have no official geographic result row and are retained as explicit no-data shapes.",
+        "Immutable parent-scoped delivery and the guarded production release have not been completed."
+      ]
+    },
+    {
+      "schemaVersion": 1,
+      "id": "sc-2020-11-03-reviewed-precinct-geometry-v1",
+      "state": "SC",
+      "election": {
+        "id": "2020-11-03-general",
+        "date": "2020-11-03",
+        "year": 2020,
+        "type": "general",
+        "office": "president"
+      },
+      "geography": {
+        "level": "precinct",
+        "parentLevel": "county",
+        "boundaryVintage": "VEST 2020 election-specific precinct geometry sourced from the South Carolina Revenue and Fiscal Affairs Office, Harvard Dataverse version 27.0",
+        "vintageStatus": "election_date_confirmed",
+        "derivationMethod": "secondary_reconstruction"
+      },
+      "source": {
+        "authority": "South Carolina Election Commission results with VEST election-specific geometry attributed to the South Carolina Revenue and Fiscal Affairs Office",
+        "url": "https://dataverse.harvard.edu/file.xhtml?fileId=4789402&version=27.0",
+        "retrievedAt": "2026-08-15T04:00:00.000Z",
+        "artifact": "data/precinct-geometry/SC/2020-11-03-general/source-evidence.json",
+        "sha256": "39f3e5c4b3fc83e407f757eb82a30660f47b71c0b6e255a071bf65e91e3975ca",
+        "byteCount": 6467,
+        "format": "precinct-source-evidence+json",
+        "licenseOrTerms": "VEST geometry is Creative Commons Attribution 4.0 under the retained Harvard Dataverse version-27 terms; official South Carolina result values remain the sole displayed vote source."
+      },
+      "normalization": {
+        "script": "scripts/build-sc-reviewed-precincts.mjs",
+        "sourceCrs": "source-defined and normalized by shpjs",
+        "servedCrs": "EPSG:4326",
+        "artifact": "data/precinct-geometry/SC/2020-11-03-general/normalized/sc-2020-reviewed-precinct-geometry.geojson.gz",
+        "sha256": "ca92095373de44ce3e7e422dc05d7e98281b4046617978f63b8375cf5e0428fc",
+        "byteCount": 17757242,
+        "featureCount": 2263,
+        "sourceFeatureIdFields": [
+          "CRM_FEATURE_ID"
+        ],
+        "parentIdFields": [
+          "CRM_PARENT_GEOID"
+        ]
+      },
+      "crosswalk": {
+        "status": "reviewed",
+        "resultSourceId": "sc-election-commission-2020-president-1974",
+        "artifact": "data/precinct-geometry/SC/2020-11-03-general/crosswalk/sc-2020-result-to-geometry-review.json",
+        "sha256": "45d65a05edfbf612a96efe275721fdf539285d4444ac7a66fdcb3d53c4ee2ca1",
+        "byteCount": 1641445,
+        "resultUnits": 2399,
+        "colorableResultUnits": 2261,
+        "matchedResultUnits": 2261,
+        "unmatchedResultUnits": 0,
+        "nonGeographicResultUnits": 138,
+        "sourceAliasResultUnits": 0,
+        "relationships": {
+          "oneToOne": 2261,
+          "oneToMany": 0,
+          "manyToOne": 0,
+          "unmatched": 0,
+          "nonGeographic": 138,
+          "sourceAlias": 0,
+          "pendingReview": 0
+        },
+        "reviewedRelationshipRecords": 2399,
+        "reviewedNoDataFeatures": 2,
+        "methods": [
+          "reviewed_name"
+        ]
+      },
+      "validation": {
+        "status": "reviewed",
+        "geometryValid": true,
+        "rowLevelRenderingSafe": true,
+        "parentTotalsReconciled": true,
+        "resultTotalsReconciled": true,
+        "errors": [],
+        "warnings": [
+          "138 official no-geometry result units remain reconciliation-only and are never allocated to polygons.",
+          "Every displayed candidate value, when authorized, comes only from the retained South Carolina Election Commission CSV.",
+          "VEST vote fields include allocated countywide categories and are deliberately removed before normalized geometry is written.",
+          "2 reviewed geometry features have no official geographic result row and are retained as explicit no-data shapes.",
+          "All 2261 displayable precinct relationships are reviewed one-to-one across all 46 South Carolina counties.",
+          "All 138 administrative reporting units remain explicitly non-geographic and are never assigned to a polygon.",
+          "The 2 zero-presidential-vote precincts remain geographic reporting units.",
+          "All 2 reviewed no-data polygons remain visible without an invented result row.",
+          "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged."
+        ]
+      },
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/sc/2020-11-03/precinct/sc-2020-11-03-reviewed-precinct-geometry-v1-e905a5f8d473/index.json",
+        "sha256": "e905a5f8d473d0381608c3d1ab4cbd0d43accd048d2134c8d414853ea981245e",
+        "byteCount": 9643,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 46,
+        "featureCount": 2263
+      },
+      "caveats": [
+        "No result value from VEST, NYT, Census, or any geometry source is used as a displayed election result.",
+        "138 official no-geometry result units remain reconciliation-only and are never allocated to polygons.",
+        "Every displayed candidate value, when authorized, comes only from the retained South Carolina Election Commission CSV.",
+        "VEST vote fields include allocated countywide categories and are deliberately removed before normalized geometry is written.",
+        "2 reviewed geometry features have no official geographic result row and are retained as explicit no-data shapes.",
+        "Immutable parent-scoped delivery and the guarded production release have not been completed."
+      ]
+    },
+    {
+      "schemaVersion": 1,
+      "id": "sc-2024-11-05-reviewed-precinct-geometry-v1",
+      "state": "SC",
+      "election": {
+        "id": "2024-11-05-general",
+        "date": "2024-11-05",
+        "year": 2024,
+        "type": "general",
+        "office": "president"
+      },
+      "geography": {
+        "level": "precinct",
+        "parentLevel": "county",
+        "boundaryVintage": "NYT 2024 election-specific South Carolina precinct package with every retained feature marked official_boundary=true",
+        "vintageStatus": "election_date_confirmed",
+        "derivationMethod": "secondary_reconstruction"
+      },
+      "source": {
+        "authority": "South Carolina Election Commission results with attributed New York Times election-specific official-boundary geometry",
+        "url": "https://int.nyt.com/newsgraphics/elections/map-data/2024/national/SC-precincts-with-results.geojson.gz",
+        "retrievedAt": "2026-08-15T04:00:00.000Z",
+        "artifact": "data/precinct-geometry/SC/2024-11-05-general/source-evidence.json",
+        "sha256": "93fb1d14e42f31f0c8ee1980e19d2a93fbf52a73e6b5a039d0cda6235008e1ee",
+        "byteCount": 7222,
+        "format": "precinct-source-evidence+json",
+        "licenseOrTerms": "NYT geometry is retained under the NYT Content API Use and Data Agreement non-commercial attribution terms; official South Carolina result values remain the sole displayed vote source."
+      },
+      "normalization": {
+        "script": "scripts/build-sc-reviewed-precincts.mjs",
+        "sourceCrs": "EPSG:4326 GeoJSON",
+        "servedCrs": "EPSG:4326",
+        "artifact": "data/precinct-geometry/SC/2024-11-05-general/normalized/sc-2024-reviewed-precinct-geometry.geojson.gz",
+        "sha256": "cbdb84a53dbdb1fa55d0a492785c08b6ed7b23ec0f6fba8a597d33cabfbcbe94",
+        "byteCount": 35604614,
+        "featureCount": 2308,
+        "sourceFeatureIdFields": [
+          "CRM_FEATURE_ID"
+        ],
+        "parentIdFields": [
+          "CRM_PARENT_GEOID"
+        ]
+      },
+      "crosswalk": {
+        "status": "reviewed",
+        "resultSourceId": "sc-election-commission-2024-president-7131",
+        "artifact": "data/precinct-geometry/SC/2024-11-05-general/crosswalk/sc-2024-result-to-geometry-review.json",
+        "sha256": "beda18befc6ddec9a1cc741910bfdd7364519634ba7126f5a47c153fd5dc8cbd",
+        "byteCount": 1778403,
+        "resultUnits": 2446,
+        "colorableResultUnits": 2308,
+        "matchedResultUnits": 2308,
+        "unmatchedResultUnits": 0,
+        "nonGeographicResultUnits": 138,
+        "sourceAliasResultUnits": 0,
+        "relationships": {
+          "oneToOne": 2308,
+          "oneToMany": 0,
+          "manyToOne": 0,
+          "unmatched": 0,
+          "nonGeographic": 138,
+          "sourceAlias": 0,
+          "pendingReview": 0
+        },
+        "reviewedRelationshipRecords": 2446,
+        "reviewedNoDataFeatures": 0,
+        "methods": [
+          "reviewed_name"
+        ]
+      },
+      "validation": {
+        "status": "reviewed",
+        "geometryValid": true,
+        "rowLevelRenderingSafe": true,
+        "parentTotalsReconciled": true,
+        "resultTotalsReconciled": true,
+        "errors": [],
+        "warnings": [
+          "138 official no-geometry result units remain reconciliation-only and are never allocated to polygons.",
+          "Every displayed candidate value, when authorized, comes only from the retained South Carolina Election Commission CSV.",
+          "The 2,308 geographic rows reconcile exactly by county and unique complete presidential vote signature; the 6,263 administrative votes remain outside geometry.",
+          "NYT non-commercial attribution terms must accompany any eventual delivery.",
+          "All 2308 displayable precinct relationships are reviewed one-to-one across all 46 South Carolina counties.",
+          "All 138 administrative reporting units remain explicitly non-geographic and are never assigned to a polygon.",
+          "The 0 zero-presidential-vote precincts remain geographic reporting units.",
+          "All 0 reviewed no-data polygons remain visible without an invented result row.",
+          "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged."
+        ]
+      },
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/sc/2024-11-05/precinct/sc-2024-11-05-reviewed-precinct-geometry-v1-cbefb0dfab41/index.json",
+        "sha256": "cbefb0dfab418e1552367fd5e9b6cfcd84726beb363e5e5644b450c0418d0c08",
+        "byteCount": 9629,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 46,
+        "featureCount": 2308
+      },
+      "caveats": [
+        "No result value from VEST, NYT, Census, or any geometry source is used as a displayed election result.",
+        "138 official no-geometry result units remain reconciliation-only and are never allocated to polygons.",
+        "Every displayed candidate value, when authorized, comes only from the retained South Carolina Election Commission CSV.",
+        "The 2,308 geographic rows reconcile exactly by county and unique complete presidential vote signature; the 6,263 administrative votes remain outside geometry.",
+        "NYT non-commercial attribution terms must accompany any eventual delivery.",
+        "Immutable parent-scoped delivery and the guarded production release have not been completed."
       ]
     }
   ]

--- a/tests/api/sc-precinct-geometry.test.mjs
+++ b/tests/api/sc-precinct-geometry.test.mjs
@@ -205,7 +205,18 @@ test("South Carolina four-year precinct packages replay byte-identically", { tim
 
 test("South Carolina packages preserve official totals and fail closed where review is incomplete", () => {
   const registry = JSON.parse(readFileSync("data/precinct-geometry-manifests.json", "utf8"));
-  assert.equal(registry.manifests.some((manifest) => manifest.state === "SC"), false);
+  const southCarolinaManifests = registry.manifests
+    .filter((manifest) => manifest.state === "SC")
+    .sort((left, right) => left.election.year - right.election.year);
+  assert.deepEqual(
+    southCarolinaManifests.map((manifest) => manifest.election.year),
+    [2016, 2020, 2024],
+  );
+  for (const manifest of southCarolinaManifests) {
+    assert.equal(manifest.validation.status, "reviewed");
+    assert.equal(manifest.validation.rowLevelRenderingSafe, true);
+    assert.equal(manifest.delivery?.format, "parent_scoped_geojson");
+  }
   const inventoryPaths = new Map([
     [2012, "data/precinct-geometry-coverage-inventory-2012.json"],
     [2016, "data/precinct-geometry-coverage-inventory-2016.json"],
@@ -277,7 +288,7 @@ test("South Carolina packages preserve official totals and fail closed where rev
     assert.ok(inventoryRow);
     assert.deepEqual(inventoryRow.geometry.manifestIds, [spec.manifestId]);
     assert.equal(inventoryRow.geometry.featureCount, spec.features);
-    assert.equal(inventoryRow.geometry.publicEligibleManifestCount, 0);
+    assert.equal(inventoryRow.geometry.publicEligibleManifestCount, spec.reviewed ? 1 : 0);
     assert.equal(inventoryRow.crosswalk.resultUnits, spec.sourceUnits);
     assert.equal(inventoryRow.crosswalk.matchedResultUnits, spec.mapped);
     assert.equal(inventoryRow.disposition, spec.reviewed ? "mapped" : "blocked");


### PR DESCRIPTION
## Scope

Activates the reviewed South Carolina precinct manifests for the 2016, 2020, and 2024 general elections. The 2012 candidate remains blocked and is not added to the canonical registry.

## What changed

- Adds the three reviewed, parent-scoped South Carolina delivery manifests to the canonical registry.
- Updates the 2016, 2020, and 2024 coverage inventories to report one public-eligible South Carolina manifest each.
- Updates the South Carolina regression test to require exactly those three eligible years while preserving the 2012 fail-closed expectation.
- Changes no application code, database rows, or production publication status.

The immutable Blob publication completed separately with 141 hash-verified objects (138 county assets and three indexes). The production database hidden load is committed but remains blocked and public-delivery authorization remains false, so merging this PR alone cannot expose South Carolina results or geometry.

## Sources and caveats

- Displayed vote values remain solely from official South Carolina Election Commission exports.
- 2016 and 2020 boundaries use attributed, version-pinned VEST geometry sourced from South Carolina RFA.
- 2024 boundaries use the attributed NYT official-boundary package under its retained non-commercial terms.
- Non-geographic administrative rows are retained for reconciliation and are never allocated to polygons.
- Election-specific shapes are not treated as directly comparable across years.
- 2012 remains unavailable pending its unresolved boundary/result review.

## Validation

- `npm.cmd run test:precinct-geometry:sc` — 35/35 passed
- `npm.cmd run typecheck` — passed
- `npm.cmd run build` — passed
- `npm.cmd run test:e2e:api` — 2/2 passed
- All four generated activation outputs byte-match the sealed activation candidate.
- Preview `CRM_PRECINCT_GEOGRAPHY_ORIGIN` already matches the exact credential-free Blob receipt origin.

## Website/API display path

After this activation tree is deployed, the database gate must still return empty South Carolina precinct results and 404 for geometry until the separately authorized atomic publication transaction runs. Post-cutover verification will exercise `/api/results`, `/api/geography-manifests`, `/api/precinct-geography`, and the county detail map for all three years.

## Review result

The deterministic activation writer, full South Carolina replay suite, production build, and public API integration gate are clean. Final public database activation is intentionally deferred until this exact tree is deployed and verified fail-closed.