### PR TITLE
Document Florida precinct production verification

### DIFF
--- a/docs/developer/fl-precinct-gis-runbook.md
+++ b/docs/developer/fl-precinct-gis-runbook.md
@@ -234,8 +234,9 @@ all unmatched-unit reconciliation evidence, and increments the public revision o
 
 For every year and several counties, verify:
 
-- `/api/geography-manifests?state=FL&year=<year>&level=precinct` returns exactly
-  one eligible manifest;
+- `/api/geography-manifests?state=FL&electionDate=<YYYY-MM-DD>&level=precinct`
+  returns exactly one eligible manifest. The route also accepts its canonical
+  `electionId`; it does not implement a `year` filter;
 - `/api/precinct-geography?manifestId=<id>&parentGeoid=<county GEOID>` returns
   the expected county-scoped GeoJSON;
 - `/api/results?state=FL&year=<year>&level=precinct&office=president&parentGeoid=<county GEOID>`
@@ -249,6 +250,40 @@ For every year and several counties, verify:
 Run the production API smoke against the exact deployed Git SHA with
 `--expect-source=database`. Preserve the publication receipt and verification
 evidence.
+
+## Completed 2026-08-16 production checkpoint
+
+- Human-merged commit: `89d4030402e1c4bbe16e8104978715cdd333fe51`;
+  reviewed tree: `6234e3d568bb5dbfbe5e89db75de80e65df18e42`.
+- READY/PROMOTED production deployment:
+  `dpl_4FPtsSkeF7pzM2BNbRThoZFU2kNC`.
+- Gate-capable rollback deployment:
+  `dpl_EArfLj4sHW4HNWD5LyP7Q5JCVUgW` at commit
+  `11f8497795819f90033e2005242c093b0f196ef9`.
+- Publication activation:
+  `fl-precinct-public-20260816T225352Z-57c2b8fb8873`; public revision `25`.
+- Publication plan SHA-256:
+  `57c2b8fb88730adfc25e5d2a93f6d8359d227544f4e84055e31466a1c3444993`.
+- Publication receipt SHA-256:
+  `1e79f8e2058472b37d65842d2888065de52e344679b9365e22f9da887e2ca2ae`.
+- Exhaustive API verification SHA-256:
+  `80bcce2c3b8291178e2f830fac99b6677dc4145a7c23874e8768d1338bb045ab`.
+- Independent read-only database verification SHA-256:
+  `64e722f1312fdd83c07e788c383d1b0103589c3d080a81f99b3d2eeb655a000a`.
+- Browser verification SHA-256:
+  `bddca4b0d1fc6c9c36857e70bee7f3ec832fd3c17c261fb78da6be315961f487`.
+- Combined production verification SHA-256:
+  `01fb7e0edc7096249ba794e1d14900e1e54ea4b43e00e9e79cef04dbacb8886f`.
+
+The live checks covered all 201 county/year parent scopes. They confirmed
+17,424 result units, 17,555 features, 131 explicit reviewed no-data features,
+140 mapped zero-vote units, 31,494,532 displayed official votes, and zero
+invalid public constraints. Browser checks confirmed the three published maps,
+OpenStreetMap attribution, source/vintage labels, interactive selection, and
+year-pinned Exports & API examples. Florida 2012 remained unavailable. An
+invalid non-Florida parent GEOID exposed no data but currently produces a
+fail-closed HTTP 500 from the geometry endpoint; early state-prefix rejection
+is a non-blocking API-hardening follow-up.
 
 ## Rollback
 

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -7992,3 +7992,72 @@ evidence against its verified top-level package.
   Blob object, Vercel setting, deployment, or Git ref is changed by this
   tooling phase. The deployment and final database publication remain
   separately reviewed operations so both public endpoints stay fail-closed.
