### PR TITLE
Record Florida precinct production verification

### DIFF
--- a/data/native-import-source-packages.json
+++ b/data/native-import-source-packages.json
@@ -1901,7 +1901,7 @@
         "Certified Florida county map totals remain anchored to the official county detail table, not the precinct ZIP.",
         "The official precinct ZIP presidential candidate total is 204 votes below the county detail table and the ZIP Trump total is one vote higher.",
         "The precinct ZIP registered-voter field is a denominator lead only because no compatible state-native ballots-cast rows are loaded.",
-        "Reviewed precinct geometry and official-result relationships are retained for 2016, 2020, and 2024 but remain outside production until immutable delivery and guarded activation are complete.",
+        "Reviewed precinct geometry and official-result relationships for 2016, 2020, and 2024 are publicly delivered at production revision 25 through the guarded, hash-pinned release; 2012 remains outside production.",
         "No complete election-effective statewide 2012 precinct boundary edition is retained, so 2012 remains fail-closed and no result is assigned to Census VTD geometry.",
         "The 2016/2020 VEST and 2024 New York Times geometry sources are secondary presentation geometry with explicit attribution and terms; Florida Department of State exports remain the sole displayed vote source.",
         "Historical baselines are secondary county context rows and not 2024 certified data."

--- a/data/source-acquisition-tiers.json
+++ b/data/source-acquisition-tiers.json
@@ -581,11 +581,11 @@
         "official 2012/2016/2020 historical baseline replacement rows",
         "normalized audit, recount, CVR availability, incident, correction, litigation, custody, and tabulator-log rows"
       ],
-      "parserStatus": "nativeFloridaDetailHtml keeps certified county map totals from the official county detail table; floridaPrecinctZipPresidentSenate loads 5,618 same-grain President-versus-U.S. Senate precinct/location review rows; scripts/collect-fl-precinct-geometry.mjs deterministically retains official four-year presidential result universes and reviewed 2016/2020/2024 geometry relationships while keeping 2012 blocked; EAC fallback turnout remains active",
+      "parserStatus": "nativeFloridaDetailHtml keeps certified county map totals from the official county detail table; floridaPrecinctZipPresidentSenate loads 5,618 same-grain President-versus-U.S. Senate precinct/location review rows; scripts/collect-fl-precinct-geometry.mjs deterministically retains official four-year presidential result universes and the reviewed 2016/2020/2024 geometry relationships published at production revision 25 while keeping 2012 blocked; EAC fallback turnout remains active",
       "manualReviewBurden": "low",
       "confidence": "loaded_with_caveat",
       "caveats": "The official precinct ZIP is valid for same-grain review rows and registration-denominator leads, but not for replacing certified county map totals: its presidential candidate total is 204 votes below the official county detail table and its Trump total is one vote higher. The ZIP does not provide compatible ballots-cast rows, so turnout remains EAC fallback. The 2016 and 2020 presentation geometry is attributed VEST data under retained CC BY 4.0 evidence; the 2024 presentation geometry is attributed New York Times data under retained C-UDA non-commercial terms. Every displayed vote value comes only from official Florida exports, and excluded units are never allocated.",
