### PR TITLE
Reject cross-state local geography parents

### DIFF
--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -8075,10 +8075,10 @@ evidence against its verified top-level package.
   that contract before their data reads, so the same invalid Florida/Georgia
   combination is rejected as HTTP 400 after deployment. Alaska's reviewed
   `HD01` through `HD40` House District parent contract remains unchanged.
-- Focused regressions cover Florida API validation and immutable-delivery
-  construction with an out-of-state county parent. This code change does not
-  alter election results, geometry, crosswalks, publication metadata, Blob
-  assets, database rows, public revision, or the Florida 2012 blocker.
+- Focused regressions cover both Florida API routes and Florida immutable-
+  delivery construction with an out-of-state county parent. This code change
+  does not alter election results, geometry, crosswalks, publication metadata,
+  Blob assets, database rows, public revision, or the Florida 2012 blocker.
 - The Florida package suite's two pre-activation assertions now require the
   canonical registry and coverage inventories to expose exactly the reviewed
   2016, 2020, and 2024 manifests while continuing to require zero public

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -8061,3 +8061,25 @@ evidence against its verified top-level package.
   geography without a future reviewed common-geography crosswalk. The 2024
   advisory indicator inventory remains 83 broad screening rows across 59
   counties; those signals are not evidence of fraud or misconduct.
+
+### 2026-08-16 - Local parent GEOID state-prefix hardening
+
+- A post-publication Florida negative check reproduced one input-validation
+  gap on production commit `47c0576a7105d89179f49d8db970fae5d3dd6070`:
+  `state=FL&parentGeoid=13001` returned an empty HTTP 200 result response and
+  an HTTP 500 geometry validation response. Both paths remained fail-closed,
+  but neither rejected the cross-state county identifier at the API boundary.
+- The shared local-geography parent contract now requires every five-digit
+  county GEOID to begin with the two-digit Census state FIPS code for the
+  requested state. Both result and immutable-geometry routes already apply
+  that contract before their data reads, so the same invalid Florida/Georgia
+  combination is rejected as HTTP 400 after deployment. Alaska's reviewed
+  `HD01` through `HD40` House District parent contract remains unchanged.
+- Focused regressions cover Florida API validation and immutable-delivery
+  construction with an out-of-state county parent. This code change does not
+  alter election results, geometry, crosswalks, publication metadata, Blob
+  assets, database rows, public revision, or the Florida 2012 blocker.
+- The Florida package suite's two pre-activation assertions now require the
+  canonical registry and coverage inventories to expose exactly the reviewed
+  2016, 2020, and 2024 manifests while continuing to require zero public
+  eligibility for the blocked 2012 package.