+
+### 2026-08-16 - Florida three-election production publication
+
+- Human-merged activation PR #280 produced commit
+  `89d4030402e1c4bbe16e8104978715cdd333fe51` and tree
+  `6234e3d568bb5dbfbe5e89db75de80e65df18e42`, exactly matching the reviewed
+  activation tree. Vercel deployment `dpl_4FPtsSkeF7pzM2BNbRThoZFU2kNC` is
+  `READY` and `PROMOTED` at that commit, and both live aliases expose the same
+  Git SHA. Preview and Production use the exact immutable Blob origin recorded
+  in the release evidence. The prior gate-capable deployment is pinned as
+  rollback target `dpl_EArfLj4sHW4HNWD5LyP7Q5JCVUgW` at commit
+  `11f8497795819f90033e2005242c093b0f196ef9`.
+- Before cutover, the merged production deployment remained fail-closed: all
+  three local-result checks returned no rows and all three geometry checks
+  returned not-active responses while the database versions were blocked.
+  The static registry contained exactly one eligible manifest for each of
+  2016, 2020, and 2024 and none for 2012. Registry verification uses the
+  route's implemented `electionId` or `electionDate` filter; `year` is not a
+  supported filter for this endpoint.
+- The immutable delivery evidence at SHA-256
+  `3648fc2ab7a2fc9c73d26676281a32b81b4c660409df0a215ee58ea52b470d71`
+  covers all 201 county files and three indexes. Every object was downloaded
+  again and byte-hash verified before authorization. The publication plan is
+  pinned at SHA-256
+  `57c2b8fb88730adfc25e5d2a93f6d8359d227544f4e84055e31466a1c3444993`.
+- Under activation
+  `fl-precinct-public-20260816T225352Z-57c2b8fb8873`, the guarded atomic
+  transaction published exactly the three reviewed geography versions,
+  authorized 17,424 reporting units and one-to-one crosswalks, retained all
+  unmatched source reconciliation evidence, and advanced the public revision
+  once from 24 to 25. The publication receipt is pinned at SHA-256
+  `1e79f8e2058472b37d65842d2888065de52e344679b9365e22f9da887e2ca2ae`;
+  it records 52,272 candidate result rows, six source documents, three import
+  runs, and zero invalid public constraints.
+- Exhaustive live verification covered all 201 election/county parent scopes
+  with 410 requests and 99,245,581 response bytes. The APIs served 17,424
+  result units and 17,555 features, including 131 reviewed no-data features
+  and 140 mapped zero-vote units, with 31,494,532 displayed official votes.
+  Every result ID joined one-for-one to a colorable feature, and every county
+  payload matched the sealed source/index SHA metadata. The exact API report
+  SHA-256 is
+  `80bcce2c3b8291178e2f830fac99b6677dc4145a7c23874e8768d1338bb045ab`.
+- A separate read-only production transaction independently confirmed public
+  revision 25, the activation metadata, all per-year row and feature counts,
+  all public-delivery flags, three published versions, and zero invalid
+  constraints. Its report SHA-256 is
+  `64e722f1312fdd83c07e788c383d1b0103589c3d080a81f99b3d2eeb655a000a`.
+  The repository public-API smoke also passed 22 checks while requiring the
+  exact merged Git SHA and database source.
+- Browser verification confirmed that the 2016, 2020, and 2024 Alachua County
+  maps render election-specific precinct polygons over OpenStreetMap with the
+  reviewed-geometry label, VEST/NYT vintage and source attribution, winner
+  colors, joined vote totals, and working year, county, and precinct controls.
+  The selected year remained pinned in Exports & API. Florida 2012 rendered no
+  precinct map and retained the intended unavailable-layer explanation. The
+  browser report SHA-256 is
+  `bddca4b0d1fc6c9c36857e70bee7f3ec832fd3c17c261fb78da6be315961f487`.
+- A deliberately invalid non-Florida parent GEOID returned zero result rows
+  and no geometry data. The geometry endpoint currently returns HTTP 500
+  rather than rejecting that state-prefix mismatch before immutable-delivery
+  validation; this is a non-blocking input-validation hardening item because
+  the request remained fail-closed. The combined production evidence is
+  pinned at SHA-256
+  `01fb7e0edc7096249ba794e1d14900e1e54ea4b43e00e9e79cef04dbacb8886f`.
+- Florida 2012 remains blocked under issue #277. The published elections retain
+  separate boundary vintages and are not an apples-to-apples precinct trend
+  geography without a future reviewed common-geography crosswalk. The 2024
+  advisory indicator inventory remains 83 broad screening rows across 59
+  counties; those signals are not evidence of fraud or misconduct.


### PR DESCRIPTION
## Scope

Records completion of the guarded Florida 2016/2020/2024 precinct release after the human merge of activation PR #280. This is documentation-only: it updates the implementation ledger and Florida release runbook; it does not change application code, canonical manifests, data, Blob objects, Vercel configuration, or production state.

## What changed

- Records the exact merged commit/tree, READY/PROMOTED production deployment, pinned gate-capable rollback deployment, Blob origin, publication activation, revision 25 receipt, and immutable evidence hashes.
- Records exhaustive live API, independent read-only database, public-API smoke, and browser verification results.
- Corrects the geography-manifest example to use the implemented `electionDate` / `electionId` filters; the route does not implement a `year` filter.
- Preserves the Florida 2012 block and election-specific boundary-vintage caveats.
- Records one non-blocking hardening follow-up: an out-of-state parent GEOID exposes no data but the geometry endpoint currently returns fail-closed HTTP 500 instead of rejecting the prefix mismatch early.

## Sources confirmed

Displayed votes remain solely from Florida Department of State precinct exports. Existing VEST 2016/2020 and New York Times 2024 geometry attribution and license caveats remain unchanged; no secondary vote values were introduced.

## Files changed

- `docs/developer/fl-precinct-gis-runbook.md`
- `docs/developer/precinct-gis-implementation.md`

## Validation

- Florida activation/publication phase tests: 13/13 passed.
- `npm.cmd run validate:maps`: passed; only the repository's existing equipment-geometry count warnings remain.
- `npm.cmd run validate:provenance`: passed with no failures.
- `npm.cmd run smoke:public-api -- --base-url=https://civicresultmaps.org --expect-git-sha=89d4030402e1c4bbe16e8104978715cdd333fe51 --expect-source=database --attempts=1 --delay-ms=0`: 22 checks passed.
- Exhaustive Florida live API verification: 201 parent scopes / 410 requests, all joins and immutable hashes passed.
- Independent production DB verification used a read-only transaction and matched revision 25, exact counts, publication metadata, and zero invalid constraints.
- Live browser verification confirmed the 2016/2020/2024 maps, OpenStreetMap attribution, source/vintage labels, winner colors, selected-unit totals, interactive year/county/precinct controls, and year-pinned Exports & API examples. Florida 2012 remained unavailable.

## Review

Coordinator inspected the complete diff and the cross-layer evidence. No review subagent was used because delegation is disabled for this task.