-      "nextAction": "Complete immutable delivery and the guarded release for 2016, 2020, and 2024; continue public archive discovery or a records request for election-effective 2012 geometry; collect compatible state-native turnout, official county historical baseline replacements, and normalized administration-context records."
+      "nextAction": "Maintain the reviewed public delivery and hash-pinned release evidence for 2016, 2020, and 2024; continue public archive discovery or a records request for election-effective 2012 geometry; collect compatible state-native turnout, official county historical baseline replacements, and normalized administration-context records."
     },
     {
       "state": "GA",

--- a/docs/developer/fl-precinct-gis-runbook.md
+++ b/docs/developer/fl-precinct-gis-runbook.md
@@ -280,10 +280,21 @@ The live checks covered all 201 county/year parent scopes. They confirmed
 140 mapped zero-vote units, 31,494,532 displayed official votes, and zero
 invalid public constraints. Browser checks confirmed the three published maps,
 OpenStreetMap attribution, source/vintage labels, interactive selection, and
-year-pinned Exports & API examples. Florida 2012 remained unavailable. An
-invalid non-Florida parent GEOID exposed no data but currently produces a
-fail-closed HTTP 500 from the geometry endpoint; early state-prefix rejection
-is a non-blocking API-hardening follow-up.
+year-pinned Exports & API examples. Florida 2012 remained unavailable.
+
+The parent-validation hardening was subsequently human-merged as commit
+`6aad834fa31306c3117f2bf974b81544b8a2859a` (tree
+`e989a76490d2c8046f3eae03002c370621008d88`) and promoted as production
+deployment `dpl_GhN6DNUBedB67u4ruNTiocquQuUo`. Live checks against the exact
+deployment SHA confirmed that a Florida request using Georgia county GEOID
+`13001` now returns HTTP 400 from both the results and geometry endpoints with
+the Florida-prefix validation message. Valid Alachua County `12001` checks
+still returned one manifest, 63 result units, and 63 features for each of 2016,
+2020, and 2024; 2012 still returned no manifest or precinct results. The
+exact-SHA, database-backed public smoke passed all 22 checks, and the deployment
+had no HTTP 500 or error-level runtime logs during the verification window.
+This hardening changed no database row, Blob object, environment variable,
+manifest eligibility, or public revision.
 
 ## Rollback
 

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -8083,3 +8083,19 @@ evidence against its verified top-level package.
   canonical registry and coverage inventories to expose exactly the reviewed
   2016, 2020, and 2024 manifests while continuing to require zero public
   eligibility for the blocked 2012 package.
+- PR #282 was human-merged at `2026-08-17T00:52:43Z` as commit
+  `6aad834fa31306c3117f2bf974b81544b8a2859a`, tree
+  `e989a76490d2c8046f3eae03002c370621008d88`. Production deployment
+  `dpl_GhN6DNUBedB67u4ruNTiocquQuUo` reached `READY` with the public aliases,
+  and live `X-Deployment-Sha` headers pinned that exact merge commit.
+- The exact-SHA, database-backed public API smoke passed all 22 checks. The
+  Florida/Georgia `13001` negative control returned HTTP 400 with the expected
+  Florida-prefix message from both API routes. Alachua County `12001` retained
+  one eligible manifest, 63 database result units, and 63 immutable geometry
+  features for each of 2016, 2020, and 2024; 2012 retained zero eligible
+  manifests and zero precinct result rows.
+- Post-deploy GitHub CI and production smoke completed successfully. The exact
+  deployment had no HTTP 500 requests or error-level runtime logs during the
+  verification window. This hardening performed no database, Blob, environment,
+  manifest-eligibility, activation, or public-revision mutation; revision 25
+  and the hash-pinned release evidence remain authoritative.


### PR DESCRIPTION
## What changed

- record the merged parent-validation production deployment and exact-SHA live verification in the Florida precinct GIS runbook and implementation ledger
- update Florida source inventories so the completed 2016/2020/2024 guarded release is no longer described as pending
- preserve the 2012 fail-closed blocker and the separate-boundary-vintage caveat

## Why

The tracked runbook and two source inventories still described the guarded release and cross-state parent validation as unfinished after PR #282 merged and deployed. This status-only change aligns those records with verified production state.

## Production evidence

- merge commit: `6aad834fa31306c3117f2bf974b81544b8a2859a`
- production deployment: `dpl_GhN6DNUBedB67u4ruNTiocquQuUo`, READY and assigned the public aliases
- public smoke: 22/22 checks, exact merge SHA, `source=database`
- invalid Florida request with Georgia county GEOID `13001`: HTTP 400 from both results and geometry routes with the expected Florida-prefix message
- valid Alachua `12001`: 1 manifest / 63 result units / 63 geometry features for each of 2016, 2020, and 2024
- 2012: zero eligible manifests and zero precinct result rows
- post-merge CI and production deployment smoke: successful
- deployment log audit: no HTTP 500 responses and no error-level runtime entries during verification

## Scope and impact

Documentation and inventory wording only. No code, election totals, geometry, crosswalks, canonical manifests, hash-sensitive activation coverage ledgers, database rows, Blob objects, environment variables, activation state, or public revision changed. Public revision remains 25. Florida 2012 remains blocked under #277.

## Validation

- `npm.cmd run test:precinct-geometry:fl` — 35/35 passed
- `npm.cmd run validate:source-acquisition-tiers`
- `npm.cmd run validate:source-packages`
- `npm.cmd run validate:maps`
- `npm.cmd run validate:provenance`
- `git diff --check`
- bounded review subagent: clean, no actionable findings

The source-package and map validators retain only their existing documented legacy-bundle and equipment-geometry warnings.