--- a/src/lib/local-geography-parent.ts
+++ b/src/lib/local-geography-parent.ts
@@ -7,6 +7,80 @@ export type LocalGeographyParentScope = {
 const countyGeoidPattern = /^\d{5}$/;
 const alaskaHouseDistrictPattern = /^HD(?:0[1-9]|[1-3][0-9]|40)$/;
 
+const stateFipsByPostal: Readonly<Record<string, string>> = Object.freeze({
+  AL: "01",
+  AK: "02",
+  AZ: "04",
+  AR: "05",
+  CA: "06",
+  CO: "08",
+  CT: "09",
+  DE: "10",
+  DC: "11",
+  FL: "12",
+  GA: "13",
+  HI: "15",
+  ID: "16",
+  IL: "17",
+  IN: "18",
+  IA: "19",
+  KS: "20",
+  KY: "21",
+  LA: "22",
+  ME: "23",
+  MD: "24",
+  MA: "25",
+  MI: "26",
+  MN: "27",
+  MS: "28",
+  MO: "29",
+  MT: "30",
+  NE: "31",
+  NV: "32",
+  NH: "33",
+  NJ: "34",
+  NM: "35",
+  NY: "36",
+  NC: "37",
+  ND: "38",
+  OH: "39",
+  OK: "40",
+  OR: "41",
+  PA: "42",
+  RI: "44",
+  SC: "45",
+  SD: "46",
+  TN: "47",
+  TX: "48",
+  UT: "49",
+  VT: "50",
+  VA: "51",
+  WA: "53",
+  WV: "54",
+  WI: "55",
+  WY: "56",
+});
+
+function countyGeoidMatchesState(state: string, parentGeoid: string) {
+  const normalizedState = state.trim().toUpperCase();
+  const normalizedParent = parentGeoid.trim();
+  const stateFips = stateFipsByPostal[normalizedState];
+  return Boolean(
+    stateFips
+    && countyGeoidPattern.test(normalizedParent)
+    && normalizedParent.startsWith(stateFips)
+  );
+}
+
+function countyParentValidationMessage(state: string) {
+  const normalizedState = state.trim().toUpperCase();
+  const stateFips = stateFipsByPostal[normalizedState];
+  return stateFips
+    ? "parentGeoid must be a five-digit county GEOID beginning with "
+      + stateFips + " for " + normalizedState
+    : "parentGeoid must be a five-digit county GEOID for a supported state";
+}
+
 export const ALASKA_HOUSE_DISTRICT_PARENT_IDS = Object.freeze(
   Array.from({ length: 40 }, (_, index) => (
     `HD${String(index + 1).padStart(2, "0")}`
@@ -56,7 +130,7 @@ export function isValidLocalGeographyParentId(input: {
   const parentGeoid = input.parentGeoid.trim();
   return scope.level === "house_district"
     ? alaskaHouseDistrictPattern.test(parentGeoid)
-    : countyGeoidPattern.test(parentGeoid);
+    : countyGeoidMatchesState(input.state, parentGeoid);
 }
 
 export function isValidLocalGeographyDeliveryParentId(
@@ -67,13 +141,13 @@ export function isValidLocalGeographyDeliveryParentId(
   const normalizedParent = parentGeoid.trim();
   return normalizedState === "AK"
     ? alaskaHouseDistrictPattern.test(normalizedParent)
-    : countyGeoidPattern.test(normalizedParent);
+    : countyGeoidMatchesState(normalizedState, normalizedParent);
 }
 
 export function localGeographyDeliveryParentValidationMessage(state: string) {
   return state.trim().toUpperCase() === "AK"
     ? "parentGeoid must be an Alaska House District ID from HD01 through HD40"
-    : "parentGeoid must be a five-digit county GEOID";
+    : countyParentValidationMessage(state);
 }
 
 export function localGeographyParentValidationMessage(input: {
@@ -85,7 +159,7 @@ export function localGeographyParentValidationMessage(input: {
     return "parentGeoid must be an Alaska House District ID from HD01 through HD40";
   }
   if (scope?.level === "county") {
-    return "parentGeoid must be a five-digit county GEOID";
+    return countyParentValidationMessage(input.state);
   }
   return "parentGeoid is supported only for parent-scoped local results";
 }

--- a/tests/api/ak-local-geography-parent.test.mjs
+++ b/tests/api/ak-local-geography-parent.test.mjs
@@ -82,3 +82,18 @@ test("county parent contracts require each state's canonical FIPS prefix", () =>
     }), false, `${state.code} should reject another state's FIPS prefix`);
   }
 });
+
+test("Alaska county-parent local levels keep the Alaska FIPS prefix", () => {
+  for (const geographyLevel of ["vtd", "local_reporting_unit"]) {
+    assert.equal(isValidLocalGeographyParentId({
+      state: "AK",
+      geographyLevel,
+      parentGeoid: "02020",
+    }), true);
+    assert.equal(isValidLocalGeographyParentId({
+      state: "AK",
+      geographyLevel,
+      parentGeoid: "19001",
+    }), false);
+  }
+});

--- a/tests/api/ak-local-geography-parent.test.mjs
+++ b/tests/api/ak-local-geography-parent.test.mjs
@@ -11,6 +11,7 @@ import {
   guardedLocalGeographyLevel,
   requiresPrecinctResultPublicationGate,
 } from "../../src/lib/precinct-result-publication.ts";
+import { states } from "../../scripts/state-metadata.mjs";
 
 test("Alaska uses forty House District parent IDs and a guarded precinct release", () => {
   assert.equal(ALASKA_HOUSE_DISTRICT_PARENT_IDS.length, 40);
@@ -64,4 +65,20 @@ test("Alaska and county-scoped parent contracts remain mutually exclusive", () =
     geographyLevel: "local_reporting_unit",
     parentGeoid: "23001",
   }), true);
+});
+
+test("county parent contracts require each state's canonical FIPS prefix", () => {
+  for (const state of states) {
+    if (state.code === "AK") continue;
+    assert.equal(isValidLocalGeographyParentId({
+      state: state.code,
+      geographyLevel: "precinct",
+      parentGeoid: state.fips + "001",
+    }), true, `${state.code} should accept its own state FIPS prefix`);
+    assert.equal(isValidLocalGeographyParentId({
+      state: state.code,
+      geographyLevel: "precinct",
+      parentGeoid: (state.fips === "01" ? "02" : "01") + "001",
+    }), false, `${state.code} should reject another state's FIPS prefix`);
+  }
 });

--- a/tests/api/fl-precinct-geometry.test.mjs
+++ b/tests/api/fl-precinct-geometry.test.mjs
@@ -99,9 +99,18 @@ test("Florida four-year source packages replay byte-identically and reject raw t
   }
 });
 
