### PR TITLE
Add guarded North Carolina local geography release

### DIFF
--- a/docs/developer/nc-local-geography-gis-runbook.md
+++ b/docs/developer/nc-local-geography-gis-runbook.md
@@ -1,0 +1,280 @@
+# North Carolina election-specific local geography release runbook
+
+## Scope and terminology
+
+This release contains three independently reviewed presidential-election
+layers. The 2012 layer is an official voting-district (`vtd`) result universe;
+the 2016 and 2020 layers are `precinct` result universes. The application,
+database, manifests, delivery files, API requests, and labels must preserve
+those exact grains. North Carolina 2012 must never be silently relabeled as a
+precinct layer.
+
+Each election keeps its own boundary vintage. These maps accurately display
+the reviewed units for that election, but do not claim that same-named units
+are unchanged or directly comparable across redistricting cycles. A separate,
+reviewed common-geography crosswalk is required for apples-to-apples trend
+analysis.
+
+The package enforces four rules:
+
+1. Every displayed vote comes from the retained official North Carolina State
+   Board of Elections (NCSBE) presidential result artifact.
+2. No result is divided, proportionally allocated, or copied to more than one
+   polygon.
+3. Geometry artifacts contain no candidate names, parties, or vote values.
+4. Administrative or otherwise non-geographic result units stay in the
+   database for reconciliation and never receive an invented polygon.
+
+## Reviewed release universe
+
+| Year | Grain | Official result units | Geographic units/features | Non-geographic units | Candidate rows | Mapped presidential votes | Official presidential votes | Status |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 2012 | `vtd` | 3,011 | 2,692 | 319 | 8,076 | 4,492,613 | 4,505,372 | Reviewed; guarded release candidate |
+| 2016 | `precinct` | 3,209 | 2,704 | 505 | 8,112 | 3,177,511 | 4,741,564 | Reviewed; guarded release candidate |
+| 2020 | `precinct` | 3,065 | 2,662 | 403 | 7,986 | 3,201,711 | 5,524,802 | Reviewed; guarded release candidate |
+| 2024 | `precinct` | 2,908 result units | 2,659 candidate features | 250 | Not in release | Not in release | Not in release | Blocked and excluded |
+
+The three-election release contains 9,285 reporting units, 24,174 candidate
+result rows, 8,058 polygons, and 9,285 reviewed relationship records. Exactly
+8,058 relationships link one geographic result unit to one polygon; the other
+1,227 retain official result units as explicitly non-geographic. The candidate
+contains no zero-vote units and no unjoined delivery features.
+
+The delivery package contains 300 county-scoped GeoJSON objects (100 per
+election) and three year indexes, for 303 immutable objects. Geometry delivery
+contains identifiers and review metadata only, never election values.
+
+## Source and interpretation notes
+
+- NCSBE is the sole vote authority for all three released years.
+- The 2012 result artifact is official NCSBE VTD analysis data. NCSBE documents
+  residence-based reassignment of accepted absentee and provisional ballots
+  and statutory statistical noise, so it is not described as the certified
+  canvass presentation. MGGG/North Carolina General Assembly geometry is
+  retained with its ODbL/DBCL terms; its election fields are stripped.
+- The 2016 layer uses the final retained official NCSBE boundary snapshot before
+  November 8, 2016. Its 505 result-only units remain non-geographic.
+- The 2020 layer uses the official October 18 snapshot, one reviewed multipart
+  dissolve, and four restored units from the official August 27, 2019 snapshot.
+  Older units are clipped to county coverage and subtracted from containing
+  current features before insertion. All 403 official `Real Precinct=N` units
+  remain non-geographic. No third-party allocated result is used.
+- The 2024 crosswalk is retained as a candidate, but three restored 2019
+  polygons lack public evidence that they were applicable on November 5, 2024.
+  The release plan, database load, delivery, static activation, and publication
+  tooling therefore reject 2024.
+
+Every retained input and derived artifact records its authority, URL, local
+path, SHA-256, byte count, election year, reporting grain, and caveats in the
+per-election source evidence.
+
+## Deterministic source-package replay
+
+From a clean checkout, run:
+
+```powershell
+npm.cmd run precinct-gis:collect:nc
+npm.cmd run test:precinct-geometry:nc
+```
+
+The suite replays the source builder in an isolated root and must reproduce the
+normalized geometry, official result package, relationship records, report,
+manifest, and source-evidence bytes. It also covers the guarded local database,
+candidate, production evidence, Blob plan, static activation, API gate,
+publication, rollback, and recovery contracts.
+
+## Guarded local rehearsal and candidate sealing
+
+Use only the fixed loopback Docker clone:
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='local'
+$env:CRM_DATABASE_STRICT='true'
+$env:CRM_DATABASE_LOCAL_WRITES='true'
+$env:DATABASE_URL='postgresql://crm_clone_admin:crm_clone_local_only@127.0.0.1:54329/crm_clone_dev'
+
+npm.cmd run precinct-gis:plan:nc
+npm.cmd run precinct-gis:setup:nc:local
+npm.cmd run precinct-gis:validate:nc:local
+
+Remove-Item Env:CRM_DATABASE_ENVIRONMENT,Env:CRM_DATABASE_STRICT,Env:CRM_DATABASE_LOCAL_WRITES,Env:DATABASE_URL
+
+npm.cmd run precinct-gis:release-candidate:nc
+npm.cmd run precinct-gis:release-candidate:nc:write
+```
+
+The validation report is `.etl/local-db/nc-local-gis-validation.json`. It must
+show zero invalid constraints, three blocked geography versions, the exact
+counts above, `publicDeliveryAuthorized: false`, and no 2024 release row.
+Record the content-addressed candidate path and SHA-256 as `$PKG` and
+`$PKG_SHA`. Candidate generation changes no production database, Blob object,
+canonical manifest, deployment, or public eligibility state.
+
+## Production evidence and hidden load
+
+Use a clean checkout of the exact reviewed commit. Supply exactly one explicit
+unpooled URL through `POSTGRES_URL_NON_POOLING` or
+`POSTGRES_DATABASE_URL_UNPOOLED`; these tools deliberately do not load
+`.env.local`.
+
+Run the read-only preflight before the full backup:
+
+```powershell
+npm.cmd run precinct-gis:production-preflight:nc -- --package=$PKG
+
+$env:CRM_DATABASE_ENVIRONMENT='production-read-only'
+$env:CRM_NC_LOCAL_GEOGRAPHY_PRODUCTION_PREFLIGHT_ACK=$PKG_SHA
+$env:POSTGRES_URL_NON_POOLING='<explicit unpooled production URL>'
+npm.cmd run precinct-gis:production-preflight:nc -- --package=$PKG --connect-read-only
+```
+
+Retain the preflight path, SHA-256, database identity, public revision, and
+64-hex endpoint fingerprint. The initial-load path rejects preexisting rows for
+the three-election North Carolina release.
+
+Create and restore-verify the complete public-schema backup strictly after the
+preflight:
+
+```powershell
+npm.cmd run precinct-gis:production-backup:nc -- -ReleasePackagePath $PKG -ReleasePackageSha256 $PKG_SHA
+
+$env:CRM_NC_LOCAL_GEOGRAPHY_BACKUP_ACK='CREATE_FULL_PUBLIC_SCHEMA_ROLLBACK_BACKUP'
+$env:CRM_NC_LOCAL_GEOGRAPHY_BACKUP_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_NC_LOCAL_GEOGRAPHY_BACKUP_ENDPOINT_FINGERPRINT='<preflight endpoint fingerprint>'
+npm.cmd run precinct-gis:production-backup:nc -- -ReleasePackagePath $PKG -ReleasePackageSha256 $PKG_SHA -Execute
+```
+
+The backup must prove an exact PostgreSQL 17 restore, identical table and row
+sets, read-only default, and zero invalid constraints. Preflight and backup
+evidence must both still be within four hours when the hidden transaction
+begins.
+
+Generate an immutable `NO_GO_PRODUCTION` authorization template:
+
+```powershell
+npm.cmd run precinct-gis:production-release:nc -- --package=$PKG --package-sha256=$PKG_SHA --preflight-sha256=$PREFLIGHT_SHA --backup-manifest-sha256=$BACKUP_SHA --write-authorization-template
+```
+
+A completed `GO_PRODUCTION` record pins the evidence and retains exactly these
+scopes:
+
+- `apply_migration_0009`
+- `load_nc_local_results_and_geometry_hidden`
+- `increment_public_data_revision`
+
+Record the authorization path and SHA-256 as `$AUTH` and `$AUTH_SHA`, then run
+the coupled migration and hidden load:
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production'
+$env:CRM_NC_LOCAL_GEOGRAPHY_PRODUCTION_WRITES=$PKG_SHA
+$env:CRM_NC_LOCAL_GEOGRAPHY_PRODUCTION_AUTHORIZATION_ID='<authorization ID>'
+$env:CRM_NC_LOCAL_GEOGRAPHY_PRODUCTION_AUTHORIZATION_SHA256=$AUTH_SHA
+
+npm.cmd run precinct-gis:production-release:nc -- --package=$PKG --package-sha256=$PKG_SHA --preflight=$PREFLIGHT --preflight-sha256=$PREFLIGHT_SHA --backup-manifest=$BACKUP_MANIFEST --backup-manifest-sha256=$BACKUP_SHA --authorization=$AUTH --authorization-sha256=$AUTH_SHA --apply
+```
+
+One transaction applies migration 0009 if necessary, loads and validates all
+three elections, stores the exact audit evidence, and increments the public
+revision. Every geography version and result unit remains blocked with
+`publicDeliveryAuthorized=false`. Preserve the immutable
+`COMMITTED_HIDDEN_NOT_PUBLIC` receipt. If commit acknowledgement or receipt
+writing is ambiguous, preserve the `.pending` marker and use the command's
+hash-authorized `--recover-receipt` mode under
+`CRM_DATABASE_ENVIRONMENT=production-read-only`; never rerun the write.
+
+## Immutable Blob delivery
+
+Plan first, then separately authorize exactly 303 content-addressed objects:
+
+```powershell
+npm.cmd run precinct-gis:delivery-publish:nc -- --package=$PKG --package-sha256=$PKG_SHA
+
+$env:CRM_NC_LOCAL_GEOGRAPHY_PUBLIC_FILE_WRITES='I_ACKNOWLEDGE_PUBLIC_IMMUTABLE_GEOMETRY_UPLOAD'
+$env:CRM_NC_LOCAL_GEOGRAPHY_PUBLIC_FILE_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_NC_LOCAL_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID='<owner authorization ID>'
+npm.cmd run precinct-gis:delivery-publish:nc -- --package=$PKG --package-sha256=$PKG_SHA --write
+```
+
+The publisher writes all 300 county objects before the three indexes, refuses
+overwrites and random suffixes, downloads every public object again, and
+verifies its hash. Preserve the Blob evidence path, SHA-256, and single
+credential-free HTTPS `deliveryOrigin`.
+
+## Static activation, deployment, and public cutover
+
+Static activation is a separate reviewed Git change:
+
+```powershell
+npm.cmd run precinct-gis:public-activation:nc -- --package=$PKG --package-sha256=$PKG_SHA
+npm.cmd run precinct-gis:public-activation:nc -- --package=$PKG --package-sha256=$PKG_SHA --write
+```
+
+The writer changes exactly four tracked files: the canonical manifest registry
+plus the 2012, 2016, and 2020 coverage inventories. It never adds 2024. Do not
+merge this activation until the hidden load, immutable Blob publication,
+delivery origin, and deployment sequence are ready.
+
+1. Record the currently promoted, gate-capable rollback deployment and verify
+   both North Carolina APIs are closed while the database is blocked.
+2. Configure the exact Blob origin for Preview; deploy the activation tree to a
+   protected Preview and verify its commit, tree, and closed gates.
+3. Configure the same origin for Production; merge the exact activation tree to
+   `main`, await READY/PROMOTED, and again verify both gates are closed.
+4. Build the publication plan and immutable `NO_GO_PUBLIC` template:
+
+```powershell
+npm.cmd run precinct-gis:publication-status:nc -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_RECEIPT --blob-evidence-sha256=$BLOB_SHA --write-plan
+
+npm.cmd run precinct-gis:publication-status:nc -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_RECEIPT --blob-evidence-sha256=$BLOB_SHA --write-authorization-template
+```
+
+The completed `GO_PUBLIC` record pins the exact activation deployment and tree,
+both closed-gate observations, Blob origin, static outputs, and rollback target.
+Run the final database transaction only with all exact acknowledgements:
+
+```powershell
+$env:CRM_DATABASE_ENVIRONMENT='production'
+$env:CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_WRITES='I_ACKNOWLEDGE_ATOMIC_NORTH_CAROLINA_LOCAL_PUBLIC_CUTOVER'
+$env:CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_PACKAGE_SHA256=$PKG_SHA
+$env:CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_PLAN_SHA256=$PUBLICATION_PLAN_SHA
+$env:CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_AUTHORIZATION_SHA256=$PUBLIC_AUTH_SHA
+$env:CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_ACTIVATION_ID='<activation ID>'
+
+npm.cmd run precinct-gis:publication-status:nc -- --package=$PKG --package-sha256=$PKG_SHA --hidden-receipt=$HIDDEN_RECEIPT --hidden-receipt-sha256=$HIDDEN_SHA --blob-evidence=$BLOB_RECEIPT --blob-evidence-sha256=$BLOB_SHA --plan-sha256=$PUBLICATION_PLAN_SHA --authorization=$PUBLIC_AUTH --authorization-sha256=$PUBLIC_AUTH_SHA --apply
+```
+
+That atomic transaction publishes exactly three geography versions, authorizes
+the 8,058 linked geographic result units, verifies all 9,285 reviewed
+relationships and 8,058 features, and increments the public revision once.
+
+## Post-cutover checks
+
+For 2012 use `level=vtd`; for 2016 and 2020 use `level=precinct`. Across several
+county GEOIDs verify:
+
+- the manifest endpoint returns exactly one eligible year/grain manifest;
+- the parent-scoped geography endpoint returns the expected GeoJSON;
+- the results endpoint returns database-backed rows that join one-for-one to
+  the colorable features;
+- administrative rows never appear as polygons;
+- 2024 has no public manifest or delivery;
+- the base map is OpenStreetMap and Exports & API links keep the selected year.
+
+Run the production API smoke against the exact deployed Git SHA with
+`--expect-source=database`, and preserve its evidence with the publication
+receipt.
+
+## Rollback and authorization status
+
+Rollback requires a new hash-pinned `GO_ROLLBACK` authorization bound to the
+exact successful publication receipt. Block the database first while the
+gate-capable application remains live, verify both endpoints close, and only
+then restore the deployment pinned in that receipt. Publication receipt
+recovery is read-only and cannot replay the initial write or rollback.
+
+This implementation and local rehearsal authorize no production database
+write, Blob upload, Vercel environment change, deployment, canonical
+activation, or public transition. All three candidate years remain blocked
+until the complete sequence is separately executed; 2024 remains outside the
+release.

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -7837,3 +7837,49 @@ evidence against its verified top-level package.
   production. Each election retains its own boundary vintage, so the maps are
   not an apples-to-apples trend geography without a separate reviewed
   cross-election correspondence.
+
+### 2026-08-16 - North Carolina guarded three-election release tooling
+
+- Added a North Carolina-only guarded local database plan, loader, validator,
+  content-addressed candidate builder, production preflight and backup
+  contracts, hidden-load receipt recovery, immutable Blob publisher, static
+  activation builder, atomic publication, rollback, and read-only publication
+  receipt recovery. The release preserves 2012 as `vtd` and 2016/2020 as
+  `precinct`; shared API and map code select the reviewed grain by state and
+  election year instead of relabeling North Carolina 2012.
+- The fixed release universe is 9,285 official reporting units, 24,174
+  candidate-result rows, 8,058 polygons, and 9,285 reviewed relationships.
+  Exactly 8,058 relationships are geographic one-to-one joins and 1,227 are
+  explicit non-geographic reconciliation rows. Delivery consists of 300
+  county-scoped objects plus three year indexes. Geometry contains no election
+  values.
+- The plan, loader, candidate, public activation, and publication paths reject
+  2024. Its three restored 2019 polygons remain blocked until election-date
+  applicability is supported by retained public evidence.
+- The fixed loopback Docker rehearsal loaded and read-only validated 2012 at
+  3,011 units / 8,076 result rows / 2,692 features, 2016 at 3,209 / 8,112 /
+  2,704, and 2020 at 3,065 / 7,986 / 2,662. All three geography versions stayed
+  `blocked`, every public-delivery flag stayed false, and invalid constraints
+  were zero at local public revision 26.
+- A local validation rehearsal sealed candidate SHA-256
+  `6362c56c1834ba5c81ec395b1643fbaec6689d2163a15bf7e8be3a89195cfdcc`
+  with 303 immutable delivery artifacts. This ignored `.etl` package is local
+  evidence only and must be resealed from the clean merged commit before any
+  production evidence is collected.
+- The implementation changes no canonical manifest, public eligibility,
+  production database, Blob object, Vercel setting, deployment, or Git ref.
+  Static activation and the final database publication remain distinct,
+  separately reviewed operations so both public endpoints stay fail-closed
+  until one exact release is authorized.
+- Verification passed the 35-test North Carolina source/release suite, 30
+  cross-state publication-gate and delivery regressions, TypeScript, the
+  production build, the two-test merge-gated HTTP API suite, North Carolina
+  ETL validation/import, and the source-package, map, and provenance
+  validators. Existing repository validators retained only their documented
+  legacy-file/equipment-shape warnings and reported no failure.
+- The normal 2024 staging advisory audit evaluated 2,658 North Carolina review
+  rows and produced 206 advisory indicator rows across 86 counties/areas: 81
+  `vote_share_pattern`, 86 `average_down_ballot_difference`, and 39
+  `down_ballot_outliers`. These are broad review signals, not evidence of fraud
+  or misconduct. This branch did not check or change the production API/DB
+  indicator counts.

--- a/package.json
+++ b/package.json
@@ -374,7 +374,18 @@
     "precinct-gis:publication-status:sc": "node --max-old-space-size=4096 --experimental-strip-types scripts/publish-sc-precinct-geography-status.mjs",
     "test:precinct-geometry:sc": "node --experimental-strip-types --test tests/api/sc-precinct-geometry.test.mjs tests/api/sc-precinct-gis-plan.test.mjs tests/api/sc-precinct-gis-local.test.mjs tests/api/sc-precinct-release-candidate.test.mjs tests/api/sc-precinct-blob-publication.test.mjs tests/api/sc-precinct-production-release.test.mjs tests/api/sc-precinct-public-activation.test.mjs tests/api/sc-precinct-publication-gate.test.mjs tests/api/sc-precinct-publication.test.mjs",
     "precinct-gis:collect:nc": "node --experimental-strip-types scripts/build-nc-reviewed-precincts.mjs",
-    "test:precinct-geometry:nc": "node --experimental-strip-types --test tests/api/nc-precinct-geometry.test.mjs"
+    "precinct-gis:plan:nc": "node --experimental-strip-types scripts/setup-nc-local-gis-local.mjs",
+    "precinct-gis:setup:nc:local": "node --experimental-strip-types scripts/setup-nc-local-gis-local.mjs --apply",
+    "precinct-gis:validate:nc:local": "node --experimental-strip-types scripts/validate-nc-local-gis-local.mjs",
+    "precinct-gis:release-candidate:nc": "node --max-old-space-size=4096 --experimental-strip-types scripts/prepare-nc-local-release-candidate.mjs",
+    "precinct-gis:release-candidate:nc:write": "node --max-old-space-size=4096 --experimental-strip-types scripts/prepare-nc-local-release-candidate.mjs --write",
+    "precinct-gis:delivery-publish:nc": "node --experimental-strip-types scripts/publish-nc-local-delivery-assets.mjs",
+    "precinct-gis:production-preflight:nc": "node --experimental-strip-types scripts/report-nc-local-production-preflight.mjs",
+    "precinct-gis:production-backup:nc": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/backup-nc-local-production.ps1",
+    "precinct-gis:production-release:nc": "node --max-old-space-size=4096 --experimental-strip-types scripts/apply-nc-local-release.mjs",
+    "precinct-gis:public-activation:nc": "node --experimental-strip-types scripts/prepare-nc-local-public-activation.mjs",
+    "precinct-gis:publication-status:nc": "node --max-old-space-size=4096 --experimental-strip-types scripts/publish-nc-local-geography-status.mjs",
+    "test:precinct-geometry:nc": "node --experimental-strip-types --test tests/api/nc-precinct-geometry.test.mjs tests/api/nc-local-gis-plan.test.mjs tests/api/nc-local-gis-local.test.mjs tests/api/nc-local-release-candidate.test.mjs tests/api/nc-local-blob-publication.test.mjs tests/api/nc-local-production-release.test.mjs tests/api/nc-local-public-activation.test.mjs tests/api/nc-local-publication-gate.test.mjs tests/api/nc-local-publication.test.mjs"
   },
   "dependencies": {
     "@clerk/nextjs": "^7.5.18",

--- a/scripts/apply-nc-local-release.mjs
+++ b/scripts/apply-nc-local-release.mjs
@@ -1,0 +1,668 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import postgres from "postgres";
+import {
+  applyNorthCarolinaLocalGisTransaction,
+  readNorthCarolinaPersistedProductionReleaseAudit,
+  validateNorthCarolinaLocalGisClient,
+} from "./lib/nc-local-gis-db.mjs";
+import { buildNorthCarolinaLocalGisPlan } from "./lib/nc-local-gis-plan.mjs";
+import { inspectReleaseArtifact } from "./lib/nc-local-release-candidate.mjs";
+import {
+  assertNorthCarolinaReleaseCandidateDocument,
+  productionEndpointFingerprint,
+} from "./lib/nc-local-production-preflight.mjs";
+import {
+  buildNorthCarolinaProductionAuthorizationTemplate,
+  sha256,
+  validateNorthCarolinaProductionAuthorization,
+  validateNorthCarolinaProductionBackupEvidence,
+  validateNorthCarolinaProductionPreflightEvidence,
+} from "./lib/nc-local-production-release.mjs";
+
+function parseArguments(args) {
+  const value = (name) => args.find((arg) => arg.startsWith(name + "="))
+    ?.slice(name.length + 1);
+  const parsed = {
+    apply: args.includes("--apply"),
+    recoverReceipt: args.includes("--recover-receipt"),
+    writeAuthorizationTemplate: args.includes("--write-authorization-template"),
+    packagePath: value("--package"),
+    packageSha256: value("--package-sha256"),
+    preflightPath: value("--preflight"),
+    preflightSha256: value("--preflight-sha256"),
+    backupManifestPath: value("--backup-manifest"),
+    backupManifestSha256: value("--backup-manifest-sha256"),
+    authorizationPath: value("--authorization"),
+    authorizationSha256: value("--authorization-sha256"),
+    authorizationTemplatePath: value("--authorization-template"),
+    receiptPath: value("--receipt"),
+  };
+  const known = new Set([
+    "--apply",
+    "--recover-receipt",
+    "--write-authorization-template",
+    "--package",
+    "--package-sha256",
+    "--preflight",
+    "--preflight-sha256",
+    "--backup-manifest",
+    "--backup-manifest-sha256",
+    "--authorization",
+    "--authorization-sha256",
+    "--authorization-template",
+    "--receipt",
+  ]);
+  for (const arg of args) {
+    const key = arg.split("=")[0];
+    if (!known.has(key)) throw new Error("Unknown North Carolina production-release option: " + arg);
+  }
+  if (!parsed.packagePath || !parsed.packageSha256) {
+    throw new Error("North Carolina production release requires --package and --package-sha256");
+  }
+  if ([parsed.apply, parsed.recoverReceipt, parsed.writeAuthorizationTemplate]
+    .filter(Boolean).length > 1) {
+    throw new Error("North Carolina production release modes are mutually exclusive");
+  }
+  return parsed;
+}
+
+function safeEtlPath(root, relativePath, requiredPrefix) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith(requiredPrefix)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+  ) {
+    throw new Error("Unsafe North Carolina release evidence path: " + relativePath);
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...requiredPrefix.replace(/\/$/, "").split("/"));
+  if (!absolute.startsWith(allowed + path.sep)) {
+    throw new Error("North Carolina release evidence escapes its .etl root");
+  }
+  return absolute;
+}
+
+function readEtlJson(root, relativePath, expectedSha256, prefix) {
+  if (!/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")) {
+    throw new Error("North Carolina release evidence requires an exact SHA-256");
+  }
+  const absolute = safeEtlPath(root, relativePath, prefix);
+  const bytes = readFileSync(absolute);
+  if (sha256(bytes) !== expectedSha256) {
+    throw new Error("North Carolina release evidence SHA-256 drifted: " + relativePath);
+  }
+  return { path: relativePath, absolute, bytes, sha256: expectedSha256, value: JSON.parse(bytes) };
+}
+
+function readBackupManifest(relativeOrAbsolutePath, expectedSha256, root) {
+  if (!/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")) {
+    throw new Error("North Carolina backup manifest requires an exact SHA-256");
+  }
+  const absolute = path.isAbsolute(relativeOrAbsolutePath)
+    ? path.resolve(relativeOrAbsolutePath)
+    : path.resolve(root, relativeOrAbsolutePath);
+  const bytes = readFileSync(absolute);
+  if (sha256(bytes) !== expectedSha256) {
+    throw new Error("North Carolina backup manifest SHA-256 drifted");
+  }
+  return { absolute, bytes, sha256: expectedSha256, value: JSON.parse(bytes) };
+}
+
+function productionUrl(environment = process.env) {
+  const first = environment.POSTGRES_URL_NON_POOLING?.trim() || "";
+  const second = environment.POSTGRES_DATABASE_URL_UNPOOLED?.trim() || "";
+  if (!first && !second) {
+    throw new Error("North Carolina production release requires an explicit unpooled PostgreSQL URL");
+  }
+  if (first && second && first !== second) {
+    throw new Error("North Carolina production release found conflicting unpooled PostgreSQL URLs");
+  }
+  return first || second;
+}
+
+function immutableJson(root, relativePath, value) {
+  const absolute = safeEtlPath(root, relativePath, path.posix.dirname(relativePath) + "/");
+  const bytes = Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+  if (existsSync(absolute)) {
+    if (!readFileSync(absolute).equals(bytes)) {
+      throw new Error("Refusing to overwrite different North Carolina release evidence");
+    }
+    return { path: relativePath, byteCount: bytes.length, sha256: sha256(bytes), disposition: "verified_existing" };
+  }
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, bytes, { flag: "wx" });
+  return { path: relativePath, byteCount: bytes.length, sha256: sha256(bytes), disposition: "created" };
+}
+
+function reserveReceipt(
+  root,
+  relativePath,
+  packageSha256,
+  authorizationSha256,
+  options = {},
+) {
+  const absolute = safeEtlPath(
+    root,
+    relativePath,
+    ".etl/production-release-receipts/NC/",
+  );
+  if (existsSync(absolute)) throw new Error("North Carolina production receipt already exists");
+  const pending = absolute + ".pending";
+  const pendingBytes = Buffer.from(JSON.stringify({
+    schemaVersion: 1,
+    state: "NC",
+    packageSha256,
+    authorizationSha256,
+    purpose: "ambiguous-commit recovery marker",
+  }, null, 2) + "\n");
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  if (existsSync(pending)) {
+    if (
+      options.allowExisting === true
+      && readFileSync(pending).equals(pendingBytes)
+    ) {
+      return {
+        absolute,
+        pending,
+        pendingBytes,
+        disposition: "reused",
+      };
+    }
+    throw new Error("A North Carolina release recovery marker already exists; reconcile it before retrying");
+  }
+  writeFileSync(pending, pendingBytes, { flag: "wx" });
+  return { absolute, pending, pendingBytes, disposition: "created" };
+}
+
+function finishReceipt(reservation, value) {
+  const bytes = Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+  const temporary = reservation.absolute + ".write-" + sha256(bytes).slice(0, 12) + ".tmp";
+  if (existsSync(temporary)) {
+    if (!readFileSync(temporary).equals(bytes)) {
+      throw new Error("North Carolina hidden receipt temporary file drifted");
+    }
+  } else {
+    writeFileSync(temporary, bytes, { flag: "wx" });
+  }
+  renameSync(temporary, reservation.absolute);
+  if (readFileSync(reservation.pending).equals(reservation.pendingBytes)) {
+    unlinkSync(reservation.pending);
+  }
+  return { byteCount: bytes.length, sha256: sha256(bytes) };
+}
+
+function defaultTemplatePath(packageSha256) {
+  return ".etl/production-authorizations/NC/nc-local-authorization-template-"
+    + packageSha256.slice(0, 12)
+    + ".json";
+}
+
+function defaultReceiptPath(packageSha256, authorizationId) {
+  const safeId = authorizationId.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 80);
+  return ".etl/production-release-receipts/NC/nc-local-hidden-load-"
+    + packageSha256.slice(0, 12)
+    + "-"
+    + safeId
+    + ".json";
+}
+
+async function ensureNorthCarolinaDerivationConstraint(tx, migrationArtifact) {
+  const inspect = async () => tx.unsafe([
+    "select pg_get_constraintdef(oid) definition from pg_constraint",
+    "where connamespace='public'::regnamespace",
+    " and conname='geography_versions_derivation_method_check'",
+  ].join("\n"));
+  const beforeRows = await inspect();
+  if (beforeRows.length !== 1) {
+    throw new Error("North Carolina derivation-method constraint is missing or ambiguous");
+  }
+  const beforeDefinition = String(beforeRows[0].definition ?? "");
+  const complete = beforeDefinition.includes("secondary_reconstruction")
+    && beforeDefinition.includes("hybrid_reconstruction");
+  if (complete) {
+    return { before: "complete", after: "complete", statementsApplied: 0 };
+  }
+  if (
+    !beforeDefinition.includes("official_export")
+    || !beforeDefinition.includes("official_service")
+    || !beforeDefinition.includes("digitized_map")
+    || !beforeDefinition.includes("official_crosswalk")
+  ) {
+    throw new Error("North Carolina derivation-method constraint preimage drifted");
+  }
+  const statements = migrationArtifact.bytes.toString("utf8")
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+  if (statements.length !== 2) {
+    throw new Error("North Carolina migration 0009 statement set drifted");
+  }
+  for (const statement of statements) await tx.unsafe(statement);
+  const afterRows = await inspect();
+  const afterDefinition = String(afterRows[0]?.definition ?? "");
+  if (
+    afterRows.length !== 1
+    || !afterDefinition.includes("secondary_reconstruction")
+    || !afterDefinition.includes("hybrid_reconstruction")
+  ) {
+    throw new Error("North Carolina migration 0009 did not establish the required constraint");
+  }
+  return { before: "absent", after: "complete", statementsApplied: 2 };
+}
+
+export async function runNorthCarolinaProductionRelease(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const parsed = options.packagePath ? options : parseArguments(process.argv.slice(2));
+  const packageArtifact = inspectReleaseArtifact(root, parsed.packagePath, {
+    allowedRoots: [".etl/precinct-release-candidates/NC/"],
+    sha256: parsed.packageSha256,
+  });
+  const packageDocument = JSON.parse(packageArtifact.bytes.toString("utf8"));
+  const releaseCandidate = assertNorthCarolinaReleaseCandidateDocument(
+    packageDocument,
+    packageArtifact.sha256,
+  );
+  const migration0009Declaration = releaseCandidate.migrations.find(
+    (migration) => migration.path === "drizzle/0009_public_wolfpack.sql",
+  );
+  const migration0009Artifact = inspectReleaseArtifact(
+    root,
+    migration0009Declaration.path,
+    {
+      allowedRoots: ["drizzle/"],
+      byteCount: migration0009Declaration.byteCount,
+      sha256: migration0009Declaration.sha256,
+    },
+  );
+  const environment = options.environment ?? process.env;
+  const clock = options.nowFactory ?? (() => options.now ?? new Date());
+  const currentTime = () => {
+    const value = clock();
+    const result = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    if (Number.isNaN(result.getTime())) {
+      throw new Error("North Carolina production release clock returned an invalid time");
+    }
+    return result;
+  };
+  if (parsed.writeAuthorizationTemplate) {
+    const relativePath = parsed.authorizationTemplatePath
+      ?? defaultTemplatePath(packageArtifact.sha256);
+    const artifact = immutableJson(root, relativePath, buildNorthCarolinaProductionAuthorizationTemplate({
+      releaseCandidate,
+      preflightSha256: parsed.preflightSha256,
+      backupManifestSha256: parsed.backupManifestSha256,
+    }));
+    return {
+      mode: "write_authorization_template",
+      decision: "NO_GO_PRODUCTION",
+      releaseCandidate,
+      authorizationTemplate: artifact,
+      productionMutationPerformed: false,
+    };
+  }
+  if (!parsed.apply && !parsed.recoverReceipt) {
+    return {
+      mode: "plan",
+      decision: "NO_GO_PRODUCTION",
+      releaseCandidate,
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      requiredEvidence: [
+        "fresh read-only production preflight",
+        "fresh full public-schema backup with exact restore verification",
+        "hash-pinned GO_PRODUCTION authorization",
+      ],
+    };
+  }
+  const databaseUrl = productionUrl(environment);
+  const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
+  const preflight = readEtlJson(
+    root,
+    parsed.preflightPath,
+    parsed.preflightSha256,
+    ".etl/production-preflight-candidates/NC/",
+  );
+  const backup = readBackupManifest(
+    parsed.backupManifestPath,
+    parsed.backupManifestSha256,
+    root,
+  );
+  const authorization = readEtlJson(
+    root,
+    parsed.authorizationPath,
+    parsed.authorizationSha256,
+    ".etl/production-authorizations/NC/",
+  );
+  const validateEvidenceAt = (now) => {
+    const preflightSummary = validateNorthCarolinaProductionPreflightEvidence(
+      preflight.value,
+      { releaseCandidate, endpointFingerprint, now },
+    );
+    const backupSummary = validateNorthCarolinaProductionBackupEvidence(backup.value, {
+      releaseCandidate,
+      endpointFingerprint,
+      preflightCapturedAtUtc: preflightSummary.capturedAtUtc,
+      now,
+    });
+    const authorizationSummary = validateNorthCarolinaProductionAuthorization(
+      authorization.value,
+      {
+        releaseCandidate,
+        preflightSha256: preflight.sha256,
+        backupManifestSha256: backup.sha256,
+        now,
+      },
+    );
+    return { preflightSummary, backupSummary, authorizationSummary };
+  };
+  const rawAuthorizationId = typeof authorization.value?.authorizationId === "string"
+    ? authorization.value.authorizationId.trim()
+    : "";
+  const receiptPath = parsed.receiptPath ?? defaultReceiptPath(
+    packageArtifact.sha256,
+    rawAuthorizationId || "invalid-authorization",
+  );
+  const plan = await buildNorthCarolinaLocalGisPlan({
+    root,
+    years: [2012, 2016, 2020],
+  });
+
+  if (parsed.recoverReceipt) {
+    if (
+      environment.CRM_DATABASE_ENVIRONMENT !== "production-read-only"
+      || environment.CRM_NC_LOCAL_GEOGRAPHY_HIDDEN_RECEIPT_RECOVERY
+        !== packageArtifact.sha256
+      || environment.CRM_NC_LOCAL_GEOGRAPHY_PRODUCTION_AUTHORIZATION_SHA256
+        !== authorization.sha256
+    ) {
+      throw new Error("North Carolina hidden receipt recovery is not explicitly read-only and hash-authorized");
+    }
+    const reservation = reserveReceipt(
+      root,
+      receiptPath,
+      packageArtifact.sha256,
+      authorization.sha256,
+      { allowExisting: true },
+    );
+    let sql;
+    try {
+      sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+        max: 1,
+        connect_timeout: 10,
+        idle_timeout: 20,
+        connection: {
+          application_name: "civicresultmaps-nc-local-hidden-receipt-recovery",
+          default_transaction_read_only: true,
+        },
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    }
+    let recovered;
+    try {
+      recovered = await sql.begin("read only", async (nv) => {
+        const persistedAudit = await readNorthCarolinaPersistedProductionReleaseAudit(
+          nv,
+          { id: releaseCandidate.id, sha256: packageArtifact.sha256 },
+        );
+        const committedAt = new Date(persistedAudit.transaction.executedAtUtc);
+        if (committedAt.getTime() > currentTime().getTime()) {
+          throw new Error("North Carolina hidden receipt recovery found a future commit timestamp");
+        }
+        const evidence = validateEvidenceAt(committedAt);
+        const expectedAudit = {
+          releasePackage: { path: parsed.packagePath, sha256: packageArtifact.sha256 },
+          authorization: { path: parsed.authorizationPath, sha256: authorization.sha256 },
+          preflight: { path: parsed.preflightPath, sha256: preflight.sha256 },
+          backupManifest: {
+            sha256: backup.sha256,
+            dumpSha256: evidence.backupSummary.dumpSha256,
+          },
+          authorizationId: evidence.authorizationSummary.authorizationId,
+          endpointFingerprint,
+          transaction: persistedAudit.transaction,
+        };
+        if (JSON.stringify(persistedAudit) !== JSON.stringify(expectedAudit)) {
+          throw new Error("North Carolina hidden receipt recovery evidence does not match the durable database audit");
+        }
+        const executionContext = {
+          mode: "production_release",
+          releasePackageSha256: packageArtifact.sha256,
+          releaseCandidateId: releaseCandidate.id,
+          databaseName: evidence.preflightSummary.databaseName,
+          productionReleaseAudit: persistedAudit,
+        };
+        const validation = await validateNorthCarolinaLocalGisClient(nv, plan, {
+          executionContext,
+          readOnlySession: true,
+        });
+        if (Number(validation.revision) !== persistedAudit.transaction.publicRevision) {
+          throw new Error("North Carolina hidden receipt recovery public revision drifted");
+        }
+        return { persistedAudit, evidence, validation, executionContext };
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+    const recoveredTransaction = {
+      database: recovered.validation.database,
+      executionMode: "production_release",
+      productionMutationPerformed: true,
+      publicDeliveryAuthorized: false,
+      releaseCandidate: recovered.validation.releaseCandidate,
+      productionReleaseAudit: recovered.persistedAudit,
+      revision: recovered.persistedAudit.transaction.publicRevision,
+      years: recovered.validation.years,
+      disposition: "recovered_existing",
+    };
+    const receiptDocument = {
+      schemaVersion: 1,
+      state: "NC",
+      decision: "COMMITTED_HIDDEN_NOT_PUBLIC",
+      releaseCandidate: {
+        id: releaseCandidate.id,
+        path: parsed.packagePath,
+        sha256: packageArtifact.sha256,
+      },
+      committedAtUtc: recovered.persistedAudit.transaction.executedAtUtc,
+      endpointFingerprint,
+      authorization: {
+        id: recovered.evidence.authorizationSummary.authorizationId,
+        path: authorization.path,
+        sha256: authorization.sha256,
+        approvedBy: recovered.evidence.authorizationSummary.approvedBy,
+      },
+      preflight: { path: preflight.path, sha256: preflight.sha256 },
+      backup: {
+        manifestSha256: backup.sha256,
+        dumpSha256: recovered.evidence.backupSummary.dumpSha256,
+      },
+      transaction: recoveredTransaction,
+      validation: recovered.validation,
+      recovery: {
+        recoveredAtUtc: currentTime().toISOString(),
+        productionMutationPerformed: false,
+      },
+      productionMutationPerformed: true,
+      canonicalManifestChanged: false,
+      publicFileWritten: false,
+      publicDeliveryAuthorized: false,
+    };
+    const receiptArtifact = finishReceipt(reservation, receiptDocument);
+    return {
+      mode: "recover_receipt",
+      decision: "RECOVERED_HIDDEN_RECEIPT",
+      releaseCandidate: receiptDocument.releaseCandidate,
+      revision: recoveredTransaction.revision,
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      receipt: { path: receiptPath, ...receiptArtifact },
+    };
+  }
+
+  const initialEvidence = validateEvidenceAt(currentTime());
+  if (
+    environment.CRM_DATABASE_ENVIRONMENT !== "production"
+    || environment.CRM_NC_LOCAL_GEOGRAPHY_PRODUCTION_WRITES !== packageArtifact.sha256
+  ) {
+    throw new Error("North Carolina production writes are not explicitly package-authorized");
+  }
+  if (
+    environment.CRM_NC_LOCAL_GEOGRAPHY_PRODUCTION_AUTHORIZATION_ID
+      !== initialEvidence.authorizationSummary.authorizationId
+    || environment.CRM_NC_LOCAL_GEOGRAPHY_PRODUCTION_AUTHORIZATION_SHA256
+      !== authorization.sha256
+  ) {
+    throw new Error("North Carolina production authorization environment acknowledgement drifted");
+  }
+  const reservation = reserveReceipt(
+    root,
+    receiptPath,
+    packageArtifact.sha256,
+    authorization.sha256,
+  );
+  let sql;
+  try {
+    sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+      max: 1,
+      connect_timeout: 10,
+      idle_timeout: 20,
+      connection: { application_name: "civicresultmaps-nc-local-production-release" },
+    });
+  } catch (error) {
+    if (existsSync(reservation.pending)) unlinkSync(reservation.pending);
+    throw error;
+  }
+  let transactionBodyCompleted = false;
+  let committed;
+  try {
+    committed = await sql.begin(async (nv) => {
+      const transactionNow = currentTime();
+      const finalEvidence = validateEvidenceAt(transactionNow);
+      const migration0009 = await ensureNorthCarolinaDerivationConstraint(
+        nv,
+        migration0009Artifact,
+      );
+      const revisions = await nv.unsafe(
+        "select revision::int revision from public_data_revisions where scope='public' for update",
+      );
+      if (revisions.length !== 1) throw new Error("North Carolina production public revision is missing");
+      const expectedRevision = Number(revisions[0].revision) + 1;
+      const releaseAudit = {
+        releasePackage: { path: parsed.packagePath, sha256: packageArtifact.sha256 },
+        authorization: { path: parsed.authorizationPath, sha256: authorization.sha256 },
+        preflight: { path: parsed.preflightPath, sha256: preflight.sha256 },
+        backupManifest: {
+          sha256: backup.sha256,
+          dumpSha256: finalEvidence.backupSummary.dumpSha256,
+        },
+        authorizationId: finalEvidence.authorizationSummary.authorizationId,
+        endpointFingerprint,
+        transaction: {
+          executedAtUtc: transactionNow.toISOString(),
+          publicRevision: expectedRevision,
+        },
+      };
+      const executionContext = {
+        mode: "production_release",
+        releasePackageSha256: packageArtifact.sha256,
+        releaseCandidateId: releaseCandidate.id,
+        databaseName: finalEvidence.preflightSummary.databaseName,
+        productionReleaseAudit: releaseAudit,
+      };
+      const applied = await applyNorthCarolinaLocalGisTransaction(nv, plan, {
+        executionContext,
+      });
+      if (applied.revision !== expectedRevision) {
+        throw new Error("North Carolina production public revision increment drifted");
+      }
+      const validation = await validateNorthCarolinaLocalGisClient(nv, plan, {
+        executionContext,
+        readOnlySession: false,
+      });
+      transactionBodyCompleted = true;
+      return {
+        applied: { ...applied, migration0009 },
+        validation,
+        releaseAudit,
+      };
+    });
+  } catch (error) {
+    // A post-COMMIT connection failure is ambiguous. Keep the pending marker
+    // once the transaction body completed so a retry cannot double-apply.
+    if (!transactionBodyCompleted && existsSync(reservation.pending)) {
+      unlinkSync(reservation.pending);
+    }
+    throw error;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+  const receiptDocument = {
+    schemaVersion: 1,
+    state: "NC",
+    decision: "COMMITTED_HIDDEN_NOT_PUBLIC",
+    releaseCandidate: {
+      id: releaseCandidate.id,
+      path: parsed.packagePath,
+      sha256: packageArtifact.sha256,
+    },
+    committedAtUtc: committed.releaseAudit.transaction.executedAtUtc,
+    endpointFingerprint,
+    authorization: {
+      id: initialEvidence.authorizationSummary.authorizationId,
+      path: authorization.path,
+      sha256: authorization.sha256,
+      approvedBy: initialEvidence.authorizationSummary.approvedBy,
+    },
+    preflight: { path: preflight.path, sha256: preflight.sha256 },
+    backup: {
+      manifestSha256: backup.sha256,
+      dumpSha256: initialEvidence.backupSummary.dumpSha256,
+    },
+    transaction: committed.applied,
+    validation: committed.validation,
+    productionMutationPerformed: true,
+    canonicalManifestChanged: false,
+    publicFileWritten: false,
+    publicDeliveryAuthorized: false,
+  };
+  const receiptArtifact = finishReceipt(reservation, receiptDocument);
+  return {
+    mode: "apply",
+    decision: receiptDocument.decision,
+    releaseCandidate: receiptDocument.releaseCandidate,
+    revision: committed.applied.revision,
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: false,
+    receipt: { path: receiptPath, ...receiptArtifact },
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runNorthCarolinaProductionRelease().then(
+    (result) => console.log(JSON.stringify(result, null, 2)),
+    (error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/backup-nc-local-production.ps1
+++ b/scripts/backup-nc-local-production.ps1
@@ -1,0 +1,393 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ReleasePackagePath,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^[a-f0-9]{64}$')]
+  [string]$ReleasePackageSha256,
+
+  [switch]$Execute
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$CloneContainer = 'crm-db-clone-postgres'
+$CloneHost = '127.0.0.1'
+$ClonePort = 54329
+$CloneAdminDatabase = 'crm_clone_admin'
+$CloneUser = 'crm_clone_admin'
+$VerifyDatabase = 'crm_nc_local_restore_verify'
+$BackupRoot = 'C:\tmp\crm-db-clone\nc-local-release-backups'
+$ContainerBackupRoot = '/backups/nc-local-release-backups'
+$ExpectedLegacyEndpointFingerprint = 'bf2bf2213814'
+
+function Fail([string]$Message) {
+  throw "North Carolina production backup aborted: $Message"
+}
+
+function Get-Sha256([byte[]]$Bytes) {
+  $algorithm = [Security.Cryptography.SHA256]::Create()
+  try {
+    return ([BitConverter]::ToString($algorithm.ComputeHash($Bytes)) -replace '-', '').ToLowerInvariant()
+  }
+  finally {
+    $algorithm.Dispose()
+  }
+}
+
+function Assert-ReleasePackage {
+  $candidateRoot = [IO.Path]::GetFullPath((Join-Path $RepoRoot '.etl\precinct-release-candidates\NC'))
+  $candidatePath = [IO.Path]::GetFullPath((Join-Path $RepoRoot $ReleasePackagePath))
+  if (
+    -not $candidatePath.StartsWith($candidateRoot + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase) -or
+    [IO.Path]::GetFileName($candidatePath) -ne 'release-candidate.json' -or
+    -not (Test-Path -LiteralPath $candidatePath -PathType Leaf)
+  ) {
+    Fail 'The release package must be an existing release-candidate.json under .etl/precinct-release-candidates/NC.'
+  }
+  $bytes = [IO.File]::ReadAllBytes($candidatePath)
+  if ((Get-Sha256 $bytes) -ne $ReleasePackageSha256) {
+    Fail 'The release package SHA-256 does not match the exact acknowledgement.'
+  }
+  $document = [Text.Encoding]::UTF8.GetString($bytes) | ConvertFrom-Json
+  if (
+    $document.schemaVersion -ne 1 -or
+    $document.id -ne 'nc-local-gis-three-election-v1' -or
+    $document.state -ne 'NC' -or
+    $document.decision -ne 'NO_GO_PRODUCTION' -or
+    $document.safety.productionMutationPerformed -ne $false -or
+    $document.safety.canonicalManifestChanged -ne $false -or
+    $document.totals.elections -ne 3
+  ) {
+    Fail 'The release package contract is incompatible.'
+  }
+  return [ordered]@{
+    id = $document.id
+    path = $ReleasePackagePath.Replace('\', '/')
+    sha256 = $ReleasePackageSha256
+  }
+}
+
+function Require-Command([string]$Name) {
+  $command = Get-Command $Name -ErrorAction SilentlyContinue
+  if (-not $command) {
+    Fail "Required command '$Name' was not found on PATH."
+  }
+  return $command.Source
+}
+
+function Get-RequiredSourceUrl {
+  $first = [Environment]::GetEnvironmentVariable('POSTGRES_URL_NON_POOLING')
+  $second = [Environment]::GetEnvironmentVariable('POSTGRES_DATABASE_URL_UNPOOLED')
+  if ([string]::IsNullOrWhiteSpace($first) -and [string]::IsNullOrWhiteSpace($second)) {
+    Fail 'Set POSTGRES_URL_NON_POOLING or POSTGRES_DATABASE_URL_UNPOOLED in this process environment.'
+  }
+  if (
+    -not [string]::IsNullOrWhiteSpace($first) -and
+    -not [string]::IsNullOrWhiteSpace($second) -and
+    $first -ne $second
+  ) {
+    Fail 'The two allowed production URL variables disagree.'
+  }
+  if (-not [string]::IsNullOrWhiteSpace($first)) { return $first }
+  return $second
+}
+
+function Assert-RemoteSource([string]$Url) {
+  try { $uri = [Uri]$Url } catch { Fail 'The production URL is not a valid PostgreSQL URI.' }
+  if (
+    $uri.Scheme -notin @('postgres', 'postgresql') -or
+    [string]::IsNullOrWhiteSpace($uri.Host) -or
+    $uri.Host.ToLowerInvariant() -in @('localhost', '127.0.0.1', '::1', $CloneHost) -or
+    $uri.Port -eq $ClonePort
+  ) {
+    Fail 'The production URL is not an allowed remote PostgreSQL endpoint.'
+  }
+}
+
+function Get-EndpointFingerprint([string]$Url) {
+  $uri = [Uri]$Url
+  $database = [Uri]::UnescapeDataString($uri.AbsolutePath.TrimStart('/'))
+  $port = if ($uri.IsDefaultPort) { '5432' } else { [string]$uri.Port }
+  $identity = @($uri.Host.ToLowerInvariant(), $port, $database) -join "`n"
+  return Get-Sha256 ([Text.Encoding]::UTF8.GetBytes($identity))
+}
+
+function Get-LegacyEndpointFingerprint([string]$Url) {
+  $uri = [Uri]$Url
+  $bytes = [Text.Encoding]::UTF8.GetBytes($uri.Host.ToLowerInvariant() + $uri.AbsolutePath)
+  return (Get-Sha256 $bytes).Substring(0, 12)
+}
+
+function Get-RemoteExecEnv([string]$Url) {
+  $uri = [Uri]$Url
+  $userinfo = [Uri]::UnescapeDataString($uri.UserInfo)
+  $separator = $userinfo.IndexOf(':')
+  if ($separator -lt 1) { Fail 'The production URL must include a username and password.' }
+  $database = [Uri]::UnescapeDataString($uri.AbsolutePath.TrimStart('/'))
+  if ([string]::IsNullOrWhiteSpace($database)) { Fail 'The production URL must include a database name.' }
+  $port = if ($uri.IsDefaultPort) { '5432' } else { [string]$uri.Port }
+  return @(
+    '--env', "PGHOST=$($uri.Host)",
+    '--env', "PGPORT=$port",
+    '--env', "PGDATABASE=$database",
+    '--env', "PGUSER=$($userinfo.Substring(0, $separator))",
+    '--env', "PGPASSWORD=$($userinfo.Substring($separator + 1))",
+    '--env', 'PGSSLMODE=require',
+    '--env', 'PGCHANNELBINDING=require',
+    '--env', 'PGOPTIONS=-c default_transaction_read_only=on'
+  )
+}
+
+function Assert-CloneContainer {
+  $container = @((& $script:Docker inspect $CloneContainer) | ConvertFrom-Json)
+  if ($LASTEXITCODE -ne 0 -or $container.Count -ne 1) { Fail 'Docker inspection failed.' }
+  $container = $container[0]
+  if (
+    $container.Name -ne "/$CloneContainer" -or
+    $container.Config.Labels.'com.civicresultmaps.purpose' -ne 'isolated-production-clone' -or
+    $container.State.Health.Status -ne 'healthy'
+  ) {
+    Fail 'The running clone container identity, purpose, or health is invalid.'
+  }
+  $bindings = @($container.NetworkSettings.Ports.'5432/tcp')
+  if (
+    $bindings.Count -ne 1 -or
+    $bindings[0].HostIp -ne $CloneHost -or
+    $bindings[0].HostPort -ne "$ClonePort"
+  ) {
+    Fail 'The clone container is not restricted to the reserved loopback port.'
+  }
+  $mounts = @($container.Mounts | Where-Object {
+    $_.Type -eq 'bind' -and $_.Destination -eq '/backups' -and $_.RW -eq $true
+  })
+  if ($mounts.Count -ne 1) { Fail 'The clone container does not have the required backup bind mount.' }
+}
+
+function Assert-ContainerTools {
+  $versions = @(
+    (& $script:Docker exec --user postgres $CloneContainer psql --version)
+    (& $script:Docker exec --user postgres $CloneContainer pg_dump --version)
+    (& $script:Docker exec --user postgres $CloneContainer pg_restore --version)
+  )
+  $majors = @($versions | ForEach-Object {
+    if ($_ -match '(\d+)(?:\.\d+)?') { [int]$Matches[1] }
+  })
+  if ($LASTEXITCODE -ne 0 -or $majors.Count -ne 3 -or @($majors | Where-Object { $_ -ne 17 }).Count) {
+    Fail 'The clone container must provide PostgreSQL 17 psql, pg_dump, and pg_restore.'
+  }
+}
+
+function Invoke-RemoteRows([string]$Sql, [string]$Description) {
+  $rows = & $script:Docker exec --user postgres @script:RemoteExecEnv $CloneContainer psql --no-psqlrc --set ON_ERROR_STOP=1 --tuples-only --no-align --quiet --command $Sql
+  if ($LASTEXITCODE -ne 0) { Fail "$Description failed." }
+  return @($rows)
+}
+
+function Invoke-LocalRows([string]$Database, [string]$Sql, [string]$Description) {
+  $rows = & $script:Docker exec --user postgres $CloneContainer psql --no-psqlrc --set ON_ERROR_STOP=1 --tuples-only --no-align --quiet --username $CloneUser --dbname $Database --command $Sql
+  if ($LASTEXITCODE -ne 0) { Fail "$Description failed." }
+  return @($rows)
+}
+
+function Invoke-LocalAdmin([string]$Sql, [string]$Description) {
+  $null = Invoke-LocalRows $CloneAdminDatabase $Sql $Description
+}
+
+function Get-TableCounts([string[]]$Tables, [scriptblock]$Runner) {
+  $counts = [ordered]@{}
+  foreach ($table in $Tables) {
+    if ($table -notmatch '^[a-z0-9_]+$') { Fail 'A public table name is unsafe.' }
+    $sql = "SELECT count(*) FROM public.`"$table`";"
+    $value = @(& $Runner $sql)
+    if ($value.Count -ne 1 -or $value[0].Trim() -notmatch '^\d+$') {
+      Fail "Could not obtain an exact row count for public.$table."
+    }
+    $counts[$table] = [int64]$value[0].Trim()
+  }
+  return $counts
+}
+
+function Assert-EqualCounts($Source, $Restored) {
+  if ($Source.Count -ne $Restored.Count) { Fail 'Restored public table count differs from production.' }
+  foreach ($key in $Source.Keys) {
+    if (-not $Restored.Contains($key) -or [int64]$Restored[$key] -ne [int64]$Source[$key]) {
+      Fail "Restored row count differs for public.$key."
+    }
+  }
+}
+
+function Restrict-BackupAccess([string[]]$Paths) {
+  $icacls = Get-Command icacls -ErrorAction SilentlyContinue
+  if (-not $icacls -or $env:OS -ne 'Windows_NT') {
+    Fail 'Restrictive Windows ACL tooling is unavailable.'
+  }
+  $user = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+  foreach ($target in $Paths) {
+    $isDirectory = Test-Path -LiteralPath $target -PathType Container
+    $userGrant = if ($isDirectory) { "$user`:(OI)(CI)F" } else { "$user`:F" }
+    $systemGrant = if ($isDirectory) { 'SYSTEM:(OI)(CI)F' } else { 'SYSTEM:F' }
+    & $icacls.Source $target '/inheritance:r' '/grant:r' $userGrant '/grant:r' $systemGrant | Out-Null
+    if ($LASTEXITCODE -ne 0) { Fail "Could not restrict ACLs on $target." }
+  }
+}
+
+$releaseCandidate = Assert-ReleasePackage
+if (-not $Execute) {
+  [ordered]@{
+    mode = 'plan'
+    decision = 'NO_BACKUP_CREATED'
+    releaseCandidate = $releaseCandidate
+    sourceEndpointFingerprint = 'computed_during_execution'
+    sourceEndpointLegacyApprovalFingerprint = $ExpectedLegacyEndpointFingerprint
+    includedSchemas = @('public')
+    excludedTableDataPatterns = @()
+    restoreVerificationRequired = $true
+    remoteMutationPerformed = $false
+    outputDirectory = $BackupRoot
+    acknowledgementRequired = @(
+      'CRM_NC_LOCAL_GEOGRAPHY_BACKUP_ACK=CREATE_FULL_PUBLIC_SCHEMA_ROLLBACK_BACKUP',
+      'CRM_NC_LOCAL_GEOGRAPHY_BACKUP_ENDPOINT_FINGERPRINT=<fresh 64-hex preflight endpoint fingerprint>'
+    )
+  } | ConvertTo-Json -Depth 6
+  exit 0
+}
+
+if (
+  [Environment]::GetEnvironmentVariable('CRM_NC_LOCAL_GEOGRAPHY_BACKUP_ACK') -ne 'CREATE_FULL_PUBLIC_SCHEMA_ROLLBACK_BACKUP' -or
+  [Environment]::GetEnvironmentVariable('CRM_NC_LOCAL_GEOGRAPHY_BACKUP_PACKAGE_SHA256') -ne $ReleasePackageSha256
+) {
+  Fail 'Execution requires the exact backup acknowledgement and release package SHA-256.'
+}
+
+$sourceUrl = Get-RequiredSourceUrl
+Assert-RemoteSource $sourceUrl
+if ((Get-LegacyEndpointFingerprint $sourceUrl) -ne $ExpectedLegacyEndpointFingerprint) {
+  Fail 'The production endpoint fingerprint is not approved.'
+}
+$sourceEndpointFingerprint = Get-EndpointFingerprint $sourceUrl
+if (
+  $sourceEndpointFingerprint -notmatch '^[a-f0-9]{64}$' -or
+  [Environment]::GetEnvironmentVariable('CRM_NC_LOCAL_GEOGRAPHY_BACKUP_ENDPOINT_FINGERPRINT') -ne $sourceEndpointFingerprint
+) {
+  Fail 'Execution requires the exact fresh 64-hex preflight endpoint fingerprint acknowledgement.'
+}
+$script:Docker = Require-Command docker
+$script:RemoteExecEnv = @(Get-RemoteExecEnv $sourceUrl)
+Assert-CloneContainer
+Assert-ContainerTools
+
+$identity = ((Invoke-RemoteRows "SELECT current_setting('server_version_num') || '|' || pg_database_size(current_database()) || '|' || current_setting('transaction_read_only') || '|' || (SELECT string_agg(lanname, ',' ORDER BY lanname) FROM pg_language WHERE lanispl);" 'Production identity preflight') -join '').Trim().Split('|')
+if (
+  $identity.Count -ne 4 -or
+  $identity[0] -notmatch '^\d{5,6}$' -or
+  [int](([int]$identity[0]) / 10000) -ne 17 -or
+  $identity[2] -ne 'on' -or
+  $identity[3] -ne 'plpgsql'
+) {
+  Fail 'The production identity or read-only session contract is incompatible.'
+}
+
+$sourceTables = @(Invoke-RemoteRows "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;" 'Production public table inventory')
+if (
+  $sourceTables.Count -lt 27 -or
+  @($sourceTables | Where-Object { $_ -notmatch '^[a-z0-9_]+$' }).Count -ne 0
+) {
+  Fail 'The production public table inventory is incomplete or unsafe.'
+}
+$sourceCounts = Get-TableCounts $sourceTables { param($sql) Invoke-RemoteRows $sql 'Production public table count' }
+$sourceInvalidConstraints = [int](((Invoke-RemoteRows "SELECT count(*) FROM pg_constraint WHERE connamespace='public'::regnamespace AND NOT convalidated;" 'Production constraint check') -join '').Trim())
+if ($sourceInvalidConstraints -ne 0) { Fail 'Production has invalid public constraints.' }
+
+New-Item -ItemType Directory -Force -Path $BackupRoot | Out-Null
+Restrict-BackupAccess @($BackupRoot)
+$stamp = [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssZ')
+$dumpFile = "nc-local-full-public-$stamp.dump"
+$dumpPath = Join-Path $BackupRoot $dumpFile
+$containerDumpPath = "$ContainerBackupRoot/$dumpFile"
+$manifestPath = Join-Path $BackupRoot "nc-local-full-public-$stamp.manifest.json"
+$createdAtUtc = [DateTime]::UtcNow.ToString('o')
+
+& $script:Docker exec --user postgres @script:RemoteExecEnv $CloneContainer pg_dump --format=custom --schema=public --file=$containerDumpPath
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $dumpPath -PathType Leaf)) {
+  Fail 'The full public-schema pg_dump failed.'
+}
+Restrict-BackupAccess @($dumpPath)
+
+$list = @(& $script:Docker exec --user postgres $CloneContainer pg_restore --list $containerDumpPath)
+if ($LASTEXITCODE -ne 0) { Fail 'Could not inspect the full dump archive.' }
+$tableDataEntries = @($list | ForEach-Object {
+  if ($_ -match ' TABLE DATA public ([^ ]+) ') { $Matches[1] }
+} | Sort-Object -Unique)
+if (@(Compare-Object $sourceTables $tableDataEntries).Count -ne 0) {
+  Fail 'The dump archive does not contain TABLE DATA entries for every public table.'
+}
+
+Invoke-LocalAdmin "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='$VerifyDatabase' AND pid <> pg_backend_pid();" 'Terminate prior verification clients'
+Invoke-LocalAdmin "DROP DATABASE IF EXISTS `"$VerifyDatabase`";" 'Drop prior verification database'
+Invoke-LocalAdmin "CREATE DATABASE `"$VerifyDatabase`" OWNER `"$CloneUser`";" 'Create verification database'
+$null = Invoke-LocalRows $VerifyDatabase 'DROP SCHEMA public CASCADE;' 'Prepare verification database'
+& $script:Docker exec --user postgres $CloneContainer pg_restore --exit-on-error --no-owner --no-privileges --username=$CloneUser --dbname=$VerifyDatabase $containerDumpPath
+if ($LASTEXITCODE -ne 0) { Fail 'Restoring the full backup into the isolated verification database failed.' }
+
+$restoredTables = @(Invoke-LocalRows $VerifyDatabase "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;" 'Restored public table inventory')
+if (@(Compare-Object $sourceTables $restoredTables).Count -ne 0) {
+  Fail 'The restored public table set differs from production.'
+}
+$restoredCounts = Get-TableCounts $restoredTables { param($sql) Invoke-LocalRows $VerifyDatabase $sql 'Restored public table count' }
+Assert-EqualCounts $sourceCounts $restoredCounts
+$restoredInvalidConstraints = [int](((Invoke-LocalRows $VerifyDatabase "SELECT count(*) FROM pg_constraint WHERE connamespace='public'::regnamespace AND NOT convalidated;" 'Restored constraint check') -join '').Trim())
+if ($restoredInvalidConstraints -ne 0) { Fail 'The restored backup has invalid public constraints.' }
+Invoke-LocalAdmin "ALTER DATABASE `"$VerifyDatabase`" SET default_transaction_read_only=on;" 'Lock verification database read-only by default'
+
+$manifest = [ordered]@{
+  manifestVersion = 3
+  backupPurpose = 'nc-local-production-release-rollback'
+  createdAtUtc = $createdAtUtc
+  releaseCandidate = $releaseCandidate
+  dumpFile = $dumpFile
+  dumpSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $dumpPath).Hash.ToLowerInvariant()
+  dumpFormat = 'custom'
+  includedSchemas = @('public')
+  excludedTableDataPatterns = @()
+  sourceEndpointFingerprint = $sourceEndpointFingerprint
+  sourceEndpointLegacyApprovalFingerprint = $ExpectedLegacyEndpointFingerprint
+  sourceServerVersionNum = [int]$identity[0]
+  sourceDatabaseBytes = [int64]$identity[1]
+  sourcePublicTableCount = $sourceTables.Count
+  sourcePublicTableRowCounts = $sourceCounts
+  sourceInvalidConstraints = $sourceInvalidConstraints
+  pgClientMajor = 17
+  remoteMutationPerformed = $false
+  restoreVerification = [ordered]@{
+    verified = $true
+    verifiedAtUtc = [DateTime]::UtcNow.ToString('o')
+    database = $VerifyDatabase
+    defaultTransactionReadOnly = $true
+    publicTableCount = $restoredTables.Count
+    publicTableRowCounts = $restoredCounts
+    invalidConstraints = $restoredInvalidConstraints
+    tableDataEntryCount = $tableDataEntries.Count
+    exactSourceTableSet = $true
+    exactSourceRowCounts = $true
+  }
+}
+$json = $manifest | ConvertTo-Json -Depth 8
+[IO.File]::WriteAllText($manifestPath, $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+Restrict-BackupAccess @($manifestPath)
+
+[ordered]@{
+  mode = 'execute'
+  decision = 'BACKUP_AND_RESTORE_VERIFIED'
+  releaseCandidate = $releaseCandidate
+  dumpFile = $dumpPath
+  dumpSha256 = $manifest.dumpSha256
+  manifest = $manifestPath
+  sourcePublicTableCount = $sourceTables.Count
+  restoredPublicTableCount = $restoredTables.Count
+  restoreVerified = $true
+  remoteMutationPerformed = $false
+} | ConvertTo-Json -Depth 6

--- a/scripts/lib/nc-local-blob-publication.mjs
+++ b/scripts/lib/nc-local-blob-publication.mjs
@@ -1,0 +1,216 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function safeReleasePackage(root, relativePath) {
+  if (
+    typeof relativePath !== "string"
+    || !/^\.etl\/precinct-release-candidates\/NC\/[^/]+\/release-candidate\.json$/.test(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+  ) {
+    throw new Error("North Carolina Blob publication package path is unsafe");
+  }
+  const resolvedRoot = path.resolve(root);
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  if (!absolutePath.startsWith(resolvedRoot + path.sep)) {
+    throw new Error("North Carolina Blob publication package escapes the repository");
+  }
+  return absolutePath;
+}
+
+function safePackageAsset(releaseRoot, relativePath) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith("delivery-assets/")
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+  ) {
+    throw new Error("North Carolina Blob publication asset path is unsafe");
+  }
+  const absolutePath = path.resolve(releaseRoot, ...relativePath.split("/"));
+  if (!absolutePath.startsWith(path.resolve(releaseRoot) + path.sep)) {
+    throw new Error("North Carolina Blob publication asset escapes the package");
+  }
+  return absolutePath;
+}
+
+function publicPathname(publicUrl) {
+  if (
+    typeof publicUrl !== "string"
+    || !publicUrl.startsWith("/data/geography/nc/")
+    || publicUrl.includes("\\")
+    || publicUrl.includes("?")
+    || publicUrl.includes("#")
+  ) {
+    throw new Error("North Carolina Blob publication URL is not a safe geography path");
+  }
+  const segments = publicUrl.split("/").filter(Boolean);
+  if (segments.some((segment) => {
+    try {
+      const decoded = decodeURIComponent(segment);
+      return decoded === "."
+        || decoded === ".."
+        || decoded.includes("/")
+        || decoded.includes("\\");
+    } catch {
+      return true;
+    }
+  })) {
+    throw new Error("North Carolina Blob publication URL has an unsafe segment");
+  }
+  return publicUrl.slice(1);
+}
+
+function inspectAsset(releaseRoot, declaration, kind, year) {
+  const absolutePath = safePackageAsset(
+    releaseRoot,
+    declaration.packageRelativePath,
+  );
+  if (!existsSync(absolutePath)) {
+    throw new Error(
+      "North Carolina " + year + " " + kind + " asset is missing",
+    );
+  }
+  const bytes = readFileSync(absolutePath);
+  const digest = sha256(bytes);
+  if (
+    bytes.length !== declaration.byteCount
+    || digest !== declaration.sha256
+  ) {
+    throw new Error(
+      "North Carolina " + year + " " + kind + " asset hash or byte count drifted",
+    );
+  }
+  return {
+    kind,
+    year,
+    packageRelativePath: declaration.packageRelativePath,
+    publicUrl: declaration.publicUrl,
+    pathname: publicPathname(declaration.publicUrl),
+    byteCount: bytes.length,
+    sha256: digest,
+    absolutePath,
+  };
+}
+
+export function inspectNorthCarolinaLocalBlobPublicationPlan(options) {
+  const root = path.resolve(options.root ?? process.cwd());
+  if (!/^[a-f0-9]{64}$/.test(options.packageSha256 ?? "")) {
+    throw new Error("North Carolina Blob publication requires the exact package SHA-256");
+  }
+  const packageAbsolutePath = safeReleasePackage(root, options.packagePath);
+  if (!existsSync(packageAbsolutePath)) {
+    throw new Error("North Carolina Blob publication package is missing");
+  }
+  const packageBytes = readFileSync(packageAbsolutePath);
+  if (sha256(packageBytes) !== options.packageSha256) {
+    throw new Error("North Carolina Blob publication package SHA-256 does not match");
+  }
+  const document = JSON.parse(packageBytes.toString("utf8"));
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "nc-local-gis-three-election-v1"
+    || document?.state !== "NC"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.safety?.publicFileWritten !== false
+    || document?.safety?.canonicalManifestChanged !== false
+    || document?.safety?.publicEligibilityChanged !== false
+    || document?.totals?.elections !== 3
+    || !Array.isArray(document.years)
+    || document.years.length !== 3
+  ) {
+    throw new Error("North Carolina Blob publication package contract is incompatible");
+  }
+  const releaseRoot = path.dirname(packageAbsolutePath);
+  const artifacts = [];
+  for (const year of document.years) {
+    const delivery = year.parentScopedDelivery;
+    if (
+      ![2012, 2016, 2020].includes(year.year)
+      || delivery?.format !== "parent_scoped_geojson"
+      || delivery?.publicationPerformed !== false
+      || delivery?.electionValuesInDelivery !== false
+      || delivery?.parentCount !== 100
+      || delivery?.featureCount !== year.reviewedGeometry?.featureCount
+      || !Array.isArray(delivery?.parentArtifacts)
+      || delivery.parentArtifacts.length !== 100
+      || year.proposedPublicDelivery?.format !== "parent_scoped_geojson"
+      || year.proposedPublicDelivery?.sha256 !== delivery.index?.sha256
+      || year.proposedPublicDelivery?.byteCount !== delivery.index?.byteCount
+      || year.proposedPublicDelivery?.url !== delivery.index?.publicUrl
+    ) {
+      throw new Error(
+        "North Carolina " + year.year + " parent-scoped publication contract drifted",
+      );
+    }
+    for (const parent of delivery.parentArtifacts) {
+      if (!/^37\d{3}$/.test(parent.parentGeoid ?? "")) {
+        throw new Error(
+          "North Carolina " + year.year + " publication has an invalid parent GEOID",
+        );
+      }
+      artifacts.push(inspectAsset(releaseRoot, parent, "parent", year.year));
+    }
+    artifacts.push(inspectAsset(
+      releaseRoot,
+      delivery.index,
+      "index",
+      year.year,
+    ));
+  }
+  const pathnames = new Set(artifacts.map((artifact) => artifact.pathname));
+  if (artifacts.length !== 303 || pathnames.size !== artifacts.length) {
+    throw new Error("North Carolina Blob publication asset set is incomplete or duplicated");
+  }
+  artifacts.sort((left, right) => {
+    if (left.kind !== right.kind) return left.kind === "parent" ? -1 : 1;
+    return left.pathname.localeCompare(right.pathname);
+  });
+  return {
+    schemaVersion: 1,
+    state: "NC",
+    releaseCandidate: {
+      id: document.id,
+      path: options.packagePath,
+      sha256: options.packageSha256,
+    },
+    decision: "NO_GO_PUBLICATION",
+    assetCount: artifacts.length,
+    indexCount: artifacts.filter((artifact) => artifact.kind === "index").length,
+    parentArtifactCount: artifacts.filter((artifact) => artifact.kind === "parent").length,
+    totalByteCount: artifacts.reduce((sum, artifact) => sum + artifact.byteCount, 0),
+    uploadOrder: "all parent artifacts before indexes",
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+    artifacts,
+  };
+}
+
+export function validateNorthCarolinaBlobPublicationAuthorization(
+  plan,
+  environment = process.env,
+) {
+  if (
+    environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLIC_FILE_WRITES
+      !== "I_ACKNOWLEDGE_PUBLIC_IMMUTABLE_GEOMETRY_UPLOAD"
+    || environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLIC_FILE_PACKAGE_SHA256
+      !== plan.releaseCandidate.sha256
+    || typeof environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID
+      !== "string"
+    || !environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID.trim()
+  ) {
+    throw new Error(
+      "North Carolina public immutable geometry upload is not explicitly authorized",
+    );
+  }
+  return {
+    authorizationId:
+      environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLIC_FILE_AUTHORIZATION_ID.trim(),
+  };
+}

--- a/scripts/lib/nc-local-gis-db.mjs
+++ b/scripts/lib/nc-local-gis-db.mjs
@@ -1,0 +1,1478 @@
+import postgres from "postgres";
+import {
+  getDatabaseDriver,
+  getLocalCloneDatabaseUrl,
+} from "../../src/db/database-driver.ts";
+import { reportingUnitCode } from "../../src/lib/precinct-geography.ts";
+
+const STATE = "NC";
+const SETUP_PARSER = "northCarolinaLocalGisSetup";
+const APPLICATION_NAME = "civicresultmaps-local-nc-local-gis";
+
+const LOCAL_EXECUTION_CONTEXT = Object.freeze({
+  mode: "local",
+  importParser: SETUP_PARSER,
+  importScope: "local-only",
+  resultParser: "scripts/setup-nc-local-gis-local.mjs",
+  reviewedBy: "repository-reviewed",
+  revisionReason: "Local-only North Carolina reviewed election geography setup",
+  database: {
+    environment: "local",
+    host: "loopback",
+    port: 54329,
+    name: "crm_clone_dev",
+  },
+  releaseCandidate: null,
+  productionReleaseAudit: null,
+});
+
+const PRODUCTION_RELEASE_AUDIT_KEYS = Object.freeze([
+  "releasePackage",
+  "authorization",
+  "preflight",
+  "backupManifest",
+  "authorizationId",
+  "endpointFingerprint",
+  "transaction",
+]);
+
+const PRODUCTION_RELEASE_AUDIT_ARTIFACT_KEYS = Object.freeze([
+  "releasePackage",
+  "authorization",
+  "preflight",
+]);
+
+function validatedProductionReleaseAudit(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Production North Carolina execution requires durable release-audit metadata");
+  }
+  const output = {};
+  for (const key of PRODUCTION_RELEASE_AUDIT_ARTIFACT_KEYS) {
+    const item = value[key];
+    if (
+      typeof item?.path !== "string"
+      || !item.path.startsWith(".etl/")
+      || item.path.includes("\\")
+      || item.path.split("/").includes("..")
+      || !/^[a-f0-9]{64}$/.test(item?.sha256 ?? "")
+    ) {
+      throw new Error("Production North Carolina execution release-audit metadata is invalid: " + key);
+    }
+    output[key] = Object.freeze({
+      path: item.path,
+      sha256: item.sha256,
+    });
+  }
+  if (
+    !value.backupManifest
+    || Object.keys(value.backupManifest).sort().join(",") !== "dumpSha256,sha256"
+    || !/^[a-f0-9]{64}$/.test(value.backupManifest.sha256 ?? "")
+    || !/^[a-f0-9]{64}$/.test(value.backupManifest.dumpSha256 ?? "")
+    || typeof value.authorizationId !== "string"
+    || !value.authorizationId.trim()
+    || !/^[a-f0-9]{64}$/.test(value.endpointFingerprint ?? "")
+    || !value.transaction
+    || Object.keys(value.transaction).sort().join(",")
+      !== "executedAtUtc,publicRevision"
+    || typeof value.transaction.executedAtUtc !== "string"
+    || Number.isNaN(Date.parse(value.transaction.executedAtUtc))
+    || !Number.isInteger(Number(value.transaction.publicRevision))
+    || Number(value.transaction.publicRevision) < 1
+  ) {
+    throw new Error("Production North Carolina execution release-audit metadata is invalid");
+  }
+  output.backupManifest = Object.freeze({
+    sha256: value.backupManifest.sha256,
+    dumpSha256: value.backupManifest.dumpSha256,
+  });
+  output.authorizationId = value.authorizationId.trim();
+  output.endpointFingerprint = value.endpointFingerprint;
+  output.transaction = Object.freeze({
+    executedAtUtc: value.transaction.executedAtUtc,
+    publicRevision: Number(value.transaction.publicRevision),
+  });
+  if (Object.keys(value).length !== PRODUCTION_RELEASE_AUDIT_KEYS.length) {
+    throw new Error("Production North Carolina execution release-audit metadata has extra fields");
+  }
+  return Object.freeze(output);
+}
+
+export function buildNorthCarolinaLocalExecutionContext(options = {}) {
+  if (!options.mode || options.mode === "local") return LOCAL_EXECUTION_CONTEXT;
+  if (options.mode !== "production_release") {
+    throw new Error("Unknown North Carolina local geography unit execution mode");
+  }
+  if (!/^[a-f0-9]{64}$/.test(options.releasePackageSha256 ?? "")) {
+    throw new Error("Production North Carolina execution requires a release-package SHA-256");
+  }
+  if (!/^nc-local-gis-three-election-v\d+$/.test(options.releaseCandidateId ?? "")) {
+    throw new Error("Production North Carolina execution requires the reviewed release-candidate ID");
+  }
+  if (typeof options.databaseName !== "string" || !options.databaseName.trim()) {
+    throw new Error("Production North Carolina execution requires the preflight database name");
+  }
+  return Object.freeze({
+    mode: "production_release",
+    importParser: "northCarolinaLocalGisProductionRelease",
+    importScope: "production-release-hidden-load",
+    resultParser: "scripts/apply-nc-local-release.mjs",
+    reviewedBy: "repository-reviewed-release",
+    revisionReason:
+      "North Carolina three-election local GIS hidden load "
+      + options.releasePackageSha256,
+    database: {
+      environment: "production",
+      host: "remote",
+      port: null,
+      name: options.databaseName,
+    },
+    releaseCandidate: Object.freeze({
+      id: options.releaseCandidateId,
+      sha256: options.releasePackageSha256,
+      publicDeliveryAuthorized: false,
+    }),
+    productionReleaseAudit: validatedProductionReleaseAudit(
+      options.productionReleaseAudit,
+    ),
+  });
+}
+
+export function assertNorthCarolinaGeometryVersionPrecondition(versions, yearPlan) {
+  if (
+    !Array.isArray(versions)
+    || versions.length > 1
+    || versions.some((row) =>
+      row.manifest_id !== yearPlan.manifest.id
+      || row.boundary_vintage !== yearPlan.manifest.geography.boundaryVintage
+    )
+  ) {
+    throw new Error(
+      "North Carolina "
+      + yearPlan.year
+      + " has multiple, foreign, or boundary-drifted geography versions",
+    );
+  }
+}
+
+function executionMetadata(context) {
+  return context.releaseCandidate
+    ? {
+      releaseCandidate: context.releaseCandidate,
+      productionReleaseAudit: context.productionReleaseAudit,
+    }
+    : {};
+}
+
+const FORBIDDEN_ELECTION_PROPERTY =
+  /^(?:USPRS|USSEN|VOTES?|TOTALVOTES?|TOTVOTING|REG7AM|EDR|CANDIDATE|PARTY)/i;
+
+function assertNoElectionValueProperties(value, context) {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertNoElectionValueProperties(item, context + "[" + index + "]"));
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_ELECTION_PROPERTY.test(key)) {
+      throw new Error(context + " contains election-value property " + key);
+    }
+    assertNoElectionValueProperties(child, context + "." + key);
+  }
+}
+
+export function canonicalJson(value) {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonicalJson(value[key])]),
+  );
+}
+
+function query(client, lines, params = []) {
+  return client.unsafe(Array.isArray(lines) ? lines.join("\n") : lines, params);
+}
+
+function chunks(rows, size = 400) {
+  const output = [];
+  for (let index = 0; index < rows.length; index += size) {
+    output.push(rows.slice(index, index + size));
+  }
+  return output;
+}
+
+async function sourceDocument(tx, document) {
+  const rows = await query(tx, [
+    "insert into source_documents (",
+    " slug, state_code, election_year, category, title, source_url, authority,",
+    " local_artifact, parser, timestamp_basis, confidence, status, metadata",
+    ") values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::text::jsonb)",
+    "on conflict (slug) do update set",
+    " election_year=excluded.election_year, category=excluded.category,",
+    " title=excluded.title, source_url=excluded.source_url,",
+    " authority=excluded.authority, local_artifact=excluded.local_artifact,",
+    " parser=excluded.parser, timestamp_basis=excluded.timestamp_basis,",
+    " confidence=excluded.confidence, status=excluded.status,",
+    " metadata=excluded.metadata",
+    "where source_documents.state_code=excluded.state_code",
+    "returning id",
+  ], [
+    document.slug,
+    STATE,
+    document.year,
+    document.category,
+    document.title,
+    document.sourceUrl,
+    document.authority,
+    document.localArtifact,
+    document.parser,
+    document.timestampBasis,
+    document.confidence,
+    document.status,
+    JSON.stringify(document.metadata),
+  ]);
+  if (rows.length !== 1) {
+    throw new Error("Source-document slug belongs to another state: " + document.slug);
+  }
+  return String(rows[0].id);
+}
+
+async function electionAndContest(tx, yearPlan) {
+  const existing = await query(tx, [
+    "select id,election_date from elections",
+    "where year=$1 and office='president'",
+  ], [yearPlan.year]);
+  if (existing.length && String(existing[0].election_date) !== yearPlan.electionDate) {
+    throw new Error(
+      "Existing " + yearPlan.year + " presidential date is "
+      + existing[0].election_date + ", expected " + yearPlan.electionDate,
+    );
+  }
+  const elections = await query(tx, [
+    "insert into elections (year,office,election_date,label)",
+    "values ($1,'president',$2,$3)",
+    "on conflict (year,office) do update set label=excluded.label",
+    "returning id",
+  ], [yearPlan.year, yearPlan.electionDate, yearPlan.year + " General Election"]);
+  const electionId = String(elections[0].id);
+  const contests = await query(tx, [
+    "insert into contests (election_id,state_code,office,title)",
+    "values ($1::uuid,$2,'president',$3)",
+    "on conflict (election_id,state_code,office) do update set title=excluded.title",
+    "returning id",
+  ], [electionId, STATE, "North Carolina " + yearPlan.year + " President"]);
+  return { electionId, contestId: String(contests[0].id) };
+}
+
+async function candidates(tx, contestId, yearPlan) {
+  const records = [];
+  const seen = new Set();
+  for (const row of yearPlan.resultRows) {
+    const key = row.candidateName + "|" + row.party;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    records.push({
+      name: row.candidateName,
+      party: row.party,
+      order: records.length + 1,
+    });
+  }
+  for (const record of records) {
+    await query(tx, [
+      "insert into candidates (contest_id,name,party,ballot_order)",
+      "values ($1::uuid,$2,$3,$4)",
+      "on conflict (contest_id,name,party) do update set ballot_order=excluded.ballot_order",
+    ], [contestId, record.name, record.party, record.order]);
+  }
+}
+
+async function importRun(tx, yearPlan, resultSourceDocumentId, context) {
+  const found = await query(tx, [
+    "select id from import_runs",
+    "where state_code=$1 and election_year=$2 and parser=$3",
+    " and source_document_id=$4::uuid",
+    "order by started_at,id limit 1",
+  ], [STATE, yearPlan.year, context.importParser, resultSourceDocumentId]);
+  const summary = JSON.stringify({
+    scope: context.importScope,
+    electionId: yearPlan.electionId,
+    reportingUnits: yearPlan.reportingUnits.length,
+    resultRows: yearPlan.resultRows.length,
+    geometryDisposition: yearPlan.geometry.disposition,
+    geometryFeatures: yearPlan.geometry.features.length,
+    crosswalks: yearPlan.geometry.crosswalks.length,
+    publicDeliveryAuthorized: false,
+    ...executionMetadata(context),
+  });
+  if (found.length) {
+    await query(tx, [
+      "update import_runs set status='promoted',finished_at=now(),",
+      " summary=$2::text::jsonb where id=$1::uuid",
+    ], [found[0].id, summary]);
+    return String(found[0].id);
+  }
+  const inserted = await query(tx, [
+    "insert into import_runs (state_code,election_year,parser,source_document_id,",
+    " status,started_at,finished_at,summary)",
+    "values ($1,$2,$3,$4::uuid,'promoted',now(),now(),$5::text::jsonb)",
+    "returning id",
+  ], [STATE, yearPlan.year, context.importParser, resultSourceDocumentId, summary]);
+  return String(inserted[0].id);
+}
+
+async function reportingUnits(
+  tx,
+  yearPlan,
+  electionId,
+  resultSourceDocumentId,
+  context,
+) {
+  for (const batch of chunks(yearPlan.reportingUnits)) {
+    const records = batch.map((unit) => ({
+      reporting_grain: unit.reportingGrain,
+      parent_geoid: unit.parentGeoid,
+      source_unit_id: unit.sourceUnitId,
+      source_display_name: unit.sourceDisplayName,
+      is_geographic: unit.isGeographic,
+      metadata: {
+        electionEventId: yearPlan.electionId,
+        reportingUnitCode: unit.code,
+        setupTool: context.resultParser,
+        resultStatus: unit.resultStatus,
+        ...(unit.resultStatus === "candidate_detail_suppressed"
+          ? {
+            reportedRegistration: unit.reportedRegistration,
+            reportedTurnout: unit.reportedTurnout,
+            reportedTotalVotes: unit.reportedTotalVotes,
+          }
+          : {}),
+        ...executionMetadata(context),
+      },
+    }));
+    await query(tx, [
+      "insert into reporting_units (state_code,election_id,reporting_grain,",
+      " parent_geoid,source_unit_id,source_display_name,is_geographic,",
+      " source_document_id,metadata)",
+      "select $1,$2::uuid,incoming.reporting_grain,incoming.parent_geoid,",
+      " incoming.source_unit_id,incoming.source_display_name,incoming.is_geographic,",
+      " $3::uuid,incoming.metadata",
+      "from jsonb_to_recordset($4::text::jsonb) incoming (",
+      " reporting_grain text,parent_geoid text,source_unit_id text,",
+      " source_display_name text,is_geographic boolean,metadata jsonb)",
+      "on conflict on constraint reporting_units_state_election_grain_parent_source_unique",
+      "do update set source_display_name=excluded.source_display_name,",
+      " is_geographic=excluded.is_geographic,",
+      " source_document_id=excluded.source_document_id,metadata=excluded.metadata,",
+      " updated_at=now()",
+    ], [STATE, electionId, resultSourceDocumentId, JSON.stringify(records)]);
+  }
+  const stored = await query(tx, [
+    "select id,reporting_grain,parent_geoid,source_unit_id",
+    "from reporting_units",
+    "where state_code=$1 and election_id=$2::uuid",
+    " and reporting_grain in ($4,'administrative_reporting_unit')",
+    " and source_document_id=$3::uuid",
+  ], [
+    STATE,
+    electionId,
+    resultSourceDocumentId,
+    yearPlan.manifest.geography.level,
+  ]);
+  if (stored.length !== yearPlan.reportingUnits.length) {
+    throw new Error("North Carolina " + yearPlan.year + " reporting-unit count drifted");
+  }
+  const ids = new Map();
+  for (const row of stored) {
+    const code = reportingUnitCode({
+      state: STATE,
+      electionId: yearPlan.electionId,
+      reportingGrain: String(row.reporting_grain),
+      parentGeoid: row.parent_geoid ? String(row.parent_geoid) : null,
+      sourceUnitId: String(row.source_unit_id),
+    });
+    ids.set(code, String(row.id));
+  }
+  for (const unit of yearPlan.reportingUnits) {
+    if (!ids.has(unit.code)) throw new Error("Missing local reporting unit " + unit.code);
+  }
+  return ids;
+}
+
+async function results(tx, yearPlan, contestId, importRunId, sourceDocumentId, unitIds) {
+  for (const batch of chunks(yearPlan.resultRows)) {
+    const records = batch.map((row) => ({
+      jurisdiction_code: row.jurisdictionCode,
+      jurisdiction_name: row.jurisdictionName,
+      candidate_name: row.candidateName,
+      party: row.party,
+      votes: row.votes,
+      reporting_unit_id: unitIds.get(row.jurisdictionCode),
+    }));
+    if (records.some((row) => !row.reporting_unit_id)) {
+      throw new Error("North Carolina " + yearPlan.year + " result lacks reporting unit");
+    }
+    await query(tx, [
+      "insert into result_rows (import_run_id,contest_id,state_code,",
+      " jurisdiction_code,jurisdiction_name,jurisdiction_tag,level,",
+      " candidate_name,party,votes,reporting_unit_id,source_document_id)",
+      "select $1::uuid,$2::uuid,$3,incoming.jurisdiction_code,",
+      " incoming.jurisdiction_name,null,$4,incoming.candidate_name,",
+      " incoming.party,incoming.votes,incoming.reporting_unit_id,$5::uuid",
+      "from jsonb_to_recordset($6::text::jsonb) incoming (",
+      " jurisdiction_code text,jurisdiction_name text,candidate_name text,",
+      " party text,votes integer,reporting_unit_id uuid)",
+      "on conflict (contest_id,level,jurisdiction_code,candidate_name,party)",
+      "do update set jurisdiction_name=excluded.jurisdiction_name,",
+      " state_code=excluded.state_code,jurisdiction_tag=excluded.jurisdiction_tag,",
+      " level=excluded.level,votes=excluded.votes,",
+      " reporting_unit_id=excluded.reporting_unit_id,",
+      " source_document_id=excluded.source_document_id,",
+      " import_run_id=excluded.import_run_id",
+    ], [
+      importRunId,
+      contestId,
+      STATE,
+      yearPlan.manifest.geography.level,
+      sourceDocumentId,
+      JSON.stringify(records),
+    ]);
+  }
+  const stored = await query(tx, [
+    "select jurisdiction_code,jurisdiction_name,candidate_name,party,votes,",
+    " reporting_unit_id from result_rows",
+    "where contest_id=$1::uuid and state_code=$2 and level=$4",
+    " and jurisdiction_code like $3",
+  ], [
+    contestId,
+    STATE,
+    "reporting:" + STATE + ":" + yearPlan.electionId + ":%",
+    yearPlan.manifest.geography.level,
+  ]);
+  if (stored.length !== yearPlan.resultRows.length) {
+    throw new Error("North Carolina " + yearPlan.year + " local-result count drifted");
+  }
+  const expected = new Map(yearPlan.resultRows.map((row) => [
+    [row.jurisdictionCode, row.candidateName, row.party].join("|"),
+    row,
+  ]));
+  for (const row of stored) {
+    const key = [row.jurisdiction_code, row.candidate_name, row.party].join("|");
+    const wanted = expected.get(key);
+    if (
+      !wanted
+      || Number(row.votes) !== wanted.votes
+      || String(row.jurisdiction_name) !== wanted.jurisdictionName
+      || String(row.reporting_unit_id) !== unitIds.get(wanted.jurisdictionCode)
+    ) {
+      throw new Error("North Carolina " + yearPlan.year + " result drift at " + key);
+    }
+  }
+}
+
+async function clearLocalReplayRows(tx, yearPlan, electionId, contestId, context) {
+  if (context.mode !== "local") return;
+  await query(tx, [
+    "delete from reporting_unit_geometry_crosswalks crosswalk",
+    "using geography_versions version",
+    "where crosswalk.geometry_version_id=version.id",
+    " and version.state_code=$1 and version.election_id=$2::uuid",
+    " and version.geography_type=$3",
+  ], [STATE, electionId, yearPlan.manifest.geography.level]);
+  // A reviewed local replay may legitimately replace an earlier blocked
+  // boundary snapshot. Never delete a release-attributed or published version;
+  // either condition survives this cleanup and the normal precondition below
+  // rejects the replay.
+  await query(tx, [
+    "delete from geography_versions",
+    "where state_code=$1 and election_id=$2::uuid",
+    " and geography_type=$3 and status='blocked'",
+    " and metadata->'releaseCandidate' is null",
+  ], [STATE, electionId, yearPlan.manifest.geography.level]);
+  await query(tx, [
+    "delete from result_rows",
+    "where contest_id=$1::uuid and state_code=$2 and level=$4",
+    " and jurisdiction_code like $3",
+  ], [
+    contestId,
+    STATE,
+    `reporting:${STATE}:${yearPlan.electionId}:%`,
+    yearPlan.manifest.geography.level,
+  ]);
+  await query(tx, [
+    "delete from reporting_units",
+    "where state_code=$1 and election_id=$2::uuid",
+    " and reporting_grain in ($4,'administrative_reporting_unit')",
+    " and metadata->>'setupTool'=$3",
+  ], [STATE, electionId, context.resultParser, yearPlan.manifest.geography.level]);
+}
+
+async function geometry(
+  tx,
+  yearPlan,
+  electionId,
+  sourceDocumentId,
+  unitIds,
+  context,
+) {
+  if (yearPlan.geometry.disposition === "blocked") {
+    const existing = await query(tx, [
+      "select count(*)::int count from geography_versions",
+      "where state_code=$1 and election_id=$2::uuid and geography_type=$3",
+    ], [STATE, electionId, yearPlan.manifest.geography.level]);
+    if (Number(existing[0].count) !== 0) {
+      throw new Error("Blocked North Carolina " + yearPlan.year + " already has geometry");
+    }
+    return { geographyVersions: 0, features: 0, crosswalks: 0 };
+  }
+
+  const versions = await query(tx, [
+    "select id,boundary_vintage,metadata->>'manifestId' manifest_id from geography_versions",
+    "where state_code=$1 and election_id=$2::uuid and geography_type=$3",
+  ], [STATE, electionId, yearPlan.manifest.geography.level]);
+  assertNorthCarolinaGeometryVersionPrecondition(versions, yearPlan);
+
+  const upserted = await query(tx, [
+    "insert into geography_versions (state_code,election_id,geography_type,",
+    " boundary_vintage,vintage_status,source_document_id,source_layer,",
+    " source_crs,served_crs,derivation_method,status,caveat,metadata,updated_at)",
+    "values ($1,$2::uuid,$3,$4,$5,$6::uuid,$7,$8,$9,$10,",
+    " 'blocked',$11,$12::text::jsonb,now())",
+    "on conflict (state_code,election_id,geography_type,boundary_vintage)",
+    "do update set vintage_status=excluded.vintage_status,",
+    " source_document_id=excluded.source_document_id,source_layer=excluded.source_layer,",
+    " source_crs=excluded.source_crs,served_crs=excluded.served_crs,",
+    " derivation_method=excluded.derivation_method,status='blocked',",
+    " caveat=excluded.caveat,metadata=excluded.metadata,updated_at=now()",
+    "returning id",
+  ], [
+    STATE,
+    electionId,
+    yearPlan.manifest.geography.level,
+    yearPlan.manifest.geography.boundaryVintage,
+    yearPlan.manifest.geography.vintageStatus,
+    sourceDocumentId,
+    yearPlan.manifest.id,
+    yearPlan.manifest.normalization.sourceCrs,
+    yearPlan.manifest.normalization.servedCrs,
+    yearPlan.manifest.geography.derivationMethod,
+    yearPlan.manifest.validation.errors.join(" "),
+    JSON.stringify({
+      manifestId: yearPlan.manifest.id,
+      manifestPath: yearPlan.manifestPath,
+      manifestSha256: yearPlan.manifestSha256,
+      manifestByteCount: yearPlan.manifestByteCount,
+      source: {
+        artifact: yearPlan.manifest.source.artifact,
+        sha256: yearPlan.manifest.source.sha256,
+        byteCount: yearPlan.artifactByteCounts.source,
+      },
+      normalization: {
+        artifact: yearPlan.manifest.normalization.artifact,
+        sha256: yearPlan.manifest.normalization.sha256,
+        byteCount: yearPlan.artifactByteCounts.normalization,
+        featureCount: yearPlan.geometry.features.length,
+      },
+      crosswalk: {
+        artifact: yearPlan.manifest.crosswalk.artifact,
+        sha256: yearPlan.manifest.crosswalk.sha256,
+        byteCount: yearPlan.artifactByteCounts.crosswalk,
+        reviewedRelationships: yearPlan.geometry.crosswalks.length,
+        reviewedNoDataFeatures:
+          yearPlan.manifest.crosswalk.reviewedNoDataFeatures,
+      },
+      licenseOrTerms: yearPlan.manifest.source.licenseOrTerms,
+      publicDeliveryAuthorized: false,
+      ...executionMetadata(context),
+    }),
+  ]);
+  const versionId = String(upserted[0].id);
+
+  for (const batch of chunks(yearPlan.geometry.features, 250)) {
+    const records = batch.map((feature) => ({
+      source_feature_id: feature.sourceFeatureId,
+      parent_geoid: feature.parentGeoid,
+      name: feature.name,
+      geometry_key: feature.geometryKey,
+      is_geographic: feature.isGeographic,
+      properties: feature.properties,
+    }));
+    await query(tx, [
+      "insert into geography_features (geometry_version_id,source_feature_id,",
+      " parent_geoid,name,geometry_key,is_geographic,properties)",
+      "select $1::uuid,incoming.source_feature_id,incoming.parent_geoid,",
+      " incoming.name,incoming.geometry_key,incoming.is_geographic,incoming.properties",
+      "from jsonb_to_recordset($2::text::jsonb) incoming (",
+      " source_feature_id text,parent_geoid text,name text,geometry_key text,",
+      " is_geographic boolean,properties jsonb)",
+      "on conflict (geometry_version_id,source_feature_id) do update set",
+      " parent_geoid=excluded.parent_geoid,name=excluded.name,",
+      " geometry_key=excluded.geometry_key,is_geographic=excluded.is_geographic,",
+      " properties=excluded.properties",
+    ], [versionId, JSON.stringify(records)]);
+  }
+  await query(tx, [
+    "delete from geography_features feature",
+    "where feature.geometry_version_id=$1::uuid and not exists (",
+    " select 1 from jsonb_array_elements_text($2::text::jsonb) ids(value)",
+    " where ids.value=feature.source_feature_id)",
+  ], [
+    versionId,
+    JSON.stringify(yearPlan.geometry.features.map((row) => row.sourceFeatureId)),
+  ]);
+  const storedFeatures = await query(tx, [
+    "select id,source_feature_id from geography_features",
+    "where geometry_version_id=$1::uuid",
+  ], [versionId]);
+  if (storedFeatures.length !== yearPlan.geometry.features.length) {
+    throw new Error("North Carolina " + yearPlan.year + " geography-feature count drifted");
+  }
+  const featureIds = new Map(
+    storedFeatures.map((row) => [String(row.source_feature_id), String(row.id)]),
+  );
+
+  await query(tx, [
+    "delete from reporting_unit_geometry_crosswalks",
+    "where geometry_version_id=$1::uuid",
+  ], [versionId]);
+  for (const batch of chunks(yearPlan.geometry.crosswalks)) {
+    const records = batch.map((row) => ({
+      reporting_unit_id: unitIds.get(row.reportingUnitCode),
+      geography_feature_id: row.sourceFeatureId === null
+        ? null
+        : featureIds.get(row.sourceFeatureId),
+      relationship_type: row.relationshipType,
+      match_method: row.matchMethod,
+      review_status: row.reviewStatus,
+      confidence: row.confidence,
+      note: row.note,
+      metadata: {
+        manifestId: yearPlan.manifest.id,
+        resultUnitCode: row.reportingUnitCode,
+        sourceFeatureId: row.sourceFeatureId,
+        publicDeliveryAuthorized: false,
+        ...executionMetadata(context),
+      },
+    }));
+    if (records.some((row) => (
+      !row.reporting_unit_id
+      || (
+        ["one_to_one", "one_to_many", "many_to_one"].includes(
+          row.relationship_type,
+        )
+        && !row.geography_feature_id
+      )
+      || (
+        ["unmatched", "non_geographic", "source_alias"].includes(
+          row.relationship_type,
+        )
+        && row.geography_feature_id !== null
+      )
+    ))) {
+      throw new Error("North Carolina " + yearPlan.year + " cannot resolve crosswalk UUIDs");
+    }
+    await query(tx, [
+      "insert into reporting_unit_geometry_crosswalks (reporting_unit_id,",
+      " geometry_version_id,geography_feature_id,relationship_type,match_method,",
+      " review_status,confidence,source_document_id,reviewed_by,note,metadata)",
+      "select incoming.reporting_unit_id,$1::uuid,incoming.geography_feature_id,",
+      " incoming.relationship_type,incoming.match_method,incoming.review_status,",
+      " incoming.confidence,$2::uuid,$3,incoming.note,",
+      " incoming.metadata",
+      "from jsonb_to_recordset($4::text::jsonb) incoming (",
+      " reporting_unit_id uuid,geography_feature_id uuid,relationship_type text,",
+      " match_method text,review_status text,confidence text,note text,metadata jsonb)",
+    ], [versionId, sourceDocumentId, context.reviewedBy, JSON.stringify(records)]);
+  }
+  const counts = await query(tx, [
+    "select count(*)::int total,",
+    " count(*) filter (where review_status='reviewed')::int reviewed",
+    "from reporting_unit_geometry_crosswalks",
+    "where geometry_version_id=$1::uuid",
+  ], [versionId]);
+  const expected = yearPlan.geometry.crosswalks.length;
+  if (["total", "reviewed"]
+    .some((key) => Number(counts[0][key]) !== expected)) {
+    throw new Error("North Carolina " + yearPlan.year + " crosswalk count drifted");
+  }
+  return { geographyVersions: 1, features: storedFeatures.length, crosswalks: expected };
+}
+
+async function applyYear(tx, yearPlan, context) {
+  const ids = await electionAndContest(tx, yearPlan);
+  await clearLocalReplayRows(
+    tx,
+    yearPlan,
+    ids.electionId,
+    ids.contestId,
+    context,
+  );
+  await candidates(tx, ids.contestId, yearPlan);
+
+  const resultSourceId = await sourceDocument(tx, {
+    slug: yearPlan.resultSource.slug,
+    year: yearPlan.year,
+    category: "Official presidential local and administrative reporting results",
+    title: "North Carolina " + yearPlan.year + " presidential local results",
+    sourceUrl: yearPlan.resultSource.url,
+    authority: yearPlan.resultSource.authority,
+    localArtifact: yearPlan.resultSource.artifact,
+    parser: context.resultParser,
+    timestampBasis: yearPlan.resultSource.timestampBasis,
+    confidence: "Official North Carolina State Board of Elections rows. Administrative reporting buckets are retained for reconciliation but are never assigned to election-geography polygons.",
+    status: "loaded",
+    metadata: {
+      sourceId: yearPlan.resultSource.id,
+      sha256: yearPlan.resultSource.sha256,
+      byteCount: yearPlan.resultSource.byteCount,
+      electionEventId: yearPlan.electionId,
+      reportingUnits: yearPlan.reportingUnits.length,
+      zeroVoteUnits: yearPlan.zeroVoteUnits,
+      totals: yearPlan.totals,
+      officialTotals: yearPlan.officialTotals,
+      supplementalArtifacts: yearPlan.resultSource.supplementalArtifacts ?? [],
+      publicDeliveryAuthorized: false,
+      ...executionMetadata(context),
+    },
+  });
+  const geometrySourceId = await sourceDocument(tx, {
+    slug: yearPlan.geometrySourceSlug,
+    year: yearPlan.year,
+    category: yearPlan.geometry.disposition === "blocked"
+      ? "Precinct geometry availability evidence"
+      : "Reviewed election-applicable statewide local boundaries",
+    title: "North Carolina " + yearPlan.year + " local geometry package",
+    sourceUrl: yearPlan.manifest.source.url,
+    authority: yearPlan.manifest.source.authority,
+    localArtifact: yearPlan.manifest.source.artifact,
+    parser: yearPlan.manifest.normalization.script,
+    timestampBasis: yearPlan.manifest.geography.boundaryVintage,
+    confidence: yearPlan.geometry.disposition === "blocked"
+      ? "Retained official evidence; geometry remains fail-closed."
+      : "Reviewed election-specific local geometry package with exact official IDs, explicit non-geographic exclusions, and retained provenance caveats.",
+    status: yearPlan.geometry.disposition === "blocked" ? "needs_data" : "loaded",
+    metadata: {
+      manifestId: yearPlan.manifest.id,
+      manifestPath: yearPlan.manifestPath,
+      manifestSha256: yearPlan.manifestSha256,
+      manifestByteCount: yearPlan.manifestByteCount,
+      source: {
+        artifact: yearPlan.manifest.source.artifact,
+        sha256: yearPlan.manifest.source.sha256,
+        byteCount: yearPlan.artifactByteCounts.source,
+      },
+      normalization: {
+        artifact: yearPlan.manifest.normalization.artifact,
+        sha256: yearPlan.manifest.normalization.sha256,
+        byteCount: yearPlan.artifactByteCounts.normalization,
+      },
+      crosswalk: {
+        artifact: yearPlan.manifest.crosswalk.artifact,
+        sha256: yearPlan.manifest.crosswalk.sha256,
+        byteCount: yearPlan.artifactByteCounts.crosswalk,
+      },
+      geometryDisposition: yearPlan.geometry.disposition,
+      blockCode: yearPlan.geometry.blockCode,
+      licenseOrTerms: yearPlan.manifest.source.licenseOrTerms,
+      publicDeliveryAuthorized: false,
+      ...executionMetadata(context),
+    },
+  });
+
+  const runId = await importRun(tx, yearPlan, resultSourceId, context);
+  const unitIds = await reportingUnits(
+    tx,
+    yearPlan,
+    ids.electionId,
+    resultSourceId,
+    context,
+  );
+  await results(tx, yearPlan, ids.contestId, runId, resultSourceId, unitIds);
+  const geometryCounts = await geometry(
+    tx,
+    yearPlan,
+    ids.electionId,
+    geometrySourceId,
+    unitIds,
+    context,
+  );
+  return {
+    year: yearPlan.year,
+    electionId: yearPlan.electionId,
+    reportingUnits: unitIds.size,
+    resultRows: yearPlan.resultRows.length,
+    zeroVoteUnits: yearPlan.zeroVoteUnits,
+    totals: yearPlan.totals,
+    geometryDisposition: yearPlan.geometry.disposition,
+    ...geometryCounts,
+  };
+}
+
+export async function applyNorthCarolinaLocalGisTransaction(
+  tx,
+  plan,
+  options = {},
+) {
+  const context = buildNorthCarolinaLocalExecutionContext(
+    options.executionContext,
+  );
+  const identity = await query(tx, [
+    "select current_database() database_name,",
+    " current_setting('transaction_read_only') transaction_read_only",
+  ]);
+  if (
+    identity.length !== 1
+    || String(identity[0].transaction_read_only) !== "off"
+    || String(identity[0].database_name) !== context.database.name
+  ) {
+    throw new Error(
+      "North Carolina local geography unit release transaction database identity or write mode drifted",
+    );
+  }
+
+  await query(tx, "select set_config('lock_timeout','30s',true)");
+  await query(
+    tx,
+    "select pg_advisory_xact_lock(hashtextextended('crm-nc-local-gis-release-v1',0))",
+  );
+  const tables = await query(tx, [
+    "select count(*)::int count from unnest(array[",
+    " 'elections','contests','candidates','source_documents','import_runs',",
+    " 'result_rows','reporting_units','geography_versions','geography_features',",
+    " 'reporting_unit_geometry_crosswalks']) required(name)",
+    "where to_regclass('public.'||required.name) is not null",
+  ]);
+  if (Number(tables[0].count) !== 10) {
+    throw new Error(
+      context.database.name + " lacks the complete migration 0008 local geography schema",
+    );
+  }
+  if (context.mode === "production_release") {
+    const targetYears = plan.years.map((year) => year.year);
+    const targetLevels = [...new Set(
+      plan.years.map((year) => year.manifest.geography.level),
+    )];
+    const existing = await query(tx, [
+      "select",
+      " (select count(*)::int from reporting_units ru",
+      "  join elections e on e.id=ru.election_id",
+      "  where ru.state_code='NC'",
+      "   and (ru.reporting_grain=any($2::text[])",
+      "    or ru.reporting_grain='administrative_reporting_unit')",
+      "   and e.office='president' and e.year=any($1::int[])) reporting_units,",
+      " (select count(*)::int from result_rows rr",
+      "  join contests c on c.id=rr.contest_id",
+      "  join elections e on e.id=c.election_id",
+      "  where rr.state_code='NC' and rr.level=any($2::text[])",
+      "   and e.office='president' and e.year=any($1::int[])) result_rows,",
+      " (select count(*)::int from geography_versions gv",
+      "  join elections e on e.id=gv.election_id",
+      "  where gv.state_code='NC' and gv.geography_type=any($2::text[])",
+      "   and e.office='president' and e.year=any($1::int[])) geography_versions",
+    ], [targetYears, targetLevels]);
+    const counts = existing[0] ?? {};
+    if (
+      Number(counts.reporting_units) !== 0
+      || Number(counts.result_rows) !== 0
+      || Number(counts.geography_versions) !== 0
+    ) {
+      throw new Error(
+        "North Carolina production hidden load refuses existing local release rows; "
+        + "use read-only receipt recovery or a separately reviewed rollback path",
+      );
+    }
+  }
+  await query(tx, [
+    "insert into states (code,name,authority) values ($1,$2,$3)",
+    "on conflict (code) do update set name=excluded.name,authority=excluded.authority",
+  ], [STATE, plan.stateName, plan.authority]);
+
+  const years = [];
+  for (const yearPlan of plan.years) {
+    years.push(await applyYear(tx, yearPlan, context));
+    if (
+      process.env.NODE_ENV === "test"
+      && options.testOnlyFailAfterYear === yearPlan.year
+    ) {
+      throw new Error("Intentional North Carolina GIS rollback after " + yearPlan.year);
+    }
+  }
+  const revisions = await query(tx, [
+    "insert into public_data_revisions (scope,revision,updated_at,reason)",
+    "values ('public',1,now(),$1)",
+    "on conflict (scope) do update set",
+    " revision=public_data_revisions.revision+1,updated_at=now(),reason=excluded.reason",
+    "returning revision::int revision",
+  ], [context.revisionReason]);
+  return {
+    database: context.database,
+    executionMode: context.mode,
+    productionMutationPerformed: context.mode === "production_release",
+    publicDeliveryAuthorized: false,
+    releaseCandidate: context.releaseCandidate,
+    productionReleaseAudit: context.productionReleaseAudit,
+    revision: Number(revisions[0].revision),
+    years,
+  };
+}
+
+export async function applyNorthCarolinaLocalGisPlan(plan, options = {}) {
+  if (getDatabaseDriver() !== "postgres") {
+    throw new Error("North Carolina local geography GIS setup requires CRM_DATABASE_DRIVER=postgres");
+  }
+  const databaseUrl = getLocalCloneDatabaseUrl({ requireWriteOptIn: true });
+  const sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+    max: 1,
+    connect_timeout: 10,
+    idle_timeout: 20,
+    connection: { application_name: APPLICATION_NAME },
+  });
+  try {
+    return await sql.begin((tx) => applyNorthCarolinaLocalGisTransaction(
+      tx,
+      plan,
+      {
+        executionContext: { mode: "local" },
+        testOnlyFailAfterYear: options.testOnlyFailAfterYear,
+      },
+    ));
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+async function validateSourceDocumentRecords(sql, yearPlan, context) {
+  const rows = await query(sql, [
+    "select slug,election_year,category,title,source_url,authority,local_artifact,",
+    " parser,timestamp_basis,status,metadata",
+    "from source_documents where state_code=$1 and slug in ($2,$3)",
+  ], [STATE, yearPlan.resultSource.slug, yearPlan.geometrySourceSlug]);
+  if (rows.length !== 2) {
+    throw new Error("North Carolina " + yearPlan.year + " source-document count drifted");
+  }
+  const bySlug = new Map(rows.map((row) => [String(row.slug), row]));
+  const result = bySlug.get(yearPlan.resultSource.slug);
+  const geometry = bySlug.get(yearPlan.geometrySourceSlug);
+  const resultMetadata = result?.metadata ?? {};
+  const geometryMetadata = geometry?.metadata ?? {};
+  if (
+    !result
+    || Number(result.election_year) !== yearPlan.year
+    || String(result.source_url) !== yearPlan.resultSource.url
+    || String(result.authority) !== yearPlan.resultSource.authority
+    || String(result.local_artifact) !== yearPlan.resultSource.artifact
+    || String(result.parser) !== context.resultParser
+    || String(result.timestamp_basis) !== yearPlan.resultSource.timestampBasis
+    || String(result.status) !== "loaded"
+    || resultMetadata.sha256 !== yearPlan.resultSource.sha256
+    || Number(resultMetadata.byteCount) !== yearPlan.resultSource.byteCount
+    || resultMetadata.electionEventId !== yearPlan.electionId
+    || resultMetadata.publicDeliveryAuthorized !== false
+    || JSON.stringify(canonicalJson(resultMetadata.supplementalArtifacts ?? []))
+      !== JSON.stringify(canonicalJson(yearPlan.resultSource.supplementalArtifacts ?? []))
+    || JSON.stringify(canonicalJson(resultMetadata.releaseCandidate ?? null))
+      !== JSON.stringify(canonicalJson(context.releaseCandidate))
+    || JSON.stringify(canonicalJson(resultMetadata.productionReleaseAudit ?? null))
+      !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
+  ) {
+    throw new Error("North Carolina " + yearPlan.year + " result provenance drifted");
+  }
+  const geometryStatus = yearPlan.geometry.disposition === "blocked" ? "needs_data" : "loaded";
+  if (
+    !geometry
+    || Number(geometry.election_year) !== yearPlan.year
+    || String(geometry.source_url) !== yearPlan.manifest.source.url
+    || String(geometry.authority) !== yearPlan.manifest.source.authority
+    || String(geometry.local_artifact) !== yearPlan.manifest.source.artifact
+    || String(geometry.parser) !== yearPlan.manifest.normalization.script
+    || String(geometry.timestamp_basis) !== yearPlan.manifest.geography.boundaryVintage
+    || String(geometry.status) !== geometryStatus
+    || geometryMetadata.manifestId !== yearPlan.manifest.id
+    || geometryMetadata.manifestPath !== yearPlan.manifestPath
+    || geometryMetadata.manifestSha256 !== yearPlan.manifestSha256
+    || Number(geometryMetadata.manifestByteCount) !== yearPlan.manifestByteCount
+    || geometryMetadata.source?.artifact !== yearPlan.manifest.source.artifact
+    || geometryMetadata.source?.sha256 !== yearPlan.manifest.source.sha256
+    || Number(geometryMetadata.source?.byteCount) !== yearPlan.artifactByteCounts.source
+    || geometryMetadata.normalization?.artifact !== yearPlan.manifest.normalization.artifact
+    || geometryMetadata.normalization?.sha256 !== yearPlan.manifest.normalization.sha256
+    || Number(geometryMetadata.normalization?.byteCount)
+      !== yearPlan.artifactByteCounts.normalization
+    || geometryMetadata.crosswalk?.artifact !== yearPlan.manifest.crosswalk.artifact
+    || geometryMetadata.crosswalk?.sha256 !== yearPlan.manifest.crosswalk.sha256
+    || Number(geometryMetadata.crosswalk?.byteCount) !== yearPlan.artifactByteCounts.crosswalk
+    || geometryMetadata.licenseOrTerms !== yearPlan.manifest.source.licenseOrTerms
+    || geometryMetadata.blockCode !== yearPlan.geometry.blockCode
+    || geometryMetadata.geometryDisposition !== yearPlan.geometry.disposition
+    || geometryMetadata.publicDeliveryAuthorized !== false
+    || JSON.stringify(canonicalJson(geometryMetadata.releaseCandidate ?? null))
+      !== JSON.stringify(canonicalJson(context.releaseCandidate))
+    || JSON.stringify(canonicalJson(geometryMetadata.productionReleaseAudit ?? null))
+      !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
+  ) {
+    throw new Error("North Carolina " + yearPlan.year + " geometry provenance drifted");
+  }
+  return {
+    resultSourceSlug: yearPlan.resultSource.slug,
+    geometrySourceSlug: yearPlan.geometrySourceSlug,
+  };
+}
+
+async function validateStoredProductionAudit(
+  sql,
+  yearPlan,
+  electionId,
+  context,
+) {
+  if (!context.releaseCandidate) return;
+  const audit = JSON.stringify(context.productionReleaseAudit);
+  // `audit` is serialized JSON text. Preserve the intermediate text cast so
+  // Postgres.js does not encode the parameter as a JSON string scalar.
+  const units = await query(sql, [
+    "select count(*)::int total,",
+    " count(*) filter (where metadata->'productionReleaseAudit'=$3::text::jsonb)::int exact_audit",
+    "from reporting_units where state_code=$1 and election_id=$2::uuid",
+    " and reporting_grain in ($4,'administrative_reporting_unit')",
+  ], [STATE, electionId, audit, yearPlan.manifest.geography.level]);
+  if (
+    Number(units[0]?.total) !== yearPlan.reportingUnits.length
+    || Number(units[0]?.exact_audit) !== yearPlan.reportingUnits.length
+  ) {
+    throw new Error("North Carolina " + yearPlan.year + " reporting-unit release audit drifted");
+  }
+  const imports = await query(sql, [
+    "select count(distinct ir.id)::int import_runs,count(rr.id)::int result_rows,",
+    " count(rr.id) filter (where ir.summary->'productionReleaseAudit'=$4::text::jsonb)::int exact_audit_rows",
+    "from import_runs ir",
+    "join result_rows rr on rr.import_run_id=ir.id and rr.state_code=$1",
+    "join contests c on c.id=rr.contest_id and c.election_id=$2::uuid",
+    "where ir.state_code=$1 and ir.election_year=$3 and ir.parser=$5",
+    " and rr.level=$6",
+  ], [
+    STATE,
+    electionId,
+    yearPlan.year,
+    audit,
+    context.importParser,
+    yearPlan.manifest.geography.level,
+  ]);
+  if (
+    Number(imports[0]?.import_runs) !== 1
+    || Number(imports[0]?.result_rows) !== yearPlan.resultRows.length
+    || Number(imports[0]?.exact_audit_rows) !== yearPlan.resultRows.length
+  ) {
+    throw new Error("North Carolina " + yearPlan.year + " import-run release audit drifted");
+  }
+}
+
+async function validateStoredGeometryRecords(sql, yearPlan, electionId, context) {
+  if (yearPlan.geometry.disposition === "blocked") {
+    return { exactFeatures: 0, exactCrosswalks: 0 };
+  }
+  const versions = await query(sql, [
+    "select metadata from geography_versions",
+    "where state_code=$1 and election_id=$2::uuid and geography_type=$3",
+  ], [STATE, electionId, yearPlan.manifest.geography.level]);
+  const expectedVersionMetadata = {
+    manifestId: yearPlan.manifest.id,
+    manifestPath: yearPlan.manifestPath,
+    manifestSha256: yearPlan.manifestSha256,
+    manifestByteCount: yearPlan.manifestByteCount,
+    source: {
+      artifact: yearPlan.manifest.source.artifact,
+      sha256: yearPlan.manifest.source.sha256,
+      byteCount: yearPlan.artifactByteCounts.source,
+    },
+    normalization: {
+      artifact: yearPlan.manifest.normalization.artifact,
+      sha256: yearPlan.manifest.normalization.sha256,
+      byteCount: yearPlan.artifactByteCounts.normalization,
+      featureCount: yearPlan.geometry.features.length,
+    },
+    crosswalk: {
+      artifact: yearPlan.manifest.crosswalk.artifact,
+      sha256: yearPlan.manifest.crosswalk.sha256,
+      byteCount: yearPlan.artifactByteCounts.crosswalk,
+      reviewedRelationships: yearPlan.geometry.crosswalks.length,
+      reviewedNoDataFeatures:
+        yearPlan.manifest.crosswalk.reviewedNoDataFeatures,
+    },
+    licenseOrTerms: yearPlan.manifest.source.licenseOrTerms,
+    publicDeliveryAuthorized: false,
+    ...executionMetadata(context),
+  };
+  if (
+    versions.length !== 1
+    || JSON.stringify(canonicalJson(versions[0].metadata))
+      !== JSON.stringify(canonicalJson(expectedVersionMetadata))
+  ) {
+    throw new Error("North Carolina " + yearPlan.year + " geography-version provenance drifted");
+  }
+  const features = await query(sql, [
+    "select gf.source_feature_id,gf.parent_geoid,gf.name,gf.geometry_key,",
+    " gf.is_geographic,gf.properties",
+    "from geography_features gf",
+    "join geography_versions gv on gv.id=gf.geometry_version_id",
+    "where gv.state_code=$1 and gv.election_id=$2::uuid",
+    " and gv.geography_type=$4 and gv.metadata->>'manifestId'=$3",
+    "order by gf.source_feature_id",
+  ], [
+    STATE,
+    electionId,
+    yearPlan.manifest.id,
+    yearPlan.manifest.geography.level,
+  ]);
+  const expectedFeatures = new Map(
+    yearPlan.geometry.features.map((feature) => [feature.sourceFeatureId, feature]),
+  );
+  if (features.length !== expectedFeatures.size) {
+    throw new Error("North Carolina " + yearPlan.year + " exact feature count drifted");
+  }
+  const seenFeatures = new Set();
+  for (const row of features) {
+    const sourceFeatureId = String(row.source_feature_id);
+    const expected = expectedFeatures.get(sourceFeatureId);
+    assertNoElectionValueProperties(
+      row.properties,
+      "North Carolina " + yearPlan.year + " stored feature " + sourceFeatureId,
+    );
+    if (
+      !expected
+      || seenFeatures.has(sourceFeatureId)
+      || String(row.parent_geoid) !== expected.parentGeoid
+      || String(row.name) !== expected.name
+      || String(row.geometry_key) !== expected.geometryKey
+      || row.is_geographic !== expected.isGeographic
+      || JSON.stringify(canonicalJson(row.properties))
+        !== JSON.stringify(canonicalJson(expected.properties))
+    ) {
+      throw new Error("North Carolina " + yearPlan.year + " stored feature drifted at " + sourceFeatureId);
+    }
+    seenFeatures.add(sourceFeatureId);
+  }
+
+  const crosswalks = await query(sql, [
+    "select ru.reporting_grain,ru.parent_geoid,ru.source_unit_id,",
+    " gf.source_feature_id,x.relationship_type,x.match_method,x.review_status,",
+    " x.confidence,x.reviewed_by,x.note,x.metadata",
+    "from reporting_unit_geometry_crosswalks x",
+    "join geography_versions gv on gv.id=x.geometry_version_id",
+    "join reporting_units ru on ru.id=x.reporting_unit_id",
+    "left join geography_features gf on gf.id=x.geography_feature_id",
+    "join source_documents sd on sd.id=x.source_document_id",
+    "where gv.state_code=$1 and gv.election_id=$2::uuid",
+    " and ru.state_code=$1 and ru.election_id=$2::uuid",
+    " and gv.metadata->>'manifestId'=$3 and sd.slug=$4",
+    "order by ru.parent_geoid,ru.source_unit_id",
+  ], [STATE, electionId, yearPlan.manifest.id, yearPlan.geometrySourceSlug]);
+  const expectedCrosswalks = new Map(yearPlan.geometry.crosswalks.map((crosswalk) => [
+    `${crosswalk.reportingUnitCode}|${crosswalk.sourceFeatureId}`,
+    crosswalk,
+  ]));
+  if (crosswalks.length !== expectedCrosswalks.size) {
+    throw new Error("North Carolina " + yearPlan.year + " exact crosswalk count drifted");
+  }
+  const seenCrosswalks = new Set();
+  for (const row of crosswalks) {
+    const reportingCode = reportingUnitCode({
+      state: STATE,
+      electionId: yearPlan.electionId,
+      reportingGrain: String(row.reporting_grain),
+      parentGeoid: row.parent_geoid ? String(row.parent_geoid) : null,
+      sourceUnitId: String(row.source_unit_id),
+    });
+    const crosswalkKey = `${reportingCode}|${row.source_feature_id}`;
+    const expected = expectedCrosswalks.get(crosswalkKey);
+    const metadata = row.metadata ?? {};
+    if (
+      !expected
+      || seenCrosswalks.has(crosswalkKey)
+      || (row.source_feature_id === null
+        ? expected.sourceFeatureId !== null
+        : String(row.source_feature_id) !== expected.sourceFeatureId)
+      || String(row.relationship_type) !== expected.relationshipType
+      || String(row.match_method) !== expected.matchMethod
+      || String(row.review_status) !== expected.reviewStatus
+      || String(row.confidence) !== expected.confidence
+      || String(row.reviewed_by) !== context.reviewedBy
+      || String(row.note ?? "") !== expected.note
+      || metadata.manifestId !== yearPlan.manifest.id
+      || metadata.resultUnitCode !== reportingCode
+      || metadata.sourceFeatureId !== expected.sourceFeatureId
+      || metadata.publicDeliveryAuthorized !== false
+      || JSON.stringify(canonicalJson(metadata.releaseCandidate ?? null))
+        !== JSON.stringify(canonicalJson(context.releaseCandidate))
+      || JSON.stringify(canonicalJson(metadata.productionReleaseAudit ?? null))
+        !== JSON.stringify(canonicalJson(context.productionReleaseAudit))
+    ) {
+      throw new Error("North Carolina " + yearPlan.year + " stored crosswalk drifted at " + reportingCode);
+    }
+    seenCrosswalks.add(crosswalkKey);
+  }
+  return { exactFeatures: features.length, exactCrosswalks: crosswalks.length };
+}
+
+export async function readNorthCarolinaPersistedProductionReleaseAudit(
+  sql,
+  releaseCandidate,
+) {
+  if (
+    typeof releaseCandidate?.id !== "string"
+    || !/^[a-f0-9]{64}$/.test(releaseCandidate?.sha256 ?? "")
+  ) {
+    throw new Error("North Carolina hidden receipt recovery requires an exact release candidate");
+  }
+  const rows = await query(sql, [
+    "select e.year,gv.geography_type,gv.status,gv.metadata",
+    "from geography_versions gv",
+    "join elections e on e.id=gv.election_id",
+    "where gv.state_code='NC' and gv.geography_type=any($3::text[])",
+    " and gv.metadata->'releaseCandidate'->>'id'=$1",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$2",
+    "order by e.year",
+  ], [releaseCandidate.id, releaseCandidate.sha256, ["vtd", "precinct"]]);
+  const expectedYears = [2012, 2016, 2020];
+  const expectedLevels = ["vtd", "precinct", "precinct"];
+  if (
+    rows.length !== expectedYears.length
+    || rows.some((row, index) => (
+      Number(row.year) !== expectedYears[index]
+      || String(row.geography_type) !== expectedLevels[index]
+    ))
+  ) {
+    throw new Error("North Carolina hidden receipt recovery found an incomplete year set");
+  }
+  const firstAudit = rows[0]?.metadata?.productionReleaseAudit;
+  const audit = validatedProductionReleaseAudit(firstAudit);
+  for (const row of rows) {
+    if (
+      String(row.status) !== "blocked"
+      || row.metadata?.publicDeliveryAuthorized !== false
+      || JSON.stringify(canonicalJson(row.metadata?.releaseCandidate ?? null))
+        !== JSON.stringify(canonicalJson({
+          id: releaseCandidate.id,
+          sha256: releaseCandidate.sha256,
+          publicDeliveryAuthorized: false,
+        }))
+      || JSON.stringify(canonicalJson(row.metadata?.productionReleaseAudit ?? null))
+        !== JSON.stringify(canonicalJson(audit))
+    ) {
+      throw new Error("North Carolina hidden receipt recovery audit drifted across years");
+    }
+  }
+  return audit;
+}
+
+export async function validateNorthCarolinaLocalGisClient(
+  sql,
+  plan,
+  options = {},
+) {
+    const context = buildNorthCarolinaLocalExecutionContext(
+      options.executionContext,
+    );
+    const output = [];
+    for (const yearPlan of plan.years) {
+      const rows = await query(sql, [
+        "select e.id election_id,",
+        " (select count(*)::int from reporting_units ru",
+        "  where ru.state_code=$1 and ru.election_id=e.id",
+        "   and ru.reporting_grain in ($6,'administrative_reporting_unit')) reporting_units,",
+        " (select count(*)::int from result_rows rr join contests c on c.id=rr.contest_id",
+        "  where rr.state_code=$1 and c.election_id=e.id and c.office='president'",
+        "   and rr.level=$6 and rr.jurisdiction_code like $3) result_rows,",
+        " (select count(*)::int from result_rows rr",
+        "  join contests c on c.id=rr.contest_id",
+        "  join reporting_units ru on ru.id=rr.reporting_unit_id",
+        "  where rr.state_code=$1 and c.election_id=e.id and c.office='president'",
+        "   and rr.level=$6 and rr.jurisdiction_code like $3",
+        "   and ru.state_code=$1 and ru.election_id=e.id and ru.reporting_grain=$6)",
+        "  same_year_result_rows,",
+        " (select count(*)::int from geography_versions gv",
+        "  where gv.state_code=$1 and gv.election_id=e.id",
+        "   and gv.geography_type=$6) geography_versions,",
+        " (select count(*)::int from geography_versions gv",
+        "  where gv.state_code=$1 and gv.election_id=e.id",
+        "   and gv.geography_type=$6 and gv.status='blocked'",
+        "   and gv.metadata->>'manifestId'=$4::text and gv.metadata->>'manifestSha256'=$5::text",
+        "   and gv.metadata->>'publicDeliveryAuthorized'='false')",
+        "  safe_geography_versions,",
+        " (select count(*)::int from geography_features gf",
+        "  join geography_versions gv on gv.id=gf.geometry_version_id",
+        "  where gv.state_code=$1 and gv.election_id=e.id",
+        "   and gv.geography_type=$6) features,",
+        " (select count(*)::int from reporting_unit_geometry_crosswalks x",
+        "  join geography_versions gv on gv.id=x.geometry_version_id",
+        "  join reporting_units ru on ru.id=x.reporting_unit_id",
+        "  where gv.state_code=$1 and gv.election_id=e.id and ru.election_id=e.id",
+        "   and x.review_status='reviewed') crosswalks",
+        "from elections e where e.year=$2 and e.office='president'",
+      ], [
+        STATE,
+        yearPlan.year,
+        "reporting:" + STATE + ":" + yearPlan.electionId + ":%",
+        yearPlan.manifest.id,
+        yearPlan.manifestSha256,
+        yearPlan.manifest.geography.level,
+      ]);
+      if (rows.length !== 1) throw new Error("Missing " + yearPlan.year + " election");
+      const row = rows[0];
+      const expectedGeometry = yearPlan.geometry.disposition === "blocked"
+        ? { versions: 0, features: 0, crosswalks: 0 }
+        : {
+          versions: 1,
+          features: yearPlan.geometry.features.length,
+          crosswalks: yearPlan.geometry.crosswalks.length,
+        };
+      if (
+        Number(row.reporting_units) !== yearPlan.reportingUnits.length
+        || Number(row.result_rows) !== yearPlan.resultRows.length
+        || Number(row.geography_versions) !== expectedGeometry.versions
+        || Number(row.features) !== expectedGeometry.features
+        || Number(row.same_year_result_rows) !== yearPlan.resultRows.length
+        || Number(row.crosswalks) !== expectedGeometry.crosswalks
+        || Number(row.safe_geography_versions) !== expectedGeometry.versions
+      ) {
+        throw new Error("North Carolina " + yearPlan.year + " database counts drifted: " + JSON.stringify({
+          actual: row,
+          expected: {
+            reportingUnits: yearPlan.reportingUnits.length,
+            resultRows: yearPlan.resultRows.length,
+            sameYearResultRows: yearPlan.resultRows.length,
+            geographyVersions: expectedGeometry.versions,
+            features: expectedGeometry.features,
+            crosswalks: expectedGeometry.crosswalks,
+            safeGeographyVersions: expectedGeometry.versions,
+          },
+        }));
+      }
+      const provenance = await validateSourceDocumentRecords(
+        sql,
+        yearPlan,
+        context,
+      );
+      await validateStoredProductionAudit(
+        sql,
+        yearPlan,
+        row.election_id,
+        context,
+      );
+      const exactGeometry = await validateStoredGeometryRecords(
+        sql,
+        yearPlan,
+        row.election_id,
+        context,
+      );
+
+      const totals = await query(sql, [
+        "select candidate_name,sum(votes)::bigint votes from result_rows rr",
+        "join contests c on c.id=rr.contest_id",
+        "where rr.state_code=$1 and c.election_id=$2::uuid and rr.level=$4",
+        " and rr.jurisdiction_code like $3",
+        "group by candidate_name order by candidate_name",
+      ], [
+        STATE,
+        row.election_id,
+        "reporting:" + STATE + ":" + yearPlan.electionId + ":%",
+        yearPlan.manifest.geography.level,
+      ]);
+      const actualTotals = Object.fromEntries(
+        totals.map((item) => [String(item.candidate_name), Number(item.votes)]),
+      );
+      const expectedTotals = {};
+      for (const result of yearPlan.resultRows) {
+        expectedTotals[result.candidateName] =
+          (expectedTotals[result.candidateName] ?? 0) + result.votes;
+      }
+      for (const [name, votes] of Object.entries(expectedTotals)) {
+        if (actualTotals[name] !== votes) {
+          throw new Error("North Carolina " + yearPlan.year + " " + name + " total drifted");
+        }
+      }
+      if (Object.keys(actualTotals).length !== Object.keys(expectedTotals).length) {
+        throw new Error("North Carolina " + yearPlan.year + " candidate grouping drifted");
+      }
+      const zero = await query(sql, [
+        "select count(*)::int count from (",
+        " select rr.reporting_unit_id from result_rows rr",
+        " join contests c on c.id=rr.contest_id",
+        " where rr.state_code=$1 and c.election_id=$2::uuid and rr.level=$4",
+        "  and rr.jurisdiction_code like $3",
+        " group by rr.reporting_unit_id having sum(rr.votes)=0) units",
+      ], [
+        STATE,
+        row.election_id,
+        "reporting:" + STATE + ":" + yearPlan.electionId + ":%",
+        yearPlan.manifest.geography.level,
+      ]);
+      if (Number(zero[0].count) !== yearPlan.zeroVoteUnits) {
+        throw new Error("North Carolina " + yearPlan.year + " zero-vote count drifted");
+      }
+      output.push({
+        year: yearPlan.year,
+        electionId: yearPlan.electionId,
+        reportingUnits: Number(row.reporting_units),
+        resultRows: Number(row.result_rows),
+        sameYearResultRows: Number(row.same_year_result_rows),
+        candidateTotals: actualTotals,
+        totalVotes: Object.values(actualTotals).reduce((sum, value) => sum + value, 0),
+        zeroVoteUnits: Number(zero[0].count),
+        resultSourceSlug: provenance.resultSourceSlug,
+        geometrySourceSlug: provenance.geometrySourceSlug,
+        geometryDisposition: yearPlan.geometry.disposition,
+        geographyVersions: Number(row.geography_versions),
+        features: Number(row.features),
+        safeBlockedGeographyVersions: Number(row.safe_geography_versions),
+        reviewedCrosswalks: Number(row.crosswalks),
+        exactFeatures: exactGeometry.exactFeatures,
+        exactCrosswalks: exactGeometry.exactCrosswalks,
+      });
+    }
+    const invalid = await query(sql, [
+      "select count(*)::int count from pg_constraint",
+      "where connamespace='public'::regnamespace and not convalidated",
+    ]);
+    if (Number(invalid[0].count) !== 0) {
+      throw new Error("North Carolina local geography unit database has unvalidated public constraints");
+    }
+    const revision = await query(sql, [
+      "select revision::int revision from public_data_revisions where scope='public'",
+    ]);
+    return {
+      database: {
+        ...context.database,
+        readOnlySession: options.readOnlySession ?? context.mode === "local",
+      },
+      executionMode: context.mode,
+      productionMutationPerformed: context.mode === "production_release",
+      publicDeliveryAuthorized: false,
+      releaseCandidate: context.releaseCandidate,
+      productionReleaseAudit: context.productionReleaseAudit,
+      invalidConstraints: 0,
+      revision: revision.length ? Number(revision[0].revision) : null,
+      years: output,
+    };
+}
+
+export async function validateNorthCarolinaLocalGisDatabase(plan, options = {}) {
+  if (getDatabaseDriver() !== "postgres") {
+    throw new Error("North Carolina local geography GIS validation requires CRM_DATABASE_DRIVER=postgres");
+  }
+  const databaseUrl = getLocalCloneDatabaseUrl();
+  const sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+    max: 1,
+    connect_timeout: 10,
+    idle_timeout: 20,
+    connection: {
+      application_name: APPLICATION_NAME + "-validator",
+      default_transaction_read_only: true,
+    },
+  });
+  try {
+    return await validateNorthCarolinaLocalGisClient(sql, plan, {
+      executionContext: { mode: "local" },
+      readOnlySession: true,
+    });
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}

--- a/scripts/lib/nc-local-gis-plan.mjs
+++ b/scripts/lib/nc-local-gis-plan.mjs
@@ -1,0 +1,663 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+import {
+  inspectPrecinctGeometryManifest,
+  reportingUnitCode,
+} from "../../src/lib/precinct-geography.ts";
+import { validateManifestArtifacts } from "./precinct-geometry-validation.mjs";
+
+const STATE = "NC";
+const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+export const NORTH_CAROLINA_LOCAL_GIS_YEAR_SPECS = Object.freeze([
+  {
+    year: 2012,
+    electionId: "2012-11-06-general",
+    electionDate: "2012-11-06",
+    geographyLevel: "vtd",
+    manifestSha256: "31c2e7a8178c2224f27e8f14dbeda4a7e93c512b0e875ea947c63a6fce63c429",
+    manifestByteCount: 4_843,
+    geometryByteCount: 26_021_871,
+    resultsSha256: "af622d482343424698b8c3a26a396bde7f1dda0c5ecb54eb89197f582c1eb47d",
+    resultsByteCount: 101_677,
+    crosswalkByteCount: 2_105_121,
+    expectedUnits: 3_011,
+    expectedSourceGeographicUnits: 2_692,
+    expectedGeographicUnits: 2_692,
+    expectedNonGeographicUnits: 319,
+    expectedFeatures: 2_692,
+    expectedCrosswalkRecords: 3_011,
+    expectedNoDataFeatures: 0,
+    expectedZeroVoteUnits: 0,
+    expectedGeographicVotes: 4_492_613,
+    expectedTotalVotes: 4_505_372,
+    democratic: {
+      name: "Obama/Biden",
+      party: "DEM",
+    },
+    republican: {
+      name: "Romney/Ryan",
+      party: "REP",
+    },
+    resultSourceId: "nc-2012-ncsbe-precinct-sorted-president",
+    resultSourceUrl:
+      "https://s3.amazonaws.com/dl.ncsbe.gov/ENRS/2012_11_06/results_sort_20121106.zip",
+  },
+  {
+    year: 2016,
+    electionId: "2016-11-08-general",
+    electionDate: "2016-11-08",
+    geographyLevel: "precinct",
+    manifestSha256: "348d4a54953dadb47de0fbd424e0edcd7407cca091252e3e6ff6a18c209faaa4",
+    manifestByteCount: 3_959,
+    geometryByteCount: 25_916_331,
+    resultsSha256: "1ee871ff48ef90ed562e52e7560a39f9b9c8dea9fa0152fdf2c9b77457773ca3",
+    resultsByteCount: 120_291,
+    crosswalkByteCount: 2_215_041,
+    expectedUnits: 3_209,
+    expectedSourceGeographicUnits: 2_704,
+    expectedGeographicUnits: 2_704,
+    expectedNonGeographicUnits: 505,
+    expectedFeatures: 2_704,
+    expectedCrosswalkRecords: 3_209,
+    expectedNoDataFeatures: 0,
+    expectedZeroVoteUnits: 0,
+    expectedGeographicVotes: 3_177_511,
+    expectedTotalVotes: 4_741_564,
+    democratic: {
+      name: "Hillary Clinton",
+      party: "DEM",
+    },
+    republican: {
+      name: "Donald J. Trump",
+      party: "REP",
+    },
+    resultSourceId: "nc-2016-results-precinct-zip",
+    resultSourceUrl:
+      "https://s3.amazonaws.com/dl.ncsbe.gov/ENRS/2016_11_08/results_pct_20161108.zip",
+  },
+  {
+    year: 2020,
+    electionId: "2020-11-03-general",
+    electionDate: "2020-11-03",
+    geographyLevel: "precinct",
+    manifestSha256: "8c13c08cad108a5863f063a88f045726b17e36e0d472e67557a81a240013fd6a",
+    manifestByteCount: 4_451,
+    geometryByteCount: 17_346_673,
+    resultsSha256: "1b02f23a00aedf700d1dc46a86683011f441c2caf5cc1346faa937aef1b13d0d",
+    resultsByteCount: 117_763,
+    crosswalkByteCount: 2_092_827,
+    expectedUnits: 3_065,
+    expectedSourceGeographicUnits: 2_662,
+    expectedGeographicUnits: 2_662,
+    expectedNonGeographicUnits: 403,
+    expectedFeatures: 2_662,
+    expectedCrosswalkRecords: 3_065,
+    expectedNoDataFeatures: 0,
+    expectedZeroVoteUnits: 0,
+    expectedGeographicVotes: 3_201_711,
+    expectedTotalVotes: 5_524_802,
+    democratic: {
+      name: "Joseph R. Biden",
+      party: "DEM",
+    },
+    republican: {
+      name: "Donald J. Trump",
+      party: "REP",
+    },
+    resultSourceId: "nc-2020-results-precinct-zip",
+    resultSourceUrl:
+      "https://s3.amazonaws.com/dl.ncsbe.gov/ENRS/2020_11_03/results_pct_20201103.zip",
+  },
+].map((spec) => Object.freeze({
+  ...spec,
+  manifestPath:
+    `data/precinct-geometry/NC/${spec.electionId}/manifest.json`,
+  resultsPath:
+    `data/precinct-geometry/NC/${spec.electionId}/normalized/nc-${spec.year}-official-president-${spec.geographyLevel}-results.json.gz`,
+  geometrySourceSlug: `nc-${spec.year}-${spec.geographyLevel}-geometry`,
+  resultSource: Object.freeze({
+    id: spec.resultSourceId,
+    slug: spec.resultSourceId,
+    url: spec.resultSourceUrl,
+    artifact:
+      `data/precinct-geometry/NC/${spec.electionId}/normalized/nc-${spec.year}-official-president-${spec.geographyLevel}-results.json.gz`,
+    sha256: spec.resultsSha256,
+    byteCount: spec.resultsByteCount,
+    timestampBasis:
+      "Official North Carolina State Board of Elections local result rows; administrative reporting units remain separately identified and are never assigned to polygons.",
+    authority: "North Carolina State Board of Elections",
+  }),
+})));
+
+function insideRoot(root, relativePath) {
+  if (
+    typeof relativePath !== "string"
+    || path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+  ) {
+    throw new Error(`Unsafe North Carolina artifact path: ${relativePath}`);
+  }
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, ...relativePath.split("/"));
+  if (
+    resolved !== resolvedRoot
+    && !resolved.startsWith(resolvedRoot + path.sep)
+  ) {
+    throw new Error(`North Carolina artifact escapes root: ${relativePath}`);
+  }
+  return resolved;
+}
+
+function verified(root, relativePath, expectedSha, expectedBytes, label) {
+  const target = insideRoot(root, relativePath);
+  if (!existsSync(target)) {
+    throw new Error(`${label} is missing: ${relativePath}`);
+  }
+  const bytes = readFileSync(target);
+  if (bytes.length !== expectedBytes || sha256(bytes) !== expectedSha) {
+    throw new Error(`${label} bytes or SHA-256 drifted`);
+  }
+  return bytes;
+}
+
+function forbiddenProperties(value, context) {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) =>
+      forbiddenProperties(entry, `${context}[${index}]`));
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (/^(?:VOTES?|TOTALVOTES?|CANDIDATE|PARTY|G\d{2}PRE)/i.test(key)) {
+      throw new Error(`${context} contains election-value property ${key}`);
+    }
+    forbiddenProperties(child, `${context}.${key}`);
+  }
+}
+
+function safeResultRow(row, context) {
+  const values = [
+    row.democratic,
+    row.republican,
+    row.other,
+    row.total,
+    row.ballotsCast ?? row.total,
+  ].map(Number);
+  if (
+    values.some((value) => !Number.isSafeInteger(value) || value < 0)
+    || values[3] !== values[0] + values[1] + values[2]
+    || values[4] < values[3]
+  ) {
+    throw new Error(`${context} result totals drifted`);
+  }
+  return {
+    democratic: values[0],
+    republican: values[1],
+    other: values[2],
+    total: values[3],
+    ballotsCast: values[4],
+  };
+}
+
+function buildResultPlan(spec, document) {
+  if (
+    document.schemaVersion !== 1
+    || document.state !== STATE
+    || document.electionId !== spec.electionId
+    || document.reportingGrain !== spec.geographyLevel
+    || document.sourceUnitCount !== spec.expectedUnits
+    || document.geographicSourceUnitCount
+      !== spec.expectedSourceGeographicUnits
+    || document.colorableUnitCount !== spec.expectedGeographicUnits
+    || document.excludedUnitCount !== spec.expectedNonGeographicUnits
+    || document.rows?.length !== spec.expectedGeographicUnits
+    || document.exclusions?.length !== spec.expectedNonGeographicUnits
+  ) {
+    throw new Error(
+      `North Carolina ${spec.year} normalized result contract drifted`,
+    );
+  }
+  const reportingUnits = [];
+  const resultRows = [];
+  const seenCodes = new Set();
+  const totals = { Democratic: 0, Republican: 0, Other: 0, Total: 0 };
+  const officialTotals = {
+    Democratic: Number(document.officialTotals?.democraticVotes),
+    Republican: Number(document.officialTotals?.republicanVotes),
+    Other: Number(document.officialTotals?.otherVotes),
+    Total: Number(document.officialTotals?.totalVotes),
+  };
+  let zeroVoteUnits = 0;
+
+  for (const row of document.rows) {
+    const code = reportingUnitCode({
+      state: STATE,
+      electionId: spec.electionId,
+      reportingGrain: spec.geographyLevel,
+      parentGeoid: row.parentGeoid,
+      sourceUnitId: row.sourceUnitId,
+    });
+    if (
+      code !== row.resultUnitCode
+      || !/^37\d{3}$/.test(row.parentGeoid)
+      || typeof row.sourceDisplayName !== "string"
+      || !row.sourceDisplayName.trim()
+      || seenCodes.has(code)
+    ) {
+      throw new Error(
+        `North Carolina ${spec.year} geographic result identity drifted`,
+      );
+    }
+    seenCodes.add(code);
+    const values = safeResultRow(
+      row,
+      `North Carolina ${spec.year} ${code}`,
+    );
+    if (values.total === 0) zeroVoteUnits += 1;
+    reportingUnits.push({
+      code,
+      sourceUnitId: row.sourceUnitId,
+      sourceDisplayName: row.sourceDisplayName,
+      parentGeoid: row.parentGeoid,
+      reportingGrain: spec.geographyLevel,
+      isGeographic: true,
+      resultStatus: "candidate_detail_complete",
+    });
+    resultRows.push(
+      {
+        jurisdictionCode: code,
+        jurisdictionName: row.sourceDisplayName,
+        candidateName: spec.democratic.name,
+        party: spec.democratic.party,
+        votes: values.democratic,
+      },
+      {
+        jurisdictionCode: code,
+        jurisdictionName: row.sourceDisplayName,
+        candidateName: spec.republican.name,
+        party: spec.republican.party,
+        votes: values.republican,
+      },
+      {
+        jurisdictionCode: code,
+        jurisdictionName: row.sourceDisplayName,
+        candidateName: "Other",
+        party: "OTHER",
+        votes: values.other,
+      },
+    );
+    totals.Democratic += values.democratic;
+    totals.Republican += values.republican;
+    totals.Other += values.other;
+    totals.Total += values.total;
+  }
+
+  for (const row of document.exclusions) {
+    const reportingGrain = "administrative_reporting_unit";
+    const code = reportingUnitCode({
+      state: STATE,
+      electionId: spec.electionId,
+      reportingGrain,
+      parentGeoid: row.parentGeoid,
+      sourceUnitId: row.sourceUnitId,
+    });
+    if (
+      code !== row.resultUnitCode
+      || !/^37\d{3}$/.test(row.parentGeoid)
+      || typeof row.sourceDisplayName !== "string"
+      || !row.sourceDisplayName.trim()
+      || seenCodes.has(code)
+    ) {
+      throw new Error(
+        `North Carolina ${spec.year} administrative result identity drifted`,
+      );
+    }
+    seenCodes.add(code);
+    safeResultRow(row, `North Carolina ${spec.year} ${code}`);
+    reportingUnits.push({
+      code,
+      sourceUnitId: row.sourceUnitId,
+      sourceDisplayName: row.sourceDisplayName,
+      parentGeoid: row.parentGeoid,
+      reportingGrain,
+      isGeographic: false,
+      resultStatus: "non_geographic_reconciliation_only",
+    });
+  }
+
+  if (
+    reportingUnits.length !== spec.expectedUnits
+    || resultRows.length !== spec.expectedGeographicUnits * 3
+    || zeroVoteUnits !== spec.expectedZeroVoteUnits
+    || totals.Total !== spec.expectedGeographicVotes
+    || officialTotals.Total !== spec.expectedTotalVotes
+    || totals.Democratic !== document.geographicTotals?.democraticVotes
+    || totals.Republican !== document.geographicTotals?.republicanVotes
+    || totals.Other !== document.geographicTotals?.otherVotes
+    || totals.Total !== document.geographicTotals?.totalVotes
+    || officialTotals.Democratic !== document.officialTotals?.democraticVotes
+    || officialTotals.Republican !== document.officialTotals?.republicanVotes
+    || officialTotals.Other !== document.officialTotals?.otherVotes
+  ) {
+    throw new Error(`North Carolina ${spec.year} official total drifted`);
+  }
+  return {
+    reportingUnits,
+    resultRows,
+    totals,
+    officialTotals,
+    zeroVoteUnits,
+    candidateDetailSuppressedUnits: 0,
+    source: spec.resultSource,
+  };
+}
+
+function buildGeometryPlan(root, spec, manifest, results) {
+  const inspection = validateManifestArtifacts(manifest, {
+    root,
+    skipDelivery: true,
+  });
+  if (inspection.errors.length) {
+    throw new Error(
+      `North Carolina ${spec.year} artifact validation failed: ${inspection.errors.join("; ")}`,
+    );
+  }
+  if (
+    manifest.geography.level !== spec.geographyLevel
+    || manifest.crosswalk.status !== "reviewed"
+    || manifest.crosswalk.resultUnits !== spec.expectedUnits
+    || manifest.crosswalk.matchedResultUnits !== spec.expectedGeographicUnits
+    || manifest.crosswalk.unmatchedResultUnits !== 0
+    || manifest.crosswalk.nonGeographicResultUnits
+      !== spec.expectedNonGeographicUnits
+    || manifest.crosswalk.reviewedRelationshipRecords
+      !== spec.expectedCrosswalkRecords
+    || manifest.crosswalk.reviewedNoDataFeatures
+      !== spec.expectedNoDataFeatures
+    || manifest.validation.rowLevelRenderingSafe !== true
+    || manifest.delivery !== null
+  ) {
+    throw new Error(
+      `North Carolina ${spec.year} reviewed local geometry contract drifted`,
+    );
+  }
+  const geometryBytes = verified(
+    root,
+    manifest.normalization.artifact,
+    manifest.normalization.sha256,
+    spec.geometryByteCount,
+    `North Carolina ${spec.year} geometry`,
+  );
+  const normalized = JSON.parse(gunzipSync(geometryBytes).toString("utf8"));
+  const features = [];
+  const featureByKey = new Map();
+  for (const feature of normalized.features ?? []) {
+    const parent = String(feature.properties?.CRM_PARENT_GEOID ?? "");
+    const id = String(feature.properties?.CRM_FEATURE_ID ?? "");
+    const sourceFeatureId = `${parent}|${id}`;
+    forbiddenProperties(
+      feature.properties,
+      `North Carolina ${spec.year} feature ${sourceFeatureId}`,
+    );
+    if (
+      !/^37\d{3}$/.test(parent)
+      || !id
+      || !["Polygon", "MultiPolygon"].includes(feature.geometry?.type)
+      || featureByKey.has(sourceFeatureId)
+    ) {
+      throw new Error(
+        `North Carolina ${spec.year} normalized feature identity drifted`,
+      );
+    }
+    const record = {
+      sourceFeatureId,
+      parentGeoid: parent,
+      name: String(feature.properties.SOURCE_NAME ?? id),
+      geometryKey: sourceFeatureId,
+      isGeographic: true,
+      properties: feature.properties,
+    };
+    features.push(record);
+    featureByKey.set(sourceFeatureId, record);
+  }
+  if (features.length !== spec.expectedFeatures) {
+    throw new Error(
+      `North Carolina ${spec.year} normalized feature count drifted`,
+    );
+  }
+  const crosswalkBytes = verified(
+    root,
+    manifest.crosswalk.artifact,
+    manifest.crosswalk.sha256,
+    spec.crosswalkByteCount,
+    `North Carolina ${spec.year} crosswalk`,
+  );
+  const crosswalk = JSON.parse(crosswalkBytes.toString("utf8"));
+  if (
+    crosswalk.state !== STATE
+    || crosswalk.electionId !== spec.electionId
+    || crosswalk.geographyLevel !== spec.geographyLevel
+    || crosswalk.resultSourceId !== manifest.crosswalk.resultSourceId
+  ) {
+    throw new Error(
+      `North Carolina ${spec.year} crosswalk envelope drifted`,
+    );
+  }
+  const unitsByCode = new Map(
+    results.reportingUnits.map((unit) => [unit.code, unit]),
+  );
+  const seenUnits = new Set();
+  const crosswalks = [];
+  for (const [index, row] of (crosswalk.rows ?? []).entries()) {
+    const unit = unitsByCode.get(row.resultUnitCode);
+    if (
+      !unit
+      || row.sourceUnitId !== unit.sourceUnitId
+      || row.parentGeoid !== unit.parentGeoid
+      || row.reportingGrain !== unit.reportingGrain
+      || row.isGeographic !== unit.isGeographic
+      || seenUnits.has(row.resultUnitCode)
+      || !Array.isArray(row.relationships)
+      || row.relationships.length !== 1
+    ) {
+      throw new Error(
+        `North Carolina ${spec.year} crosswalk identity drift at row ${index}`,
+      );
+    }
+    seenUnits.add(row.resultUnitCode);
+    const relationship = row.relationships[0];
+    forbiddenProperties(
+      relationship,
+      `North Carolina ${spec.year} crosswalk row ${index}`,
+    );
+    const commonRelationshipValid = relationship.reviewStatus === "reviewed"
+      && relationship.confidence === "high"
+      && ["exact_official_id", "official_crosswalk"].includes(
+        relationship.matchMethod,
+      );
+    const geographicRelationshipValid = unit.isGeographic
+      && relationship.relationshipType === "one_to_one"
+      && ["exact_official_id", "official_crosswalk"].includes(
+        relationship.matchMethod,
+      )
+      && featureByKey.has(relationship.sourceFeatureId);
+    const nonGeographicRelationshipValid = !unit.isGeographic
+      && relationship.relationshipType === "non_geographic"
+      && relationship.matchMethod === "exact_official_id"
+      && relationship.sourceFeatureId === null;
+    if (
+      !commonRelationshipValid
+      || (!geographicRelationshipValid && !nonGeographicRelationshipValid)
+    ) {
+      throw new Error(
+        `North Carolina ${spec.year} crosswalk relationship drift at row ${index}`,
+      );
+    }
+    crosswalks.push({
+      reportingUnitCode: row.resultUnitCode,
+      sourceFeatureId: relationship.sourceFeatureId,
+      relationshipType: relationship.relationshipType,
+      matchMethod: relationship.matchMethod,
+      reviewStatus: relationship.reviewStatus,
+      confidence: relationship.confidence,
+      note: String(relationship.note ?? ""),
+    });
+  }
+  if (
+    seenUnits.size !== spec.expectedUnits
+    || crosswalks.length !== spec.expectedCrosswalkRecords
+    || crosswalks.filter((row) => row.sourceFeatureId !== null).length
+      !== spec.expectedGeographicUnits
+  ) {
+    throw new Error(`North Carolina ${spec.year} crosswalk counts drifted`);
+  }
+  return {
+    disposition: "loadable_reviewed",
+    sourceGatePassed: true,
+    publicReleaseEligible: false,
+    blockCode: null,
+    reasons: [...manifest.validation.errors],
+    features,
+    crosswalks,
+    artifactWarnings: inspection.warnings,
+  };
+}
+
+async function loadYear(root, spec) {
+  const manifestBytes = verified(
+    root,
+    spec.manifestPath,
+    spec.manifestSha256,
+    spec.manifestByteCount,
+    `North Carolina ${spec.year} manifest`,
+  );
+  const manifest = JSON.parse(manifestBytes.toString("utf8"));
+  const contract = inspectPrecinctGeometryManifest(manifest);
+  if (
+    contract.errors.length
+    || manifest.state !== STATE
+    || manifest.election.id !== spec.electionId
+    || manifest.election.date !== spec.electionDate
+    || manifest.geography.level !== spec.geographyLevel
+  ) {
+    throw new Error(
+      `North Carolina ${spec.year} manifest contract drifted: ${contract.errors.join("; ")}`,
+    );
+  }
+  const resultBytes = verified(
+    root,
+    spec.resultsPath,
+    spec.resultsSha256,
+    spec.resultsByteCount,
+    `North Carolina ${spec.year} normalized results`,
+  );
+  const results = buildResultPlan(
+    spec,
+    JSON.parse(gunzipSync(resultBytes).toString("utf8")),
+  );
+  return {
+    year: spec.year,
+    electionId: spec.electionId,
+    electionDate: spec.electionDate,
+    manifestPath: spec.manifestPath,
+    manifestSha256: spec.manifestSha256,
+    manifestByteCount: spec.manifestByteCount,
+    artifactByteCounts: {
+      source: manifest.source.byteCount,
+      normalization: spec.geometryByteCount,
+      crosswalk: spec.crosswalkByteCount,
+    },
+    manifest,
+    resultSource: results.source,
+    reportingUnits: results.reportingUnits,
+    resultRows: results.resultRows,
+    totals: results.totals,
+    officialTotals: results.officialTotals,
+    zeroVoteUnits: results.zeroVoteUnits,
+    candidateDetailSuppressedUnits: 0,
+    sourceRows: results.reportingUnits.length,
+    geometry: buildGeometryPlan(root, spec, manifest, results),
+    geometrySourceSlug: spec.geometrySourceSlug,
+  };
+}
+
+export async function buildNorthCarolinaLocalGisPlan(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const selected = options.years
+    ? new Set(options.years.map(Number))
+    : new Set(
+      NORTH_CAROLINA_LOCAL_GIS_YEAR_SPECS.map((spec) => spec.year),
+    );
+  for (const selectedYear of selected) {
+    if (
+      !NORTH_CAROLINA_LOCAL_GIS_YEAR_SPECS.some(
+        (spec) => spec.year === selectedYear,
+      )
+    ) {
+      throw new Error(
+        "Supported North Carolina public-release years are 2012, 2016, and 2020; 2024 remains separately blocked",
+      );
+    }
+  }
+  const years = [];
+  for (const spec of NORTH_CAROLINA_LOCAL_GIS_YEAR_SPECS.filter(
+    (entry) => selected.has(entry.year),
+  )) {
+    years.push(await loadYear(root, spec));
+  }
+  if (!years.length) {
+    throw new Error("Select at least one North Carolina local geography GIS year");
+  }
+  return {
+    schemaVersion: 1,
+    state: STATE,
+    stateName: "North Carolina",
+    authority: "North Carolina State Board of Elections",
+    scope:
+      "local-only 2012 VTD plus 2016 and 2020 precinct presidential general-election GIS setup; 2024 remains separately blocked",
+    geographyLevels: Object.fromEntries(
+      years.map((year) => [year.year, year.manifest.geography.level]),
+    ),
+    years,
+  };
+}
+
+export function summarizeNorthCarolinaLocalGisPlan(plan) {
+  return {
+    schemaVersion: plan.schemaVersion,
+    state: plan.state,
+    scope: plan.scope,
+    geographyLevels: plan.geographyLevels,
+    years: plan.years.map((year) => ({
+      year: year.year,
+      electionId: year.electionId,
+      manifestId: year.manifest.id,
+      geographyLevel: year.manifest.geography.level,
+      manifestSha256: year.manifestSha256,
+      reportingUnits: year.reportingUnits.length,
+      geographicReportingUnits: year.reportingUnits.filter(
+        (unit) => unit.isGeographic,
+      ).length,
+      nonGeographicReportingUnits: year.reportingUnits.filter(
+        (unit) => !unit.isGeographic,
+      ).length,
+      resultRows: year.resultRows.length,
+      zeroVoteUnits: year.zeroVoteUnits,
+      totals: year.totals,
+      officialTotals: year.officialTotals,
+      geometryDisposition: year.geometry.disposition,
+      geometryFeatures: year.geometry.features.length,
+      reviewedCrosswalks: year.geometry.crosswalks.length,
+      reviewedNoDataFeatures: year.manifest.crosswalk.reviewedNoDataFeatures,
+      sourceGatePassed: year.geometry.sourceGatePassed,
+      publicReleaseEligible: year.geometry.publicReleaseEligible,
+      publicDeliveryAuthorized: false,
+      blockers: year.geometry.reasons,
+      caveats: year.manifest.caveats,
+    })),
+  };
+}

--- a/scripts/lib/nc-local-production-preflight.mjs
+++ b/scripts/lib/nc-local-production-preflight.mjs
@@ -1,0 +1,361 @@
+import { createHash } from "node:crypto";
+
+const LOOPBACK_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "::1",
+  "[::1]",
+]);
+
+const PRECINCT_TABLES = Object.freeze([
+  "geography_features",
+  "geography_versions",
+  "reporting_unit_geometry_crosswalks",
+  "reporting_units",
+]);
+
+const REPORTING_UNIT_COLUMNS = Object.freeze([
+  ["result_rows", "reporting_unit_id"],
+  ["review_rows", "reporting_unit_id"],
+  ["turnout_rows", "reporting_unit_id"],
+]);
+
+function query(client, lines, params = []) {
+  return client.unsafe(Array.isArray(lines) ? lines.join("\n") : lines, params);
+}
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function productionEndpointFingerprint(databaseUrl) {
+  let parsed;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    throw new Error("North Carolina production preflight requires a valid PostgreSQL URL");
+  }
+  if (!/^postgres(?:ql)?:$/.test(parsed.protocol)) {
+    throw new Error("North Carolina production preflight requires a PostgreSQL URL");
+  }
+  if (LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase())) {
+    throw new Error("North Carolina production preflight refuses a loopback database URL");
+  }
+  const databaseName = decodeURIComponent(parsed.pathname).replace(/^\//, "");
+  if (!databaseName) {
+    throw new Error("North Carolina production preflight requires a database name");
+  }
+  return createHash("sha256")
+    .update([
+      parsed.hostname.toLowerCase(),
+      parsed.port || "5432",
+      databaseName,
+    ].join("\n"))
+    .digest("hex");
+}
+
+export function assertNorthCarolinaReleaseCandidateDocument(
+  document,
+  packageSha256,
+) {
+  if (!/^[a-f0-9]{64}$/.test(packageSha256 ?? "")) {
+    throw new Error("North Carolina release package SHA-256 is invalid");
+  }
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "nc-local-gis-three-election-v1"
+    || document?.state !== "NC"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.safety?.explicitProductionAuthorizationRequired !== true
+    || document?.safety?.productionMutationPerformed !== false
+    || document?.safety?.publicFileWritten !== false
+    || document?.safety?.canonicalManifestChanged !== false
+    || document?.safety?.canonicalRegistryChanged !== false
+  ) {
+    throw new Error("North Carolina release candidate does not match the guarded contract");
+  }
+  const expectedTotals = {
+    elections: 3,
+    reportingUnits: 9_285,
+    candidateResultRows: 24_174,
+    zeroVoteUnits: 0,
+    geometryFeatures: 8_058,
+    reviewedRelationships: 9_285,
+  };
+  for (const [key, value] of Object.entries(expectedTotals)) {
+    if (Number(document?.totals?.[key]) !== value) {
+      throw new Error("North Carolina release candidate total drifted: " + key);
+    }
+  }
+  const migrations = document?.databaseActivationContract?.migrations;
+  const expectedMigrationPaths = [
+    "drizzle/0008_typical_thunderbolts.sql",
+    "drizzle/0009_public_wolfpack.sql",
+  ];
+  if (
+    !Array.isArray(migrations)
+    || migrations.length !== expectedMigrationPaths.length
+    || migrations.some((migration, index) =>
+      migration?.path !== expectedMigrationPaths[index]
+      || !Number.isSafeInteger(migration?.byteCount)
+      || migration.byteCount <= 0
+      || !/^[a-f0-9]{64}$/.test(migration?.sha256 ?? ""))
+  ) {
+    throw new Error("North Carolina release candidate migration pins are invalid");
+  }
+  const years = (document.years ?? []).map((year) => Number(year.year));
+  if (JSON.stringify(years) !== JSON.stringify([2012, 2016, 2020])) {
+    throw new Error("North Carolina release candidate year set drifted");
+  }
+  return {
+    id: document.id,
+    sha256: packageSha256,
+    migrations,
+    totals: expectedTotals,
+    canonicalManifestPreimages: document.years.map((year) => ({
+      year: year.year,
+      path: year.canonicalManifest.path,
+      byteCount: year.canonicalManifest.byteCount,
+      sha256: year.canonicalManifest.sha256,
+      validationStatus: year.canonicalManifest.validationStatus,
+      rowLevelRenderingSafe: year.canonicalManifest.rowLevelRenderingSafe,
+      delivery: year.canonicalManifest.delivery,
+    })),
+  };
+}
+
+function migrationState(tableRows, columnRows) {
+  const tables = new Set(tableRows.map((row) => String(row.table_name)));
+  const columns = new Set(
+    columnRows.map((row) => `${row.table_name}.${row.column_name}`),
+  );
+  const presentTables = PRECINCT_TABLES.filter((name) => tables.has(name));
+  const presentColumns = REPORTING_UNIT_COLUMNS.filter(([table, column]) =>
+    columns.has(`${table}.${column}`));
+  const absent = presentTables.length === 0 && presentColumns.length === 0;
+  const complete = presentTables.length === PRECINCT_TABLES.length
+    && presentColumns.length === REPORTING_UNIT_COLUMNS.length;
+  return {
+    status: absent ? "absent" : complete ? "complete" : "partial_blocked",
+    expectedTables: [...PRECINCT_TABLES],
+    presentTables,
+    expectedReportingUnitColumns: REPORTING_UNIT_COLUMNS.map(
+      ([table, column]) => `${table}.${column}`,
+    ),
+    presentReportingUnitColumns: presentColumns.map(
+      ([table, column]) => `${table}.${column}`,
+    ),
+  };
+}
+
+function derivationConstraintState(rows, schemaStatus) {
+  if (schemaStatus === "absent") {
+    return { status: "absent", definition: null };
+  }
+  if (rows.length !== 1) {
+    return { status: "partial_blocked", definition: null };
+  }
+  const definition = String(rows[0].definition ?? "");
+  return {
+    status: definition.includes("secondary_reconstruction")
+        && definition.includes("hybrid_reconstruction")
+      ? "complete"
+      : "absent",
+    definition,
+  };
+}
+
+export function buildNorthCarolinaProductionPreflightReport(snapshot, context) {
+  if (String(snapshot.identity?.transaction_read_only) !== "on") {
+    throw new Error("North Carolina production preflight did not use a read-only transaction");
+  }
+  const schema = migrationState(snapshot.precinctTables, snapshot.precinctColumns);
+  if (schema.status === "partial_blocked") {
+    throw new Error("North Carolina production schema is partially migrated; release is blocked");
+  }
+  const invalidConstraints = Number(snapshot.invalidConstraints ?? NaN);
+  if (!Number.isInteger(invalidConstraints)) {
+    throw new Error("North Carolina production preflight constraint count is invalid");
+  }
+  const migration0009 = derivationConstraintState(
+    snapshot.derivationConstraint,
+    schema.status,
+  );
+  if (migration0009.status === "partial_blocked") {
+    throw new Error("North Carolina production derivation-method constraint is ambiguous");
+  }
+  const report = {
+    schemaVersion: 1,
+    state: "NC",
+    scope: "read-only North Carolina local geography unit GIS production preflight",
+    capturedAtUtc: context.capturedAtUtc,
+    releaseCandidate: context.releaseCandidate,
+    endpointFingerprint: context.endpointFingerprint,
+    database: {
+      name: String(snapshot.identity.database_name),
+      serverVersionNum: String(snapshot.identity.server_version_num),
+      databaseBytes: String(snapshot.identity.database_bytes),
+      transactionReadOnly: true,
+    },
+    productionMutationPerformed: false,
+    canonicalManifestChanged: false,
+    publicFileWritten: false,
+    publicTableCount: snapshot.publicTables.length,
+    publicTables: snapshot.publicTables.map((row) => String(row.table_name)),
+    migration0008: schema,
+    migration0009,
+    invalidConstraints,
+    publicRevision: snapshot.revision.length
+      ? Number(snapshot.revision[0].revision)
+      : null,
+    northCarolina: {
+      coreYearRows: snapshot.coreYears.map((row) => ({
+        year: Number(row.year),
+        electionDate: String(row.election_date),
+        resultRows: Number(row.result_rows),
+        localResultRows: Number(row.local_result_rows),
+        countyResultRows: Number(row.county_result_rows),
+      })),
+      localYearRows: snapshot.localYears.map((row) => ({
+        year: Number(row.year),
+        reportingUnits: Number(row.reporting_units),
+        linkedLocalResultRows: Number(row.linked_local_result_rows),
+        geographyVersions: Number(row.geography_versions),
+        geometryFeatures: Number(row.geometry_features),
+        reviewedRelationships: Number(row.reviewed_relationships),
+      })),
+      sourceDocuments: snapshot.sourceDocuments.map((row) => ({
+        slug: String(row.slug),
+        electionYear: Number(row.election_year),
+        status: String(row.status),
+        localArtifact: String(row.local_artifact ?? ""),
+      })),
+    },
+    canonicalManifestPreimages:
+      context.releaseCandidate.canonicalManifestPreimages,
+    stopConditions: [
+      "migration0008.status is partial_blocked",
+      "migration0009.status is partial_blocked",
+      "any invalid public constraint exists",
+      "the endpoint fingerprint or database name differs from authorization",
+      "any North Carolina year or row set differs before the write transaction",
+      "any canonical manifest preimage differs from the release package",
+    ],
+  };
+  return report;
+}
+
+export async function collectNorthCarolinaProductionPreflight(sql, context) {
+  const identityRows = await query(sql, [
+    "select current_database() database_name,",
+    " current_setting('server_version_num') server_version_num,",
+    " current_setting('transaction_read_only') transaction_read_only,",
+    " pg_database_size(current_database())::text database_bytes",
+  ]);
+  if (identityRows.length !== 1) {
+    throw new Error("North Carolina production preflight database identity is missing");
+  }
+  const publicTables = await query(sql, [
+    "select tablename table_name from pg_catalog.pg_tables",
+    "where schemaname='public' order by tablename",
+  ]);
+  const precinctTables = await query(sql, [
+    "select table_name from information_schema.tables",
+    "where table_schema='public' and table_name = any($1::text[])",
+    "order by table_name",
+  ], [[...PRECINCT_TABLES]]);
+  const precinctColumns = await query(sql, [
+    "select table_name,column_name from information_schema.columns",
+    "where table_schema='public' and (table_name,column_name) in (",
+    " ('result_rows','reporting_unit_id'),",
+    " ('review_rows','reporting_unit_id'),",
+    " ('turnout_rows','reporting_unit_id'))",
+    "order by table_name,column_name",
+  ]);
+  const invalid = await query(sql, [
+    "select count(*)::int count from pg_constraint",
+    "where connamespace='public'::regnamespace and not convalidated",
+  ]);
+  const revision = await query(sql, [
+    "select revision::int revision from public_data_revisions where scope='public'",
+  ]);
+  const derivationConstraint = await query(sql, [
+    "select pg_get_constraintdef(oid) definition from pg_constraint",
+    "where connamespace='public'::regnamespace",
+    " and conname='geography_versions_derivation_method_check'",
+  ]);
+  const coreYears = await query(sql, [
+    "select e.year,e.election_date,",
+    " count(rr.id)::int result_rows,",
+    " count(rr.id) filter (where rr.level in ('vtd','precinct'))::int local_result_rows,",
+    " count(rr.id) filter (where rr.level='county')::int county_result_rows",
+    "from elections e",
+    "left join contests c on c.election_id=e.id and c.state_code='NC'",
+    "left join result_rows rr on rr.contest_id=c.id and rr.state_code='NC'",
+    "where e.office='president' and (c.id is not null or e.year in (2012,2016,2020))",
+    "group by e.year,e.election_date order by e.year",
+  ]);
+  const sourceDocuments = await query(sql, [
+    "select slug,election_year,status,local_artifact from source_documents",
+    "where state_code='NC' order by election_year,slug",
+  ]);
+
+  const state = migrationState(precinctTables, precinctColumns);
+  let localYears = [];
+  if (state.status === "complete") {
+    localYears = await query(sql, [
+      "select e.year,",
+      " (select count(*)::int from reporting_units ru",
+      "  where ru.state_code='NC' and ru.election_id=e.id",
+      "   and ru.reporting_grain in (",
+      "    case when e.year=2012 then 'vtd' else 'precinct' end,",
+      "    'administrative_reporting_unit')) reporting_units,",
+      " (select count(*)::int from result_rows rr",
+      "  join contests c on c.id=rr.contest_id",
+      "  where rr.state_code='NC' and c.election_id=e.id",
+      "   and rr.level=case when e.year=2012 then 'vtd' else 'precinct' end",
+      "   and rr.reporting_unit_id is not null)",
+      "  linked_local_result_rows,",
+      " (select count(*)::int from geography_versions gv",
+      "  where gv.state_code='NC' and gv.election_id=e.id",
+      "   and gv.geography_type=case when e.year=2012 then 'vtd' else 'precinct' end)",
+      "  geography_versions,",
+      " (select count(*)::int from geography_features gf",
+      "  join geography_versions gv on gv.id=gf.geometry_version_id",
+      "  where gv.state_code='NC' and gv.election_id=e.id",
+      "   and gv.geography_type=case when e.year=2012 then 'vtd' else 'precinct' end)",
+      "  geometry_features,",
+      " (select count(*)::int from reporting_unit_geometry_crosswalks x",
+      "  join geography_versions gv on gv.id=x.geometry_version_id",
+      "  join reporting_units ru on ru.id=x.reporting_unit_id",
+      "  where gv.state_code='NC' and gv.election_id=e.id",
+      "   and gv.geography_type=case when e.year=2012 then 'vtd' else 'precinct' end",
+      "   and ru.election_id=e.id",
+      "   and ru.reporting_grain in (",
+      "    case when e.year=2012 then 'vtd' else 'precinct' end,",
+      "    'administrative_reporting_unit')",
+      "   and x.review_status='reviewed' and x.confidence='high')",
+      "  reviewed_relationships",
+      "from elections e where e.office='president'",
+      " and e.year in (2012,2016,2020) order by e.year",
+    ]);
+  }
+
+  return buildNorthCarolinaProductionPreflightReport({
+    identity: identityRows[0],
+    publicTables,
+    precinctTables,
+    precinctColumns,
+    derivationConstraint,
+    invalidConstraints: invalid[0]?.count,
+    revision,
+    coreYears,
+    localYears,
+    sourceDocuments,
+  }, context);
+}
+
+export const northCarolinaLocalSchemaContract = Object.freeze({
+  tables: PRECINCT_TABLES,
+  reportingUnitColumns: REPORTING_UNIT_COLUMNS,
+});

--- a/scripts/lib/nc-local-production-release.mjs
+++ b/scripts/lib/nc-local-production-release.mjs
@@ -1,0 +1,235 @@
+import { createHash } from "node:crypto";
+
+export const NORTH_CAROLINA_PRODUCTION_RELEASE_SCOPES = Object.freeze([
+  "apply_migration_0009",
+  "load_nc_local_results_and_geometry_hidden",
+  "increment_public_data_revision",
+]);
+export const NORTH_CAROLINA_MAX_RELEASE_EVIDENCE_AGE_MS = 4 * 60 * 60 * 1000;
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function validIso(value) {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function normalizeIdentity(value) {
+  return typeof value === "string"
+    ? value.trim().normalize("NFKC").replace(/\s+/gu, " ").toLocaleLowerCase("en-US")
+    : "";
+}
+
+function semantic(value) {
+  if (Array.isArray(value)) return value.map(semantic);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, semantic(value[key])]),
+  );
+}
+
+function semanticallyEqual(left, right) {
+  return JSON.stringify(semantic(left)) === JSON.stringify(semantic(right));
+}
+
+function validArtifact(value, prefix) {
+  return typeof value?.path === "string"
+    && value.path.startsWith(prefix)
+    && !value.path.includes("\\")
+    && !value.path.split("/").includes("..")
+    && /^[a-f0-9]{64}$/.test(value?.sha256 ?? "");
+}
+
+function expectedScopes() {
+  return [...NORTH_CAROLINA_PRODUCTION_RELEASE_SCOPES];
+}
+
+export function buildNorthCarolinaProductionAuthorizationTemplate(context) {
+  return {
+    schemaVersion: 1,
+    state: "NC",
+    decision: "NO_GO_PRODUCTION",
+    authorizationId: null,
+    releaseCandidate: {
+      id: context.releaseCandidate.id,
+      sha256: context.releaseCandidate.sha256,
+    },
+    evidence: {
+      preflightSha256: context.preflightSha256 ?? null,
+      backupManifestSha256: context.backupManifestSha256 ?? null,
+    },
+    approvedBy: null,
+    authorizedAtUtc: null,
+    expiresAtUtc: null,
+    scopes: expectedScopes(),
+    acknowledgement:
+      "This template is not authorization. GO_PRODUCTION authorizes only migration 0009, the hidden North Carolina load, and one public revision increment; public geometry and result visibility remain blocked.",
+  };
+}
+
+export function validateNorthCarolinaProductionPreflightEvidence(report, context) {
+  const targetYears = [2012, 2016, 2020];
+  const localYearRows = report?.northCarolina?.localYearRows;
+  const coreYearRows = report?.northCarolina?.coreYearRows;
+  const expectedYearRows = targetYears.map((year) => ({
+      year,
+      reportingUnits: 0,
+      resultRows: 0,
+      geometryFeatures: 0,
+      reviewedRelationships: 0,
+    }));
+  if (
+    report?.schemaVersion !== 1
+    || report?.state !== "NC"
+    || report?.productionMutationPerformed !== false
+    || report?.database?.transactionReadOnly !== true
+    || report?.invalidConstraints !== 0
+    || report?.migration0008?.status !== "complete"
+    || !["absent", "complete"].includes(report?.migration0009?.status)
+    || report?.releaseCandidate?.id !== context.releaseCandidate.id
+    || report?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || report?.endpointFingerprint !== context.endpointFingerprint
+    || !/^[a-f0-9]{64}$/.test(report?.endpointFingerprint ?? "")
+    || !Number.isInteger(Number(report?.publicRevision))
+    || Number(report.publicRevision) < 1
+    || !validIso(report?.capturedAtUtc)
+    || !Array.isArray(localYearRows)
+    || !Array.isArray(coreYearRows)
+    || JSON.stringify(localYearRows.map((row) => Number(row.year)))
+      !== JSON.stringify(targetYears)
+    || localYearRows.some((row, index) => {
+      const expected = expectedYearRows[index];
+      return Number(row.reportingUnits) !== expected.reportingUnits
+        || Number(row.linkedLocalResultRows) !== expected.resultRows
+        || Number(row.geographyVersions) !== 0
+        || Number(row.geometryFeatures) !== expected.geometryFeatures
+        || Number(row.reviewedRelationships) !== expected.reviewedRelationships;
+    })
+    || coreYearRows.some((row) => {
+      const index = targetYears.indexOf(Number(row.year));
+      return index >= 0
+        && Number(row.localResultRows) !== expectedYearRows[index].resultRows;
+    })
+  ) {
+    throw new Error(
+      "North Carolina production preflight evidence is incompatible or already contains local release rows",
+    );
+  }
+  const age = context.now.getTime() - Date.parse(report.capturedAtUtc);
+  if (age < 0 || age > NORTH_CAROLINA_MAX_RELEASE_EVIDENCE_AGE_MS) {
+    throw new Error("North Carolina production preflight is outside the four-hour release window");
+  }
+  if (typeof report.database.name !== "string" || !report.database.name.trim()) {
+    throw new Error("North Carolina production preflight database name is missing");
+  }
+  return {
+    databaseName: report.database.name.trim(),
+    capturedAtUtc: report.capturedAtUtc,
+    publicRevision: Number(report.publicRevision),
+    releaseMode: "initial_hidden_load",
+  };
+}
+
+export function validateNorthCarolinaProductionBackupEvidence(manifest, context) {
+  const restore = manifest?.restoreVerification;
+  if (
+    !Number.isInteger(manifest?.manifestVersion)
+    || manifest.manifestVersion < 3
+    || manifest?.backupPurpose !== "nc-local-production-release-rollback"
+    || manifest?.releaseCandidate?.id !== context.releaseCandidate.id
+    || manifest?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || manifest?.sourceEndpointFingerprint !== context.endpointFingerprint
+    || !/^[a-f0-9]{64}$/.test(manifest?.dumpSha256 ?? "")
+    || manifest?.dumpFormat !== "custom"
+    || Number(manifest?.pgClientMajor) !== 17
+    || Math.trunc(Number(manifest?.sourceServerVersionNum) / 10_000) !== 17
+    || JSON.stringify(manifest?.includedSchemas) !== JSON.stringify(["public"])
+    || !Array.isArray(manifest?.excludedTableDataPatterns)
+    || manifest.excludedTableDataPatterns.length !== 0
+    || manifest?.remoteMutationPerformed !== false
+    || Number(manifest?.sourceInvalidConstraints) !== 0
+    || restore?.verified !== true
+    || restore?.defaultTransactionReadOnly !== true
+    || restore?.exactSourceTableSet !== true
+    || restore?.exactSourceRowCounts !== true
+    || Number(restore?.invalidConstraints) !== 0
+    || !validIso(manifest?.createdAtUtc)
+    || !validIso(restore?.verifiedAtUtc)
+  ) {
+    throw new Error("North Carolina production backup evidence is incomplete or incompatible");
+  }
+  const created = Date.parse(manifest.createdAtUtc);
+  const restored = Date.parse(restore.verifiedAtUtc);
+  const preflight = Date.parse(context.preflightCapturedAtUtc);
+  const now = context.now.getTime();
+  if (
+    Number.isNaN(preflight)
+    || created <= preflight
+    || restored < created
+    || now - created < 0
+    || now - created > NORTH_CAROLINA_MAX_RELEASE_EVIDENCE_AGE_MS
+    || now - restored < 0
+    || now - restored > NORTH_CAROLINA_MAX_RELEASE_EVIDENCE_AGE_MS
+  ) {
+    throw new Error("North Carolina backup must follow the fresh preflight and restore within four hours");
+  }
+  const sourceCounts = manifest.sourcePublicTableRowCounts;
+  const restoredCounts = restore.publicTableRowCounts;
+  const sourceTableCount = Number(manifest.sourcePublicTableCount);
+  if (
+    !sourceCounts
+    || !restoredCounts
+    || typeof sourceCounts !== "object"
+    || typeof restoredCounts !== "object"
+    || Array.isArray(sourceCounts)
+    || Array.isArray(restoredCounts)
+    || sourceTableCount !== Number(restore.publicTableCount)
+    || sourceTableCount !== Number(restore.tableDataEntryCount)
+    || Object.keys(sourceCounts).length !== sourceTableCount
+    || Object.keys(restoredCounts).length !== sourceTableCount
+    || !semanticallyEqual(sourceCounts, restoredCounts)
+  ) {
+    throw new Error("North Carolina production backup exact table or row-count proof drifted");
+  }
+  return {
+    dumpSha256: manifest.dumpSha256,
+    createdAtUtc: manifest.createdAtUtc,
+    restoredAtUtc: restore.verifiedAtUtc,
+    sourcePublicTableCount: sourceTableCount,
+  };
+}
+
+export function validateNorthCarolinaProductionAuthorization(value, context) {
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "NC"
+    || value?.decision !== "GO_PRODUCTION"
+    || typeof value?.authorizationId !== "string"
+    || !value.authorizationId.trim()
+    || value?.releaseCandidate?.id !== context.releaseCandidate.id
+    || value?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || value?.evidence?.preflightSha256 !== context.preflightSha256
+    || value?.evidence?.backupManifestSha256 !== context.backupManifestSha256
+    || !validIso(value?.authorizedAtUtc)
+    || !validIso(value?.expiresAtUtc)
+    || !normalizeIdentity(value?.approvedBy)
+    || value?.replacement !== undefined
+    || !Array.isArray(value?.scopes)
+    || !semanticallyEqual(value.scopes, expectedScopes())
+  ) {
+    throw new Error("North Carolina production authorization is incomplete or incompatible");
+  }
+  const authorized = Date.parse(value.authorizedAtUtc);
+  const expires = Date.parse(value.expiresAtUtc);
+  const now = context.now.getTime();
+  if (authorized > now || expires <= now || expires <= authorized) {
+    throw new Error("North Carolina production authorization is not active");
+  }
+  return {
+    authorizationId: value.authorizationId.trim(),
+    approvedBy: value.approvedBy.trim(),
+    authorizedAtUtc: value.authorizedAtUtc,
+    expiresAtUtc: value.expiresAtUtc,
+  };
+}

--- a/scripts/lib/nc-local-public-activation.mjs
+++ b/scripts/lib/nc-local-public-activation.mjs
@@ -1,0 +1,454 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { inspectReleaseArtifact } from "./nc-local-release-candidate.mjs";
+import {
+  inspectPrecinctGeometryManifest,
+  inspectPrecinctGeometryRegistry,
+} from "../../src/lib/precinct-geography.ts";
+
+export const NORTH_CAROLINA_PUBLIC_ACTIVATION_ROOT =
+  ".etl/precinct-public-activations/NC";
+export const NORTH_CAROLINA_PUBLIC_ACTIVATION_YEARS = Object.freeze([
+  2012,
+  2016,
+  2020,
+]);
+
+const REGISTRY_PATH = "data/precinct-geometry-manifests.json";
+const COVERAGE_PATHS = Object.freeze([
+  [2012, "data/precinct-geometry-coverage-inventory-2012.json"],
+  [2016, "data/precinct-geometry-coverage-inventory-2016.json"],
+  [2020, "data/precinct-geometry-coverage-inventory-2020.json"],
+]);
+
+const EXPECTED_GEOGRAPHY_LEVELS = Object.freeze({
+  2012: "vtd",
+  2016: "precinct",
+  2020: "precinct",
+});
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function serializeNorthCarolinaPublicActivationDocument(value) {
+  return Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonical(value[key])]),
+  );
+}
+
+function semanticallyEqual(left, right) {
+  return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+}
+
+function readRepositoryJson(root, relativePath) {
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  if (!existsSync(absolutePath)) {
+    throw new Error("North Carolina public activation target is missing: " + relativePath);
+  }
+  const bytes = readFileSync(absolutePath);
+  return {
+    path: relativePath,
+    absolutePath,
+    bytes,
+    byteCount: bytes.length,
+    sha256: sha256(bytes),
+    value: JSON.parse(bytes.toString("utf8")),
+  };
+}
+
+function loadReleasePackage(options) {
+  if (!/^[a-f0-9]{64}$/.test(options.packageSha256 ?? "")) {
+    throw new Error("North Carolina public activation requires the exact package SHA-256");
+  }
+  const artifact = inspectReleaseArtifact(options.root, options.packagePath, {
+    allowedRoots: [".etl/precinct-release-candidates/NC/"],
+    sha256: options.packageSha256,
+  });
+  const document = JSON.parse(artifact.bytes.toString("utf8"));
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "nc-local-gis-three-election-v1"
+    || document?.state !== "NC"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.safety?.canonicalManifestChanged !== false
+    || document?.safety?.publicEligibilityChanged !== false
+    || document?.totals?.elections !== 3
+    || !Array.isArray(document?.years)
+    || !semanticallyEqual(
+      document.years.map((year) => Number(year.year)),
+      NORTH_CAROLINA_PUBLIC_ACTIVATION_YEARS,
+    )
+    || Number.isNaN(Date.parse(document?.preparedFromLocalValidationAt))
+  ) {
+    throw new Error("North Carolina public-activation package contract is incompatible");
+  }
+  return {
+    artifact,
+    document,
+    packageRoot: path.dirname(path.resolve(
+      options.root,
+      ...artifact.path.split("/"),
+    )),
+    identity: {
+      id: document.id,
+      path: options.packagePath,
+      sha256: artifact.sha256,
+    },
+  };
+}
+
+function loadDraftManifests(root, loaded) {
+  return loaded.document.years.map((year) => {
+    const draft = inspectReleaseArtifact(
+      loaded.packageRoot,
+      year.draftManifest.path,
+      {
+        allowedRoots: ["draft-manifests/"],
+        byteCount: year.draftManifest.byteCount,
+        sha256: year.draftManifest.sha256,
+      },
+    );
+    const manifest = JSON.parse(draft.bytes.toString("utf8"));
+    const inspection = inspectPrecinctGeometryManifest(manifest);
+    if (
+      inspection.errors.length
+      || inspection.publicEligibilityReasons.length
+      || manifest.state !== "NC"
+      || manifest.election?.year !== year.year
+      || manifest.id !== year.manifestId
+      || manifest.geography?.level !== EXPECTED_GEOGRAPHY_LEVELS[year.year]
+      || manifest.delivery?.format !== "parent_scoped_geojson"
+      || manifest.delivery?.url !== year.proposedPublicDelivery?.url
+      || manifest.delivery?.sha256 !== year.proposedPublicDelivery?.sha256
+      || manifest.delivery?.byteCount !== year.proposedPublicDelivery?.byteCount
+      || manifest.delivery?.featureCount !== year.reviewedGeometry?.featureCount
+      || manifest.delivery?.parentCount !== 100
+    ) {
+      throw new Error("North Carolina " + year.year + " draft manifest is not public-eligible");
+    }
+    const preimage = inspectReleaseArtifact(root, year.canonicalManifest.path, {
+      allowedRoots: ["data/precinct-geometry/NC/"],
+      byteCount: year.canonicalManifest.byteCount,
+      sha256: year.canonicalManifest.sha256,
+    });
+    const preimageManifest = JSON.parse(preimage.bytes.toString("utf8"));
+    if (
+      preimageManifest.id !== manifest.id
+      || preimageManifest.validation?.status !== "blocked"
+      || preimageManifest.validation?.rowLevelRenderingSafe !== true
+      || preimageManifest.delivery !== null
+    ) {
+      throw new Error("North Carolina " + year.year + " canonical source preimage is not blocked");
+    }
+    return {
+      year: year.year,
+      manifestId: manifest.id,
+      preimage: {
+        path: year.canonicalManifest.path,
+        byteCount: preimage.byteCount,
+        sha256: preimage.sha256,
+      },
+      draft: {
+        path: path.posix.join(
+          path.posix.dirname(loaded.identity.path),
+          year.draftManifest.path,
+        ),
+        byteCount: draft.byteCount,
+        sha256: draft.sha256,
+        manifest,
+      },
+    };
+  });
+}
+
+function updateRegistry(root, manifests, activatedAtUtc) {
+  const current = readRepositoryJson(root, REGISTRY_PATH);
+  if (
+    current.value?.schemaVersion !== 1
+    || !Array.isArray(current.value?.manifests)
+  ) {
+    throw new Error("North Carolina canonical manifest registry is invalid");
+  }
+  const existing = current.value.manifests.filter((row) => row?.state === "NC");
+  const drafts = manifests.map((item) => item.draft.manifest);
+  let disposition;
+  let nextRows;
+  if (existing.length === 0) {
+    disposition = "activate";
+    nextRows = [...current.value.manifests, ...drafts];
+  } else if (
+    existing.length === drafts.length
+    && drafts.every((draft) => existing.some((row) => semanticallyEqual(row, draft)))
+  ) {
+    disposition = "verified_existing";
+    nextRows = current.value.manifests;
+  } else {
+    throw new Error("North Carolina canonical registry is partially activated or drifted");
+  }
+  const value = {
+    ...current.value,
+    updatedAt: disposition === "activate" ? activatedAtUtc : current.value.updatedAt,
+    manifests: nextRows,
+  };
+  const inspection = inspectPrecinctGeometryRegistry(
+    value,
+    Math.max(Date.now(), Date.parse(activatedAtUtc) + 1),
+  );
+  if (inspection.errors.length) {
+    throw new Error(
+      "North Carolina activated registry is invalid: " + inspection.errors.join("; "),
+    );
+  }
+  const eligible = inspection.manifests.filter((item, index) =>
+    value.manifests[index]?.state === "NC"
+    && item.publicEligibilityReasons.length === 0);
+  if (eligible.length !== 3) {
+    throw new Error("North Carolina activated registry does not contain three eligible manifests");
+  }
+  return { current, value, disposition };
+}
+
+function recomputeCoverageSummary(value) {
+  const states = value.states ?? [];
+  const count = (field, choices) => Object.fromEntries(
+    choices.map((choice) => [
+      choice,
+      states.filter((row) => (row[field] ?? "undecided") === choice).length,
+    ]),
+  );
+  return {
+    totalJurisdictions: states.length,
+    programStatus: count("programStatus", ["not_started", "in_progress", "reviewed"]),
+    disposition: count("disposition", [
+      "undecided",
+      "mapped",
+      "partial",
+      "official_geometry_unavailable",
+      "blocked",
+    ]),
+    publicEligibleJurisdictions: states.filter((row) =>
+      (row.geometry?.publicEligibleManifestCount ?? 0) > 0).length,
+  };
+}
+
+function northCarolinaCoverageRow(manifest, activatedAtUtc) {
+  return {
+    state: "NC",
+    stateName: "North Carolina",
+    electionId: manifest.election.id,
+    programStatus: "reviewed",
+    wave: 8,
+    disposition: "mapped",
+    checkedAt: activatedAtUtc,
+    sourceTiers: manifest.geography.derivationMethod === "official_export"
+      ? ["tier_1_official_export_database"]
+      : ["tier_1_official_export_database", "tier_3_secondary_geometry"],
+    resultReportingGrains: [
+      manifest.geography.level,
+      "administrative_reporting_unit",
+    ],
+    generalOfficialSourceLeads: [
+      manifest.source.url,
+      "https://www.ncsbe.gov/results-data/election-results/historical-election-results-data",
+    ],
+    geometry: {
+      manifestIds: [manifest.id],
+      officialSourceLeads: [manifest.source.url],
+      retainedArtifacts: [
+        manifest.source.artifact,
+        manifest.normalization.artifact,
+        manifest.crosswalk.artifact,
+      ],
+      levels: [manifest.geography.level],
+      vintageStatuses: [manifest.geography.vintageStatus],
+      featureCount: manifest.normalization.featureCount,
+      publicEligibleManifestCount: 1,
+    },
+    crosswalk: {
+      resultUnits: manifest.crosswalk.resultUnits,
+      colorableResultUnits: manifest.crosswalk.colorableResultUnits,
+      matchedResultUnits: manifest.crosswalk.matchedResultUnits,
+      unmatchedResultUnits: manifest.crosswalk.unmatchedResultUnits,
+      nonGeographicResultUnits: manifest.crosswalk.nonGeographicResultUnits,
+      sourceAliasResultUnits: manifest.crosswalk.sourceAliasResultUnits,
+    },
+    blockers: [],
+    nextAction:
+      "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
+    notes: [
+      "Official North Carolina State Board of Elections results supply every displayed value; geometry delivery contains no election values.",
+      "Geographic VTDs or precincts use reviewed election-specific relationships. Administrative reporting buckets remain non-geographic and are never assigned to polygons.",
+      "The map is parent-scoped by North Carolina county GEOID; election values are excluded from geometry delivery.",
+      "Each election retains its own boundary vintage. Cross-election local-unit comparison requires a separately reviewed common-geography crosswalk and is not inferred by this release.",
+    ],
+  };
+}
+
+function updateCoverage(root, manifest, relativePath, activatedAtUtc) {
+  const current = readRepositoryJson(root, relativePath);
+  if (!Array.isArray(current.value?.states)) {
+    throw new Error("North Carolina coverage inventory is invalid: " + relativePath);
+  }
+  const existing = current.value.states.filter((row) => row?.state === "NC");
+  let disposition;
+  let states;
+  if (existing.length === 0) {
+    const expectedRow = northCarolinaCoverageRow(manifest, activatedAtUtc);
+    disposition = "activate";
+    states = [...current.value.states, expectedRow];
+  } else if (existing.length === 1) {
+    const row = existing[0];
+    const currentEligible = Number(
+      row.geometry?.publicEligibleManifestCount,
+    );
+    if (
+      row.electionId !== manifest.election.id
+      || row.programStatus !== "reviewed"
+      || row.disposition !== "mapped"
+      || !Array.isArray(row.geometry?.manifestIds)
+      || row.geometry.manifestIds.length !== 1
+      || row.geometry.manifestIds[0] !== manifest.id
+      || row.geometry.featureCount !== manifest.normalization.featureCount
+      || !semanticallyEqual(
+        row.geometry.levels,
+        [manifest.geography.level],
+      )
+      || ![0, 1].includes(currentEligible)
+      || row.crosswalk?.resultUnits !== manifest.crosswalk.resultUnits
+      || row.crosswalk?.matchedResultUnits
+        !== manifest.crosswalk.matchedResultUnits
+      || row.crosswalk?.unmatchedResultUnits
+        !== manifest.crosswalk.unmatchedResultUnits
+    ) {
+      throw new Error(relativePath + " contains a drifted North Carolina row");
+    }
+    const expectedRow = {
+      ...row,
+      checkedAt: currentEligible === 1 ? row.checkedAt : activatedAtUtc,
+      geometry: {
+        ...row.geometry,
+        publicEligibleManifestCount: 1,
+      },
+      blockers: [],
+      nextAction:
+        "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
+    };
+    if (currentEligible === 1) {
+      if (!semanticallyEqual(row, expectedRow)) {
+        throw new Error(relativePath + " contains a partial North Carolina activation");
+      }
+      disposition = "verified_existing";
+      states = current.value.states;
+    } else {
+      disposition = "activate";
+      states = current.value.states.map((candidate) =>
+        candidate?.state === "NC" ? expectedRow : candidate);
+    }
+  } else {
+    throw new Error(relativePath + " contains a partial or drifted North Carolina row");
+  }
+  const value = {
+    ...current.value,
+    updatedAt: disposition === "activate" ? activatedAtUtc : current.value.updatedAt,
+    states,
+  };
+  value.summary = recomputeCoverageSummary(value);
+  return { current, value, disposition };
+}
+
+function outputFile(relativePath, built) {
+  const bytes = serializeNorthCarolinaPublicActivationDocument(built.value);
+  return {
+    path: relativePath,
+    absolutePath: built.current.absolutePath,
+    preimage: {
+      byteCount: built.current.byteCount,
+      sha256: built.current.sha256,
+    },
+    byteCount: bytes.length,
+    sha256: sha256(bytes),
+    disposition: built.disposition,
+    bytes,
+  };
+}
+
+export function inspectNorthCarolinaPublicActivationPlan(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const loaded = loadReleasePackage({ ...options, root });
+  const manifests = loadDraftManifests(root, loaded);
+  const activatedAtUtc = loaded.document.preparedFromLocalValidationAt;
+  const outputs = [outputFile(
+    REGISTRY_PATH,
+    updateRegistry(root, manifests, activatedAtUtc),
+  )];
+  for (const [year, relativePath] of COVERAGE_PATHS) {
+    const manifest = manifests.find((item) => item.year === year)?.draft.manifest;
+    if (!manifest) throw new Error("North Carolina activation is missing year " + year);
+    outputs.push(outputFile(
+      relativePath,
+      updateCoverage(root, manifest, relativePath, activatedAtUtc),
+    ));
+  }
+  const plan = {
+    schemaVersion: 1,
+    id: "nc-local-public-activation-three-election-v1",
+    state: "NC",
+    decision: "DEPLOY_GUARDED_STATIC_MANIFESTS_DATABASE_REMAINS_BLOCKED",
+    releaseCandidate: loaded.identity,
+    activatedAtUtc,
+    manifests: manifests.map((item) => ({
+      year: item.year,
+      manifestId: item.manifestId,
+      canonicalSourcePreimage: item.preimage,
+      draftManifest: {
+        path: item.draft.path,
+        byteCount: item.draft.byteCount,
+        sha256: item.draft.sha256,
+        publicManifestSha256: sha256(
+          serializeNorthCarolinaPublicActivationDocument(item.draft.manifest),
+        ),
+        delivery: item.draft.manifest.delivery,
+      },
+    })),
+    trackedOutputs: outputs.map(({
+      bytes: _bytes,
+      absolutePath: _absolutePath,
+      ...file
+    }) => file),
+    safety: {
+      productionContacted: false,
+      productionMutationPerformed: false,
+      publicFileWritten: false,
+      databasePublicationStatusChanged: false,
+      publicEndpointsRemainDatabaseGated: true,
+      gitPublicationPerformed: false,
+    },
+  };
+  const bytes = serializeNorthCarolinaPublicActivationDocument(plan);
+  const digest = sha256(bytes);
+  return {
+    root,
+    packageDocument: loaded.document,
+    plan,
+    bytes,
+    sha256: digest,
+    outputPath: path.posix.join(
+      NORTH_CAROLINA_PUBLIC_ACTIVATION_ROOT,
+      loaded.identity.sha256.slice(0, 12) + "-" + digest.slice(0, 12),
+      "activation-candidate.json",
+    ),
+    outputs,
+  };
+}

--- a/scripts/lib/nc-local-publication.mjs
+++ b/scripts/lib/nc-local-publication.mjs
@@ -1,0 +1,654 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { inspectNorthCarolinaLocalBlobPublicationPlan } from "./nc-local-blob-publication.mjs";
+import { inspectReleaseArtifact } from "./nc-local-release-candidate.mjs";
+import {
+  inspectPrecinctGeometryManifest,
+  inspectPrecinctGeometryRegistry,
+} from "../../src/lib/precinct-geography.ts";
+
+export const NORTH_CAROLINA_PUBLICATION_YEARS = Object.freeze([2012, 2016, 2020]);
+export const NORTH_CAROLINA_PUBLICATION_SCOPES = Object.freeze([
+  "publish_nc_local_geography_versions",
+  "authorize_nc_local_results",
+  "increment_public_data_revision",
+]);
+export const NORTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES = Object.freeze([
+  "block_nc_local_geography_versions",
+  "revoke_nc_local_results",
+  "increment_public_data_revision",
+]);
+
+const EXPECTED_TOTALS = Object.freeze({
+  reportingUnits: 9_285,
+  candidateResultRows: 24_174,
+  geometryFeatures: 8_058,
+  reviewedRelationships: 9_285,
+  zeroVoteUnits: 0,
+  sourceDocuments: 6,
+  importRuns: 3,
+});
+
+export function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function serializeNorthCarolinaPublicationDocument(value) {
+  return Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, canonical(value[key])]),
+  );
+}
+
+export function semanticallyEqual(left, right) {
+  return JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+}
+
+function safeEvidence(root, relativePath, allowedRoot, expectedSha256) {
+  if (
+    typeof relativePath !== "string"
+    || path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !relativePath.startsWith(allowedRoot + "/")
+    || !relativePath.endsWith(".json")
+    || !/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")
+  ) {
+    throw new Error("North Carolina publication evidence path is unsafe");
+  }
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...allowedRoot.split("/"));
+  if (!absolutePath.startsWith(allowed + path.sep) || !existsSync(absolutePath)) {
+    throw new Error("North Carolina publication evidence is missing");
+  }
+  const bytes = readFileSync(absolutePath);
+  const digest = sha256(bytes);
+  if (digest !== expectedSha256) {
+    throw new Error("North Carolina publication evidence SHA-256 drifted");
+  }
+  return {
+    path: relativePath,
+    absolutePath,
+    bytes,
+    sha256: digest,
+    value: JSON.parse(bytes.toString("utf8")),
+  };
+}
+
+function credentialFreeHttpsOrigin(value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error("North Carolina publication delivery origin is invalid");
+  }
+  if (
+    parsed.protocol !== "https:"
+    || parsed.username
+    || parsed.password
+    || parsed.search
+    || parsed.hash
+    || parsed.pathname !== "/"
+    || parsed.origin !== value
+  ) {
+    throw new Error("North Carolina publication origin must be credential-free HTTPS");
+  }
+  return parsed.origin;
+}
+
+function loadPackage(root, packagePath, packageSha256) {
+  if (!/^[a-f0-9]{64}$/.test(packageSha256 ?? "")) {
+    throw new Error("North Carolina publication requires the exact package SHA-256");
+  }
+  const artifact = inspectReleaseArtifact(root, packagePath, {
+    allowedRoots: [".etl/precinct-release-candidates/NC/"],
+    sha256: packageSha256,
+  });
+  const document = JSON.parse(artifact.bytes.toString("utf8"));
+  if (
+    document?.schemaVersion !== 1
+    || document?.id !== "nc-local-gis-three-election-v1"
+    || document?.state !== "NC"
+    || document?.decision !== "NO_GO_PRODUCTION"
+    || document?.totals?.reportingUnits !== EXPECTED_TOTALS.reportingUnits
+    || document?.totals?.candidateResultRows !== EXPECTED_TOTALS.candidateResultRows
+    || document?.totals?.geometryFeatures !== EXPECTED_TOTALS.geometryFeatures
+    || document?.totals?.reviewedRelationships
+      !== EXPECTED_TOTALS.reviewedRelationships
+    || document?.totals?.zeroVoteUnits !== EXPECTED_TOTALS.zeroVoteUnits
+    || !Array.isArray(document?.years)
+    || !semanticallyEqual(
+      document.years.map((year) => Number(year.year)),
+      NORTH_CAROLINA_PUBLICATION_YEARS,
+    )
+  ) {
+    throw new Error("North Carolina publication release package is incompatible");
+  }
+  return {
+    artifact,
+    document,
+    root: path.dirname(path.resolve(root, ...artifact.path.split("/"))),
+    identity: { id: document.id, path: packagePath, sha256: artifact.sha256 },
+  };
+}
+
+function publicManifests(root, loaded) {
+  const registryPath = "data/precinct-geometry-manifests.json";
+  const registryBytes = readFileSync(path.resolve(root, registryPath));
+  const registry = JSON.parse(registryBytes.toString("utf8"));
+  const inspection = inspectPrecinctGeometryRegistry(registry);
+  if (inspection.errors.length) {
+    throw new Error("North Carolina publication registry is invalid: " + inspection.errors.join("; "));
+  }
+  const rows = registry.manifests.filter((manifest) => manifest?.state === "NC");
+  if (rows.length !== 3) {
+    throw new Error("North Carolina publication registry does not contain three manifests");
+  }
+  return loaded.document.years.map((year) => {
+    const draftArtifact = inspectReleaseArtifact(loaded.root, year.draftManifest.path, {
+      allowedRoots: ["draft-manifests/"],
+      byteCount: year.draftManifest.byteCount,
+      sha256: year.draftManifest.sha256,
+    });
+    const draft = JSON.parse(draftArtifact.bytes.toString("utf8"));
+    const manifest = rows.find((row) => row.id === year.manifestId);
+    const manifestInspection = inspectPrecinctGeometryManifest(manifest);
+    if (
+      !manifest
+      || !semanticallyEqual(manifest, draft)
+      || manifestInspection.errors.length
+      || manifestInspection.publicEligibilityReasons.length
+      || manifest.election?.year !== year.year
+      || manifest.delivery?.format !== "parent_scoped_geojson"
+      || manifest.delivery?.featureCount !== year.reviewedGeometry.featureCount
+      || manifest.delivery?.parentCount !== 100
+    ) {
+      throw new Error("North Carolina " + year.year + " public manifest drifted from the package");
+    }
+    return {
+      year: year.year,
+      electionId: year.electionId,
+      manifestId: manifest.id,
+      publicManifestSha256: sha256(serializeNorthCarolinaPublicationDocument(manifest)),
+      delivery: manifest.delivery,
+      geographyLevel: manifest.geography.level,
+      boundaryVintage: manifest.geography.boundaryVintage,
+      blockedManifestSha256: year.canonicalManifest.sha256,
+      featureCount: manifest.delivery.featureCount,
+      zeroVoteUnits: year.certifiedResults.zeroVoteUnits,
+      resultRows: year.certifiedResults.resultRows,
+      manifest,
+    };
+  }).map((item, _index, all) => {
+    if (new Set(all.map((row) => row.manifestId)).size !== 3) {
+      throw new Error("North Carolina publication manifest IDs are duplicated");
+    }
+    return item;
+  });
+}
+
+function validAuditArtifact(value) {
+  return typeof value?.path === "string"
+    && value.path.startsWith(".etl/")
+    && !value.path.includes("\\")
+    && !value.path.split("/").includes("..")
+    && /^[a-f0-9]{64}$/.test(value?.sha256 ?? "");
+}
+
+export function validateNorthCarolinaHiddenLoadReceipt(value, context) {
+  const audit = value?.transaction?.productionReleaseAudit;
+  const validation = value?.validation;
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "NC"
+    || value?.decision !== "COMMITTED_HIDDEN_NOT_PUBLIC"
+    || value?.releaseCandidate?.id !== context.releaseCandidate.id
+    || value?.releaseCandidate?.path !== context.releaseCandidate.path
+    || value?.releaseCandidate?.sha256 !== context.releaseCandidate.sha256
+    || typeof value?.committedAtUtc !== "string"
+    || Number.isNaN(Date.parse(value.committedAtUtc))
+    || Date.parse(value.committedAtUtc) > context.now
+    || !/^[a-f0-9]{64}$/.test(value?.endpointFingerprint ?? "")
+    || value?.productionMutationPerformed !== true
+    || value?.canonicalManifestChanged !== false
+    || value?.publicFileWritten !== false
+    || value?.publicDeliveryAuthorized !== false
+    || value?.transaction?.productionMutationPerformed !== true
+    || value?.transaction?.publicDeliveryAuthorized !== false
+    || validation?.productionMutationPerformed !== true
+    || validation?.publicDeliveryAuthorized !== false
+    || value?.transaction?.revision !== validation?.revision
+    || !Number.isInteger(Number(value?.transaction?.revision))
+    || Number(value.transaction.revision) < 1
+    || value?.committedAtUtc !== audit?.transaction?.executedAtUtc
+    || value?.transaction?.revision !== audit?.transaction?.publicRevision
+    || value?.authorization?.id !== audit?.authorizationId
+    || value?.authorization?.path !== audit?.authorization?.path
+    || value?.authorization?.sha256 !== audit?.authorization?.sha256
+    || value?.preflight?.path !== audit?.preflight?.path
+    || value?.preflight?.sha256 !== audit?.preflight?.sha256
+    || value?.backup?.manifestSha256 !== audit?.backupManifest?.sha256
+    || value?.backup?.dumpSha256 !== audit?.backupManifest?.dumpSha256
+    || value?.endpointFingerprint !== audit?.endpointFingerprint
+    || audit?.releasePackage?.path !== context.releaseCandidate.path
+    || audit?.releasePackage?.sha256 !== context.releaseCandidate.sha256
+    || ![
+      audit?.releasePackage,
+      audit?.authorization,
+      audit?.preflight,
+    ].every(validAuditArtifact)
+    || !/^[a-f0-9]{64}$/.test(audit?.backupManifest?.sha256 ?? "")
+    || !/^[a-f0-9]{64}$/.test(audit?.backupManifest?.dumpSha256 ?? "")
+    || !semanticallyEqual(validation?.productionReleaseAudit, audit)
+    || !semanticallyEqual(validation?.releaseCandidate, {
+      id: context.releaseCandidate.id,
+      sha256: context.releaseCandidate.sha256,
+      publicDeliveryAuthorized: false,
+    })
+    || validation?.database?.name !== value?.transaction?.database?.name
+    || typeof validation?.database?.name !== "string"
+    || !validation.database.name
+    || !Array.isArray(validation?.years)
+    || validation.years.length !== 3
+    || !semanticallyEqual(
+      validation.years.map((year) => Number(year.year)),
+      NORTH_CAROLINA_PUBLICATION_YEARS,
+    )
+  ) {
+    throw new Error("North Carolina hidden-load receipt is incomplete or incompatible");
+  }
+  const totals = {
+    reportingUnits: validation.years.reduce((sum, year) => sum + year.reportingUnits, 0),
+    candidateResultRows: validation.years.reduce((sum, year) => sum + year.resultRows, 0),
+    geometryFeatures: validation.years.reduce((sum, year) => sum + year.features, 0),
+    reviewedRelationships: validation.years.reduce(
+      (sum, year) => sum + year.exactCrosswalks,
+      0,
+    ),
+    zeroVoteUnits: validation.years.reduce((sum, year) => sum + year.zeroVoteUnits, 0),
+  };
+  for (const [key, expected] of Object.entries(EXPECTED_TOTALS)) {
+    if (key === "sourceDocuments" || key === "importRuns") continue;
+    if (Number(totals[key]) !== expected) {
+      throw new Error("North Carolina hidden-load receipt total drifted: " + key);
+    }
+  }
+  return {
+    committedAtUtc: value.committedAtUtc,
+    databaseName: validation.database.name,
+    endpointFingerprint: value.endpointFingerprint,
+    hiddenRevision: value.transaction.revision,
+    productionReleaseAudit: audit,
+    totals,
+  };
+}
+
+export function validateNorthCarolinaBlobPublicationEvidence(value, blobPlan, now = Date.now()) {
+  const origin = credentialFreeHttpsOrigin(value?.deliveryOrigin);
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "NC"
+    || value?.purpose !== "nc-local-parent-scoped-immutable-geometry-publication"
+    || value?.releaseCandidate?.id !== blobPlan.releaseCandidate.id
+    || value?.releaseCandidate?.path !== blobPlan.releaseCandidate.path
+    || value?.releaseCandidate?.sha256 !== blobPlan.releaseCandidate.sha256
+    || typeof value?.publishedAtUtc !== "string"
+    || Number.isNaN(Date.parse(value.publishedAtUtc))
+    || Date.parse(value.publishedAtUtc) > now
+    || value?.assetCount !== 303
+    || value?.canonicalManifestChanged !== false
+    || value?.publicEligibilityChanged !== false
+    || !Array.isArray(value?.artifacts)
+    || value.artifacts.length !== 303
+  ) {
+    throw new Error("North Carolina Blob publication evidence is incomplete or incompatible");
+  }
+  const expected = new Map(blobPlan.artifacts.map((artifact) => [artifact.pathname, artifact]));
+  const seen = new Set();
+  for (const artifact of value.artifacts) {
+    const wanted = expected.get(artifact?.pathname);
+    let remote;
+    try {
+      remote = new URL(artifact?.url);
+    } catch {
+      throw new Error("North Carolina Blob publication evidence contains an invalid URL");
+    }
+    if (
+      !wanted
+      || seen.has(artifact.pathname)
+      || artifact.kind !== wanted.kind
+      || artifact.year !== wanted.year
+      || artifact.packageRelativePath !== wanted.packageRelativePath
+      || artifact.publicUrl !== wanted.publicUrl
+      || artifact.byteCount !== wanted.byteCount
+      || artifact.sha256 !== wanted.sha256
+      || remote.origin !== origin
+      || remote.pathname !== "/" + wanted.pathname
+      || !["created", "verified_existing"].includes(artifact.disposition)
+    ) {
+      throw new Error("North Carolina Blob publication artifact set drifted");
+    }
+    seen.add(artifact.pathname);
+  }
+  if (seen.size !== expected.size) {
+    throw new Error("North Carolina Blob publication artifact set is incomplete");
+  }
+  return {
+    publishedAtUtc: value.publishedAtUtc,
+    deliveryOrigin: origin,
+    authorizationId: value.authorizationId ?? null,
+    assetCount: seen.size,
+  };
+}
+
+export function inspectNorthCarolinaPublicationPlan(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const now = options.now ?? Date.now();
+  const loaded = loadPackage(root, options.packagePath, options.packageSha256);
+  const manifests = publicManifests(root, loaded);
+  const hiddenArtifact = safeEvidence(
+    root,
+    options.hiddenReceiptPath,
+    ".etl/production-release-receipts/NC",
+    options.hiddenReceiptSha256,
+  );
+  const hidden = validateNorthCarolinaHiddenLoadReceipt(hiddenArtifact.value, {
+    now,
+    releaseCandidate: loaded.identity,
+  });
+  const blobArtifact = safeEvidence(
+    root,
+    options.blobEvidencePath,
+    ".etl/precinct-blob-publications/NC",
+    options.blobEvidenceSha256,
+  );
+  const blobPlan = inspectNorthCarolinaLocalBlobPublicationPlan({
+    root,
+    packagePath: loaded.identity.path,
+    packageSha256: loaded.identity.sha256,
+  });
+  const blob = validateNorthCarolinaBlobPublicationEvidence(blobArtifact.value, blobPlan, now);
+  const registryBytes = readFileSync(path.resolve(root, "data/precinct-geometry-manifests.json"));
+  const plan = {
+    schemaVersion: 1,
+    id: "nc-local-database-publication-v1",
+    state: "NC",
+    decision: "GO_AUTHORIZATION_AND_VERIFIED_DEPLOYMENT_REQUIRED",
+    releaseCandidate: loaded.identity,
+    hiddenLoad: {
+      path: hiddenArtifact.path,
+      sha256: hiddenArtifact.sha256,
+      ...hidden,
+    },
+    blobPublication: {
+      path: blobArtifact.path,
+      sha256: blobArtifact.sha256,
+      ...blob,
+    },
+    staticRegistry: {
+      path: "data/precinct-geometry-manifests.json",
+      byteCount: registryBytes.length,
+      sha256: sha256(registryBytes),
+    },
+    manifests: manifests.map(({ manifest: _manifest, ...manifest }) => manifest),
+    expectedTotals: EXPECTED_TOTALS,
+    safety: {
+      databaseMutationPerformed: false,
+      blobMutationPerformed: false,
+      gitMutationPerformed: false,
+      deploymentMutationPerformed: false,
+      publicCutoverIsSingleDatabaseTransaction: true,
+    },
+  };
+  const bytes = serializeNorthCarolinaPublicationDocument(plan);
+  return {
+    root,
+    packageDocument: loaded.document,
+    plan,
+    bytes,
+    sha256: sha256(bytes),
+  };
+}
+
+export function buildNorthCarolinaPublicationAuthorizationTemplate(plan, planSha256) {
+  return {
+    schemaVersion: 1,
+    state: "NC",
+    decision: "NO_GO_PUBLIC",
+    activationId: null,
+    approvedBy: null,
+    authorizedAtUtc: null,
+    expiresAtUtc: null,
+    releaseCandidate: plan.releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    scopes: [...NORTH_CAROLINA_PUBLICATION_SCOPES],
+    productionDeployment: {
+      deploymentId: null,
+      url: null,
+      gitSha: null,
+      gitTreeSha: null,
+      readyVerified: false,
+      promotedVerified: false,
+      blockedResultGateVerified: false,
+      blockedGeometryGateVerified: false,
+      verifiedAtUtc: null,
+      deliveryOrigin: plan.blobPublication.deliveryOrigin,
+      staticRegistrySha256: plan.staticRegistry.sha256,
+    },
+    rollbackTarget: {
+      deploymentId: null,
+      url: null,
+      gitSha: null,
+      gitTreeSha: null,
+      verifiedAtUtc: null,
+      gateCapableVerified: false,
+      blockedResultGateVerified: false,
+      blockedGeometryGateVerified: false,
+    },
+    evidence: {
+      hiddenLoad: { path: plan.hiddenLoad.path, sha256: plan.hiddenLoad.sha256 },
+      blobPublication: {
+        path: plan.blobPublication.path,
+        sha256: plan.blobPublication.sha256,
+      },
+    },
+  };
+}
+
+export function validateNorthCarolinaPublicationAuthorization(value, context) {
+  const now = context.now ?? Date.now();
+  const authorizedAt = Date.parse(value?.authorizedAtUtc);
+  const expiresAt = Date.parse(value?.expiresAtUtc);
+  const deployedAt = Date.parse(value?.productionDeployment?.verifiedAtUtc);
+  const rollbackTargetAt = Date.parse(value?.rollbackTarget?.verifiedAtUtc);
+  const recovery = context.recovery === true;
+  let deploymentUrl;
+  let rollbackTargetUrl;
+  try {
+    deploymentUrl = new URL(value?.productionDeployment?.url);
+  } catch {
+    // The common fail-closed check below reports an incompatible record.
+  }
+  try {
+    rollbackTargetUrl = new URL(value?.rollbackTarget?.url);
+  } catch {
+    // The common fail-closed check below reports an incompatible record.
+  }
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "NC"
+    || value?.decision !== "GO_PUBLIC"
+    || typeof value?.activationId !== "string"
+    || !value.activationId.trim()
+    || typeof value?.approvedBy !== "string"
+    || !value.approvedBy.trim()
+    || value?.releaseCandidate?.id !== context.plan.releaseCandidate.id
+    || value?.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
+    || value?.publicationPlan?.id !== context.plan.id
+    || value?.publicationPlan?.sha256 !== context.planSha256
+    || !semanticallyEqual(value?.scopes, NORTH_CAROLINA_PUBLICATION_SCOPES)
+    || [authorizedAt, expiresAt, deployedAt, rollbackTargetAt].some(Number.isNaN)
+    || expiresAt <= authorizedAt
+    || deployedAt > authorizedAt
+    || typeof value?.productionDeployment?.deploymentId !== "string"
+    || !value.productionDeployment.deploymentId.trim()
+    || !/^[a-f0-9]{40}$/.test(value?.productionDeployment?.gitSha ?? "")
+    || !/^[a-f0-9]{40}$/.test(value?.productionDeployment?.gitTreeSha ?? "")
+    || value?.productionDeployment?.readyVerified !== true
+    || value?.productionDeployment?.promotedVerified !== true
+    || value?.productionDeployment?.blockedResultGateVerified !== true
+    || value?.productionDeployment?.blockedGeometryGateVerified !== true
+    || value?.productionDeployment?.deliveryOrigin
+      !== context.plan.blobPublication.deliveryOrigin
+    || value?.productionDeployment?.staticRegistrySha256
+      !== context.plan.staticRegistry.sha256
+    || deploymentUrl?.protocol !== "https:"
+    || deploymentUrl?.username
+    || deploymentUrl?.password
+    || deploymentUrl?.search
+    || deploymentUrl?.hash
+    || typeof value?.rollbackTarget?.deploymentId !== "string"
+    || !value.rollbackTarget.deploymentId.trim()
+    || value.rollbackTarget.deploymentId
+      === value.productionDeployment.deploymentId
+    || !/^[a-f0-9]{40}$/.test(value?.rollbackTarget?.gitSha ?? "")
+    || !/^[a-f0-9]{40}$/.test(value?.rollbackTarget?.gitTreeSha ?? "")
+    || value.rollbackTarget.gitTreeSha
+      === value.productionDeployment.gitTreeSha
+    || value?.rollbackTarget?.gateCapableVerified !== true
+    || value?.rollbackTarget?.blockedResultGateVerified !== true
+    || value?.rollbackTarget?.blockedGeometryGateVerified !== true
+    || rollbackTargetUrl?.protocol !== "https:"
+    || rollbackTargetUrl?.username
+    || rollbackTargetUrl?.password
+    || rollbackTargetUrl?.search
+    || rollbackTargetUrl?.hash
+    || rollbackTargetAt > authorizedAt
+    || (!recovery && (
+      authorizedAt > now
+      || now > expiresAt
+      || deployedAt > now
+      || now - deployedAt > 4 * 60 * 60 * 1000
+      || rollbackTargetAt > now
+      || now - rollbackTargetAt > 4 * 60 * 60 * 1000
+    ))
+    || value?.evidence?.hiddenLoad?.path !== context.plan.hiddenLoad.path
+    || value?.evidence?.hiddenLoad?.sha256 !== context.plan.hiddenLoad.sha256
+    || value?.evidence?.blobPublication?.path
+      !== context.plan.blobPublication.path
+    || value?.evidence?.blobPublication?.sha256
+      !== context.plan.blobPublication.sha256
+  ) {
+    throw new Error("North Carolina public authorization is absent, expired, or incompatible");
+  }
+  return {
+    activationId: value.activationId.trim(),
+    approvedBy: value.approvedBy.trim(),
+    productionDeployment: value.productionDeployment,
+    rollbackTarget: value.rollbackTarget,
+  };
+}
+
+export function buildNorthCarolinaPublicRollbackAuthorizationTemplate(
+  plan,
+  planSha256,
+  publicationReceipt,
+) {
+  return {
+    schemaVersion: 1,
+    state: "NC",
+    decision: "NO_GO_ROLLBACK",
+    rollbackId: null,
+    approvedBy: null,
+    authorizedAtUtc: null,
+    expiresAtUtc: null,
+    releaseCandidate: plan.releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    publication: {
+      activationId: publicationReceipt.activationId,
+      revision: publicationReceipt.revision,
+      changedAtUtc: publicationReceipt.changedAtUtc,
+    },
+    scopes: [...NORTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES],
+    rollbackWindow: {
+      startsAtUtc: null,
+      endsAtUtc: null,
+    },
+    applicationRollback: {
+      target: publicationReceipt.rollbackTarget,
+      databaseBlockFirstAcknowledged: false,
+      restoreAfterDatabaseRollbackAcknowledged: false,
+    },
+    evidence: {
+      publicationReceipt: {
+        path: publicationReceipt.path,
+        sha256: publicationReceipt.sha256,
+      },
+    },
+  };
+}
+
+export function validateNorthCarolinaPublicRollbackAuthorization(value, context) {
+  const now = context.now ?? Date.now();
+  const authorizedAt = Date.parse(value?.authorizedAtUtc);
+  const expiresAt = Date.parse(value?.expiresAtUtc);
+  const startsAt = Date.parse(value?.rollbackWindow?.startsAtUtc);
+  const endsAt = Date.parse(value?.rollbackWindow?.endsAtUtc);
+  const receipt = context.publicationReceipt;
+  const recovery = context.recovery === true;
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "NC"
+    || value?.decision !== "GO_ROLLBACK"
+    || typeof value?.rollbackId !== "string"
+    || !value.rollbackId.trim()
+    || typeof value?.approvedBy !== "string"
+    || !value.approvedBy.trim()
+    || value?.releaseCandidate?.id !== context.plan.releaseCandidate.id
+    || value?.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
+    || value?.publicationPlan?.id !== context.plan.id
+    || value?.publicationPlan?.sha256 !== context.planSha256
+    || value?.publication?.activationId !== receipt.activationId
+    || Number(value?.publication?.revision) !== receipt.revision
+    || value?.publication?.changedAtUtc !== receipt.changedAtUtc
+    || !semanticallyEqual(value?.scopes, NORTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES)
+    || [authorizedAt, expiresAt, startsAt, endsAt].some(Number.isNaN)
+    || expiresAt <= authorizedAt
+    || startsAt > endsAt
+    || (!recovery && (
+      authorizedAt > now
+      || now > expiresAt
+      || startsAt > now
+      || now > endsAt
+    ))
+    || !semanticallyEqual(
+      value?.applicationRollback?.target,
+      receipt.rollbackTarget,
+    )
+    || value?.applicationRollback?.databaseBlockFirstAcknowledged !== true
+    || value?.applicationRollback?.restoreAfterDatabaseRollbackAcknowledged
+      !== true
+    || value?.evidence?.publicationReceipt?.path !== receipt.path
+    || value?.evidence?.publicationReceipt?.sha256 !== receipt.sha256
+  ) {
+    throw new Error("North Carolina rollback authorization is absent, expired, or incompatible");
+  }
+  return {
+    activationId: value.rollbackId.trim(),
+    rollbackId: value.rollbackId.trim(),
+    publicationActivationId: receipt.activationId,
+    approvedBy: value.approvedBy.trim(),
+    rollbackWindow: value.rollbackWindow,
+    applicationRollback: value.applicationRollback,
+  };
+}

--- a/scripts/lib/nc-local-release-candidate.mjs
+++ b/scripts/lib/nc-local-release-candidate.mjs
@@ -1,0 +1,625 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+import { buildPrecinctDeliveryCandidateFeatureCollection } from "./precinct-delivery-builder.mjs";
+import { buildParentScopedPrecinctDeliveryPackage } from "./precinct-parent-delivery-builder.mjs";
+import { buildNorthCarolinaLocalGisPlan } from "./nc-local-gis-plan.mjs";
+import { inspectPrecinctGeometryManifest } from "../../src/lib/precinct-geography.ts";
+
+export const NORTH_CAROLINA_RELEASE_CANDIDATE_ID = "nc-local-gis-three-election-v1";
+export const NORTH_CAROLINA_RELEASE_CANDIDATE_ROOT = ".etl/precinct-release-candidates/NC";
+export const NORTH_CAROLINA_LOCAL_VALIDATION_REPORT = ".etl/local-db/nc-local-gis-validation.json";
+export const NORTH_CAROLINA_PUBLIC_RELEASE_YEARS = Object.freeze([
+  2012,
+  2016,
+  2020,
+]);
+export const NORTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS = 7;
+export const NORTH_CAROLINA_DELIVERY_SIMPLIFICATION_TOLERANCE_DEGREES = 0.000005;
+export const NORTH_CAROLINA_MAX_PARENT_DELIVERY_BYTES = 8_000_000;
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function serializeNorthCarolinaReleaseDocument(value) {
+  return Buffer.from(JSON.stringify(value, null, 2) + "\n", "utf8");
+}
+
+function safePath(root, relativePath, allowedRoots) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath
+    || path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !allowedRoots.some((prefix) => relativePath.startsWith(prefix))
+  ) {
+    throw new Error("Unsafe North Carolina release artifact path: " + relativePath);
+  }
+  const resolvedRoot = path.resolve(root);
+  const absolutePath = path.resolve(resolvedRoot, ...relativePath.split("/"));
+  if (!absolutePath.startsWith(resolvedRoot + path.sep)) {
+    throw new Error("North Carolina release artifact escapes repository root: " + relativePath);
+  }
+  return absolutePath;
+}
+
+function readArtifact(root, declaration, allowedRoots = ["data/", ".etl/"]) {
+  const absolutePath = safePath(root, declaration.path, allowedRoots);
+  if (!existsSync(absolutePath)) {
+    throw new Error("North Carolina release artifact is missing: " + declaration.path);
+  }
+  const bytes = readFileSync(absolutePath);
+  const digest = sha256(bytes);
+  if (
+    Number.isInteger(declaration.byteCount)
+    && bytes.length !== declaration.byteCount
+  ) {
+    throw new Error("North Carolina release artifact byte count drifted: " + declaration.path);
+  }
+  if (declaration.sha256 && digest !== declaration.sha256) {
+    throw new Error("North Carolina release artifact SHA-256 drifted: " + declaration.path);
+  }
+  return { path: declaration.path, byteCount: bytes.length, sha256: digest, bytes };
+}
+
+export function inspectReleaseArtifact(root, relativePath, options = {}) {
+  return readArtifact(root, {
+    path: relativePath,
+    byteCount: options.byteCount,
+    sha256: options.sha256,
+  }, options.allowedRoots ?? ["data/", ".etl/", "drizzle/", "scripts/"]);
+}
+
+function parseJsonArtifact(root, declaration, allowedRoots) {
+  const artifact = readArtifact(root, declaration, allowedRoots);
+  const payload = declaration.path.endsWith(".gz")
+    ? gunzipSync(artifact.bytes)
+    : artifact.bytes;
+  return { artifact, value: JSON.parse(payload.toString("utf8")) };
+}
+
+function validateLocalReport(report, plan) {
+  if (
+    report?.schemaVersion !== 1
+    || report?.productionMutationPerformed !== false
+    || report?.publicDeliveryAuthorized !== false
+    || report?.validation?.database?.environment !== "local"
+    || report?.validation?.database?.host !== "loopback"
+    || report?.validation?.database?.port !== 54329
+    || report?.validation?.database?.name !== "crm_clone_dev"
+    || report?.validation?.database?.readOnlySession !== true
+    || report?.validation?.invalidConstraints !== 0
+    || !Number.isInteger(report?.validation?.revision)
+    || Number.isNaN(Date.parse(report?.generatedAtUtc))
+  ) {
+    throw new Error("North Carolina local geography database validation report is not release-safe");
+  }
+  const rows = new Map(
+    (report.validation.years ?? []).map((row) => [Number(row.year), row]),
+  );
+  for (const year of plan.years) {
+    const row = rows.get(year.year);
+    const expected = {
+      reportingUnits: year.reportingUnits.length,
+      resultRows: year.resultRows.length,
+      sameYearResultRows: year.resultRows.length,
+      totalVotes: year.totals.Total,
+      zeroVoteUnits: year.zeroVoteUnits,
+      geographyVersions: 1,
+      features: year.geometry.features.length,
+      safeBlockedGeographyVersions: 1,
+      reviewedCrosswalks: year.geometry.crosswalks.length,
+      exactFeatures: year.geometry.features.length,
+      exactCrosswalks: year.geometry.crosswalks.length,
+    };
+    if (!row) throw new Error("North Carolina local geography validation is missing " + year.year);
+    for (const [key, value] of Object.entries(expected)) {
+      if (Number(row[key]) !== value) {
+        throw new Error("North Carolina " + year.year + " local validation " + key + " drifted");
+      }
+    }
+  }
+  if (rows.size !== plan.years.length) {
+    throw new Error("North Carolina local geography validation year set drifted");
+  }
+  return {
+    generatedAtUtc: report.generatedAtUtc,
+    revision: report.validation.revision,
+    invalidConstraints: report.validation.invalidConstraints,
+    database: report.validation.database,
+  };
+}
+
+function publicUrl(year, manifestId, indexSha256) {
+  return "/data/geography/nc/"
+    + year.electionDate
+    + "/"
+    + year.manifest.geography.level
+    + "/"
+    + manifestId
+    + "-"
+    + indexSha256.slice(0, 12)
+    + "/index.json";
+}
+
+function squaredDistanceToSegment(point, start, end) {
+  const dx = end[0] - start[0];
+  const dy = end[1] - start[1];
+  if (dx === 0 && dy === 0) {
+    return (point[0] - start[0]) ** 2 + (point[1] - start[1]) ** 2;
+  }
+  const amount = Math.max(
+    0,
+    Math.min(
+      1,
+      ((point[0] - start[0]) * dx + (point[1] - start[1]) * dy)
+        / (dx * dx + dy * dy),
+    ),
+  );
+  const projectedX = start[0] + amount * dx;
+  const projectedY = start[1] + amount * dy;
+  return (point[0] - projectedX) ** 2 + (point[1] - projectedY) ** 2;
+}
+
+function simplifyLine(points, squaredTolerance) {
+  if (points.length <= 2) return points;
+  let maximumDistance = squaredTolerance;
+  let maximumIndex = -1;
+  const start = points[0];
+  const end = points[points.length - 1];
+  for (let index = 1; index < points.length - 1; index += 1) {
+    const distance = squaredDistanceToSegment(points[index], start, end);
+    if (distance > maximumDistance) {
+      maximumDistance = distance;
+      maximumIndex = index;
+    }
+  }
+  if (maximumIndex < 0) return [start, end];
+  const left = simplifyLine(points.slice(0, maximumIndex + 1), squaredTolerance);
+  const right = simplifyLine(points.slice(maximumIndex), squaredTolerance);
+  return [...left.slice(0, -1), ...right];
+}
+
+function samePoint(left, right) {
+  return left[0] === right[0] && left[1] === right[1];
+}
+
+function quantizeCoordinate(coordinate, scale) {
+  return coordinate.map((value) =>
+    Number.isFinite(value) ? Math.round(value * scale) / scale : value);
+}
+
+function simplifyRing(ring, scale, tolerance) {
+  const quantized = ring
+    .map((coordinate) => quantizeCoordinate(coordinate, scale))
+    .filter((coordinate, index, rows) =>
+      index === 0 || !samePoint(coordinate, rows[index - 1]));
+  if (
+    quantized.length > 1
+    && samePoint(quantized[0], quantized[quantized.length - 1])
+  ) {
+    quantized.pop();
+  }
+  if (new Set(quantized.map((coordinate) => coordinate.join(","))).size < 3) {
+    return null;
+  }
+
+  let anchorIndex = 0;
+  for (let index = 1; index < quantized.length; index += 1) {
+    if (
+      quantized[index][0] < quantized[anchorIndex][0]
+      || (
+        quantized[index][0] === quantized[anchorIndex][0]
+        && quantized[index][1] < quantized[anchorIndex][1]
+      )
+    ) {
+      anchorIndex = index;
+    }
+  }
+  const rotated = [
+    ...quantized.slice(anchorIndex),
+    ...quantized.slice(0, anchorIndex),
+  ];
+  let splitIndex = 1;
+  let splitDistance = -1;
+  for (let index = 1; index < rotated.length; index += 1) {
+    const distance = (rotated[index][0] - rotated[0][0]) ** 2
+      + (rotated[index][1] - rotated[0][1]) ** 2;
+    if (distance > splitDistance) {
+      splitDistance = distance;
+      splitIndex = index;
+    }
+  }
+  const squaredTolerance = tolerance ** 2;
+  const firstArc = simplifyLine(
+    rotated.slice(0, splitIndex + 1),
+    squaredTolerance,
+  );
+  const secondArc = simplifyLine(
+    [...rotated.slice(splitIndex), rotated[0]],
+    squaredTolerance,
+  );
+  const simplified = [...firstArc, ...secondArc.slice(1, -1)];
+  const usable = new Set(
+    simplified.map((coordinate) => coordinate.join(",")),
+  ).size >= 3 ? simplified : rotated;
+  return [...usable, usable[0]];
+}
+
+function simplifyPolygon(polygon, scale, tolerance) {
+  const outer = simplifyRing(polygon[0], scale, tolerance);
+  if (!outer) return null;
+  return [
+    outer,
+    ...polygon.slice(1)
+      .map((ring) => simplifyRing(ring, scale, tolerance))
+      .filter(Boolean),
+  ];
+}
+
+function simplifyGeometry(geometry, scale, tolerance) {
+  if (geometry.type === "Polygon") {
+    const polygon = simplifyPolygon(geometry.coordinates, scale, tolerance);
+    if (!polygon) {
+      throw new Error("North Carolina presentation simplification collapsed a polygon");
+    }
+    return {
+      type: "Polygon",
+      coordinates: polygon,
+    };
+  }
+  if (geometry.type === "MultiPolygon") {
+    const polygons = geometry.coordinates
+      .map((polygon) => simplifyPolygon(polygon, scale, tolerance))
+      .filter(Boolean);
+    if (polygons.length === 0) {
+      throw new Error("North Carolina presentation simplification collapsed a multipolygon");
+    }
+    return {
+      type: "MultiPolygon",
+      coordinates: polygons,
+    };
+  }
+  throw new Error("North Carolina delivery has an unsupported geometry type");
+}
+
+export function quantizeNorthCarolinaDeliveryCollection(collection) {
+  const scale = 10 ** NORTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS;
+  const tolerance = NORTH_CAROLINA_DELIVERY_SIMPLIFICATION_TOLERANCE_DEGREES;
+  return {
+    ...collection,
+    metadata: {
+      ...collection.metadata,
+      coordinatePrecisionDecimals: NORTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS,
+      simplificationToleranceDegrees: tolerance,
+      presentationGeometry: "source-normalized geometry is rounded to seven decimals and simplified at a 0.000005-degree presentation tolerance for county-scoped web delivery; zero-area polygon parts are omitted while source artifacts, identities, and joins remain unchanged",
+    },
+    features: collection.features.map((feature) => ({
+      ...feature,
+      geometry: simplifyGeometry(feature.geometry, scale, tolerance),
+    })),
+  };
+}
+
+function buildDraftManifest(year, delivery) {
+  const geographicReportingUnits = year.reportingUnits.filter(
+    (unit) => unit.isGeographic,
+  ).length;
+  const nonGeographicReportingUnits = year.reportingUnits.length
+    - geographicReportingUnits;
+  const draft = JSON.parse(JSON.stringify(year.manifest));
+  const warnings = [
+    ...draft.validation.warnings,
+    "All " + geographicReportingUnits
+      + " displayable " + year.manifest.geography.level
+      + " relationships are reviewed one-to-one across all 100 North Carolina counties.",
+    "All " + nonGeographicReportingUnits
+      + " administrative reporting units remain explicitly non-geographic and are never assigned to a polygon.",
+    "The " + year.zeroVoteUnits
+      + " zero-presidential-vote local units remain geographic reporting units.",
+    "All " + year.manifest.crosswalk.reviewedNoDataFeatures
+      + " reviewed no-data polygons remain visible without an invented result row.",
+    "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged.",
+  ];
+  draft.validation = {
+    ...draft.validation,
+    status: "reviewed",
+    rowLevelRenderingSafe: true,
+    errors: [],
+    warnings: [...new Set(warnings)],
+  };
+  draft.delivery = {
+    format: "parent_scoped_geojson",
+    url: publicUrl(year, draft.id, delivery.indexSha256),
+    sha256: delivery.indexSha256,
+    byteCount: delivery.indexByteCount,
+    featureIdProperty: "geometryFeatureId",
+    resultUnitProperty: "resultUnitCode",
+    parentGeoidProperty: "parentGeoid",
+    parentCount: delivery.parentCount,
+    featureCount: delivery.featureCount,
+  };
+  draft.caveats = [...new Set(draft.caveats)];
+  const inspection = inspectPrecinctGeometryManifest(draft);
+  if (inspection.errors.length || inspection.publicEligibilityReasons.length) {
+    throw new Error(
+      "North Carolina " + year.year + " public draft is invalid: "
+      + inspection.errors.concat(inspection.publicEligibilityReasons).join("; "),
+    );
+  }
+  return draft;
+}
+
+function buildYear(root, year) {
+  const geographicReportingUnits = year.reportingUnits.filter(
+    (unit) => unit.isGeographic,
+  ).length;
+  const nonGeographicReportingUnits = year.reportingUnits.length
+    - geographicReportingUnits;
+  const normalized = parseJsonArtifact(root, {
+    path: year.manifest.normalization.artifact,
+    byteCount: year.manifest.normalization.byteCount,
+    sha256: year.manifest.normalization.sha256,
+  }, ["data/"]);
+  const crosswalk = parseJsonArtifact(root, {
+    path: year.manifest.crosswalk.artifact,
+    byteCount: year.manifest.crosswalk.byteCount,
+    sha256: year.manifest.crosswalk.sha256,
+  }, ["data/"]);
+  const statewide = quantizeNorthCarolinaDeliveryCollection(
+    buildPrecinctDeliveryCandidateFeatureCollection(
+      year.manifest,
+      normalized.value,
+      crosswalk.value,
+    ),
+  );
+  const delivery = buildParentScopedPrecinctDeliveryPackage(statewide);
+  if (
+    delivery.parentCount !== 100
+    || delivery.featureCount !== year.geometry.features.length
+    || delivery.resultUnitCount !== year.geometry.features.length
+  ) {
+    throw new Error("North Carolina " + year.year + " parent-scoped delivery drifted");
+  }
+  const largestParentByteCount = Math.max(
+    ...delivery.parentArtifacts.map((artifact) => artifact.byteCount),
+  );
+  if (largestParentByteCount > NORTH_CAROLINA_MAX_PARENT_DELIVERY_BYTES) {
+    throw new Error(
+      "North Carolina " + year.year + " parent delivery exceeds the web response safety limit",
+    );
+  }
+  const draft = buildDraftManifest(year, delivery);
+  const draftBytes = serializeNorthCarolinaReleaseDocument(draft);
+  const assetRoot = path.posix.join(
+    "delivery-assets",
+    draft.id + "-" + delivery.indexSha256.slice(0, 12),
+  );
+  const index = {
+    packageRelativePath: path.posix.join(assetRoot, "index.json"),
+    publicUrl: draft.delivery.url,
+    byteCount: delivery.indexByteCount,
+    sha256: delivery.indexSha256,
+  };
+  const parentArtifacts = delivery.parentArtifacts.map((artifact) => ({
+    parentGeoid: artifact.parentGeoid,
+    packageRelativePath: path.posix.join(assetRoot, artifact.path),
+    publicUrl: path.posix.join(path.posix.dirname(draft.delivery.url), artifact.path),
+    byteCount: artifact.byteCount,
+    sha256: artifact.sha256,
+    featureCount: artifact.featureCount,
+  }));
+  return {
+    summary: {
+      year: year.year,
+      electionId: year.electionId,
+      manifestId: year.manifest.id,
+      canonicalManifest: {
+        path: year.manifestPath,
+        sha256: year.manifestSha256,
+        byteCount: year.manifestByteCount,
+        validationStatus: "blocked",
+        rowLevelRenderingSafe:
+          year.manifest.validation.rowLevelRenderingSafe,
+        delivery: null,
+      },
+      certifiedResults: {
+        authority: year.resultSource.authority,
+        sourceId: year.resultSource.id,
+        sourceUrl: year.resultSource.url,
+        artifact: {
+          path: year.resultSource.artifact,
+          byteCount: year.resultSource.byteCount,
+          sha256: year.resultSource.sha256,
+        },
+        reportingUnits: year.reportingUnits.length,
+        geographicReportingUnits,
+        nonGeographicReportingUnits,
+        resultRows: year.resultRows.length,
+        zeroVoteUnits: year.zeroVoteUnits,
+        candidateDetailSuppressedUnits: year.candidateDetailSuppressedUnits,
+        totals: year.totals,
+        officialTotals: year.officialTotals,
+      },
+      reviewedGeometry: {
+        sourceAuthority: year.manifest.source.authority,
+        sourceUrl: year.manifest.source.url,
+        sourceTerms: year.manifest.source.licenseOrTerms,
+        featureCount: year.geometry.features.length,
+        parentCount: delivery.parentCount,
+        reviewedRelationships: year.geometry.crosswalks.length,
+        reviewedNoDataFeatures: year.manifest.crosswalk.reviewedNoDataFeatures,
+        publicGeographyLabel:
+          "Reviewed election-specific " + year.manifest.geography.level
+          + " geometry from " + year.manifest.source.authority
+          + ", joined only to official North Carolina State Board of Elections results",
+        electionValuesInDelivery: false,
+      },
+      parentScopedDelivery: {
+        format: "parent_scoped_geojson",
+        originEnvironmentVariable: "CRM_PRECINCT_GEOGRAPHY_ORIGIN",
+        index,
+        parentCount: delivery.parentCount,
+        featureCount: delivery.featureCount,
+        deliveryIdentityCount: delivery.resultUnitCount,
+        colorableResultUnitCount: geographicReportingUnits,
+        nonGeographicResultUnitCount: nonGeographicReportingUnits,
+        candidateDetailSuppressedResultUnitCount:
+          year.candidateDetailSuppressedUnits,
+        reviewedNoDataFeatureCount:
+          year.manifest.crosswalk.reviewedNoDataFeatures,
+        parentArtifactByteCount: delivery.parentArtifactByteCount,
+        largestParentByteCount,
+        coordinatePrecisionDecimals: NORTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS,
+        simplificationToleranceDegrees:
+          NORTH_CAROLINA_DELIVERY_SIMPLIFICATION_TOLERANCE_DEGREES,
+        maximumParentByteCount: NORTH_CAROLINA_MAX_PARENT_DELIVERY_BYTES,
+        parentArtifacts,
+        electionValuesInDelivery: false,
+        publicationPerformed: false,
+      },
+      proposedPublicDelivery: draft.delivery,
+      draftManifest: {
+        path: path.posix.join("draft-manifests", draft.id + ".json"),
+        byteCount: draftBytes.length,
+        sha256: sha256(draftBytes),
+        canonicalMutationPerformed: false,
+        reviewRequired: true,
+      },
+    },
+    draft: { path: path.posix.join("draft-manifests", draft.id + ".json"), bytes: draftBytes },
+    assets: [
+      { path: index.packageRelativePath, bytes: delivery.indexBytes },
+      ...delivery.parentArtifacts.map((artifact) => ({
+        path: path.posix.join(assetRoot, artifact.path),
+        bytes: artifact.bytes,
+      })),
+    ],
+  };
+}
+
+function sum(years, selector) {
+  return years.reduce((total, year) => total + selector(year), 0);
+}
+
+export async function buildNorthCarolinaLocalReleaseCandidate(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const plan = await buildNorthCarolinaLocalGisPlan({
+    root,
+    years: [...NORTH_CAROLINA_PUBLIC_RELEASE_YEARS],
+  });
+  const validationPath = options.validationReportPath
+    ?? NORTH_CAROLINA_LOCAL_VALIDATION_REPORT;
+  const validationArtifact = readArtifact(root, { path: validationPath }, [".etl/"]);
+  const validationValue = JSON.parse(validationArtifact.bytes.toString("utf8"));
+  const localValidation = validateLocalReport(validationValue, plan);
+  const migration0008Artifact = readArtifact(root, {
+    path: "drizzle/0008_typical_thunderbolts.sql",
+  }, ["drizzle/"]);
+  const migration0009Artifact = readArtifact(root, {
+    path: "drizzle/0009_public_wolfpack.sql",
+  }, ["drizzle/"]);
+  const yearBuilds = plan.years.map((year) => buildYear(root, year));
+  const years = yearBuilds.map((year) => year.summary);
+  const packageDocument = {
+    schemaVersion: 1,
+    id: NORTH_CAROLINA_RELEASE_CANDIDATE_ID,
+    state: "NC",
+    stateName: "North Carolina",
+    scope: "reviewed 2012 VTD plus 2016 and 2020 precinct North Carolina presidential GIS release preparation; 2024 remains blocked and excluded",
+    preparedFromLocalValidationAt: localValidation.generatedAtUtc,
+    disposition: "prepared_awaiting_explicit_production_authorization",
+    decision: "NO_GO_PRODUCTION",
+    safety: {
+      productionMutationPerformed: false,
+      publicFileWritten: false,
+      canonicalManifestChanged: false,
+      canonicalRegistryChanged: false,
+      publicEligibilityChanged: false,
+      gitPublicationPerformed: false,
+      explicitProductionAuthorizationRequired: true,
+    },
+    totals: {
+      elections: years.length,
+      countyParentsPerElection: 100,
+      reportingUnits: sum(years, (year) => year.certifiedResults.reportingUnits),
+      candidateResultRows: sum(years, (year) => year.certifiedResults.resultRows),
+      zeroVoteUnits: sum(years, (year) => year.certifiedResults.zeroVoteUnits),
+      geometryFeatures: sum(years, (year) => year.reviewedGeometry.featureCount),
+      reviewedRelationships: sum(years, (year) => year.reviewedGeometry.reviewedRelationships),
+      deliveryIndexes: years.length,
+      parentDeliveryArtifacts: sum(
+        years,
+        (year) => year.reviewedGeometry.parentCount,
+      ),
+    },
+    years,
+    localValidation: {
+      path: validationPath,
+      byteCount: validationArtifact.byteCount,
+      sha256: validationArtifact.sha256,
+      ...localValidation,
+    },
+    databaseActivationContract: {
+      migrations: [migration0008Artifact, migration0009Artifact].map((artifact) => ({
+        path: artifact.path,
+        byteCount: artifact.byteCount,
+        sha256: artifact.sha256,
+      })),
+      productionWriterImplemented: true,
+      productionWriterEnabled: false,
+      expectedPostLoad: {
+        reportingUnits: sum(years, (year) => year.certifiedResults.reportingUnits),
+        candidateResultRows: sum(years, (year) => year.certifiedResults.resultRows),
+        geographyVersions: 3,
+        geometryFeatures: sum(years, (year) => year.reviewedGeometry.featureCount),
+        reviewedRelationships: sum(years, (year) => year.reviewedGeometry.reviewedRelationships),
+        reviewedNoDataFeatures: sum(
+          years,
+          (year) => year.reviewedGeometry.reviewedNoDataFeatures,
+        ),
+        zeroVoteUnits: sum(years, (year) => year.certifiedResults.zeroVoteUnits),
+        invalidConstraints: 0,
+      },
+    },
+    releasePolicy: {
+      officialResultsScope: "Official North Carolina State Board of Elections presidential rows are retained at their reported grain. Only reviewed geographic VTD or precinct rows are displayed; official totals and non-geographic exclusions remain reconciled in the source package.",
+      certifiedCanvassBoundary: "Administrative, one-stop, absentee, provisional, transfer, and other non-geographic reporting buckets are not assigned or estimated onto VTD or precinct polygons. A geographic map therefore need not sum to the statewide certified total.",
+      publicLabel: "North Carolina local geography results with reviewed election-specific geometry",
+      hiddenLoadRequired: true,
+      immutableBlobPublicationRequired: true,
+      protectedPreviewRequired: true,
+      databasePublicationGateRequired: true,
+    },
+    goNoGoGates: [
+      { id: "official_sources_hash_pinned", status: "passed" },
+      { id: "three_year_exact_result_geometry_join", status: "passed" },
+      { id: "2024_excluded_until_election_date_boundary_proof_exists", status: "passed" },
+      { id: "non_geographic_vote_buckets_retained_without_polygon_assignment", status: "passed" },
+      { id: "local_database_exact_validation", status: "passed", evidence: validationPath },
+      { id: "immutable_parent_scoped_delivery", status: "passed" },
+      { id: "production_hidden_load", status: "pending" },
+      { id: "blob_publication", status: "pending" },
+      { id: "protected_preview_and_public_activation", status: "pending" },
+    ],
+  };
+  return {
+    packageDocument,
+    packageBytes: serializeNorthCarolinaReleaseDocument(packageDocument),
+    draftManifests: yearBuilds.map((year) => year.draft),
+    deliveryAssets: yearBuilds.flatMap((year) => year.assets),
+  };
+}
+
+export function northCarolinaReleaseCandidateOutputRoot(packageSha256) {
+  if (!/^[a-f0-9]{64}$/.test(packageSha256)) {
+    throw new Error("North Carolina release package hash must be SHA-256");
+  }
+  return path.posix.join(
+    NORTH_CAROLINA_RELEASE_CANDIDATE_ROOT,
+    NORTH_CAROLINA_RELEASE_CANDIDATE_ID + "-" + packageSha256.slice(0, 12),
+  );
+}

--- a/scripts/prepare-nc-local-public-activation.mjs
+++ b/scripts/prepare-nc-local-public-activation.mjs
@@ -1,0 +1,144 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  inspectNorthCarolinaPublicActivationPlan,
+} from "./lib/nc-local-public-activation.mjs";
+
+function parseArguments(args) {
+  const packagePath = args.find((arg) => arg.startsWith("--package="))
+    ?.slice("--package=".length);
+  const packageSha256 = args.find((arg) => arg.startsWith("--package-sha256="))
+    ?.slice("--package-sha256=".length);
+  const write = args.includes("--write");
+  for (const arg of args) {
+    if (
+      arg !== "--write"
+      && !arg.startsWith("--package=")
+      && !arg.startsWith("--package-sha256=")
+    ) {
+      throw new Error("Unknown North Carolina public-activation option: " + arg);
+    }
+  }
+  if (!packagePath || !packageSha256) {
+    throw new Error(
+      "North Carolina public activation requires --package and --package-sha256",
+    );
+  }
+  return { packagePath, packageSha256, write };
+}
+
+function immutableWrite(root, relativePath, bytes) {
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ".etl", "precinct-public-activations", "NC");
+  if (!absolutePath.startsWith(allowed + path.sep)) {
+    throw new Error("North Carolina activation evidence escapes its fixed .etl root");
+  }
+  if (existsSync(absolutePath)) {
+    if (!readFileSync(absolutePath).equals(bytes)) {
+      throw new Error("Refusing to overwrite different North Carolina activation evidence");
+    }
+    return "verified_existing";
+  }
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, bytes, { mode: 0o600, flag: "wx" });
+  return "created";
+}
+
+export function writeNorthCarolinaActivationTrackedOutputs(outputs) {
+  if (outputs.length !== 4 || new Set(outputs.map((item) => item.path)).size !== 4) {
+    throw new Error("North Carolina activation requires exactly four unique tracked outputs");
+  }
+  const staged = [];
+  const committed = [];
+  try {
+    for (const output of outputs) {
+      const before = readFileSync(output.absolutePath);
+      if (before.length !== output.preimage.byteCount) {
+        throw new Error("North Carolina activation target changed after plan: " + output.path);
+      }
+      const currentHash = createHash("sha256").update(before).digest("hex");
+      if (currentHash !== output.preimage.sha256) {
+        throw new Error("North Carolina activation target preimage drifted: " + output.path);
+      }
+      const temporaryPath = output.absolutePath
+        + ".crm-nc-activation-" + randomUUID() + ".tmp";
+      writeFileSync(temporaryPath, output.bytes, { flag: "wx" });
+      staged.push({ output, before, temporaryPath });
+    }
+    for (const item of staged) {
+      renameSync(item.temporaryPath, item.output.absolutePath);
+      committed.push(item);
+    }
+  } catch (error) {
+    for (const item of staged) {
+      if (existsSync(item.temporaryPath)) unlinkSync(item.temporaryPath);
+    }
+    for (const item of committed.reverse()) {
+      const rollbackPath = item.output.absolutePath
+        + ".crm-nc-rollback-" + randomUUID() + ".tmp";
+      writeFileSync(rollbackPath, item.before, { flag: "wx" });
+      renameSync(rollbackPath, item.output.absolutePath);
+    }
+    throw error;
+  }
+  return outputs.map((output) => ({
+    path: output.path,
+    sha256: output.sha256,
+    byteCount: output.byteCount,
+  }));
+}
+
+export async function prepareNorthCarolinaPublicActivation(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const built = inspectNorthCarolinaPublicActivationPlan({ ...options, root });
+  if (!options.write) {
+    return {
+      mode: "plan",
+      decision: built.plan.decision,
+      releaseCandidate: built.plan.releaseCandidate,
+      activationCandidate: {
+        path: built.outputPath,
+        sha256: built.sha256,
+        byteCount: built.bytes.length,
+      },
+      trackedOutputs: built.plan.trackedOutputs,
+      productionMutationPerformed: false,
+      publicEndpointsRemainDatabaseGated: true,
+    };
+  }
+  const trackedOutputs = writeNorthCarolinaActivationTrackedOutputs(built.outputs);
+  const evidenceDisposition = immutableWrite(root, built.outputPath, built.bytes);
+  return {
+    mode: "write",
+    decision: built.plan.decision,
+    releaseCandidate: built.plan.releaseCandidate,
+    activationCandidate: {
+      path: built.outputPath,
+      sha256: built.sha256,
+      byteCount: built.bytes.length,
+      disposition: evidenceDisposition,
+    },
+    trackedOutputs,
+    productionMutationPerformed: false,
+    publicEndpointsRemainDatabaseGated: true,
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  prepareNorthCarolinaPublicActivation(parseArguments(process.argv.slice(2))).then(
+    (result) => console.log(JSON.stringify(result, null, 2)),
+    (error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/prepare-nc-local-release-candidate.mjs
+++ b/scripts/prepare-nc-local-release-candidate.mjs
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildNorthCarolinaLocalReleaseCandidate,
+  northCarolinaReleaseCandidateOutputRoot,
+} from "./lib/nc-local-release-candidate.mjs";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function immutableWrite(root, relativePath, bytes) {
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  const expectedRoot = path.resolve(root, ".etl", "precinct-release-candidates", "NC");
+  if (!absolutePath.startsWith(expectedRoot + path.sep)) {
+    throw new Error("North Carolina release output escapes its content-addressed root");
+  }
+  if (existsSync(absolutePath)) {
+    if (!readFileSync(absolutePath).equals(bytes)) {
+      throw new Error("Refusing to overwrite different North Carolina release bytes: " + relativePath);
+    }
+    return "verified_existing";
+  }
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, bytes);
+  return "created";
+}
+
+export async function prepareNorthCarolinaLocalReleaseCandidate(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const built = await buildNorthCarolinaLocalReleaseCandidate({
+    root,
+    validationReportPath: options.validationReportPath,
+  });
+  const packageSha256 = sha256(built.packageBytes);
+  const outputRoot = northCarolinaReleaseCandidateOutputRoot(packageSha256);
+  const files = [
+    { path: "release-candidate.json", bytes: built.packageBytes },
+    ...built.draftManifests,
+    ...built.deliveryAssets,
+  ];
+  const disposition = options.write
+    ? files.map((file) => immutableWrite(
+      root,
+      path.posix.join(outputRoot, file.path),
+      file.bytes,
+    ))
+    : [];
+  return {
+    mode: options.write ? "write" : "plan",
+    decision: "NO_GO_PRODUCTION",
+    state: "NC",
+    releaseCandidate: {
+      id: built.packageDocument.id,
+      path: path.posix.join(outputRoot, "release-candidate.json"),
+      sha256: packageSha256,
+      byteCount: built.packageBytes.length,
+    },
+    totals: built.packageDocument.totals,
+    fileCount: files.length,
+    createdCount: disposition.filter((value) => value === "created").length,
+    verifiedExistingCount: disposition.filter((value) => value === "verified_existing").length,
+    productionMutationPerformed: false,
+    publicFileWritten: false,
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const unknown = args.filter((arg) => arg !== "--write" && !arg.startsWith("--validation-report="));
+  if (unknown.length) throw new Error("Unknown North Carolina release-candidate option: " + unknown[0]);
+  const validationReportPath = args.find((arg) => arg.startsWith("--validation-report="))
+    ?.slice("--validation-report=".length);
+  console.log(JSON.stringify(await prepareNorthCarolinaLocalReleaseCandidate({
+    write: args.includes("--write"),
+    validationReportPath,
+  }), null, 2));
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/publish-nc-local-delivery-assets.mjs
+++ b/scripts/publish-nc-local-delivery-assets.mjs
@@ -1,0 +1,264 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  inspectNorthCarolinaLocalBlobPublicationPlan,
+  validateNorthCarolinaBlobPublicationAuthorization,
+} from "./lib/nc-local-blob-publication.mjs";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function parseArguments(args) {
+  const write = args.includes("--write");
+  const packagePath = args.find((argument) =>
+    argument.startsWith("--package="))?.slice("--package=".length);
+  const packageSha256 = args.find((argument) =>
+    argument.startsWith("--package-sha256="))
+    ?.slice("--package-sha256=".length);
+  const concurrencyValue = args.find((argument) =>
+    argument.startsWith("--concurrency="))?.slice("--concurrency=".length);
+  const concurrency = concurrencyValue ? Number(concurrencyValue) : 4;
+  for (const argument of args) {
+    if (
+      argument !== "--write"
+      && !argument.startsWith("--package=")
+      && !argument.startsWith("--package-sha256=")
+      && !argument.startsWith("--concurrency=")
+    ) {
+      throw new Error("Unknown North Carolina Blob publication option: " + argument);
+    }
+  }
+  if (!packagePath || !packageSha256) {
+    throw new Error(
+      "usage: npm run precinct-gis:delivery-publish:nc -- "
+      + "--package=<release-candidate.json> --package-sha256=<sha256> "
+      + "[--concurrency=4] [--write]",
+    );
+  }
+  if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 8) {
+    throw new Error("North Carolina Blob publication concurrency must be 1 through 8");
+  }
+  return { write, packagePath, packageSha256, concurrency };
+}
+
+function publicPlan(plan) {
+  return {
+    schemaVersion: plan.schemaVersion,
+    state: plan.state,
+    releaseCandidate: plan.releaseCandidate,
+    decision: plan.decision,
+    assetCount: plan.assetCount,
+    indexCount: plan.indexCount,
+    parentArtifactCount: plan.parentArtifactCount,
+    totalByteCount: plan.totalByteCount,
+    uploadOrder: plan.uploadOrder,
+    canonicalManifestChanged: plan.canonicalManifestChanged,
+    publicEligibilityChanged: plan.publicEligibilityChanged,
+    artifacts: plan.artifacts.map(({ absolutePath: _absolutePath, ...artifact }) =>
+      artifact),
+  };
+}
+
+async function verifyPublicBlob(url, artifact) {
+  const response = await fetch(url, {
+    cache: "no-store",
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!response.ok) {
+    throw new Error(
+      "Published North Carolina geometry returned HTTP " + response.status,
+    );
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.length !== artifact.byteCount || sha256(bytes) !== artifact.sha256) {
+    throw new Error("Published North Carolina geometry failed byte/hash verification");
+  }
+}
+
+async function publishArtifact(artifact, sdk) {
+  let existing = null;
+  try {
+    existing = await sdk.head(artifact.pathname);
+  } catch (error) {
+    if (!(error instanceof sdk.BlobNotFoundError)) throw error;
+  }
+  if (existing) {
+    if (existing.size !== artifact.byteCount) {
+      throw new Error(
+        "Existing immutable North Carolina geometry has a different byte count",
+      );
+    }
+    await verifyPublicBlob(existing.url, artifact);
+    return {
+      ...artifact,
+      disposition: "verified_existing",
+      url: existing.url,
+      remoteMutationPerformed: false,
+    };
+  }
+
+  const bytes = readFileSync(artifact.absolutePath);
+  const uploaded = await sdk.put(artifact.pathname, bytes, {
+    access: "public",
+    addRandomSuffix: false,
+    allowOverwrite: false,
+    cacheControlMaxAge: 31_536_000,
+    contentType: artifact.kind === "index"
+      ? "application/json"
+      : "application/geo+json",
+    multipart: bytes.length >= 4 * 1024 * 1024,
+  });
+  if (
+    uploaded.pathname !== artifact.pathname
+    || new URL(uploaded.url).pathname !== "/" + artifact.pathname
+  ) {
+    throw new Error("Published North Carolina geometry URL/pathname drifted");
+  }
+  await verifyPublicBlob(uploaded.url, artifact);
+  return {
+    ...artifact,
+    disposition: "created",
+    url: uploaded.url,
+    remoteMutationPerformed: true,
+  };
+}
+
+async function publishBatch(artifacts, concurrency, sdk) {
+  const results = new Array(artifacts.length);
+  let nextIndex = 0;
+  async function worker() {
+    while (nextIndex < artifacts.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await publishArtifact(artifacts[index], sdk);
+    }
+  }
+  await Promise.all(
+    Array.from(
+      { length: Math.min(concurrency, artifacts.length) },
+      () => worker(),
+    ),
+  );
+  return results;
+}
+
+function writeEvidence(root, evidence) {
+  const bytes = Buffer.from(JSON.stringify(evidence, null, 2) + "\n", "utf8");
+  const digest = sha256(bytes);
+  const relativePath = path.posix.join(
+    ".etl",
+    "precinct-blob-publications",
+    "NC",
+    "nc-local-blob-publication-"
+      + evidence.releaseCandidate.sha256.slice(0, 12)
+      + "-"
+      + digest.slice(0, 12)
+      + ".json",
+  );
+  const absolutePath = path.resolve(root, ...relativePath.split("/"));
+  if (existsSync(absolutePath)) {
+    if (!readFileSync(absolutePath).equals(bytes)) {
+      throw new Error("Refusing to overwrite different Blob publication evidence");
+    }
+  } else {
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, bytes, { mode: 0o600 });
+  }
+  return { path: relativePath, byteCount: bytes.length, sha256: digest };
+}
+
+export async function publishNorthCarolinaLocalDeliveryAssets(options) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const plan = inspectNorthCarolinaLocalBlobPublicationPlan({
+    root,
+    packagePath: options.packagePath,
+    packageSha256: options.packageSha256,
+  });
+  if (!options.write) {
+    return {
+      mode: "plan",
+      ...publicPlan(plan),
+      remoteMutationPerformed: false,
+      evidence: null,
+    };
+  }
+  const authorization = validateNorthCarolinaBlobPublicationAuthorization(plan);
+  const sdk = await import("@vercel/blob");
+  const parentResults = await publishBatch(
+    plan.artifacts.filter((artifact) => artifact.kind === "parent"),
+    options.concurrency ?? 4,
+    sdk,
+  );
+  const indexResults = await publishBatch(
+    plan.artifacts.filter((artifact) => artifact.kind === "index"),
+    options.concurrency ?? 4,
+    sdk,
+  );
+  const results = [...parentResults, ...indexResults];
+  const origins = new Set(results.map((result) => new URL(result.url).origin));
+  if (origins.size !== 1) {
+    throw new Error("North Carolina geometry assets were not published to one origin");
+  }
+  const evidenceDocument = {
+    schemaVersion: 1,
+    state: "NC",
+    purpose: "nc-local-parent-scoped-immutable-geometry-publication",
+    publishedAtUtc: new Date().toISOString(),
+    authorizationId: authorization.authorizationId,
+    releaseCandidate: plan.releaseCandidate,
+    deliveryOrigin: [...origins][0],
+    assetCount: results.length,
+    createdCount: results.filter((result) => result.disposition === "created").length,
+    verifiedExistingCount: results.filter(
+      (result) => result.disposition === "verified_existing",
+    ).length,
+    remoteMutationPerformed: results.some(
+      (result) => result.remoteMutationPerformed,
+    ),
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+    nextRequiredStep:
+      "Configure CRM_PRECINCT_GEOGRAPHY_ORIGIN to deliveryOrigin in a protected preview and verify every election and county before canonical manifest activation.",
+    artifacts: results.map(({
+      absolutePath: _absolutePath,
+      remoteMutationPerformed: _remoteMutationPerformed,
+      ...result
+    }) => result),
+  };
+  const evidence = writeEvidence(root, evidenceDocument);
+  return {
+    mode: "write",
+    decision: "ASSETS_PUBLISHED_MANIFESTS_STILL_BLOCKED",
+    releaseCandidate: plan.releaseCandidate,
+    deliveryOrigin: evidenceDocument.deliveryOrigin,
+    assetCount: evidenceDocument.assetCount,
+    createdCount: evidenceDocument.createdCount,
+    verifiedExistingCount: evidenceDocument.verifiedExistingCount,
+    remoteMutationPerformed: evidenceDocument.remoteMutationPerformed,
+    canonicalManifestChanged: false,
+    publicEligibilityChanged: false,
+    evidence,
+  };
+}
+
+async function main() {
+  const args = parseArguments(process.argv.slice(2));
+  const result = await publishNorthCarolinaLocalDeliveryAssets(args);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/publish-nc-local-geography-status.mjs
+++ b/scripts/publish-nc-local-geography-status.mjs
@@ -1,0 +1,1240 @@
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import postgres from "postgres";
+import {
+  buildNorthCarolinaLocalExecutionContext,
+  validateNorthCarolinaLocalGisClient,
+} from "./lib/nc-local-gis-db.mjs";
+import { buildNorthCarolinaLocalGisPlan } from "./lib/nc-local-gis-plan.mjs";
+import { productionEndpointFingerprint } from "./lib/nc-local-production-preflight.mjs";
+import {
+  NORTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES,
+  buildNorthCarolinaPublicRollbackAuthorizationTemplate,
+  buildNorthCarolinaPublicationAuthorizationTemplate,
+  inspectNorthCarolinaPublicationPlan,
+  semanticallyEqual,
+  serializeNorthCarolinaPublicationDocument,
+  sha256,
+  validateNorthCarolinaPublicRollbackAuthorization,
+  validateNorthCarolinaPublicationAuthorization,
+} from "./lib/nc-local-publication.mjs";
+
+const NORTH_CAROLINA_LOCAL_GEOGRAPHY_LEVELS = Object.freeze(["vtd", "precinct"]);
+const NORTH_CAROLINA_EXPECTED_REPORTING_UNITS = 9_285;
+const NORTH_CAROLINA_EXPECTED_RESULT_ROWS = 24_174;
+const NORTH_CAROLINA_PUBLIC_CAVEAT_PREFIX =
+  "Reviewed North Carolina election-specific local geometry is publicly authorized under activation ";
+
+function parseArguments(args) {
+  const read = (name) => args.find((arg) => arg.startsWith(name + "="))
+    ?.slice(name.length + 1);
+  const parsed = {
+    packagePath: read("--package"),
+    packageSha256: read("--package-sha256"),
+    hiddenReceiptPath: read("--hidden-receipt"),
+    hiddenReceiptSha256: read("--hidden-receipt-sha256"),
+    blobEvidencePath: read("--blob-evidence"),
+    blobEvidenceSha256: read("--blob-evidence-sha256"),
+    planSha256: read("--plan-sha256"),
+    authorizationPath: read("--authorization"),
+    authorizationSha256: read("--authorization-sha256"),
+    publicationReceiptPath: read("--publication-receipt"),
+    publicationReceiptSha256: read("--publication-receipt-sha256"),
+    outputPath: read("--output"),
+    writePlan: args.includes("--write-plan"),
+    writeAuthorizationTemplate: args.includes("--write-authorization-template"),
+    apply: args.includes("--apply"),
+    recoverReceipt: args.includes("--recover-receipt"),
+    rollback: args.includes("--rollback"),
+  };
+  const allowed = new Set([
+    "--package",
+    "--package-sha256",
+    "--hidden-receipt",
+    "--hidden-receipt-sha256",
+    "--blob-evidence",
+    "--blob-evidence-sha256",
+    "--plan-sha256",
+    "--authorization",
+    "--authorization-sha256",
+    "--publication-receipt",
+    "--publication-receipt-sha256",
+    "--output",
+  ]);
+  for (const arg of args) {
+    if (
+      ![
+        "--write-plan",
+        "--write-authorization-template",
+        "--apply",
+        "--recover-receipt",
+        "--rollback",
+      ].includes(arg)
+      && ![...allowed].some((name) => arg.startsWith(name + "="))
+    ) {
+      throw new Error("Unknown North Carolina publication-status option: " + arg);
+    }
+  }
+  const modes = [
+    parsed.writePlan,
+    parsed.writeAuthorizationTemplate,
+    parsed.apply,
+    parsed.recoverReceipt,
+  ]
+    .filter(Boolean).length;
+  if (modes > 1) throw new Error("North Carolina publication-status modes are mutually exclusive");
+  for (const field of [
+    "packagePath",
+    "packageSha256",
+    "hiddenReceiptPath",
+    "hiddenReceiptSha256",
+    "blobEvidencePath",
+    "blobEvidenceSha256",
+  ]) {
+    if (!parsed[field]) throw new Error("North Carolina publication-status requires " + field);
+  }
+  if (
+    parsed.rollback
+    && (!parsed.publicationReceiptPath || !parsed.publicationReceiptSha256)
+  ) {
+    throw new Error("North Carolina rollback requires the exact publication receipt and SHA-256");
+  }
+  return parsed;
+}
+
+function safeJson(root, relativePath, expectedSha256, allowedRoot) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith(allowedRoot + "/")
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+    || !relativePath.endsWith(".json")
+    || !/^[a-f0-9]{64}$/.test(expectedSha256 ?? "")
+  ) {
+    throw new Error("North Carolina publication-status JSON path is unsafe");
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...allowedRoot.split("/"));
+  if (!absolute.startsWith(allowed + path.sep) || !existsSync(absolute)) {
+    throw new Error("North Carolina publication-status JSON is missing");
+  }
+  const bytes = readFileSync(absolute);
+  if (sha256(bytes) !== expectedSha256) {
+    throw new Error("North Carolina publication-status JSON SHA-256 drifted");
+  }
+  return {
+    path: relativePath,
+    absolute,
+    bytes,
+    sha256: expectedSha256,
+    value: JSON.parse(bytes.toString("utf8")),
+  };
+}
+
+function immutableJson(root, relativePath, value, allowedRoot) {
+  if (
+    typeof relativePath !== "string"
+    || !relativePath.startsWith(allowedRoot + "/")
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || path.isAbsolute(relativePath)
+    || !relativePath.endsWith(".json")
+  ) {
+    throw new Error("North Carolina publication-status output path is unsafe");
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ...allowedRoot.split("/"));
+  if (!absolute.startsWith(allowed + path.sep)) {
+    throw new Error("North Carolina publication-status output escapes its fixed root");
+  }
+  const bytes = serializeNorthCarolinaPublicationDocument(value);
+  if (existsSync(absolute)) {
+    if (!readFileSync(absolute).equals(bytes)) {
+      throw new Error("Refusing to overwrite different North Carolina publication evidence");
+    }
+    return { path: relativePath, sha256: sha256(bytes), byteCount: bytes.length };
+  }
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, bytes, { flag: "wx", mode: 0o600 });
+  return { path: relativePath, sha256: sha256(bytes), byteCount: bytes.length };
+}
+
+function productionUrl(environment = process.env) {
+  const first = environment.POSTGRES_URL_NON_POOLING;
+  const second = environment.POSTGRES_DATABASE_URL_UNPOOLED;
+  if (first && second && first !== second) {
+    throw new Error("Production unpooled URL variables disagree");
+  }
+  const value = first ?? second;
+  if (!value) throw new Error("Production unpooled database URL is unavailable");
+  return value;
+}
+
+function runGit(root, args, runner = execFileSync) {
+  return runner("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    windowsHide: true,
+  }).trim();
+}
+
+export function verifyNorthCarolinaPublicationGitCandidate(
+  root,
+  publicAuthorization,
+  runner = execFileSync,
+) {
+  let head;
+  let headTree;
+  let productionTree;
+  let rollbackTree;
+  let trackedStatus;
+  try {
+    head = runGit(root, ["rev-parse", "HEAD"], runner);
+    headTree = runGit(root, ["rev-parse", "HEAD^{tree}"], runner);
+    productionTree = runGit(
+      root,
+      ["rev-parse", `${publicAuthorization.productionDeployment.gitSha}^{tree}`],
+      runner,
+    );
+    rollbackTree = runGit(
+      root,
+      ["rev-parse", `${publicAuthorization.rollbackTarget.gitSha}^{tree}`],
+      runner,
+    );
+    trackedStatus = runGit(
+      root,
+      ["status", "--porcelain", "--untracked-files=no"],
+      runner,
+    );
+  } catch {
+    throw new Error("North Carolina publication Git evidence could not be resolved locally");
+  }
+  if (
+    head !== publicAuthorization.productionDeployment.gitSha
+    || headTree !== publicAuthorization.productionDeployment.gitTreeSha
+    || productionTree !== publicAuthorization.productionDeployment.gitTreeSha
+    || rollbackTree !== publicAuthorization.rollbackTarget.gitTreeSha
+    || trackedStatus
+  ) {
+    throw new Error("North Carolina publication checkout or deployment Git evidence drifted");
+  }
+  return {
+    gitSha: head,
+    gitTreeSha: headTree,
+    rollbackTarget: {
+      gitSha: publicAuthorization.rollbackTarget.gitSha,
+      gitTreeSha: rollbackTree,
+    },
+    trackedWorktreeClean: true,
+  };
+}
+
+export function assertNorthCarolinaPublicationRecoveryVersionSet(versions) {
+  if (!Array.isArray(versions) || versions.length !== 3) {
+    throw new Error("North Carolina publication receipt recovery found an incomplete version set");
+  }
+  return versions;
+}
+
+function expectedActivationMetadata(
+  context,
+  manifest,
+  previousCaveat,
+  revision,
+  changedAtUtc = context.changedAtUtc,
+) {
+  const publication = context.publicationReceipt ?? {
+    activationId: context.authorization.activationId,
+    authorizationSha256: context.authorizationSha256,
+    rollbackTarget: context.authorization.rollbackTarget,
+  };
+  return {
+    activationId: publication.activationId,
+    activationCandidateSha256: context.planSha256,
+    releasePackageSha256: context.plan.releaseCandidate.sha256,
+    blobPublicationSha256: context.plan.blobPublication.sha256,
+    deliveryOrigin: context.plan.blobPublication.deliveryOrigin,
+    authorizationSha256: publication.authorizationSha256,
+    rollbackTarget: publication.rollbackTarget,
+    mode: "publish",
+    year: manifest.year,
+    geographyLevel: manifest.geographyLevel,
+    manifestId: manifest.manifestId,
+    publicManifestSha256: manifest.publicManifestSha256,
+    delivery: manifest.delivery,
+    previousCaveat,
+    changedAtUtc,
+    revision,
+  };
+}
+
+function expectedRollbackMetadata(context, revision) {
+  return {
+    rollbackId: context.authorization.rollbackId,
+    publicationActivationId: context.publicationReceipt.activationId,
+    activationCandidateSha256: context.planSha256,
+    releasePackageSha256: context.plan.releaseCandidate.sha256,
+    blobPublicationSha256: context.plan.blobPublication.sha256,
+    authorizationSha256: context.authorizationSha256,
+    publicationReceiptSha256: context.publicationReceipt.sha256,
+    rollbackTarget: context.authorization.applicationRollback.target,
+    changedAtUtc: context.changedAtUtc,
+    revision,
+    mode: "rollback",
+  };
+}
+
+async function verifyPostconditions(
+  nv,
+  context,
+  revision,
+  mode = context.mode ?? "publish",
+) {
+  const publicAuthorized = mode === "publish";
+  const wantedStatus = publicAuthorized ? "published" : "blocked";
+  const versions = await nv.unsafe([
+    "select e.year,gv.geography_type,gv.status,gv.caveat,gv.metadata",
+    "from geography_versions gv join elections e on e.id=gv.election_id",
+    "where gv.state_code='NC' and gv.geography_type=any($2::text[])",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+    "order by e.year",
+  ].join("\n"), [
+    context.plan.releaseCandidate.sha256,
+    [...NORTH_CAROLINA_LOCAL_GEOGRAPHY_LEVELS],
+  ]);
+  if (versions.length !== 3) {
+    throw new Error("North Carolina publication postcondition has an incomplete version set");
+  }
+  for (const [index, row] of versions.entries()) {
+    const manifest = context.plan.manifests[index];
+    const previousCaveat = context.gisPlan.years[index].manifest.validation.errors
+      .join(" ");
+    const metadata = row.metadata ?? {};
+    const publicationRevision = context.publicationReceipt?.revision ?? revision;
+    const publicationChangedAt = context.publicationReceipt?.changedAtUtc
+      ?? context.changedAtUtc;
+    const originalActivation = expectedActivationMetadata(
+      context,
+      manifest,
+      previousCaveat,
+      publicationRevision,
+      publicationChangedAt,
+    );
+    const expectedActivation = publicAuthorized
+      ? originalActivation
+      : {
+        ...originalActivation,
+        rollback: expectedRollbackMetadata(context, revision),
+      };
+    const expectedCaveat = publicAuthorized
+      ? NORTH_CAROLINA_PUBLIC_CAVEAT_PREFIX + originalActivation.activationId + "."
+      : previousCaveat;
+    if (
+      Number(row.year) !== manifest.year
+      || String(row.geography_type) !== manifest.geographyLevel
+      || row.status !== wantedStatus
+      || String(row.caveat ?? "") !== expectedCaveat
+      || metadata.manifestId !== manifest.manifestId
+      || metadata.publicDeliveryAuthorized !== publicAuthorized
+      || metadata.releaseCandidate?.publicDeliveryAuthorized !== publicAuthorized
+      || metadata.releaseCandidate?.sha256 !== context.plan.releaseCandidate.sha256
+      || !semanticallyEqual(metadata.publicActivation, expectedActivation)
+    ) {
+      throw new Error("North Carolina " + manifest.year + " geography publication drifted");
+    }
+  }
+  const linked = await nv.unsafe([
+    "select count(*)::int total,",
+    " count(*) filter (where ((x.relationship_type='one_to_one'",
+    "   and x.match_method in ('exact_official_id','official_crosswalk')",
+    "   and x.geography_feature_id is not null)",
+    "  or (x.relationship_type='non_geographic'",
+    "   and x.match_method='exact_official_id'",
+    "   and x.geography_feature_id is null))",
+    "  and x.review_status='reviewed'",
+    "  and x.confidence='high' and x.metadata->>'publicDeliveryAuthorized'=$2",
+    "  and x.metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from reporting_unit_geometry_crosswalks x",
+    "join geography_versions gv on gv.id=x.geometry_version_id",
+    "where gv.state_code='NC' and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (
+    Number(linked[0]?.total) !== NORTH_CAROLINA_EXPECTED_REPORTING_UNITS
+    || Number(linked[0]?.exact) !== NORTH_CAROLINA_EXPECTED_REPORTING_UNITS
+  ) {
+    throw new Error("North Carolina publication crosswalk postcondition failed");
+  }
+  const units = await nv.unsafe([
+    "select count(*)::int total, count(*) filter (where",
+    " metadata->>'publicDeliveryAuthorized'=$2 and",
+    " metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from reporting_units where state_code='NC'",
+    " and reporting_grain in ('vtd','precinct','administrative_reporting_unit')",
+    " and metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (
+    Number(units[0]?.total) !== NORTH_CAROLINA_EXPECTED_REPORTING_UNITS
+    || Number(units[0]?.exact) !== NORTH_CAROLINA_EXPECTED_REPORTING_UNITS
+  ) {
+    throw new Error("North Carolina publication reporting-unit postcondition failed");
+  }
+  const sources = await nv.unsafe([
+    "select count(*)::int total, count(*) filter (where",
+    " metadata->>'publicDeliveryAuthorized'=$2 and",
+    " metadata->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from source_documents where state_code='NC'",
+    " and metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (Number(sources[0]?.total) !== 6 || Number(sources[0]?.exact) !== 6) {
+    throw new Error("North Carolina publication source-document postcondition failed");
+  }
+  const runs = await nv.unsafe([
+    "select count(*)::int total, count(*) filter (where",
+    " summary->>'publicDeliveryAuthorized'=$2 and",
+    " summary->'releaseCandidate'->>'publicDeliveryAuthorized'=$2)::int exact",
+    "from import_runs where state_code='NC'",
+    " and summary->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, String(publicAuthorized)]);
+  if (Number(runs[0]?.total) !== 3 || Number(runs[0]?.exact) !== 3) {
+    throw new Error("North Carolina publication import-run postcondition failed");
+  }
+  const results = await nv.unsafe([
+    "select count(*)::int total from result_rows rr",
+    "join reporting_units ru on ru.id=rr.reporting_unit_id",
+    "where rr.state_code='NC' and rr.level=any($2::text[])",
+    " and ru.metadata->'releaseCandidate'->>'sha256'=$1",
+  ].join("\n"), [
+    context.plan.releaseCandidate.sha256,
+    [...NORTH_CAROLINA_LOCAL_GEOGRAPHY_LEVELS],
+  ]);
+  if (Number(results[0]?.total) !== NORTH_CAROLINA_EXPECTED_RESULT_ROWS) {
+    throw new Error("North Carolina publication result-row postcondition failed");
+  }
+  const invalid = await nv.unsafe(
+    "select count(*)::int count from pg_constraint where connamespace='public'::regnamespace and not convalidated",
+  );
+  if (Number(invalid[0]?.count) !== 0) {
+    throw new Error("North Carolina publication left invalid public constraints");
+  }
+  const revisionRows = await nv.unsafe([
+    "select revision::int revision,reason from public_data_revisions",
+    "where scope='public'",
+  ].join("\n"));
+  const expectedReason = "North Carolina local geography unit geometry " + mode + " "
+    + (publicAuthorized
+      ? context.authorization.activationId
+      : context.authorization.rollbackId);
+  if (
+    Number(revisionRows[0]?.revision) !== revision
+    || String(revisionRows[0]?.reason) !== expectedReason
+  ) {
+    throw new Error("North Carolina publication revision postcondition failed");
+  }
+  return {
+    mode,
+    status: wantedStatus,
+    publicDeliveryAuthorized: publicAuthorized,
+    geographyVersions: 3,
+    crosswalks: NORTH_CAROLINA_EXPECTED_REPORTING_UNITS,
+    reportingUnits: NORTH_CAROLINA_EXPECTED_REPORTING_UNITS,
+    sourceDocuments: 6,
+    importRuns: 3,
+    resultRows: NORTH_CAROLINA_EXPECTED_RESULT_ROWS,
+    invalidConstraints: 0,
+  };
+}
+
+export async function applyNorthCarolinaGeographyPublicationTransaction(nv, context) {
+  const mode = context.mode ?? "publish";
+  if (!new Set(["publish", "rollback"]).has(mode)) {
+    throw new Error("North Carolina publication transaction mode is invalid");
+  }
+  const publicAuthorized = mode === "publish";
+  if (mode === "rollback" && !context.publicationReceipt) {
+    throw new Error("North Carolina rollback requires the exact publication receipt");
+  }
+  if (mode === "rollback" && (
+    context.authorization.publicationActivationId
+      !== context.publicationReceipt.activationId
+    || !semanticallyEqual(
+      context.authorization.applicationRollback?.target,
+      context.publicationReceipt.rollbackTarget,
+    )
+  )) {
+    throw new Error("North Carolina rollback authorization drifted from the publication receipt");
+  }
+  const identity = await nv.unsafe([
+    "select current_database() database_name,",
+    " current_setting('transaction_read_only') transaction_read_only",
+  ].join("\n"));
+  if (
+    identity.length !== 1
+    || String(identity[0].database_name) !== context.plan.hiddenLoad.databaseName
+    || String(identity[0].transaction_read_only) !== "off"
+  ) {
+    throw new Error("North Carolina publication transaction database identity drifted");
+  }
+  await nv.unsafe("select set_config('lock_timeout','30s',true)");
+  await nv.unsafe(
+    "select pg_advisory_xact_lock(hashtextextended('crm-nc-local-gis-release-v1',0))",
+  );
+  const revisions = await nv.unsafe(
+    "select revision::int revision from public_data_revisions where scope='public' for update",
+  );
+  const currentRevision = Number(revisions[0]?.revision);
+  if (
+    revisions.length !== 1
+    || !Number.isInteger(currentRevision)
+    || currentRevision < 0
+  ) {
+    throw new Error("North Carolina public revision is missing or invalid");
+  }
+  const revision = currentRevision + 1;
+  const gisPlan = context.gisPlan;
+  if (mode === "publish") {
+    await (context.validateCurrentDatabase ?? validateNorthCarolinaLocalGisClient)(nv, gisPlan, {
+      executionContext: context.executionContext,
+      readOnlySession: false,
+    });
+  }
+  const versions = await nv.unsafe([
+    "select gv.id,e.year,gv.geography_type,gv.status,gv.caveat,gv.metadata",
+    "from geography_versions gv join elections e on e.id=gv.election_id",
+    "where gv.state_code='NC' and gv.geography_type=any($2::text[])",
+    " and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+    "order by e.year for update of gv",
+  ].join("\n"), [
+    context.plan.releaseCandidate.sha256,
+    [...NORTH_CAROLINA_LOCAL_GEOGRAPHY_LEVELS],
+  ]);
+  if (versions.length !== 3) {
+    throw new Error("North Carolina publication requires three exact geography versions");
+  }
+  for (const [index, version] of versions.entries()) {
+    const manifest = context.plan.manifests[index];
+    const expectedBlockedCaveat = gisPlan.years[index].manifest.validation.errors
+      .join(" ");
+    const commonDrift = Number(version.year) !== manifest.year
+      || String(version.geography_type) !== manifest.geographyLevel
+      || version.metadata?.manifestId !== manifest.manifestId
+      || version.metadata?.releaseCandidate?.sha256
+        !== context.plan.releaseCandidate.sha256;
+    const originalActivation = mode === "rollback"
+      ? expectedActivationMetadata(
+        context,
+        manifest,
+        expectedBlockedCaveat,
+        context.publicationReceipt.revision,
+        context.publicationReceipt.changedAtUtc,
+      )
+      : null;
+    if (mode === "publish" && (
+      commonDrift
+      || version.status !== "blocked"
+      || version.metadata?.manifestSha256 !== manifest.blockedManifestSha256
+      || version.metadata?.publicDeliveryAuthorized !== false
+      || version.metadata?.releaseCandidate?.publicDeliveryAuthorized !== false
+      || String(version.caveat ?? "") !== expectedBlockedCaveat
+      || Object.hasOwn(version.metadata ?? {}, "publicActivation")
+    )) {
+      throw new Error("North Carolina " + manifest.year + " publication precondition drifted");
+    }
+    if (mode === "rollback" && (
+      commonDrift
+      || version.status !== "published"
+      || String(version.caveat ?? "")
+        !== NORTH_CAROLINA_PUBLIC_CAVEAT_PREFIX
+          + context.publicationReceipt.activationId + "."
+      || version.metadata?.publicDeliveryAuthorized !== true
+      || version.metadata?.releaseCandidate?.publicDeliveryAuthorized !== true
+      || !semanticallyEqual(version.metadata?.publicActivation, originalActivation)
+    )) {
+      throw new Error(
+        "North Carolina " + manifest.year
+          + " rollback does not match the publication being reversed",
+      );
+    }
+    const activation = mode === "publish"
+      ? expectedActivationMetadata(
+        context,
+        manifest,
+        expectedBlockedCaveat,
+        revision,
+      )
+      : {
+        ...originalActivation,
+        rollback: expectedRollbackMetadata(context, revision),
+      };
+    const wantedStatus = publicAuthorized ? "published" : "blocked";
+    const wantedCaveat = publicAuthorized
+      ? NORTH_CAROLINA_PUBLIC_CAVEAT_PREFIX
+        + context.authorization.activationId + "."
+      : originalActivation.previousCaveat;
+    const currentStatus = publicAuthorized ? "blocked" : "published";
+    const updated = await nv.unsafe([
+      "update geography_versions set status=$2,",
+      " caveat=$3,",
+      " metadata=jsonb_set(jsonb_set(jsonb_set(metadata,",
+      "  '{publicDeliveryAuthorized}',$4::text::jsonb,true),",
+      "  '{releaseCandidate,publicDeliveryAuthorized}',$4::text::jsonb,true),",
+      "  '{publicActivation}',$5::text::jsonb,true),",
+      " updated_at=now() where id=$1::uuid and status=$6 returning id",
+    ].join("\n"), [
+      version.id,
+      wantedStatus,
+      wantedCaveat,
+      JSON.stringify(publicAuthorized),
+      JSON.stringify(activation),
+      currentStatus,
+    ]);
+    if (updated.length !== 1) {
+      throw new Error("North Carolina " + manifest.year + " publication update lost its lock");
+    }
+  }
+  const crosswalks = await nv.unsafe([
+    "update reporting_unit_geometry_crosswalks x set metadata=",
+    " jsonb_set(jsonb_set(x.metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "from geography_versions gv where gv.id=x.geometry_version_id",
+    " and gv.state_code='NC' and gv.metadata->'releaseCandidate'->>'sha256'=$1",
+    "returning x.id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (crosswalks.length !== NORTH_CAROLINA_EXPECTED_REPORTING_UNITS) {
+    throw new Error("North Carolina publication crosswalk update count drifted");
+  }
+  const units = await nv.unsafe([
+    "update reporting_units set metadata=",
+    " jsonb_set(jsonb_set(metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "where state_code='NC'",
+    " and reporting_grain in ('vtd','precinct','administrative_reporting_unit')",
+    " and metadata->'releaseCandidate'->>'sha256'=$1 returning id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (units.length !== NORTH_CAROLINA_EXPECTED_REPORTING_UNITS) {
+    throw new Error("North Carolina publication reporting-unit update count drifted");
+  }
+  const sources = await nv.unsafe([
+    "update source_documents set metadata=",
+    " jsonb_set(jsonb_set(metadata,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "where state_code='NC' and metadata->'releaseCandidate'->>'sha256'=$1 returning id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (sources.length !== 6) {
+    throw new Error("North Carolina publication source-document update count drifted");
+  }
+  const runs = await nv.unsafe([
+    "update import_runs set summary=",
+    " jsonb_set(jsonb_set(summary,'{publicDeliveryAuthorized}',$2::text::jsonb,true),",
+    " '{releaseCandidate,publicDeliveryAuthorized}',$2::text::jsonb,true)",
+    "where state_code='NC' and summary->'releaseCandidate'->>'sha256'=$1 returning id",
+  ].join("\n"), [context.plan.releaseCandidate.sha256, JSON.stringify(publicAuthorized)]);
+  if (runs.length !== 3) {
+    throw new Error("North Carolina publication import-run update count drifted");
+  }
+  const revisionRows = await nv.unsafe([
+    "update public_data_revisions set revision=revision+1,updated_at=now(),reason=$1",
+    "where scope='public' returning revision::int revision,updated_at",
+  ].join("\n"), [
+    "North Carolina local geography unit geometry " + mode + " "
+      + (publicAuthorized
+        ? context.authorization.activationId
+        : context.authorization.rollbackId),
+  ]);
+  if (Number(revisionRows[0]?.revision) !== revision) {
+    throw new Error("North Carolina publication revision increment drifted");
+  }
+  const postconditions = await verifyPostconditions(nv, context, revision, mode);
+  return {
+    result: publicAuthorized ? "PUBLISHED" : "ROLLED_BACK",
+    mode,
+    revision,
+    changedAtUtc: context.changedAtUtc,
+    postconditions,
+    publicDeliveryAuthorized: publicAuthorized,
+  };
+}
+
+function defaultPlanPath(planSha256) {
+  return ".etl/precinct-publication-plans/NC/nc-local-publication-plan-"
+    + planSha256.slice(0, 12) + ".json";
+}
+
+function defaultAuthorizationPath(planSha256, mode = "publish") {
+  return ".etl/production-authorizations/NC/nc-local-" + mode + "-authorization-template-"
+    + planSha256.slice(0, 12) + ".json";
+}
+
+export function inspectNorthCarolinaPublicationReceipt(root, options, built) {
+  const artifact = safeJson(
+    root,
+    options.publicationReceiptPath,
+    options.publicationReceiptSha256,
+    ".etl/production-publication-receipts/NC",
+  );
+  const value = artifact.value;
+  const publicAuthorizationArtifact = safeJson(
+    root,
+    value?.authorization?.path,
+    value?.authorization?.sha256,
+    ".etl/production-authorizations/NC",
+  );
+  const publicAuthorization = validateNorthCarolinaPublicationAuthorization(
+    publicAuthorizationArtifact.value,
+    {
+      plan: built.plan,
+      planSha256: built.sha256,
+      now: options.now ?? Date.now(),
+      recovery: true,
+    },
+  );
+  const changedAt = Date.parse(value?.changedAtUtc);
+  if (
+    value?.schemaVersion !== 1
+    || value?.state !== "NC"
+    || value?.mode !== "publish"
+    || value?.decision !== "PUBLISHED"
+    || value?.activationId !== publicAuthorization.activationId
+    || value?.approvedBy !== publicAuthorization.approvedBy
+    || !semanticallyEqual(value?.releaseCandidate, built.plan.releaseCandidate)
+    || value?.publicationPlan?.id !== built.plan.id
+    || value?.publicationPlan?.sha256 !== built.sha256
+    || value?.authorization?.path !== publicAuthorizationArtifact.path
+    || value?.authorization?.sha256 !== publicAuthorizationArtifact.sha256
+    || value?.hiddenLoad?.path !== built.plan.hiddenLoad.path
+    || value?.hiddenLoad?.sha256 !== built.plan.hiddenLoad.sha256
+    || value?.blobPublication?.path !== built.plan.blobPublication.path
+    || value?.blobPublication?.sha256 !== built.plan.blobPublication.sha256
+    || value?.blobPublication?.deliveryOrigin
+      !== built.plan.blobPublication.deliveryOrigin
+    || !semanticallyEqual(
+      value?.productionDeployment,
+      publicAuthorization.productionDeployment,
+    )
+    || !semanticallyEqual(value?.rollbackTarget, publicAuthorization.rollbackTarget)
+    || Number.isNaN(changedAt)
+    || changedAt > (options.now ?? Date.now())
+    || Date.parse(publicAuthorization.rollbackTarget.verifiedAtUtc) > changedAt
+    || !Number.isInteger(Number(value?.revision))
+    || Number(value.revision) < 1
+    || value?.postconditions?.mode !== "publish"
+    || value?.postconditions?.status !== "published"
+    || value?.postconditions?.publicDeliveryAuthorized !== true
+    || value?.postconditions?.geographyVersions !== 3
+    || value?.postconditions?.crosswalks !== NORTH_CAROLINA_EXPECTED_REPORTING_UNITS
+    || value?.postconditions?.reportingUnits !== NORTH_CAROLINA_EXPECTED_REPORTING_UNITS
+    || value?.postconditions?.sourceDocuments !== 6
+    || value?.postconditions?.importRuns !== 3
+    || value?.postconditions?.resultRows !== NORTH_CAROLINA_EXPECTED_RESULT_ROWS
+    || value?.postconditions?.invalidConstraints !== 0
+    || value?.productionMutationPerformed !== true
+    || value?.publicDeliveryAuthorized !== true
+  ) {
+    throw new Error("North Carolina publication receipt is incomplete or incompatible");
+  }
+  return {
+    artifact,
+    publicAuthorization,
+    summary: {
+      path: artifact.path,
+      sha256: artifact.sha256,
+      activationId: value.activationId,
+      authorizationSha256: publicAuthorizationArtifact.sha256,
+      revision: Number(value.revision),
+      changedAtUtc: value.changedAtUtc,
+      rollbackTarget: value.rollbackTarget,
+      productionDeployment: value.productionDeployment,
+    },
+  };
+}
+
+function defaultReceiptPath(planSha256, activationId, mode = "publish") {
+  const safeId = activationId.replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 80);
+  return ".etl/production-publication-receipts/NC/nc-local-" + mode + "-"
+    + planSha256.slice(0, 12) + "-" + safeId + ".json";
+}
+
+function reserveReceipt(
+  root,
+  relativePath,
+  planSha256,
+  authorizationSha256,
+  mode,
+  publicationReceiptSha256 = null,
+  options = {},
+) {
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ".etl", "production-publication-receipts", "NC");
+  if (!absolute.startsWith(allowed + path.sep) || !relativePath.endsWith(".json")) {
+    throw new Error("North Carolina publication receipt path is unsafe");
+  }
+  if (existsSync(absolute)) throw new Error("North Carolina publication receipt already exists");
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  const pending = absolute + ".pending";
+  const pendingDocument = {
+    schemaVersion: 1,
+    state: "NC",
+    purpose: "ambiguous-commit recovery marker",
+    mode,
+    planSha256,
+    authorizationSha256,
+    publicationReceiptSha256,
+  };
+  const pendingBytes = serializeNorthCarolinaPublicationDocument(pendingDocument);
+  if (existsSync(pending)) {
+    if (
+      options.allowExisting === true
+      && readFileSync(pending).equals(pendingBytes)
+    ) {
+      return { absolute, pending, pendingBytes, disposition: "reused" };
+    }
+    throw new Error("A North Carolina publication recovery marker already exists; reconcile it before retrying");
+  }
+  writeFileSync(pending, pendingBytes, { flag: "wx", mode: 0o600 });
+  return { absolute, pending, pendingBytes, disposition: "created" };
+}
+
+function finishPublicationReceipt(reservation, receipt) {
+  const receiptBytes = serializeNorthCarolinaPublicationDocument(receipt);
+  const temporary = reservation.absolute + ".write-"
+    + sha256(receiptBytes).slice(0, 12) + ".tmp";
+  if (existsSync(temporary)) {
+    if (!readFileSync(temporary).equals(receiptBytes)) {
+      throw new Error("North Carolina publication receipt temporary file drifted");
+    }
+  } else {
+    writeFileSync(temporary, receiptBytes, { flag: "wx", mode: 0o600 });
+  }
+  renameSync(temporary, reservation.absolute);
+  if (readFileSync(reservation.pending).equals(reservation.pendingBytes)) {
+    unlinkSync(reservation.pending);
+  }
+  return receiptBytes;
+}
+
+export async function runNorthCarolinaGeographyPublication(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const parsed = options.packagePath ? options : parseArguments(process.argv.slice(2));
+  const mode = parsed.rollback ? "rollback" : "publish";
+  const environment = options.environment ?? process.env;
+  const clock = options.nowFactory ?? (() => options.now ?? new Date());
+  const currentTime = () => {
+    const value = clock();
+    const result = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+    if (Number.isNaN(result.getTime())) {
+      throw new Error("North Carolina publication clock returned an invalid time");
+    }
+    return result;
+  };
+  const built = inspectNorthCarolinaPublicationPlan({ ...parsed, root });
+  if (parsed.planSha256 && parsed.planSha256 !== built.sha256) {
+    throw new Error("North Carolina publication plan SHA-256 drifted");
+  }
+  const publicationReceipt = mode === "rollback"
+    ? inspectNorthCarolinaPublicationReceipt(root, {
+      ...parsed,
+      now: currentTime().getTime(),
+    }, built)
+    : null;
+  if (parsed.writePlan) {
+    if (mode === "rollback") {
+      throw new Error("North Carolina rollback reuses the exact hash-pinned publication plan");
+    }
+    const artifact = immutableJson(
+      root,
+      parsed.outputPath ?? defaultPlanPath(built.sha256),
+      built.plan,
+      ".etl/precinct-publication-plans/NC",
+    );
+    return {
+      mode: "write_plan",
+      decision: built.plan.decision,
+      publicationPlan: artifact,
+      productionMutationPerformed: false,
+    };
+  }
+  if (parsed.writeAuthorizationTemplate) {
+    const template = mode === "rollback"
+      ? buildNorthCarolinaPublicRollbackAuthorizationTemplate(
+        built.plan,
+        built.sha256,
+        publicationReceipt.summary,
+      )
+      : buildNorthCarolinaPublicationAuthorizationTemplate(built.plan, built.sha256);
+    const artifact = immutableJson(
+      root,
+      parsed.outputPath ?? defaultAuthorizationPath(built.sha256, mode),
+      template,
+      ".etl/production-authorizations/NC",
+    );
+    return {
+      mode: "write_authorization_template",
+      operation: mode,
+      decision: mode === "rollback" ? "NO_GO_ROLLBACK" : "NO_GO_PUBLIC",
+      publicationPlanSha256: built.sha256,
+      authorizationTemplate: artifact,
+      productionMutationPerformed: false,
+    };
+  }
+  if (!parsed.apply && !parsed.recoverReceipt) {
+    return {
+      mode: "plan",
+      operation: mode,
+      decision: mode === "rollback"
+        ? "GO_ROLLBACK_AUTHORIZATION_REQUIRED"
+        : built.plan.decision,
+      publicationPlanSha256: built.sha256,
+      requiredScopes: mode === "rollback"
+        ? [...NORTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES]
+        : undefined,
+      productionMutationPerformed: false,
+      expectedTotals: built.plan.expectedTotals,
+    };
+  }
+  const authorizationArtifact = safeJson(
+    root,
+    parsed.authorizationPath,
+    parsed.authorizationSha256,
+    ".etl/production-authorizations/NC",
+  );
+  const validateAuthorizationAt = (now, recovery = false) => mode === "rollback"
+    ? validateNorthCarolinaPublicRollbackAuthorization(authorizationArtifact.value, {
+      plan: built.plan,
+      planSha256: built.sha256,
+      publicationReceipt: publicationReceipt.summary,
+      now: now.getTime(),
+      recovery,
+    })
+    : validateNorthCarolinaPublicationAuthorization(authorizationArtifact.value, {
+      plan: built.plan,
+      planSha256: built.sha256,
+      now: now.getTime(),
+      recovery,
+    });
+  const databaseUrl = productionUrl(environment);
+  const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
+  if (endpointFingerprint !== built.plan.hiddenLoad.endpointFingerprint) {
+    throw new Error("North Carolina publication database endpoint drifted from the hidden load");
+  }
+  const gisPlan = await buildNorthCarolinaLocalGisPlan({
+    root,
+    years: [2012, 2016, 2020],
+  });
+  const executionContext = {
+    mode: "production_release",
+    releasePackageSha256: built.plan.releaseCandidate.sha256,
+    releaseCandidateId: built.plan.releaseCandidate.id,
+    databaseName: built.plan.hiddenLoad.databaseName,
+    productionReleaseAudit: built.plan.hiddenLoad.productionReleaseAudit,
+  };
+  buildNorthCarolinaLocalExecutionContext(executionContext);
+  const rawOperationId = mode === "rollback"
+    ? authorizationArtifact.value?.rollbackId
+    : authorizationArtifact.value?.activationId;
+  const operationId = typeof rawOperationId === "string"
+    ? rawOperationId.trim()
+    : "";
+  const receiptPath = parsed.outputPath ?? defaultReceiptPath(
+    built.sha256,
+    operationId || "invalid-authorization",
+    mode,
+  );
+  const publicAuthorization = mode === "publish"
+    ? null
+    : publicationReceipt.publicAuthorization;
+
+  const receiptDocument = (authorization, committed, recovery = null) => {
+    const originalPublicAuthorization = mode === "publish"
+      ? authorization
+      : publicAuthorization;
+    return {
+      schemaVersion: 1,
+      state: "NC",
+      mode,
+      decision: mode === "publish" ? "PUBLISHED" : "ROLLED_BACK",
+      activationId: mode === "publish"
+        ? authorization.activationId
+        : publicationReceipt.summary.activationId,
+      ...(mode === "rollback" ? { rollbackId: authorization.rollbackId } : {}),
+      approvedBy: authorization.approvedBy,
+      releaseCandidate: built.plan.releaseCandidate,
+      publicationPlan: { id: built.plan.id, sha256: built.sha256 },
+      authorization: {
+        path: authorizationArtifact.path,
+        sha256: authorizationArtifact.sha256,
+      },
+      hiddenLoad: {
+        path: built.plan.hiddenLoad.path,
+        sha256: built.plan.hiddenLoad.sha256,
+      },
+      blobPublication: {
+        path: built.plan.blobPublication.path,
+        sha256: built.plan.blobPublication.sha256,
+        deliveryOrigin: built.plan.blobPublication.deliveryOrigin,
+      },
+      productionDeployment: originalPublicAuthorization.productionDeployment,
+      rollbackTarget: originalPublicAuthorization.rollbackTarget,
+      ...(mode === "rollback"
+        ? { publicationReceipt: publicationReceipt.summary }
+        : {}),
+      changedAtUtc: committed.changedAtUtc,
+      revision: committed.revision,
+      postconditions: committed.postconditions,
+      ...(recovery ? { recovery } : {}),
+      productionMutationPerformed: true,
+      publicDeliveryAuthorized: mode === "publish",
+    };
+  };
+
+  if (parsed.recoverReceipt) {
+    if (
+      environment.CRM_DATABASE_ENVIRONMENT !== "production-read-only"
+      || environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_RECEIPT_RECOVERY !== built.sha256
+      || environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_AUTHORIZATION_SHA256
+        !== authorizationArtifact.sha256
+      || (mode === "rollback"
+        && environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_RECEIPT_SHA256
+          !== publicationReceipt.summary.sha256)
+    ) {
+      throw new Error(
+        "North Carolina publication receipt recovery is not explicitly read-only and hash-authorized",
+      );
+    }
+    const reservation = reserveReceipt(
+      root,
+      receiptPath,
+      built.sha256,
+      authorizationArtifact.sha256,
+      mode,
+      publicationReceipt?.summary.sha256 ?? null,
+      { allowExisting: true },
+    );
+    let sql;
+    try {
+      sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+        max: 1,
+        connect_timeout: 10,
+        idle_timeout: 20,
+        connection: {
+          application_name: "civicresultmaps-nc-local-publication-receipt-recovery",
+          default_transaction_read_only: true,
+        },
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    }
+    let recovered;
+    try {
+      recovered = await sql.begin("read only", async (nv) => {
+        const identity = await nv.unsafe([
+          "select current_database() database_name,",
+          " current_setting('transaction_read_only') transaction_read_only",
+        ].join("\n"));
+        if (
+          identity.length !== 1
+          || String(identity[0].database_name) !== built.plan.hiddenLoad.databaseName
+          || String(identity[0].transaction_read_only) !== "on"
+        ) {
+          throw new Error("North Carolina publication receipt recovery database identity drifted");
+        }
+        const versions = await nv.unsafe([
+          "select e.year,gv.geography_type,gv.status,gv.caveat,gv.metadata from geography_versions gv",
+          "join elections e on e.id=gv.election_id",
+          "where gv.state_code='NC' and gv.geography_type=any($2::text[])",
+          " and gv.metadata->'releaseCandidate'->>'sha256'=$1 order by e.year",
+        ].join("\n"), [
+          built.plan.releaseCandidate.sha256,
+          [...NORTH_CAROLINA_LOCAL_GEOGRAPHY_LEVELS],
+        ]);
+        assertNorthCarolinaPublicationRecoveryVersionSet(versions);
+        const operationAudit = mode === "publish"
+          ? versions[0]?.metadata?.publicActivation
+          : versions[0]?.metadata?.publicActivation?.rollback;
+        const changedAtUtc = operationAudit?.changedAtUtc;
+        const revision = Number(operationAudit?.revision);
+        const recoveryNow = currentTime();
+        if (
+          typeof changedAtUtc !== "string"
+          || Number.isNaN(Date.parse(changedAtUtc))
+          || Date.parse(changedAtUtc) > recoveryNow.getTime()
+          || !Number.isInteger(revision)
+          || revision < 1
+        ) {
+          throw new Error("North Carolina publication receipt recovery audit is incomplete");
+        }
+        const authorization = validateAuthorizationAt(
+          new Date(changedAtUtc),
+          true,
+        );
+        const context = {
+          mode,
+          plan: built.plan,
+          planSha256: built.sha256,
+          authorization,
+          authorizationSha256: authorizationArtifact.sha256,
+          publicationReceipt: publicationReceipt?.summary ?? null,
+          changedAtUtc,
+          gisPlan,
+          executionContext,
+        };
+        const postconditions = await verifyPostconditions(
+          nv,
+          context,
+          revision,
+          mode,
+        );
+        return { authorization, changedAtUtc, revision, postconditions };
+      });
+    } catch (error) {
+      if (reservation.disposition === "created" && existsSync(reservation.pending)) {
+        unlinkSync(reservation.pending);
+      }
+      throw error;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+    const receipt = receiptDocument(recovered.authorization, recovered, {
+      recoveredAtUtc: currentTime().toISOString(),
+      productionMutationPerformed: false,
+    });
+    const receiptBytes = finishPublicationReceipt(reservation, receipt);
+    return {
+      mode: "recover_receipt",
+      operation: mode,
+      decision: mode === "publish"
+        ? "RECOVERED_PUBLICATION_RECEIPT"
+        : "RECOVERED_ROLLBACK_RECEIPT",
+      activationId: recovered.authorization.activationId,
+      revision: recovered.revision,
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: mode === "publish",
+      receipt: {
+        path: receiptPath,
+        sha256: sha256(receiptBytes),
+        byteCount: receiptBytes.length,
+      },
+    };
+  }
+
+  const initialNow = currentTime();
+  const authorization = validateAuthorizationAt(initialNow);
+  const writeAuthorized = mode === "publish"
+    ? environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_WRITES
+        === "I_ACKNOWLEDGE_ATOMIC_NORTH_CAROLINA_LOCAL_PUBLIC_CUTOVER"
+      && environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_ACTIVATION_ID
+        === authorization.activationId
+    : environment.CRM_NC_LOCAL_GEOGRAPHY_ROLLBACK_WRITES
+        === "I_ACKNOWLEDGE_DATABASE_FIRST_NORTH_CAROLINA_LOCAL_PUBLIC_ROLLBACK"
+      && environment.CRM_NC_LOCAL_GEOGRAPHY_ROLLBACK_ID === authorization.rollbackId
+      && environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_RECEIPT_SHA256
+        === publicationReceipt.summary.sha256;
+  if (
+    environment.CRM_DATABASE_ENVIRONMENT !== "production"
+    || !writeAuthorized
+    || environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_PACKAGE_SHA256
+      !== built.plan.releaseCandidate.sha256
+    || environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_PLAN_SHA256 !== built.sha256
+    || environment.CRM_NC_LOCAL_GEOGRAPHY_PUBLICATION_AUTHORIZATION_SHA256
+      !== authorizationArtifact.sha256
+  ) {
+    throw new Error("North Carolina public " + mode + " is not explicitly hash-authorized");
+  }
+  const activePublicAuthorization = mode === "publish"
+    ? authorization
+    : publicAuthorization;
+  verifyNorthCarolinaPublicationGitCandidate(root, activePublicAuthorization, options.gitRunner);
+  const reservation = reserveReceipt(
+    root,
+    receiptPath,
+    built.sha256,
+    authorizationArtifact.sha256,
+    mode,
+    publicationReceipt?.summary.sha256 ?? null,
+  );
+  let sql;
+  try {
+    sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+      max: 1,
+      connect_timeout: 10,
+      idle_timeout: 20,
+      connection: { application_name: "civicresultmaps-nc-local-publication-status" },
+    });
+  } catch (error) {
+    if (existsSync(reservation.pending)) unlinkSync(reservation.pending);
+    throw error;
+  }
+  let transactionBodyCompleted = false;
+  let committed;
+  try {
+    committed = await sql.begin(async (nv) => {
+      const transactionNow = currentTime();
+      const finalAuthorization = validateAuthorizationAt(transactionNow);
+      if (finalAuthorization.activationId !== authorization.activationId) {
+        throw new Error("North Carolina publication authorization drifted before the transaction");
+      }
+      verifyNorthCarolinaPublicationGitCandidate(
+        root,
+        activePublicAuthorization,
+        options.gitRunner,
+      );
+      const result = await applyNorthCarolinaGeographyPublicationTransaction(nv, {
+        mode,
+        plan: built.plan,
+        planSha256: built.sha256,
+        authorization: finalAuthorization,
+        authorizationSha256: authorizationArtifact.sha256,
+        publicationReceipt: publicationReceipt?.summary ?? null,
+        changedAtUtc: transactionNow.toISOString(),
+        gisPlan,
+        executionContext,
+      });
+      transactionBodyCompleted = true;
+      return result;
+    });
+  } catch (error) {
+    if (!transactionBodyCompleted && existsSync(reservation.pending)) {
+      unlinkSync(reservation.pending);
+    }
+    throw error;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+  const receipt = receiptDocument(authorization, committed);
+  const receiptBytes = finishPublicationReceipt(reservation, receipt);
+  return {
+    mode: "apply",
+    operation: mode,
+    decision: mode === "publish" ? "PUBLISHED" : "ROLLED_BACK",
+    activationId: authorization.activationId,
+    revision: committed.revision,
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: mode === "publish",
+    receipt: {
+      path: receiptPath,
+      sha256: sha256(receiptBytes),
+      byteCount: receiptBytes.length,
+    },
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runNorthCarolinaGeographyPublication().then(
+    (result) => console.log(JSON.stringify(result, null, 2)),
+    (error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/report-nc-local-production-preflight.mjs
+++ b/scripts/report-nc-local-production-preflight.mjs
@@ -1,0 +1,202 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import postgres from "postgres";
+import { inspectReleaseArtifact } from "./lib/nc-local-release-candidate.mjs";
+import {
+  assertNorthCarolinaReleaseCandidateDocument,
+  collectNorthCarolinaProductionPreflight,
+  productionEndpointFingerprint,
+  sha256,
+} from "./lib/nc-local-production-preflight.mjs";
+
+// Deliberately do not load .env.local. A production read is opt-in and must use
+// one explicitly supplied unpooled URL plus the exact release-package hash.
+
+function parseArguments(args) {
+  const packageArgument = args.find((arg) => arg.startsWith("--package="));
+  const reportArgument = args.find((arg) => arg.startsWith("--report="));
+  const connectReadOnly = args.includes("--connect-read-only");
+  for (const arg of args) {
+    if (
+      arg !== "--connect-read-only"
+      && !arg.startsWith("--package=")
+      && !arg.startsWith("--report=")
+    ) {
+      throw new Error("Unknown North Carolina production-preflight option: " + arg);
+    }
+  }
+  const packagePath = packageArgument?.slice("--package=".length);
+  if (!packagePath) {
+    throw new Error("--package is required for North Carolina production preflight");
+  }
+  return {
+    packagePath,
+    reportPath: reportArgument?.slice("--report=".length),
+    connectReadOnly,
+  };
+}
+
+function productionUrl() {
+  const first = process.env.POSTGRES_URL_NON_POOLING;
+  const second = process.env.POSTGRES_DATABASE_URL_UNPOOLED;
+  if (first && second && first !== second) {
+    throw new Error("Production unpooled URL variables disagree");
+  }
+  const value = first ?? second;
+  if (!value) throw new Error("Production unpooled database URL is unavailable");
+  return value;
+}
+
+function safeReportPath(root, requested, packageSha256, reportSha256) {
+  const relativePath = requested ?? path.posix.join(
+    ".etl",
+    "production-preflight-candidates",
+    "NC",
+    "nc-local-production-preflight-"
+      + packageSha256.slice(0, 12)
+      + "-"
+      + reportSha256.slice(0, 12)
+      + ".json",
+  );
+  if (
+    path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !relativePath.startsWith(".etl/production-preflight-candidates/NC/")
+  ) {
+    throw new Error("North Carolina production preflight report must remain in its .etl root");
+  }
+  const absolute = path.resolve(root, ...relativePath.split("/"));
+  const allowed = path.resolve(root, ".etl", "production-preflight-candidates", "NC");
+  if (!absolute.startsWith(allowed + path.sep)) {
+    throw new Error("North Carolina production preflight report escapes its .etl root");
+  }
+  return { relativePath, absolute };
+}
+
+function loadReleaseCandidate(root, relativePath) {
+  if (
+    path.isAbsolute(relativePath)
+    || relativePath.includes("\\")
+    || relativePath.split("/").includes("..")
+    || !relativePath.startsWith(".etl/precinct-release-candidates/NC/")
+    || !relativePath.endsWith("/release-candidate.json")
+  ) {
+    throw new Error("North Carolina production preflight package path is unsafe");
+  }
+  const artifact = inspectReleaseArtifact(root, relativePath, {
+    allowedRoots: [".etl/precinct-release-candidates/NC/"],
+  });
+  const document = JSON.parse(artifact.bytes.toString("utf8"));
+  const releaseCandidate = assertNorthCarolinaReleaseCandidateDocument(
+    document,
+    artifact.sha256,
+  );
+  for (const manifest of releaseCandidate.canonicalManifestPreimages) {
+    const current = inspectReleaseArtifact(root, manifest.path, {
+      allowedRoots: ["data/precinct-geometry/NC/"],
+      byteCount: manifest.byteCount,
+      sha256: manifest.sha256,
+    });
+    if (!current.bytes.length) throw new Error("Canonical manifest is empty");
+  }
+  return { artifact, document, releaseCandidate };
+}
+
+export async function runNorthCarolinaProductionPreflight(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  const parsed = options.packagePath
+    ? options
+    : parseArguments(process.argv.slice(2));
+  const loaded = loadReleaseCandidate(root, parsed.packagePath);
+  if (!parsed.connectReadOnly) {
+    return {
+      mode: "plan",
+      state: "NC",
+      releasePackageSha256: loaded.artifact.sha256,
+      connectionOpened: false,
+      productionMutationPerformed: false,
+      requiredEnvironment: {
+        CRM_DATABASE_ENVIRONMENT: "production-read-only",
+        CRM_NC_LOCAL_GEOGRAPHY_PRODUCTION_PREFLIGHT_ACK: loaded.artifact.sha256,
+        unpooledUrl: "POSTGRES_URL_NON_POOLING or POSTGRES_DATABASE_URL_UNPOOLED",
+      },
+    };
+  }
+  if (process.env.CRM_DATABASE_ENVIRONMENT !== "production-read-only") {
+    throw new Error("North Carolina production preflight requires production-read-only environment");
+  }
+  if (
+    process.env.CRM_NC_LOCAL_GEOGRAPHY_PRODUCTION_PREFLIGHT_ACK
+      !== loaded.artifact.sha256
+  ) {
+    throw new Error("North Carolina production preflight acknowledgement must equal the package SHA-256");
+  }
+  const databaseUrl = productionUrl();
+  const endpointFingerprint = productionEndpointFingerprint(databaseUrl);
+  const sql = (options.postgresFactory ?? postgres)(databaseUrl, {
+    max: 1,
+    connect_timeout: 10,
+    idle_timeout: 20,
+    connection: {
+      application_name: "civicresultmaps-nc-local-production-preflight",
+      default_transaction_read_only: true,
+    },
+  });
+  let report;
+  try {
+    report = await sql.begin("read only", (nv) =>
+      collectNorthCarolinaProductionPreflight(nv, {
+        capturedAtUtc: new Date().toISOString(),
+        endpointFingerprint,
+        releaseCandidate: loaded.releaseCandidate,
+      }));
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+  const bytes = Buffer.from(JSON.stringify(report, null, 2) + "\n", "utf8");
+  const reportSha256 = sha256(bytes);
+  const output = safeReportPath(
+    root,
+    parsed.reportPath,
+    loaded.artifact.sha256,
+    reportSha256,
+  );
+  if (existsSync(output.absolute)) {
+    if (!readFileSync(output.absolute).equals(bytes)) {
+      throw new Error("Refusing to overwrite different North Carolina preflight evidence");
+    }
+  } else {
+    mkdirSync(path.dirname(output.absolute), { recursive: true });
+    writeFileSync(output.absolute, bytes);
+  }
+  return {
+    mode: "read_only_production_preflight",
+    state: "NC",
+    releasePackageSha256: loaded.artifact.sha256,
+    endpointFingerprint,
+    connectionOpened: true,
+    productionMutationPerformed: false,
+    reportPath: output.relativePath,
+    reportByteCount: bytes.length,
+    reportSha256,
+    migration0008Status: report.migration0008.status,
+    migration0009Status: report.migration0009.status,
+    invalidConstraints: report.invalidConstraints,
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    console.log(JSON.stringify(await runNorthCarolinaProductionPreflight(), null, 2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}

--- a/scripts/setup-nc-local-gis-local.mjs
+++ b/scripts/setup-nc-local-gis-local.mjs
@@ -1,0 +1,79 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+// This command intentionally does not load .env.local. The database guard accepts
+// only an explicitly supplied loopback crm_clone_dev URL and local-write opt-in.
+process.env.CRM_DATABASE_DRIVER = "postgres";
+
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const yearsArgument = args.find((arg) => arg.startsWith("--years="));
+const reportArgument = args.find((arg) => arg.startsWith("--report="));
+const allowed = new Set(["--apply"]);
+for (const arg of args) {
+  if (
+    !allowed.has(arg)
+    && !arg.startsWith("--years=")
+    && !arg.startsWith("--report=")
+  ) {
+    throw new Error("Unknown North Carolina GIS setup option: " + arg);
+  }
+}
+const years = yearsArgument
+  ? yearsArgument.slice("--years=".length).split(",").map((value) => Number(value.trim()))
+  : undefined;
+
+function writeReport(relativePath, value) {
+  const etlRoot = path.resolve(".etl");
+  const target = path.resolve(relativePath);
+  if (target !== etlRoot && !target.startsWith(etlRoot + path.sep)) {
+    throw new Error("North Carolina GIS reports must remain under .etl");
+  }
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, JSON.stringify(value, null, 2) + "\n", "utf8");
+  return path.relative(process.cwd(), target).replaceAll("\\", "/");
+}
+
+try {
+  const {
+    buildNorthCarolinaLocalGisPlan,
+    summarizeNorthCarolinaLocalGisPlan,
+  } = await import("./lib/nc-local-gis-plan.mjs");
+  const plan = await buildNorthCarolinaLocalGisPlan({ years });
+  const summary = summarizeNorthCarolinaLocalGisPlan(plan);
+  if (!apply) {
+    console.log(JSON.stringify({
+      mode: "plan",
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      ...summary,
+    }, null, 2));
+  } else {
+    const {
+      applyNorthCarolinaLocalGisPlan,
+      validateNorthCarolinaLocalGisDatabase,
+    } = await import("./lib/nc-local-gis-db.mjs");
+    const applied = await applyNorthCarolinaLocalGisPlan(plan);
+    const validation = await validateNorthCarolinaLocalGisDatabase(plan);
+    const report = {
+      schemaVersion: 1,
+      generatedAtUtc: new Date().toISOString(),
+      scope: "local-only North Carolina local geography GIS setup",
+      productionMutationPerformed: false,
+      publicDeliveryAuthorized: false,
+      plan: summary,
+      applied,
+      validation,
+    };
+    const reportPath = writeReport(
+      reportArgument
+        ? reportArgument.slice("--report=".length)
+        : ".etl/local-db/nc-local-gis-setup-report.json",
+      report,
+    );
+    console.log(JSON.stringify({ ...report, reportPath }, null, 2));
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/scripts/validate-nc-local-gis-local.mjs
+++ b/scripts/validate-nc-local-gis-local.mjs
@@ -1,0 +1,58 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+// Validation is local-only and uses a read-only startup session.
+process.env.CRM_DATABASE_DRIVER = "postgres";
+
+const args = process.argv.slice(2);
+const yearsArgument = args.find((arg) => arg.startsWith("--years="));
+const reportArgument = args.find((arg) => arg.startsWith("--report="));
+for (const arg of args) {
+  if (!arg.startsWith("--years=") && !arg.startsWith("--report=")) {
+    throw new Error("Unknown North Carolina GIS validation option: " + arg);
+  }
+}
+const years = yearsArgument
+  ? yearsArgument.slice("--years=".length).split(",").map((value) => Number(value.trim()))
+  : undefined;
+
+function writeReport(relativePath, value) {
+  const etlRoot = path.resolve(".etl");
+  const target = path.resolve(relativePath);
+  if (target !== etlRoot && !target.startsWith(etlRoot + path.sep)) {
+    throw new Error("North Carolina GIS reports must remain under .etl");
+  }
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, JSON.stringify(value, null, 2) + "\n", "utf8");
+  return path.relative(process.cwd(), target).replaceAll("\\", "/");
+}
+
+try {
+  const {
+    buildNorthCarolinaLocalGisPlan,
+    summarizeNorthCarolinaLocalGisPlan,
+  } = await import("./lib/nc-local-gis-plan.mjs");
+  const { validateNorthCarolinaLocalGisDatabase } =
+    await import("./lib/nc-local-gis-db.mjs");
+  const plan = await buildNorthCarolinaLocalGisPlan({ years });
+  const validation = await validateNorthCarolinaLocalGisDatabase(plan);
+  const report = {
+    schemaVersion: 1,
+    generatedAtUtc: new Date().toISOString(),
+    scope: "local-only North Carolina local geography GIS validation",
+    productionMutationPerformed: false,
+    publicDeliveryAuthorized: false,
+    plan: summarizeNorthCarolinaLocalGisPlan(plan),
+    validation,
+  };
+  const reportPath = writeReport(
+    reportArgument
+      ? reportArgument.slice("--report=".length)
+      : ".etl/local-db/nc-local-gis-validation.json",
+    report,
+  );
+  console.log(JSON.stringify({ ...report, reportPath }, null, 2));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/src/app/precinct-detail-map.tsx
+++ b/src/app/precinct-detail-map.tsx
@@ -283,7 +283,10 @@ export function PrecinctDetailMap({
   selectedState,
 }: PrecinctDetailMapProps) {
   const electionDate = electionDates[electionYear];
-  const requestedGeographyLevel = guardedLocalGeographyLevel(selectedState)
+  const requestedGeographyLevel = guardedLocalGeographyLevel(
+    selectedState,
+    electionYear,
+  )
     ?? "precinct";
   const manifestQueryKey = selectedState
     + "|"
@@ -398,10 +401,14 @@ export function PrecinctDetailMap({
   const manifestLevel = manifest?.geography.level ?? requestedGeographyLevel;
   const unitLabel = manifestLevel === "local_reporting_unit"
     ? "local reporting unit"
-    : "precinct";
+    : manifestLevel === "vtd"
+      ? "VTD"
+      : "precinct";
   const unitLabelPlural = manifestLevel === "local_reporting_unit"
     ? "local reporting units"
-    : "precincts";
+    : manifestLevel === "vtd"
+      ? "VTDs"
+      : "precincts";
   const parentScope = localGeographyParentScope({
     state: selectedState,
     geographyLevel: manifestLevel,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -78,7 +78,7 @@ export const officeQuery = z
   .default("president");
 
 export const levelQuery = z
-  .enum(["county", "state", "district", "precinct", "local_reporting_unit", "city", "city_town", "town", "federal_precincts", "non_geographic"])
+  .enum(["county", "state", "district", "precinct", "vtd", "local_reporting_unit", "city", "city_town", "town", "federal_precincts", "non_geographic"])
   .default("county");
 
 export const parentGeoidQuery = z

--- a/src/lib/local-geography-parent.ts
+++ b/src/lib/local-geography-parent.ts
@@ -28,6 +28,7 @@ export function localGeographyParentScope(input: {
   }
   if (
     geographyLevel === "precinct"
+    || geographyLevel === "vtd"
     || geographyLevel === "local_reporting_unit"
   ) {
     return {

--- a/src/lib/precinct-result-publication.ts
+++ b/src/lib/precinct-result-publication.ts
@@ -1,6 +1,14 @@
 import { createHash } from "node:crypto";
 import type { PrecinctGeometryManifest } from "./precinct-geography";
 
+type GuardedReleaseContract = {
+  geographyLevel: string;
+  geographyLevels?: readonly string[];
+  geographyLevelByYear?: Readonly<Record<number, string>>;
+  releaseCandidatePattern: RegExp;
+  reviewedMatchMethods?: readonly string[];
+};
+
 const GUARDED_LOCAL_GEOGRAPHY_RELEASES = Object.freeze({
   AK: {
     geographyLevel: "precinct",
@@ -31,6 +39,16 @@ const GUARDED_LOCAL_GEOGRAPHY_RELEASES = Object.freeze({
       "reviewed_name",
     ]),
   },
+  NC: {
+    geographyLevel: "precinct",
+    geographyLevels: Object.freeze(["vtd", "precinct"]),
+    geographyLevelByYear: Object.freeze({
+      2012: "vtd",
+      2016: "precinct",
+      2020: "precinct",
+    }),
+    releaseCandidatePattern: /^nc-local-gis-three-election-v\d+$/,
+  },
   TX: {
     geographyLevel: "precinct",
     releaseCandidatePattern: /^tx-precinct-gis-four-election-v\d+$/,
@@ -45,11 +63,7 @@ const GUARDED_LOCAL_GEOGRAPHY_RELEASES = Object.freeze({
       "spatial_review",
     ]),
   },
-} satisfies Record<string, {
-  geographyLevel: string;
-  releaseCandidatePattern: RegExp;
-  reviewedMatchMethods?: readonly string[];
-}>);
+} satisfies Record<string, GuardedReleaseContract>);
 
 const DEFAULT_REVIEWED_MATCH_METHODS = Object.freeze([
   "exact_official_id",
@@ -58,17 +72,30 @@ const DEFAULT_REVIEWED_MATCH_METHODS = Object.freeze([
 
 type GuardedLocalGeographyState = keyof typeof GUARDED_LOCAL_GEOGRAPHY_RELEASES;
 
-function guardedReleaseContract(state: string) {
+function guardedReleaseContract(state: string): GuardedReleaseContract | null {
   const normalized = state.trim().toUpperCase();
   return Object.hasOwn(GUARDED_LOCAL_GEOGRAPHY_RELEASES, normalized)
     ? GUARDED_LOCAL_GEOGRAPHY_RELEASES[
         normalized as GuardedLocalGeographyState
-      ]
+      ] as GuardedReleaseContract
     : null;
 }
 
-export function guardedLocalGeographyLevel(state: string) {
-  return guardedReleaseContract(state)?.geographyLevel ?? null;
+function guardedGeographyLevels(contract: GuardedReleaseContract) {
+  return contract.geographyLevels ?? [contract.geographyLevel];
+}
+
+export function guardedLocalGeographyLevel(state: string, year?: number) {
+  const contract = guardedReleaseContract(state);
+  if (!contract) return null;
+  if (
+    year !== undefined
+    && contract.geographyLevelByYear
+    && Object.hasOwn(contract.geographyLevelByYear, year)
+  ) {
+    return contract.geographyLevelByYear[year];
+  }
+  return contract.geographyLevel;
 }
 
 export function guardedLocalGeographyMatchMethods(state: string) {
@@ -83,7 +110,7 @@ export function requiresPrecinctResultPublicationGate(input: {
   level: string;
 }) {
   const contract = guardedReleaseContract(input.state);
-  return contract !== null && input.level === contract.geographyLevel;
+  return contract !== null && guardedGeographyLevels(contract).includes(input.level);
 }
 
 export function requiresPrecinctGeometryPublicationGate(
@@ -91,7 +118,7 @@ export function requiresPrecinctGeometryPublicationGate(
 ) {
   const contract = guardedReleaseContract(manifest.state);
   return contract !== null
-    && manifest.geography.level === contract.geographyLevel;
+    && guardedGeographyLevels(contract).includes(manifest.geography.level);
 }
 
 function canonicalize(value: unknown): unknown {
@@ -211,6 +238,10 @@ export function matchesPrecinctGeometryPublicationMetadata(
     && /^[a-f0-9]{64}$/.test(activation.authorizationSha256)
     && activation.mode === "publish"
     && activation.year === manifest.election.year
+    && (
+      manifest.state !== "NC"
+      || activation.geographyLevel === manifest.geography.level
+    )
     && activation.manifestId === manifest.id
     && activation.publicManifestSha256
       === precinctGeometryPublicManifestSha256(manifest)

--- a/tests/api/nc-local-blob-publication.test.mjs
+++ b/tests/api/nc-local-blob-publication.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { inspectNorthCarolinaLocalBlobPublicationPlan } from "../../scripts/lib/nc-local-blob-publication.mjs";
+import { buildNorthCarolinaTestReleaseFixture } from "./nc-local-release-fixture.mjs";
+
+const { prepared } = await buildNorthCarolinaTestReleaseFixture({ write: true });
+const plan = inspectNorthCarolinaLocalBlobPublicationPlan({
+  packagePath: prepared.releaseCandidate.path,
+  packageSha256: prepared.releaseCandidate.sha256,
+});
+
+test("North Carolina Blob plan pins all 300 county assets before three indexes", () => {
+  assert.equal(plan.artifacts.length, 303);
+  assert.equal(plan.artifacts.filter((artifact) => artifact.kind === "parent").length, 300);
+  assert.equal(plan.artifacts.filter((artifact) => artifact.kind === "index").length, 3);
+  assert.ok(plan.artifacts.slice(0, 300).every((artifact) => artifact.kind === "parent"));
+  assert.ok(plan.artifacts.slice(300).every((artifact) => artifact.kind === "index"));
+  assert.ok(plan.artifacts.every((artifact) => artifact.pathname.startsWith("data/geography/nc/")));
+  assert.equal(plan.decision, "NO_GO_PUBLICATION");
+  assert.equal(plan.canonicalManifestChanged, false);
+  assert.equal(plan.publicEligibilityChanged, false);
+});

--- a/tests/api/nc-local-gis-local.test.mjs
+++ b/tests/api/nc-local-gis-local.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  assertNorthCarolinaGeometryVersionPrecondition,
+  canonicalJson,
+} from "../../scripts/lib/nc-local-gis-db.mjs";
+import {
+  guardedLocalGeographyLevel,
+  requiresPrecinctGeometryPublicationGate,
+  requiresPrecinctResultPublicationGate,
+} from "../../src/lib/precinct-result-publication.ts";
+import {
+  isValidLocalGeographyParentId,
+  localGeographyParentScope,
+} from "../../src/lib/local-geography-parent.ts";
+
+test("North Carolina local geography GIS commands remain loopback-only and public-fail-closed", () => {
+  const setup = readFileSync("scripts/setup-nc-local-gis-local.mjs", "utf8");
+  const validate = readFileSync("scripts/validate-nc-local-gis-local.mjs", "utf8");
+  const database = readFileSync("scripts/lib/nc-local-gis-db.mjs", "utf8");
+  const packageJson = JSON.parse(readFileSync("package.json"));
+  assert.match(setup, /CRM_DATABASE_DRIVER = "postgres"/);
+  assert.match(validate, /CRM_DATABASE_DRIVER = "postgres"/);
+  assert.doesNotMatch(setup + validate, /--env-file|dotenv/);
+  assert.match(database, /getLocalCloneDatabaseUrl\(\{ requireWriteOptIn: true \}\)/);
+  assert.match(database, /\["vtd", "precinct"\]/);
+  assert.match(database, /status='blocked'| 'blocked'/);
+  assert.match(database, /publicDeliveryAuthorized: false/);
+  assert.doesNotMatch(database, /runNeonTransaction|@neondatabase/);
+  assert.equal(packageJson.scripts["precinct-gis:plan:nc"], "node --experimental-strip-types scripts/setup-nc-local-gis-local.mjs");
+  assert.equal(packageJson.scripts["precinct-gis:setup:nc:local"], "node --experimental-strip-types scripts/setup-nc-local-gis-local.mjs --apply");
+});
+
+test("North Carolina results and geometry require exact publication evidence", () => {
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "NC", level: "precinct" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "NC", level: "vtd" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ME", level: "precinct" }), false);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ia", level: "precinct" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "NC", level: "county" }), false);
+  assert.equal(requiresPrecinctGeometryPublicationGate({
+    state: "NC",
+    geography: { level: "precinct" },
+  }), true);
+  assert.equal(requiresPrecinctGeometryPublicationGate({
+    state: "NC",
+    geography: { level: "vtd" },
+  }), true);
+  assert.equal(guardedLocalGeographyLevel("NC", 2012), "vtd");
+  assert.equal(guardedLocalGeographyLevel("NC", 2016), "precinct");
+  assert.equal(guardedLocalGeographyLevel("NC", 2024), "precinct");
+});
+
+test("North Carolina VTD API requests retain county parent scope", () => {
+  const apiSource = readFileSync("src/lib/api.ts", "utf8");
+  assert.match(apiSource, /"precinct", "vtd", "local_reporting_unit"/);
+  assert.deepEqual(localGeographyParentScope({
+    state: "NC",
+    geographyLevel: "vtd",
+  }), {
+    level: "county",
+    singularLabel: "county",
+    pluralLabel: "counties",
+  });
+  assert.equal(isValidLocalGeographyParentId({
+    state: "NC",
+    geographyLevel: "vtd",
+    parentGeoid: "37001",
+  }), true);
+  assert.equal(isValidLocalGeographyParentId({
+    state: "NC",
+    geographyLevel: "vtd",
+    parentGeoid: "HD01",
+  }), false);
+});
+
+test("North Carolina release precondition rejects duplicate or boundary-drifted versions", () => {
+  const yearPlan = {
+    year: 2012,
+    manifest: {
+      id: "nc-2012-11-06-reviewed-vtd-geometry-v1",
+      geography: { boundaryVintage: "reviewed North Carolina 2012 VTD boundaries" },
+    },
+  };
+  assert.doesNotThrow(() => assertNorthCarolinaGeometryVersionPrecondition([], yearPlan));
+  assert.doesNotThrow(() => assertNorthCarolinaGeometryVersionPrecondition([{
+    manifest_id: yearPlan.manifest.id,
+    boundary_vintage: yearPlan.manifest.geography.boundaryVintage,
+  }], yearPlan));
+  assert.throws(() => assertNorthCarolinaGeometryVersionPrecondition([{
+    manifest_id: yearPlan.manifest.id,
+    boundary_vintage: "drifted",
+  }], yearPlan), /boundary-drifted geography versions/);
+});
+
+test("North Carolina database validation compares nested JSON independent of key order", () => {
+  const left = {
+    z: [{ beta: 2, alpha: 1 }],
+    a: { delta: 4, gamma: 3 },
+  };
+  const right = {
+    a: { gamma: 3, delta: 4 },
+    z: [{ alpha: 1, beta: 2 }],
+  };
+  assert.deepEqual(canonicalJson(left), canonicalJson(right));
+});

--- a/tests/api/nc-local-gis-plan.test.mjs
+++ b/tests/api/nc-local-gis-plan.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildNorthCarolinaLocalGisPlan,
+  summarizeNorthCarolinaLocalGisPlan,
+} from "../../scripts/lib/nc-local-gis-plan.mjs";
+
+const plan = await buildNorthCarolinaLocalGisPlan();
+const summary = summarizeNorthCarolinaLocalGisPlan(plan);
+
+test("North Carolina plan preserves three exact election-specific source universes", () => {
+  assert.deepEqual(summary.years.map((year) => ({
+    year: year.year,
+    units: year.reportingUnits,
+    rows: year.resultRows,
+    features: year.geometryFeatures,
+    relationships: year.reviewedCrosswalks,
+    mappedVotes: year.totals.Total,
+    officialVotes: year.officialTotals.Total,
+    sourceGatePassed: year.sourceGatePassed,
+  })), [
+    { year: 2012, units: 3011, rows: 8076, features: 2692, relationships: 3011, mappedVotes: 4492613, officialVotes: 4505372, sourceGatePassed: true },
+    { year: 2016, units: 3209, rows: 8112, features: 2704, relationships: 3209, mappedVotes: 3177511, officialVotes: 4741564, sourceGatePassed: true },
+    { year: 2020, units: 3065, rows: 7986, features: 2662, relationships: 3065, mappedVotes: 3201711, officialVotes: 5524802, sourceGatePassed: true },
+  ]);
+});
+
+test("North Carolina uses county parents and never maps administrative buckets", () => {
+  for (const year of plan.years) {
+    assert.equal(new Set(year.geometry.features.map((feature) => feature.parentGeoid)).size, 100);
+    const geographic = year.reportingUnits.filter((unit) => unit.isGeographic);
+    const nonGeographic = year.reportingUnits.filter((unit) => !unit.isGeographic);
+    assert.equal(
+      year.geometry.features.length - geographic.length,
+      year.manifest.crosswalk.reviewedNoDataFeatures,
+    );
+    assert.ok(geographic.every((unit) =>
+      unit.reportingGrain === year.manifest.geography.level
+      && /^37\d{3}$/.test(unit.parentGeoid)));
+    assert.ok(nonGeographic.every((unit) =>
+      unit.reportingGrain === "administrative_reporting_unit"
+      && /^37\d{3}$/.test(unit.parentGeoid)));
+    assert.ok(year.geometry.crosswalks.every((relationship) =>
+      relationship.reviewStatus === "reviewed"
+      && relationship.confidence === "high"
+      && (relationship.sourceFeatureId === null
+        ? relationship.relationshipType === "non_geographic"
+        : relationship.relationshipType === "one_to_one")));
+    assert.ok(year.resultRows.every((row) =>
+      geographic.some((unit) => unit.code === row.jurisdictionCode)));
+  }
+});
+
+test("North Carolina plan excludes blocked 2024 and rejects unsupported years", async () => {
+  await assert.rejects(
+    buildNorthCarolinaLocalGisPlan({ years: [2024] }),
+    /2024 remains separately blocked/,
+  );
+  await assert.rejects(
+    buildNorthCarolinaLocalGisPlan({ years: [2008] }),
+    /Supported North Carolina public-release years/,
+  );
+});

--- a/tests/api/nc-local-production-release.test.mjs
+++ b/tests/api/nc-local-production-release.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  assertNorthCarolinaReleaseCandidateDocument,
+  sha256,
+} from "../../scripts/lib/nc-local-production-preflight.mjs";
+import {
+  NORTH_CAROLINA_PRODUCTION_RELEASE_SCOPES,
+  buildNorthCarolinaProductionAuthorizationTemplate,
+  validateNorthCarolinaProductionAuthorization,
+  validateNorthCarolinaProductionBackupEvidence,
+  validateNorthCarolinaProductionPreflightEvidence,
+} from "../../scripts/lib/nc-local-production-release.mjs";
+import { buildNorthCarolinaTestReleaseFixture } from "./nc-local-release-fixture.mjs";
+
+const { built } = await buildNorthCarolinaTestReleaseFixture();
+const packageSha256 = sha256(built.packageBytes);
+const candidate = assertNorthCarolinaReleaseCandidateDocument(built.packageDocument, packageSha256);
+const now = new Date("2026-08-13T00:30:00.000Z");
+const endpointFingerprint = "a".repeat(64);
+
+test("North Carolina release candidate and authorization scopes are state-specific", () => {
+  assert.deepEqual(NORTH_CAROLINA_PRODUCTION_RELEASE_SCOPES, [
+    "apply_migration_0009",
+    "load_nc_local_results_and_geometry_hidden",
+    "increment_public_data_revision",
+  ]);
+  const template = buildNorthCarolinaProductionAuthorizationTemplate({
+    releaseCandidate: candidate,
+    preflightSha256: "b".repeat(64),
+    backupManifestSha256: "c".repeat(64),
+  });
+  assert.equal(template.decision, "NO_GO_PRODUCTION");
+  assert.deepEqual(template.scopes, NORTH_CAROLINA_PRODUCTION_RELEASE_SCOPES);
+  assert.equal(template.replacement, undefined);
+});
+
+test("North Carolina fresh empty production evidence validates and preexisting rows fail", () => {
+  const report = {
+    schemaVersion: 1,
+    state: "NC",
+    productionMutationPerformed: false,
+    database: { transactionReadOnly: true, name: "production" },
+    invalidConstraints: 0,
+    migration0008: { status: "complete" },
+    migration0009: { status: "absent" },
+    releaseCandidate: { id: candidate.id, sha256: candidate.sha256 },
+    endpointFingerprint,
+    publicRevision: 10,
+    capturedAtUtc: "2026-08-13T00:00:00.000Z",
+    northCarolina: {
+      localYearRows: [2012, 2016, 2020].map((year) => ({
+        year,
+        reportingUnits: 0,
+        linkedLocalResultRows: 0,
+        geographyVersions: 0,
+        geometryFeatures: 0,
+        reviewedRelationships: 0,
+      })),
+      coreYearRows: [2012, 2016, 2020].map((year) => ({ year, localResultRows: 0 })),
+    },
+  };
+  assert.doesNotThrow(() => validateNorthCarolinaProductionPreflightEvidence(report, {
+    releaseCandidate: candidate,
+    endpointFingerprint,
+    now,
+  }));
+  report.northCarolina.localYearRows[0].reportingUnits = 1;
+  assert.throws(() => validateNorthCarolinaProductionPreflightEvidence(report, {
+    releaseCandidate: candidate,
+    endpointFingerprint,
+    now,
+  }), /already contains local release rows/);
+});
+
+test("North Carolina backup and authorization require exact fresh hashes", () => {
+  const preflightCapturedAtUtc = "2026-08-13T00:00:00.000Z";
+  const backup = {
+    manifestVersion: 3,
+    backupPurpose: "nc-local-production-release-rollback",
+    releaseCandidate: { id: candidate.id, sha256: candidate.sha256 },
+    sourceEndpointFingerprint: endpointFingerprint,
+    dumpSha256: "d".repeat(64),
+    dumpFormat: "custom",
+    pgClientMajor: 17,
+    sourceServerVersionNum: 170000,
+    includedSchemas: ["public"],
+    excludedTableDataPatterns: [],
+    remoteMutationPerformed: false,
+    sourceInvalidConstraints: 0,
+    createdAtUtc: "2026-08-13T00:05:00.000Z",
+    sourcePublicTableCount: 2,
+    sourcePublicTableRowCounts: { elections: 4, contests: 8 },
+    restoreVerification: {
+      verified: true,
+      defaultTransactionReadOnly: true,
+      exactSourceTableSet: true,
+      exactSourceRowCounts: true,
+      invalidConstraints: 0,
+      verifiedAtUtc: "2026-08-13T00:10:00.000Z",
+      publicTableCount: 2,
+      tableDataEntryCount: 2,
+      publicTableRowCounts: { elections: 4, contests: 8 },
+    },
+  };
+  assert.doesNotThrow(() => validateNorthCarolinaProductionBackupEvidence(backup, {
+    releaseCandidate: candidate,
+    endpointFingerprint,
+    preflightCapturedAtUtc,
+    now,
+  }));
+  const authorization = {
+    ...buildNorthCarolinaProductionAuthorizationTemplate({
+      releaseCandidate: candidate,
+      preflightSha256: "b".repeat(64),
+      backupManifestSha256: "c".repeat(64),
+    }),
+    decision: "GO_PRODUCTION",
+    authorizationId: "nc-release-1",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T00:15:00.000Z",
+    expiresAtUtc: "2026-08-13T01:15:00.000Z",
+  };
+  assert.doesNotThrow(() => validateNorthCarolinaProductionAuthorization(authorization, {
+    releaseCandidate: candidate,
+    preflightSha256: "b".repeat(64),
+    backupManifestSha256: "c".repeat(64),
+    now,
+  }));
+  authorization.scopes[1] = "load_nv_precinct_results_and_geometry_hidden";
+  assert.throws(() => validateNorthCarolinaProductionAuthorization(authorization, {
+    releaseCandidate: candidate,
+    preflightSha256: "b".repeat(64),
+    backupManifestSha256: "c".repeat(64),
+    now,
+  }), /incomplete or incompatible/);
+});
+
+test("North Carolina production runners use the correctly spelled environment guard", () => {
+  const files = [
+    "scripts/apply-nc-local-release.mjs",
+    "scripts/report-nc-local-production-preflight.mjs",
+    "scripts/publish-nc-local-geography-status.mjs",
+  ].map((file) => readFileSync(file, "utf8")).join("\n");
+  assert.match(files, /CRM_DATABASE_ENVIRONMENT/);
+  assert.doesNotMatch(files, /CRM_DATABASE_EIAIRONMENT|NODE_EIA/);
+  assert.doesNotMatch(files, /replacement-publication-receipt|GO_PRODUCTION_UPGRADE/);
+});
+
+test("North Carolina backup guard accepts only the three-election release package", () => {
+  const backupScript = readFileSync(
+    "scripts/backup-nc-local-production.ps1",
+    "utf8",
+  );
+  assert.equal(built.packageDocument.totals.elections, 3);
+  assert.match(backupScript, /\$document\.totals\.elections -ne 3/);
+  assert.doesNotMatch(backupScript, /\$document\.totals\.elections -ne 4/);
+});

--- a/tests/api/nc-local-public-activation.test.mjs
+++ b/tests/api/nc-local-public-activation.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { inspectNorthCarolinaPublicActivationPlan } from "../../scripts/lib/nc-local-public-activation.mjs";
+import { writeNorthCarolinaActivationTrackedOutputs } from "../../scripts/prepare-nc-local-public-activation.mjs";
+import { buildNorthCarolinaTestReleaseFixture } from "./nc-local-release-fixture.mjs";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+const coverage = JSON.parse(readFileSync(
+  "data/precinct-geometry-coverage-inventory-2012.json",
+  "utf8",
+));
+const existingNorthCarolinaRow = coverage.states.find((row) => row.state === "NC");
+const { prepared } = await buildNorthCarolinaTestReleaseFixture({
+  write: true,
+  generatedAtUtc: existingNorthCarolinaRow?.checkedAt,
+});
+const inspected = inspectNorthCarolinaPublicActivationPlan({
+  packagePath: prepared.releaseCandidate.path,
+  packageSha256: prepared.releaseCandidate.sha256,
+});
+
+test("North Carolina static activation adds or verifies exactly three guarded manifests", () => {
+  assert.equal(inspected.plan.manifests.length, 3);
+  assert.deepEqual(inspected.plan.manifests.map((item) => item.year), [2012, 2016, 2020]);
+  assert.equal(inspected.plan.trackedOutputs.length, 4);
+  const dispositions = new Set(
+    inspected.plan.trackedOutputs.map((output) => output.disposition),
+  );
+  assert.equal(dispositions.size, 1);
+  assert.ok(["activate", "verified_existing"].includes([...dispositions][0]));
+  assert.equal(inspected.plan.safety.productionMutationPerformed, false);
+  assert.equal(inspected.plan.safety.publicEndpointsRemainDatabaseGated, true);
+});
+
+test("North Carolina activation atomically writes its registry and three inventories", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "crm-nc-activation-"));
+  try {
+    const outputs = Array.from({ length: 4 }, (_, index) => {
+      const absolutePath = path.join(root, `target-${index}.json`);
+      const before = Buffer.from(`before-${index}\n`, "utf8");
+      const bytes = Buffer.from(`after-${index}\n`, "utf8");
+      writeFileSync(absolutePath, before);
+      return {
+        path: `data/target-${index}.json`,
+        absolutePath,
+        preimage: { byteCount: before.length, sha256: sha256(before) },
+        byteCount: bytes.length,
+        sha256: sha256(bytes),
+        bytes,
+      };
+    });
+    assert.equal(writeNorthCarolinaActivationTrackedOutputs(outputs).length, 4);
+    for (const output of outputs) {
+      assert.deepEqual(readFileSync(output.absolutePath), output.bytes);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/api/nc-local-publication-gate.test.mjs
+++ b/tests/api/nc-local-publication-gate.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  guardedLocalGeographyMatchMethods,
+  matchesPrecinctGeometryPublicationMetadata,
+  precinctGeometryPublicManifestSha256,
+  requiresPrecinctGeometryPublicationGate,
+  requiresPrecinctResultPublicationGate,
+} from "../../src/lib/precinct-result-publication.ts";
+
+function manifest() {
+  return {
+    schemaVersion: 1,
+    id: "nc-2012-11-06-reviewed-vtd-geometry-v1",
+    state: "NC",
+    election: { id: "2012-11-06-general", date: "2012-11-06", year: 2012, type: "general", office: "president" },
+    geography: { level: "vtd", parentLevel: "county", boundaryVintage: "reviewed", vintageStatus: "election_date_confirmed", derivationMethod: "secondary_reconstruction" },
+    source: {},
+    normalization: { featureCount: 2 },
+    crosswalk: {},
+    validation: {},
+    delivery: {
+      format: "parent_scoped_geojson",
+      url: "/data/geography/nc/2012-11-06/vtd/candidate/index.json",
+      sha256: "1".repeat(64),
+      byteCount: 123,
+      featureIdProperty: "geometryFeatureId",
+      resultUnitProperty: "resultUnitCode",
+      parentGeoidProperty: "parentGeoid",
+      parentCount: 1,
+      featureCount: 2,
+    },
+    caveats: [],
+  };
+}
+
+function metadata(value) {
+  const releaseSha256 = "2".repeat(64);
+  return {
+    manifestId: value.id,
+    publicDeliveryAuthorized: true,
+    normalization: { featureCount: 2 },
+    crosswalk: { reviewedRelationships: 2 },
+    releaseCandidate: { id: "nc-local-gis-three-election-v1", sha256: releaseSha256, publicDeliveryAuthorized: true },
+    publicActivation: {
+      activationId: "nc-local-public-2012",
+      activationCandidateSha256: "3".repeat(64),
+      releasePackageSha256: releaseSha256,
+      blobPublicationSha256: "4".repeat(64),
+      deliveryOrigin: "https://example.public.blob.vercel-storage.com",
+      authorizationSha256: "5".repeat(64),
+      changedAtUtc: "2026-08-12T23:59:00.000Z",
+      revision: 50,
+      mode: "publish",
+      year: 2012,
+      geographyLevel: "vtd",
+      manifestId: value.id,
+      publicManifestSha256: precinctGeometryPublicManifestSha256(value),
+      delivery: value.delivery,
+      previousCaveat: "blocked pending release",
+    },
+  };
+}
+
+test("North Carolina local geography unit results and geometry use the guarded publication path", () => {
+  const value = manifest();
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "NC", level: "precinct" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "NC", level: "vtd" }), true);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "ME", level: "precinct" }), false);
+  assert.equal(requiresPrecinctResultPublicationGate({ state: "NC", level: "county" }), false);
+  assert.equal(requiresPrecinctGeometryPublicationGate(value), true);
+  assert.deepEqual(guardedLocalGeographyMatchMethods("NC"), [
+    "exact_official_id",
+    "official_crosswalk",
+  ]);
+  assert.deepEqual(guardedLocalGeographyMatchMethods("AK"), [
+    "exact_official_id",
+    "official_crosswalk",
+  ]);
+  assert.equal(matchesPrecinctGeometryPublicationMetadata(value, metadata(value)), true);
+  const foreign = metadata(value);
+  foreign.releaseCandidate.id = "nv-precinct-gis-three-election-v2";
+  assert.equal(matchesPrecinctGeometryPublicationMetadata(value, foreign), false);
+});
+
+test("Minnesota rehearsal cannot bypass the North Carolina publication gate", () => {
+  const source = readFileSync("src/lib/data-access.ts", "utf8");
+  assert.match(source, /input\.state\.toUpperCase\(\) === "MN"\s*\? resolveMinnesotaPrecinctRehearsal\(\)/);
+  assert.doesNotMatch(source, /requiresPrecinctResultPublicationGate\(input\)\s*&&\s*!resolveMinnesotaPrecinctRehearsal\(\)\.enabled/);
+});

--- a/tests/api/nc-local-publication.test.mjs
+++ b/tests/api/nc-local-publication.test.mjs
@@ -1,0 +1,613 @@
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  NORTH_CAROLINA_PUBLICATION_SCOPES,
+  NORTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES,
+  buildNorthCarolinaPublicRollbackAuthorizationTemplate,
+  buildNorthCarolinaPublicationAuthorizationTemplate,
+  serializeNorthCarolinaPublicationDocument,
+  sha256,
+  validateNorthCarolinaBlobPublicationEvidence,
+  validateNorthCarolinaPublicRollbackAuthorization,
+  validateNorthCarolinaPublicationAuthorization,
+} from "../../scripts/lib/nc-local-publication.mjs";
+import {
+  applyNorthCarolinaGeographyPublicationTransaction,
+  assertNorthCarolinaPublicationRecoveryVersionSet,
+  inspectNorthCarolinaPublicationReceipt,
+  verifyNorthCarolinaPublicationGitCandidate,
+} from "../../scripts/publish-nc-local-geography-status.mjs";
+const deliveryOrigin = "https://example.public.blob.vercel-storage.com";
+const blobReleaseCandidate = {
+  id: "nc-local-gis-three-election-v1",
+  path: ".etl/precinct-release-candidates/NC/example/release-candidate.json",
+  sha256: "d".repeat(64),
+};
+const blobArtifacts = Array.from({ length: 303 }, (_, index) => {
+  const year = [2012, 2016, 2020][Math.min(2, Math.floor(index / 101))];
+  const level = year === 2012 ? "vtd" : "precinct";
+  const kind = index % 101 === 100 ? "index" : "parent";
+  return {
+    kind,
+    year,
+    packageRelativePath: `delivery-assets/${year}/file-${index}.json`,
+    publicUrl: `/data/geography/nc/${year}/${level}/file-${index}.json`,
+    pathname: `data/geography/nc/${year}/${level}/file-${index}.json`,
+    byteCount: 100 + index,
+    sha256: index.toString(16).padStart(64, "0"),
+  };
+});
+const blobPlan = {
+  releaseCandidate: blobReleaseCandidate,
+  artifacts: blobArtifacts,
+};
+const evidence = {
+  schemaVersion: 1,
+  state: "NC",
+  purpose: "nc-local-parent-scoped-immutable-geometry-publication",
+  releaseCandidate: blobReleaseCandidate,
+  authorizationId: "nc-blob-publication-1",
+  publishedAtUtc: "2026-08-13T00:00:00.000Z",
+  deliveryOrigin,
+  assetCount: blobPlan.artifacts.length,
+  canonicalManifestChanged: false,
+  publicEligibilityChanged: false,
+  artifacts: blobPlan.artifacts.map((artifact) => ({
+    ...artifact,
+    url: `${deliveryOrigin}/${artifact.pathname}`,
+    disposition: "created",
+  })),
+};
+
+const releaseCandidate = {
+  id: "nc-local-gis-three-election-v1",
+  path: ".etl/precinct-release-candidates/NC/example/release-candidate.json",
+  sha256: "1".repeat(64),
+};
+const planSha256 = "2".repeat(64);
+const rollbackTarget = {
+  deploymentId: "dpl_northCarolina_previous",
+  url: "https://previous.civicresultmaps.org",
+  gitSha: "3".repeat(40),
+  gitTreeSha: "4".repeat(40),
+  verifiedAtUtc: "2026-08-13T00:30:00.000Z",
+  gateCapableVerified: true,
+  blockedResultGateVerified: true,
+  blockedGeometryGateVerified: true,
+};
+const authorizationPlan = {
+  id: "nc-local-database-publication-v1",
+  releaseCandidate,
+  hiddenLoad: { path: "hidden.json", sha256: "5".repeat(64) },
+  blobPublication: {
+    path: "blob.json",
+    sha256: "6".repeat(64),
+    deliveryOrigin,
+  },
+  staticRegistry: { sha256: "7".repeat(64) },
+};
+
+function publicAuthorization() {
+  const value = buildNorthCarolinaPublicationAuthorizationTemplate(
+    authorizationPlan,
+    planSha256,
+  );
+  Object.assign(value, {
+    decision: "GO_PUBLIC",
+    activationId: "nc-local-public-camreyn",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T00:50:00.000Z",
+    expiresAtUtc: "2026-08-13T02:00:00.000Z",
+  });
+  Object.assign(value.productionDeployment, {
+    deploymentId: "dpl_northCarolina_public",
+    url: "https://civicresultmaps.org",
+    gitSha: "8".repeat(40),
+    gitTreeSha: "9".repeat(40),
+    readyVerified: true,
+    promotedVerified: true,
+    blockedResultGateVerified: true,
+    blockedGeometryGateVerified: true,
+    verifiedAtUtc: "2026-08-13T00:45:00.000Z",
+  });
+  Object.assign(value.rollbackTarget, rollbackTarget);
+  return value;
+}
+
+function publicationSummary() {
+  return {
+    path: ".etl/production-publication-receipts/NC/nc-local-publish.json",
+    sha256: "a".repeat(64),
+    activationId: "nc-local-public-camreyn",
+    authorizationSha256: "b".repeat(64),
+    revision: 41,
+    changedAtUtc: "2026-08-13T01:00:00.000Z",
+    rollbackTarget,
+    productionDeployment: publicAuthorization().productionDeployment,
+  };
+}
+
+test("North Carolina Blob evidence requires all 303 immutable artifacts", () => {
+  const result = validateNorthCarolinaBlobPublicationEvidence(
+    evidence,
+    blobPlan,
+    Date.parse("2026-08-13T00:01:00.000Z"),
+  );
+  assert.equal(result.assetCount, 303);
+  assert.equal(result.deliveryOrigin, deliveryOrigin);
+  const incomplete = { ...evidence, assetCount: 302 };
+  assert.throws(
+    () => validateNorthCarolinaBlobPublicationEvidence(incomplete, blobPlan),
+    /incomplete or incompatible/,
+  );
+});
+
+test("North Carolina public authorization pins production and rollback deployment trees", () => {
+  const value = publicAuthorization();
+  const checked = validateNorthCarolinaPublicationAuthorization(value, {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  assert.equal(checked.approvedBy, "Camreyn");
+  assert.deepEqual(value.scopes, NORTH_CAROLINA_PUBLICATION_SCOPES);
+  assert.deepEqual(checked.rollbackTarget, rollbackTarget);
+
+  const sameTree = structuredClone(value);
+  sameTree.rollbackTarget.gitTreeSha = value.productionDeployment.gitTreeSha;
+  assert.throws(
+    () => validateNorthCarolinaPublicationAuthorization(sameTree, {
+      plan: authorizationPlan,
+      planSha256,
+      now: Date.parse("2026-08-13T01:01:00.000Z"),
+    }),
+    /incompatible/,
+  );
+});
+
+test("North Carolina rollback authorization is bound to the exact publication receipt", () => {
+  const receipt = publicationSummary();
+  const value = buildNorthCarolinaPublicRollbackAuthorizationTemplate(
+    authorizationPlan,
+    planSha256,
+    receipt,
+  );
+  Object.assign(value, {
+    decision: "GO_ROLLBACK",
+    rollbackId: "nc-rollback-camreyn",
+    approvedBy: "Camreyn",
+    authorizedAtUtc: "2026-08-13T01:10:00.000Z",
+    expiresAtUtc: "2026-08-13T02:00:00.000Z",
+  });
+  Object.assign(value.rollbackWindow, {
+    startsAtUtc: "2026-08-13T01:10:00.000Z",
+    endsAtUtc: "2026-08-13T01:50:00.000Z",
+  });
+  value.applicationRollback.databaseBlockFirstAcknowledged = true;
+  value.applicationRollback.restoreAfterDatabaseRollbackAcknowledged = true;
+  const checked = validateNorthCarolinaPublicRollbackAuthorization(value, {
+    plan: authorizationPlan,
+    planSha256,
+    publicationReceipt: receipt,
+    now: Date.parse("2026-08-13T01:20:00.000Z"),
+  });
+  assert.equal(checked.rollbackId, "nc-rollback-camreyn");
+  assert.deepEqual(value.scopes, NORTH_CAROLINA_PUBLIC_ROLLBACK_SCOPES);
+
+  const substituted = structuredClone(value);
+  substituted.applicationRollback.target.deploymentId = "dpl_substituted";
+  assert.throws(
+    () => validateNorthCarolinaPublicRollbackAuthorization(substituted, {
+      plan: authorizationPlan,
+      planSha256,
+      publicationReceipt: receipt,
+      now: Date.parse("2026-08-13T01:20:00.000Z"),
+    }),
+    /incompatible/,
+  );
+});
+
+test("North Carolina publication receipt reloads its exact original public authorization", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "crm-nc-local-publication-"));
+  const authorizationPath =
+    ".etl/production-authorizations/NC/nc-local-public-authorization.json";
+  const receiptPath =
+    ".etl/production-publication-receipts/NC/nc-local-publish-receipt.json";
+  const authorization = publicAuthorization();
+  const authorizationBytes = serializeNorthCarolinaPublicationDocument(authorization);
+  const authorizationSha256 = sha256(authorizationBytes);
+  const plan = {
+    ...authorizationPlan,
+    hiddenLoad: authorizationPlan.hiddenLoad,
+    blobPublication: authorizationPlan.blobPublication,
+  };
+  const receipt = {
+    schemaVersion: 1,
+    state: "NC",
+    mode: "publish",
+    decision: "PUBLISHED",
+    activationId: authorization.activationId,
+    approvedBy: authorization.approvedBy,
+    releaseCandidate,
+    publicationPlan: { id: plan.id, sha256: planSha256 },
+    authorization: { path: authorizationPath, sha256: authorizationSha256 },
+    hiddenLoad: plan.hiddenLoad,
+    blobPublication: {
+      ...plan.blobPublication,
+      deliveryOrigin,
+    },
+    productionDeployment: authorization.productionDeployment,
+    rollbackTarget,
+    changedAtUtc: "2026-08-13T01:00:00.000Z",
+    revision: 41,
+    postconditions: {
+      mode: "publish",
+      status: "published",
+      publicDeliveryAuthorized: true,
+      geographyVersions: 3,
+      crosswalks: 9_285,
+      reportingUnits: 9_285,
+      sourceDocuments: 6,
+      importRuns: 3,
+      resultRows: 24_174,
+      invalidConstraints: 0,
+    },
+    productionMutationPerformed: true,
+    publicDeliveryAuthorized: true,
+  };
+  for (const [relative, bytes] of [
+    [authorizationPath, authorizationBytes],
+    [receiptPath, serializeNorthCarolinaPublicationDocument(receipt)],
+  ]) {
+    const absolute = path.resolve(root, ...relative.split("/"));
+    mkdirSync(path.dirname(absolute), { recursive: true });
+    writeFileSync(absolute, bytes);
+  }
+  const receiptBytes = readFileSync(path.resolve(root, ...receiptPath.split("/")));
+  const inspected = inspectNorthCarolinaPublicationReceipt(root, {
+    publicationReceiptPath: receiptPath,
+    publicationReceiptSha256: sha256(receiptBytes),
+    now: Date.parse("2026-08-13T01:10:00.000Z"),
+  }, { plan, sha256: planSha256 });
+  assert.equal(inspected.summary.activationId, authorization.activationId);
+
+  const substituted = structuredClone(receipt);
+  substituted.rollbackTarget.deploymentId = "dpl_substituted";
+  const substitutedPath =
+    ".etl/production-publication-receipts/NC/nc-local-substituted-receipt.json";
+  const substitutedBytes = serializeNorthCarolinaPublicationDocument(substituted);
+  writeFileSync(
+    path.resolve(root, ...substitutedPath.split("/")),
+    substitutedBytes,
+  );
+  assert.throws(
+    () => inspectNorthCarolinaPublicationReceipt(root, {
+      publicationReceiptPath: substitutedPath,
+      publicationReceiptSha256: sha256(substitutedBytes),
+      now: Date.parse("2026-08-13T01:10:00.000Z"),
+    }, { plan, sha256: planSha256 }),
+    /incomplete or incompatible/,
+  );
+});
+
+test("North Carolina Git verifier resolves both the live and rollback deployment trees", () => {
+  const authorization = validateNorthCarolinaPublicationAuthorization(publicAuthorization(), {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  const outputs = new Map([
+    ["rev-parse HEAD", authorization.productionDeployment.gitSha],
+    ["rev-parse HEAD^{tree}", authorization.productionDeployment.gitTreeSha],
+    [
+      `rev-parse ${authorization.productionDeployment.gitSha}^{tree}`,
+      authorization.productionDeployment.gitTreeSha,
+    ],
+    [
+      `rev-parse ${authorization.rollbackTarget.gitSha}^{tree}`,
+      authorization.rollbackTarget.gitTreeSha,
+    ],
+    ["status --porcelain --untracked-files=no", ""],
+  ]);
+  const runner = (_command, args) => outputs.get(args.join(" ")) + "\n";
+  assert.equal(
+    verifyNorthCarolinaPublicationGitCandidate(process.cwd(), authorization, runner)
+      .trackedWorktreeClean,
+    true,
+  );
+  outputs.set(
+    `rev-parse ${authorization.rollbackTarget.gitSha}^{tree}`,
+    "f".repeat(40),
+  );
+  assert.throws(
+    () => verifyNorthCarolinaPublicationGitCandidate(process.cwd(), authorization, runner),
+    /drifted/,
+  );
+});
+
+function rollbackTransactionFixture() {
+  const manifests = [2012, 2016, 2020].map((year, index) => ({
+    year,
+    geographyLevel: year === 2012 ? "vtd" : "precinct",
+    manifestId: `nc-${year}-manifest`,
+    publicManifestSha256: String(index + 3).repeat(64).slice(0, 64),
+    blockedManifestSha256: String(index + 6).repeat(64).slice(0, 64),
+    delivery: {
+      format: "parent_scoped_geojson",
+      featureCount: [2692, 2704, 2662][index],
+      parentCount: 100,
+      indexPath: `/data/geography/nc/${year}/${year === 2012 ? "vtd" : "precinct"}/index.json`,
+    },
+  }));
+  const plan = {
+    id: authorizationPlan.id,
+    releaseCandidate,
+    hiddenLoad: { databaseName: "neondb" },
+    blobPublication: {
+      sha256: "6".repeat(64),
+      deliveryOrigin,
+    },
+    manifests,
+  };
+  const publicationReceipt = publicationSummary();
+  const gisPlan = {
+    years: manifests.map((manifest) => ({
+      manifest: { validation: { errors: [`blocked ${manifest.year}`] } },
+    })),
+  };
+  const versions = manifests.map((manifest, index) => {
+    const previousCaveat = gisPlan.years[index].manifest.validation.errors.join(" ");
+    return {
+      id: `00000000-0000-0000-0000-00000000${index + 1}`,
+      year: manifest.year,
+      geography_type: manifest.geographyLevel,
+      status: "published",
+      caveat: "Reviewed North Carolina election-specific local geometry is publicly authorized under activation "
+        + publicationReceipt.activationId + ".",
+      metadata: {
+        manifestId: manifest.manifestId,
+        publicDeliveryAuthorized: true,
+        releaseCandidate: {
+          sha256: releaseCandidate.sha256,
+          publicDeliveryAuthorized: true,
+        },
+        publicActivation: {
+          activationId: publicationReceipt.activationId,
+          activationCandidateSha256: planSha256,
+          releasePackageSha256: releaseCandidate.sha256,
+          blobPublicationSha256: plan.blobPublication.sha256,
+          deliveryOrigin,
+          authorizationSha256: publicationReceipt.authorizationSha256,
+          rollbackTarget,
+          mode: "publish",
+          year: manifest.year,
+          geographyLevel: manifest.geographyLevel,
+          manifestId: manifest.manifestId,
+          publicManifestSha256: manifest.publicManifestSha256,
+          delivery: manifest.delivery,
+          previousCaveat,
+          changedAtUtc: publicationReceipt.changedAtUtc,
+          revision: publicationReceipt.revision,
+        },
+      },
+    };
+  });
+  const authorization = {
+    activationId: "nc-rollback-camreyn",
+    rollbackId: "nc-rollback-camreyn",
+    publicationActivationId: publicationReceipt.activationId,
+    approvedBy: "Camreyn",
+    applicationRollback: { target: rollbackTarget },
+  };
+  return { plan, publicationReceipt, gisPlan, versions, authorization };
+}
+
+function rollbackClient(fixture) {
+  let revision = 41;
+  let reason = "North Carolina local geography unit geometry publish nc-local-public-camreyn";
+  let versionUpdateCount = 0;
+  const unsafe = async (statement, parameters = []) => {
+    const sql = String(statement);
+    if (sql.includes("current_database()")) {
+      return [{ database_name: "neondb", transaction_read_only: "off" }];
+    }
+    if (sql.includes("set_config") || sql.includes("pg_advisory_xact_lock")) {
+      return [];
+    }
+    if (sql.includes("for update") && sql.includes("public_data_revisions")) {
+      return [{ revision }];
+    }
+    if (sql.includes("for update of gv")) return fixture.versions;
+    if (sql.startsWith("update geography_versions")) {
+      const row = fixture.versions.find((item) => item.id === parameters[0]);
+      row.status = parameters[1];
+      row.caveat = parameters[2];
+      row.metadata.publicDeliveryAuthorized = JSON.parse(parameters[3]);
+      row.metadata.releaseCandidate.publicDeliveryAuthorized = JSON.parse(parameters[3]);
+      row.metadata.publicActivation = JSON.parse(parameters[4]);
+      versionUpdateCount += 1;
+      return [{ id: row.id }];
+    }
+    if (sql.startsWith("update reporting_unit_geometry_crosswalks")) {
+      return Array.from({ length: 9_285 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update reporting_units")) {
+      return Array.from({ length: 9_285 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update source_documents")) {
+      return Array.from({ length: 6 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update import_runs")) {
+      return Array.from({ length: 3 }, (_, id) => ({ id }));
+    }
+    if (sql.startsWith("update public_data_revisions")) {
+      revision += 1;
+      reason = parameters[0];
+      return [{ revision }];
+    }
+    if (sql.includes("select e.year,gv.geography_type")) return fixture.versions;
+    if (sql.includes("from reporting_unit_geometry_crosswalks")) {
+      assert.doesNotMatch(sql, /'reviewed_name'/);
+      assert.match(sql, /x\.match_method='exact_official_id'/);
+      assert.match(sql, /x\.geography_feature_id is not null/);
+      assert.doesNotMatch(sql, /x\.geometry_feature_id/);
+      return [{ total: 9_285, exact: 9_285 }];
+    }
+    if (sql.includes("from reporting_units where")) {
+      return [{ total: 9_285, exact: 9_285 }];
+    }
+    if (sql.includes("from source_documents where")) {
+      return [{ total: 6, exact: 6 }];
+    }
+    if (sql.includes("from import_runs where")) {
+      return [{ total: 3, exact: 3 }];
+    }
+    if (sql.includes("from result_rows rr")) return [{ total: 24_174 }];
+    if (sql.includes("from pg_constraint")) return [{ count: 0 }];
+    if (sql.includes("from public_data_revisions")) return [{ revision, reason }];
+    throw new Error("Unexpected North Carolina publication SQL: " + sql);
+  };
+  return { unsafe, get versionUpdateCount() { return versionUpdateCount; } };
+}
+
+test("North Carolina rollback atomically blocks database delivery and preserves publish audit", async () => {
+  const fixture = rollbackTransactionFixture();
+  const client = rollbackClient(fixture);
+  const result = await applyNorthCarolinaGeographyPublicationTransaction(client, {
+    mode: "rollback",
+    plan: fixture.plan,
+    planSha256,
+    authorization: fixture.authorization,
+    authorizationSha256: "c".repeat(64),
+    publicationReceipt: fixture.publicationReceipt,
+    changedAtUtc: "2026-08-13T01:30:00.000Z",
+    gisPlan: fixture.gisPlan,
+  });
+  assert.equal(result.result, "ROLLED_BACK");
+  assert.equal(result.publicDeliveryAuthorized, false);
+  assert.equal(client.versionUpdateCount, 3);
+  for (const [index, version] of fixture.versions.entries()) {
+    assert.equal(version.status, "blocked");
+    assert.equal(version.caveat, `blocked ${[2012, 2016, 2020][index]}`);
+    assert.equal(version.metadata.publicDeliveryAuthorized, false);
+    assert.equal(version.metadata.publicActivation.activationId, "nc-local-public-camreyn");
+    assert.equal(
+      version.metadata.publicActivation.rollback.rollbackId,
+      "nc-rollback-camreyn",
+    );
+    assert.equal(
+      version.metadata.publicActivation.rollback.publicationReceiptSha256,
+      fixture.publicationReceipt.sha256,
+    );
+  }
+});
+
+test("North Carolina publication atomically records the pinned rollback target", async () => {
+  const fixture = rollbackTransactionFixture();
+  for (const [index, version] of fixture.versions.entries()) {
+    version.status = "blocked";
+    version.caveat = `blocked ${version.year}`;
+    version.metadata = {
+      manifestId: fixture.plan.manifests[index].manifestId,
+      manifestSha256: fixture.plan.manifests[index].blockedManifestSha256,
+      publicDeliveryAuthorized: false,
+      releaseCandidate: {
+        sha256: releaseCandidate.sha256,
+        publicDeliveryAuthorized: false,
+      },
+    };
+  }
+  const authorization = validateNorthCarolinaPublicationAuthorization(publicAuthorization(), {
+    plan: authorizationPlan,
+    planSha256,
+    now: Date.parse("2026-08-13T01:01:00.000Z"),
+  });
+  const client = rollbackClient(fixture);
+  const result = await applyNorthCarolinaGeographyPublicationTransaction(client, {
+    mode: "publish",
+    plan: fixture.plan,
+    planSha256,
+    authorization,
+    authorizationSha256: "b".repeat(64),
+    changedAtUtc: "2026-08-13T01:02:00.000Z",
+    gisPlan: fixture.gisPlan,
+    executionContext: {},
+    validateCurrentDatabase: async () => ({ validated: true }),
+  });
+  assert.equal(result.result, "PUBLISHED");
+  assert.equal(result.publicDeliveryAuthorized, true);
+  assert.equal(client.versionUpdateCount, 3);
+  for (const version of fixture.versions) {
+    assert.equal(version.status, "published");
+    assert.equal(version.metadata.publicDeliveryAuthorized, true);
+    assert.equal(
+      version.metadata.publicActivation.activationId,
+      authorization.activationId,
+    );
+    assert.deepEqual(
+      version.metadata.publicActivation.rollbackTarget,
+      rollbackTarget,
+    );
+    assert.equal(
+      Object.hasOwn(version.metadata.publicActivation, "rollback"),
+      false,
+    );
+  }
+});
+
+test("North Carolina rollback transaction rejects a substituted live rollback target", async () => {
+  const fixture = rollbackTransactionFixture();
+  fixture.authorization.applicationRollback.target = {
+    ...rollbackTarget,
+    deploymentId: "dpl_substituted",
+  };
+  const client = rollbackClient(fixture);
+  await assert.rejects(
+    () => applyNorthCarolinaGeographyPublicationTransaction(client, {
+      mode: "rollback",
+      plan: fixture.plan,
+      planSha256,
+      authorization: fixture.authorization,
+      authorizationSha256: "c".repeat(64),
+      publicationReceipt: fixture.publicationReceipt,
+      changedAtUtc: "2026-08-13T01:30:00.000Z",
+      gisPlan: fixture.gisPlan,
+    }),
+    /drifted from the publication receipt/,
+  );
+  assert.equal(client.versionUpdateCount, 0);
+});
+
+test("North Carolina publication runner contains database-first rollback and read-only recovery guards", () => {
+  const source = readFileSync(
+    "scripts/publish-nc-local-geography-status.mjs",
+    "utf8",
+  );
+  assert.match(source, /--rollback/);
+  assert.match(source, /--publication-receipt-sha256/);
+  assert.match(
+    source,
+    /I_ACKNOWLEDGE_DATABASE_FIRST_NORTH_CAROLINA_LOCAL_PUBLIC_ROLLBACK/,
+  );
+  assert.match(source, /sql\.begin\("read only"/);
+  assert.match(source, /publicationReceiptSha256/);
+  assert.match(source, /transactionBodyCompleted/);
+  assert.match(source, /disposition === "created"/);
+});
+
+test("North Carolina publication receipt recovery requires all three geography versions", () => {
+  const versions = [2012, 2016, 2020].map((year) => ({ year }));
+  assert.equal(assertNorthCarolinaPublicationRecoveryVersionSet(versions), versions);
+  assert.throws(
+    () => assertNorthCarolinaPublicationRecoveryVersionSet(versions.slice(0, 2)),
+    /incomplete version set/,
+  );
+});

--- a/tests/api/nc-local-release-candidate.test.mjs
+++ b/tests/api/nc-local-release-candidate.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { inspectPrecinctGeometryManifest } from "../../src/lib/precinct-geography.ts";
+import {
+  NORTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS,
+  NORTH_CAROLINA_MAX_PARENT_DELIVERY_BYTES,
+} from "../../scripts/lib/nc-local-release-candidate.mjs";
+import { buildNorthCarolinaTestReleaseFixture } from "./nc-local-release-fixture.mjs";
+
+const { built } = await buildNorthCarolinaTestReleaseFixture();
+
+test("North Carolina release candidate freezes three complete county-scoped deliveries", () => {
+  const document = built.packageDocument;
+  assert.equal(document.id, "nc-local-gis-three-election-v1");
+  assert.equal(document.decision, "NO_GO_PRODUCTION");
+  assert.deepEqual(document.totals, {
+    elections: 3,
+    countyParentsPerElection: 100,
+    reportingUnits: 9285,
+    candidateResultRows: 24174,
+    zeroVoteUnits: 0,
+    geometryFeatures: 8058,
+    reviewedRelationships: 9285,
+    deliveryIndexes: 3,
+    parentDeliveryArtifacts: 300,
+  });
+  assert.equal(built.deliveryAssets.length, 303);
+  for (const year of document.years) {
+    assert.equal(year.parentScopedDelivery.parentCount, 100);
+    assert.equal(year.parentScopedDelivery.parentArtifacts.length, 100);
+    assert.equal(year.parentScopedDelivery.coordinatePrecisionDecimals, NORTH_CAROLINA_DELIVERY_COORDINATE_DECIMALS);
+    assert.ok(year.parentScopedDelivery.largestParentByteCount <= NORTH_CAROLINA_MAX_PARENT_DELIVERY_BYTES);
+    assert.equal(year.parentScopedDelivery.electionValuesInDelivery, false);
+    assert.equal(year.canonicalManifest.validationStatus, "blocked");
+    assert.equal(year.canonicalManifest.delivery, null);
+  }
+});
+
+test("North Carolina draft manifests are eligible without changing canonical manifests", () => {
+  assert.equal(built.draftManifests.length, 3);
+  for (const draft of built.draftManifests) {
+    const value = JSON.parse(draft.bytes);
+    const inspection = inspectPrecinctGeometryManifest(value);
+    assert.deepEqual(inspection.errors, []);
+    assert.deepEqual(inspection.publicEligibilityReasons, []);
+    assert.equal(value.delivery.format, "parent_scoped_geojson");
+    assert.equal(value.delivery.parentCount, 100);
+    assert.ok(["vtd", "precinct"].includes(value.geography.level));
+    assert.equal(value.crosswalk.reviewedNoDataFeatures, 0);
+  }
+});
+
+test("North Carolina delivery preserves reviewed no-data shapes without election values", () => {
+  const parentCollections = built.deliveryAssets
+    .filter((artifact) => artifact.path.includes("/parents/"))
+    .map((artifact) => JSON.parse(artifact.bytes.toString("utf8")));
+  const noDataFeatures = parentCollections.flatMap((collection) =>
+    collection.features.filter((feature) =>
+      feature.properties.relationshipType === "no_data"));
+  assert.equal(noDataFeatures.length, 0);
+  assert.ok(noDataFeatures.every((feature) =>
+    feature.properties.resultUnitCode.startsWith("no-data:")
+    && !Object.keys(feature.properties).some((key) =>
+      /candidate|party|vote/i.test(key))));
+  assert.deepEqual(
+    built.packageDocument.years.map((year) =>
+      year.parentScopedDelivery.colorableResultUnitCount),
+    [2692, 2704, 2662],
+  );
+});

--- a/tests/api/nc-local-release-fixture.mjs
+++ b/tests/api/nc-local-release-fixture.mjs
@@ -1,0 +1,69 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { buildNorthCarolinaLocalGisPlan } from "../../scripts/lib/nc-local-gis-plan.mjs";
+import { buildNorthCarolinaLocalReleaseCandidate } from "../../scripts/lib/nc-local-release-candidate.mjs";
+import { prepareNorthCarolinaLocalReleaseCandidate } from "../../scripts/prepare-nc-local-release-candidate.mjs";
+
+export const NORTH_CAROLINA_TEST_VALIDATION_PATH =
+  `.etl/test-artifacts/NC/${process.pid}-nc-local-public-local-gis-validation.json`;
+
+async function writeSyntheticValidationReport(
+  root,
+  generatedAtUtc = "2026-08-12T23:58:58.000Z",
+) {
+  const plan = await buildNorthCarolinaLocalGisPlan({
+    root,
+    years: [2012, 2016, 2020],
+  });
+  const report = {
+    schemaVersion: 1,
+    generatedAtUtc,
+    productionMutationPerformed: false,
+    publicDeliveryAuthorized: false,
+    validation: {
+      database: {
+        environment: "local",
+        host: "loopback",
+        port: 54329,
+        name: "crm_clone_dev",
+        readOnlySession: true,
+      },
+      invalidConstraints: 0,
+      revision: 1,
+      years: plan.years.map((year) => ({
+        year: year.year,
+        reportingUnits: year.reportingUnits.length,
+        resultRows: year.resultRows.length,
+        sameYearResultRows: year.resultRows.length,
+        totalVotes: year.totals.Total,
+        zeroVoteUnits: year.zeroVoteUnits,
+        geographyVersions: 1,
+        features: year.geometry.features.length,
+        safeBlockedGeographyVersions: 1,
+        reviewedCrosswalks: year.geometry.crosswalks.length,
+        exactFeatures: year.geometry.features.length,
+        exactCrosswalks: year.geometry.crosswalks.length,
+      })),
+    },
+  };
+  const absolute = path.resolve(root, ...NORTH_CAROLINA_TEST_VALIDATION_PATH.split("/"));
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, JSON.stringify(report, null, 2) + "\n");
+}
+
+export async function buildNorthCarolinaTestReleaseFixture(options = {}) {
+  const root = path.resolve(options.root ?? process.cwd());
+  await writeSyntheticValidationReport(root, options.generatedAtUtc);
+  const built = await buildNorthCarolinaLocalReleaseCandidate({
+    root,
+    validationReportPath: NORTH_CAROLINA_TEST_VALIDATION_PATH,
+  });
+  const prepared = options.write
+    ? await prepareNorthCarolinaLocalReleaseCandidate({
+      root,
+      validationReportPath: NORTH_CAROLINA_TEST_VALIDATION_PATH,
+      write: true,
+    })
+    : null;
+  return { built, prepared };
+}

--- a/tests/api/nv-precinct-publication-gate.test.mjs
+++ b/tests/api/nv-precinct-publication-gate.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
+  guardedLocalGeographyMatchMethods,
   matchesPrecinctGeometryPublicationMetadata,
   precinctGeometryPublicManifestSha256,
   requiresPrecinctGeometryPublicationGate,
@@ -104,10 +105,11 @@ test("Nevada precinct results and geometry use the guarded publication path", ()
 
 test("Nevada exact reviewed rows are accepted only inside the full public gate", () => {
   const source = readFileSync("src/lib/data-access.ts", "utf8");
-  assert.equal(
-    (source.match(/'official_crosswalk'/g) ?? []).length,
-    3,
-  );
+  assert.deepEqual(guardedLocalGeographyMatchMethods("NV"), [
+    "exact_official_id",
+    "official_crosswalk",
+  ]);
+  assert.match(source, /reviewedMatchMethods/);
   assert.equal(
     (source.match(/gate_version\.status = 'published'/g) ?? []).length,
     2,

--- a/tests/api/tx-precinct-publication-gate.test.mjs
+++ b/tests/api/tx-precinct-publication-gate.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
+  guardedLocalGeographyMatchMethods,
   matchesPrecinctGeometryPublicationMetadata,
   precinctGeometryPublicManifestSha256,
   requiresPrecinctGeometryPublicationGate,
@@ -104,10 +105,11 @@ test("Texas precinct results and geometry use the guarded publication path", () 
 
 test("Texas official_crosswalk rows are accepted only inside the full public gate", () => {
   const source = readFileSync("src/lib/data-access.ts", "utf8");
-  assert.equal(
-    (source.match(/'official_crosswalk'/g) ?? []).length,
-    3,
-  );
+  assert.deepEqual(guardedLocalGeographyMatchMethods("TX"), [
+    "exact_official_id",
+    "official_crosswalk",
+  ]);
+  assert.match(source, /reviewedMatchMethods/);
   assert.equal(
     (source.match(/gate_version\.status = 'published'/g) ?? []).length,
     2,


### PR DESCRIPTION
## Scope

Adds the guarded North Carolina local-geography release path for reviewed 2012, 2016, and 2020 presidential maps. It preserves 2012 as `vtd`, preserves 2016/2020 as `precinct`, and keeps 2024 excluded until the three restored 2019 polygons have election-date applicability evidence.

## What changed

- Added North Carolina local database planning, guarded loading, read-only validation, content-addressed release candidates, production preflight/backup contracts, hidden-load receipt recovery, immutable Blob delivery, static activation, atomic publication, rollback, and read-only publication-receipt recovery.
- Added year-aware geography selection to the shared map/API gate so NC 2012 uses VTD county parents without changing existing IA/ME/MN/NV/SC/TX/WI/AK contracts.
- Added a North Carolina release runbook and implementation ledger entry.
- Added focused release, publication, recovery, and API-gate coverage; updated stale NV/TX tests to assert the centralized match-method contract.

## Reviewed release universe

- 2012: 3,011 result units, 8,076 candidate rows, 2,692 features.
- 2016: 3,209 result units, 8,112 candidate rows, 2,704 features.
- 2020: 3,065 result units, 7,986 candidate rows, 2,662 features.
- Total: 9,285 units, 24,174 candidate rows, 8,058 features/linked geographic units.
- Delivery plan: 300 county objects plus three indexes.
- Displayed votes remain sourced only from retained official NCSBE artifacts; non-geographic rows are retained without invented polygons or allocation.

## Validation

- `npm.cmd run test:precinct-geometry:nc` — 35/35 passed, including byte-identical four-year source replay.
- Cross-state publication gate/map suite — 30/30 passed.
- `npm.cmd test` — passed; 183 Python tests passed with one documented skip.
- `npm.cmd run typecheck` — passed.
- `npm.cmd run build` — passed.
- `npm.cmd run test:e2e:api` — 2/2 passed.
- `npm.cmd run etl:validate:nc` and `etl:import:nc` — passed.
- Source-package, map, and provenance validators — passed with only existing documented warnings.
- Loopback Docker load/validation — exact three-year counts, zero invalid constraints, all versions blocked/public-delivery false.
- Advisory audit: 2,658 review rows, 206 indicator rows across 86 counties/areas (81 vote-share pattern, 86 average down-ballot difference, 39 down-ballot outlier). These are advisory review signals, not evidence of fraud or misconduct.

## Display/API path

The map requests `level=vtd` for NC 2012 and `level=precinct` for 2016/2020, with five-digit county parent GEOIDs. Both public endpoints remain fail-closed until the separately reviewed static activation and final database publication agree.

## Caveats and remaining work

- 2024 is deliberately not released.
- This PR performs no production DB write, Blob upload, manifest activation, Vercel change, deployment, or public cutover.
- The ignored local candidate SHA `6362c56c1834ba5c81ec395b1643fbaec6689d2163a15bf7e8be3a89195cfdcc` is rehearsal evidence only; reseal from the merged commit before production evidence.
- Each election has its own boundary vintage. Cross-election apples-to-apples analysis still requires a separately reviewed common-geography crosswalk.

## Review

Coordinator staged-diff review, stale-state/count scan, complete local rehearsal, and cross-state regression review found no remaining blocker. No delegated review agent was used for this change.