### PR TITLE
Fix Wisconsin publication zero-vote total

### DIFF
--- a/scripts/lib/wi-local-publication.mjs
+++ b/scripts/lib/wi-local-publication.mjs
@@ -20,15 +20,16 @@ export const WISCONSIN_PUBLIC_ROLLBACK_SCOPES = Object.freeze([
   "increment_public_data_revision",
 ]);
 
-const EXPECTED_TOTALS = Object.freeze({
+export const WISCONSIN_PUBLICATION_EXPECTED_TOTALS = Object.freeze({
   reportingUnits: 10_937,
   candidateResultRows: 32_475,
   geometryFeatures: 10_856,
   reviewedRelationships: 10_937,
-  zeroVoteUnits: 0,
+  zeroVoteUnits: 316,
   sourceDocuments: 6,
   importRuns: 3,
 });
+const EXPECTED_TOTALS = WISCONSIN_PUBLICATION_EXPECTED_TOTALS;
 
 export function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");

--- a/tests/api/wi-local-publication.test.mjs
+++ b/tests/api/wi-local-publication.test.mjs
@@ -10,6 +10,7 @@ import path from "node:path";
 import test from "node:test";
 import {
   WISCONSIN_PUBLICATION_SCOPES,
+  WISCONSIN_PUBLICATION_EXPECTED_TOTALS,
   WISCONSIN_PUBLIC_ROLLBACK_SCOPES,
   buildWisconsinPublicRollbackAuthorizationTemplate,
   buildWisconsinPublicationAuthorizationTemplate,
@@ -19,6 +20,7 @@ import {
   validateWisconsinPublicRollbackAuthorization,
   validateWisconsinPublicationAuthorization,
 } from "../../scripts/lib/wi-local-publication.mjs";
+import { WISCONSIN_LOCAL_GIS_YEAR_SPECS } from "../../scripts/lib/wi-local-gis-plan.mjs";
 import {
   applyWisconsinGeographyPublicationTransaction,
   inspectWisconsinPublicationReceipt,
@@ -92,6 +94,18 @@ const authorizationPlan = {
   },
   staticRegistry: { sha256: "7".repeat(64) },
 };
+
+test("Wisconsin publication totals retain every reviewed zero-vote unit", () => {
+  const reviewedZeroVoteUnits = WISCONSIN_LOCAL_GIS_YEAR_SPECS.reduce(
+    (sum, year) => sum + year.expectedZeroVoteGeographicUnits,
+    0,
+  );
+  assert.equal(reviewedZeroVoteUnits, 316);
+  assert.equal(
+    WISCONSIN_PUBLICATION_EXPECTED_TOTALS.zeroVoteUnits,
+    reviewedZeroVoteUnits,
+  );
+});
 
 function publicAuthorization() {
   const value = buildWisconsinPublicationAuthorizationTemplate(


### PR DESCRIPTION
## What changed

- Corrects the Wisconsin public-cutover guard from zero to the sealed total of 316 reviewed zero-vote geographic reporting units.
- Exports the expected publication totals and adds a regression that derives the value from the three reviewed Wisconsin year specifications.

## Root cause

The merged publication runner correctly failed closed because its duplicated expected-total constant said `zeroVoteUnits: 0`. The sealed release package and committed hidden-load receipt both contain 316: 126 in 2016, 190 in 2020, and zero in 2024. No votes, boundaries, crosswalks, manifests, or production rows are changed by this PR.

## Production state

Wisconsin remains blocked in the production database. The static manifests are deployed and the 219 immutable delivery assets are present, but results and geometry still return closed-gate responses. After this guard correction is merged, the already-sealed publication plan can be used for the separate atomic database cutover.

## Validation

- Real hash-pinned publication plan generation — passed (`442909edafcf…`)
- `npm.cmd run test:local-gis:wi` — 37/37 passed
- `node --experimental-strip-types --test tests/api/wi-local-publication.test.mjs` — 10/10 passed
- `npm.cmd run typecheck` — passed
- `git diff --check` — passed