-test("Florida packages preserve the official result universe while keeping 2012 fail closed", () => {
+test("Florida packages preserve the official result universe while only reviewed years are active", () => {
   const registry = JSON.parse(readFileSync("data/precinct-geometry-manifests.json", "utf8"));
-  assert.deepEqual(registry.manifests.filter((manifest) => manifest.state === "FL"), []);
+  assert.deepEqual(
+    registry.manifests
+      .filter((manifest) => manifest.state === "FL")
+      .map((manifest) => manifest.id),
+    YEARS.filter((spec) => spec.safe).map((spec) => spec.manifestId),
+  );
+  assert.equal(
+    registry.manifests.some((manifest) => manifest.id === YEARS[0].manifestId),
+    false,
+  );
   for (const spec of YEARS) {
     const { manifest, evidence, report, results, geometry, crosswalk } = parse(process.cwd(), spec);
     assert.equal(manifest.id, spec.manifestId);
@@ -144,7 +153,7 @@ test("Florida packages preserve the official result universe while keeping 2012 
   }
 });
 
-test("Florida coverage inventories expose reviewed candidates without public eligibility", () => {
+test("Florida coverage inventories expose only reviewed years as publicly eligible", () => {
   const inventories = new Map([
     [2012, "data/precinct-geometry-coverage-inventory-2012.json"],
     [2016, "data/precinct-geometry-coverage-inventory-2016.json"],
@@ -160,7 +169,7 @@ test("Florida coverage inventories expose reviewed candidates without public eli
     assert.equal(row.disposition, spec.safe ? "mapped" : "blocked");
     assert.deepEqual(row.geometry.manifestIds, [spec.manifestId]);
     assert.equal(row.geometry.featureCount, spec.features);
-    assert.equal(row.geometry.publicEligibleManifestCount, 0);
+    assert.equal(row.geometry.publicEligibleManifestCount, spec.safe ? 1 : 0);
     assert.equal(row.crosswalk.resultUnits, spec.safe ? spec.mapped : spec.sourceUnits);
     assert.equal(row.crosswalk.matchedResultUnits, spec.mapped);
   }

--- a/tests/api/fl-precinct-gis-local.test.mjs
+++ b/tests/api/fl-precinct-gis-local.test.mjs
@@ -9,6 +9,10 @@ import {
   requiresPrecinctGeometryPublicationGate,
   requiresPrecinctResultPublicationGate,
 } from "../../src/lib/precinct-result-publication.ts";
+import {
+  isValidLocalGeographyParentId,
+  localGeographyParentValidationMessage,
+} from "../../src/lib/local-geography-parent.ts";
 
 test("Florida precinct GIS commands remain loopback-only and public-fail-closed", () => {
   const setup = readFileSync("scripts/setup-fl-precinct-gis-local.mjs", "utf8");
@@ -36,6 +40,23 @@ test("Florida results and geometry require exact publication evidence", () => {
     state: "FL",
     geography: { level: "precinct" },
   }), true);
+});
+
+test("Florida county parents require the Florida state FIPS prefix", () => {
+  assert.equal(isValidLocalGeographyParentId({
+    state: "FL",
+    geographyLevel: "precinct",
+    parentGeoid: "12001",
+  }), true);
+  assert.equal(isValidLocalGeographyParentId({
+    state: "FL",
+    geographyLevel: "precinct",
+    parentGeoid: "13001",
+  }), false);
+  assert.match(localGeographyParentValidationMessage({
+    state: "FL",
+    geographyLevel: "precinct",
+  }), /beginning with 12 for FL/);
 });
 
 test("Florida release precondition rejects duplicate or boundary-drifted versions", () => {

--- a/tests/api/precinct-parent-delivery-builder.test.mjs
+++ b/tests/api/precinct-parent-delivery-builder.test.mjs
@@ -159,4 +159,18 @@ test("parent-scoped builder supports Alaska House District parents without weake
     () => buildParentScopedPrecinctDeliveryPackage(iowaForeignCountyParent),
     /beginning with 19 for IA/,
   );
+
+  const floridaForeignCountyParent = statewideCollection();
+  floridaForeignCountyParent.metadata = {
+    ...floridaForeignCountyParent.metadata,
+    manifestId: "fl-2024-11-05-reviewed-precinct-geometry-v1",
+    state: "FL",
+  };
+  floridaForeignCountyParent.features = [feature("P1", "13001")];
+  assert.throws(
+    () => buildParentScopedPrecinctDeliveryPackage(
+      floridaForeignCountyParent,
+    ),
+    /beginning with 12 for FL/,
+  );
 });

--- a/tests/api/precinct-parent-delivery-builder.test.mjs
+++ b/tests/api/precinct-parent-delivery-builder.test.mjs
@@ -152,4 +152,11 @@ test("parent-scoped builder supports Alaska House District parents without weake
     () => buildParentScopedPrecinctDeliveryPackage(iowaHouseDistrictParent),
     /five-digit county GEOID/,
   );
+
+  const iowaForeignCountyParent = statewideCollection();
+  iowaForeignCountyParent.features[0].properties.parentGeoid = "12001";
+  assert.throws(
+    () => buildParentScopedPrecinctDeliveryPackage(iowaForeignCountyParent),
+    /beginning with 19 for IA/,
+  );
 });

--- a/tests/e2e/public-api.spec.ts
+++ b/tests/e2e/public-api.spec.ts
@@ -27,3 +27,29 @@ test("public API verification rejects a production fallback or stale deployment"
     }),
   ).rejects.toThrow(/deployment that triggered this smoke test/);
 });
+
+test("local geography routes reject a cross-state county parent at the API boundary", async ({
+  request,
+}) => {
+  const expectedError =
+    "parentGeoid must be a five-digit county GEOID beginning with 12 for FL";
+  const responses = await Promise.all([
+    request.get(
+      "/api/results?state=FL&year=2024&level=precinct"
+      + "&office=president&parentGeoid=13001",
+    ),
+    request.get(
+      "/api/precinct-geography"
+      + "?manifestId=fl-2024-11-05-reviewed-precinct-geometry-v1"
+      + "&parentGeoid=13001",
+    ),
+  ]);
+
+  for (const response of responses) {
+    expect(response.status()).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      data: null,
+      error: expectedError,
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- require five-digit county GEOIDs to begin with the requested state's Census FIPS prefix
- apply the shared contract to local-result validation and immutable parent-scoped delivery construction
- preserve Alaska's reviewed `HD01` through `HD40` precinct-parent contract and verify Alaska county-parent local levels still use the `02` prefix
- realign the Florida package suite with the merged 2016/2020/2024 activation while keeping 2012 absent and ineligible
- add direct HTTP 400 regressions for both public API routes

## Root cause and impact

The shared parent validator checked only five-digit county-GEOID syntax. On production commit `47c0576a7105d89179f49d8db970fae5d3dd6070`, a Florida request with Georgia GEOID `13001` therefore reached downstream handling: results returned an empty HTTP 200 response and geometry failed closed with HTTP 500.

The built application and final commit-pinned Vercel preview now reject that request from both routes with HTTP 400 before any database or Blob read:

`parentGeoid must be a five-digit county GEOID beginning with 12 for FL`

This changes no election result, geometry, crosswalk, publication metadata, Blob object, database row, public revision, or Florida 2012 blocker.

## Validation

- Florida precinct-geometry suite: 35/35 passed, including four-year byte-identical replay
- initial shared local-parent focused tests: 23/23 passed
- review-fix focused tests: 7/7 passed
- Playwright public API integration: 3/3 passed, including direct HTTP 400 assertions for both routes
- full `npm test`: passed; Python ETL phase ran 183 tests with one existing skip
- `npm run typecheck`: passed
- `node tests/api/api-contract.test.mjs`: passed
- `npm run build`: passed
- `npm run validate:maps`: passed
- `npm run validate:provenance`: passed
- `npm run validate:source-packages`: passed with existing informational legacy-reference warnings
- `npm run validate:turnout-packages`: passed
- built loopback API proof: both invalid-parent routes returned HTTP 400 with the expected state-prefix error
- final preview `dpl_ETs96zh8f7SZNT2t8N6cZNu3Nakc` at head `cacfee0ba60f6216927db10082cba56af305f002`: both invalid-parent routes returned HTTP 400; valid 2024 Alachua delivery remained 1 manifest / 63 result units / 63 features; 2012 remained at zero manifests and results
- `git diff --check`: passed

## Independent review

A bounded review verified that the 51-jurisdiction FIPS table matches the canonical repository metadata and found the implementation correct. It requested route-level status coverage, Alaska VTD/local-reporting-unit coverage, and a Florida-specific delivery-builder case. A closure review confirmed all three are resolved and reported no open findings.

No production mutation was performed.