### PR TITLE
Activate guarded Pennsylvania precinct maps

### DIFF
--- a/data/precinct-geometry-coverage-inventory-2016.json
+++ b/data/precinct-geometry-coverage-inventory-2016.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-16T21:24:13.304Z",
+  "updatedAt": "2026-08-17T23:11:19.225Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2016-11-08-general",
@@ -39,7 +39,7 @@
       "official_geometry_unavailable": 0,
       "blocked": 1
     },
-    "publicEligibleJurisdictions": 10
+    "publicEligibleJurisdictions": 11
   },
   "states": [
     {
@@ -670,7 +670,7 @@
       "programStatus": "reviewed",
       "wave": 14,
       "disposition": "partial",
-      "checkedAt": "2026-08-16T18:00:00.000Z",
+      "checkedAt": "2026-08-17T23:11:19.225Z",
       "sourceTiers": [
         "tier_1_official_export_database",
         "tier_2_public_secondary"
@@ -701,7 +701,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 9167,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 8014,
@@ -711,10 +711,8 @@
         "nonGeographicResultUnits": 0,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Immutable parent-scoped delivery and the guarded production release have not been completed."
-      ],
-      "nextAction": "After source-package review and merge, build a hash-pinned parent-scoped delivery candidate and run the separate guarded release workflow without expanding the reviewed crosswalk.",
+      "blockers": [],
+      "nextAction": "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
       "notes": [
         "8,014 VEST polygons match 8,018 complete official DOS source units by unique county-qualified VTD identity and exact complete presidential candidate vector.",
         "1,158 official source units totaling 782,683 votes remain excluded, and 1,153 polygons remain reviewed no-data features.",

--- a/data/precinct-geometry-coverage-inventory-2020.json
+++ b/data/precinct-geometry-coverage-inventory-2020.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-16T21:24:13.304Z",
+  "updatedAt": "2026-08-17T23:11:19.225Z",
   "purpose": "Authoritative progress ledger for election-applicable precinct, ward, VTD, and equivalent local geometry acquisition and result crosswalks.",
   "election": {
     "id": "2020-11-03-general",
@@ -39,7 +39,7 @@
       "official_geometry_unavailable": 0,
       "blocked": 1
     },
-    "publicEligibleJurisdictions": 10
+    "publicEligibleJurisdictions": 11
   },
   "states": [
     {
@@ -672,7 +672,7 @@
       "programStatus": "reviewed",
       "wave": 14,
       "disposition": "partial",
-      "checkedAt": "2026-08-16T18:00:00.000Z",
+      "checkedAt": "2026-08-17T23:11:19.225Z",
       "sourceTiers": [
         "tier_1_official_export_database",
         "tier_2_public_secondary"
@@ -703,7 +703,7 @@
           "election_date_confirmed"
         ],
         "featureCount": 9150,
-        "publicEligibleManifestCount": 0
+        "publicEligibleManifestCount": 1
       },
       "crosswalk": {
         "resultUnits": 6805,
@@ -713,10 +713,8 @@
         "nonGeographicResultUnits": 0,
         "sourceAliasResultUnits": 0
       },
-      "blockers": [
-        "Immutable parent-scoped delivery and the guarded production release have not been completed."
-      ],
-      "nextAction": "After source-package review and merge, build a hash-pinned parent-scoped delivery candidate and run the separate guarded release workflow without expanding the reviewed crosswalk.",
+      "blockers": [],
+      "nextAction": "Keep both guarded public APIs closed until the reviewed hidden load, immutable Blob publication, deployment-origin verification, and atomic database publication are complete.",
       "notes": [
         "6,805 VEST polygons match 6,827 complete official DOS source units by unique county-qualified VTD identity and exact complete presidential candidate vector.",
         "2,360 official source units totaling 1,545,703 votes remain excluded, and 2,345 polygons remain reviewed no-data features.",

--- a/data/precinct-geometry-manifests.json
+++ b/data/precinct-geometry-manifests.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-16T21:24:13.304Z",
+  "updatedAt": "2026-08-17T23:11:19.225Z",
   "manifests": [
     {
       "schemaVersion": 1,
@@ -3483,6 +3483,223 @@
         "Every displayed vote value comes only from the retained Florida Department of State precinct result export.",
         "126 official source units totaling 17,948 candidate votes lack reviewed geometry and are never allocated to polygons.",
         "1,264 NYT features use generated boundaries and remain explicitly disclosed; no NYT result value is displayed.",
+        "Immutable delivery and guarded production activation remain separate decisions."
+      ]
+    },
+    {
+      "schemaVersion": 1,
+      "id": "pa-2016-11-08-reviewed-precinct-geometry-v1",
+      "state": "PA",
+      "election": {
+        "id": "2016-11-08-general",
+        "date": "2016-11-08",
+        "year": 2016,
+        "type": "general",
+        "office": "president"
+      },
+      "geography": {
+        "level": "precinct",
+        "parentLevel": "county",
+        "boundaryVintage": "VEST 2016 election-specific Pennsylvania precinct reconstruction with exact-vector acceptance review",
+        "vintageStatus": "election_date_confirmed",
+        "derivationMethod": "secondary_reconstruction"
+      },
+      "source": {
+        "authority": "Pennsylvania Department of State results with attributed VEST election-specific geometry",
+        "url": "https://raw.githubusercontent.com/PlanScore/National-Input-Data/b8d27cbdc2e752fbadf8e3432d8eb3c96ba579b7/VEST/pa_2016.zip",
+        "retrievedAt": "2026-08-16T18:00:00.000Z",
+        "artifact": "data/precinct-geometry/PA/2016-11-08-general/source-evidence.json",
+        "sha256": "4a6bc00d89e09a9fd12244a785e4b382e5d95d8e428a9ec0a4972f4bf67eaf12",
+        "byteCount": 8923,
+        "format": "precinct-source-evidence+json",
+        "licenseOrTerms": "VEST database geometry is retained under CC BY 4.0 with version and custody evidence; Pennsylvania DOS remains the sole displayed vote authority."
+      },
+      "normalization": {
+        "script": "scripts/collect-pa-precinct-geometry.mjs",
+        "sourceCrs": "GEOGCS[\"GCS_North_American_1983\",DATUM[\"D_North_American_1983\",SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]]",
+        "servedCrs": "EPSG:4326",
+        "artifact": "data/precinct-geometry/PA/2016-11-08-general/normalized/pa-2016-reviewed-precinct-geometry.geojson.gz",
+        "sha256": "3d95de1a3784a2151f00ea7e1f15794b92834480a2c94c5f232b9cdc5898c8d0",
+        "byteCount": 14033577,
+        "featureCount": 9167,
+        "sourceFeatureIdFields": [
+          "CRM_FEATURE_ID"
+        ],
+        "parentIdFields": [
+          "CRM_PARENT_GEOID"
+        ]
+      },
+      "crosswalk": {
+        "status": "reviewed",
+        "resultSourceId": "pa-dos-2016-general-precinct-results",
+        "artifact": "data/precinct-geometry/PA/2016-11-08-general/crosswalk/pa-2016-result-to-geometry-review.json",
+        "sha256": "22863fa57661ebe3045c71f2e9f05ef13dfc765b8102d7acc64afae28ef6242c",
+        "byteCount": 6513290,
+        "resultUnits": 8014,
+        "colorableResultUnits": 8014,
+        "matchedResultUnits": 8014,
+        "unmatchedResultUnits": 0,
+        "nonGeographicResultUnits": 0,
+        "sourceAliasResultUnits": 0,
+        "relationships": {
+          "oneToOne": 8014,
+          "oneToMany": 0,
+          "manyToOne": 0,
+          "unmatched": 0,
+          "nonGeographic": 0,
+          "sourceAlias": 0,
+          "pendingReview": 0
+        },
+        "reviewedRelationshipRecords": 8014,
+        "reviewedNoDataFeatures": 1153,
+        "methods": [
+          "official_crosswalk"
+        ]
+      },
+      "validation": {
+        "status": "reviewed",
+        "geometryValid": true,
+        "rowLevelRenderingSafe": true,
+        "parentTotalsReconciled": true,
+        "resultTotalsReconciled": true,
+        "errors": [],
+        "warnings": [
+          "Every displayed vote value comes only from the retained Pennsylvania Department of State precinct result export.",
+          "1158 official source units totaling 782,683 presidential candidate votes lack a reviewed polygon relationship and are never allocated.",
+          "The retained Redistricting Data Hub report could not fully reproduce VEST's joins and validation; CivicResultMaps accepts only exact county-qualified VTD and complete-candidate-vector matches.",
+          "All 8014 displayable precinct relationships are reviewed one-to-one across 67 mapped Pennsylvania county scopes.",
+          "Geometry delivery retains reviewed features for all 67 Pennsylvania counties, including explicit no-data shapes.",
+          "All official result units without reviewed geometry remain excluded from display and are never spatially allocated.",
+          "The 0 zero-presidential-vote precincts remain geographic reporting units.",
+          "All 1153 reviewed no-data polygons remain visible without an invented result row.",
+          "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged."
+        ]
+      },
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/pa/2016-11-08/precinct/pa-2016-11-08-reviewed-precinct-geometry-v1-10d8b4d4f777/index.json",
+        "sha256": "10d8b4d4f777b3e5abce09918fe379eac45bbcfd31b45e234522aa11095f99cb",
+        "byteCount": 13380,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 67,
+        "featureCount": 9167
+      },
+      "caveats": [
+        "No vote is estimated, spatially allocated, or copied from a geometry source.",
+        "Every displayed vote value comes only from the retained Pennsylvania Department of State precinct result export.",
+        "1158 official source units totaling 782,683 presidential candidate votes lack a reviewed polygon relationship and are never allocated.",
+        "The retained Redistricting Data Hub report could not fully reproduce VEST's joins and validation; CivicResultMaps accepts only exact county-qualified VTD and complete-candidate-vector matches.",
+        "Immutable delivery and guarded production activation remain separate decisions."
+      ]
+    },
+    {
+      "schemaVersion": 1,
+      "id": "pa-2020-11-03-reviewed-precinct-geometry-v1",
+      "state": "PA",
+      "election": {
+        "id": "2020-11-03-general",
+        "date": "2020-11-03",
+        "year": 2020,
+        "type": "general",
+        "office": "president"
+      },
+      "geography": {
+        "level": "precinct",
+        "parentLevel": "county",
+        "boundaryVintage": "VEST 2020 election-specific Pennsylvania precinct reconstruction with exact-vector acceptance review",
+        "vintageStatus": "election_date_confirmed",
+        "derivationMethod": "secondary_reconstruction"
+      },
+      "source": {
+        "authority": "Pennsylvania Department of State results with attributed VEST election-specific geometry",
+        "url": "https://raw.githubusercontent.com/PlanScore/National-Input-Data/4ee0f4724a1e99213c95bd5c00926fb4b0c3d4c6/VEST/pa_2020.zip",
+        "retrievedAt": "2026-08-16T18:00:00.000Z",
+        "artifact": "data/precinct-geometry/PA/2020-11-03-general/source-evidence.json",
+        "sha256": "36fddd63655e27dd235ec96b23f2c0f33d3dd90f46bf3b4e455e012a8e51464e",
+        "byteCount": 8925,
+        "format": "precinct-source-evidence+json",
+        "licenseOrTerms": "VEST database geometry is retained under CC BY 4.0 with version and custody evidence; Pennsylvania DOS remains the sole displayed vote authority."
+      },
+      "normalization": {
+        "script": "scripts/collect-pa-precinct-geometry.mjs",
+        "sourceCrs": "GEOGCS[\"GCS_North_American_1983\",DATUM[\"D_North_American_1983\",SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]]",
+        "servedCrs": "EPSG:4326",
+        "artifact": "data/precinct-geometry/PA/2020-11-03-general/normalized/pa-2020-reviewed-precinct-geometry.geojson.gz",
+        "sha256": "17bb9a62e9c948de41e8d51079e4ff6f0f4b922e8bdb4e5f81ab3301ca21f2db",
+        "byteCount": 14085181,
+        "featureCount": 9150,
+        "sourceFeatureIdFields": [
+          "CRM_FEATURE_ID"
+        ],
+        "parentIdFields": [
+          "CRM_PARENT_GEOID"
+        ]
+      },
+      "crosswalk": {
+        "status": "reviewed",
+        "resultSourceId": "pa-dos-2020-general-precinct-results",
+        "artifact": "data/precinct-geometry/PA/2020-11-03-general/crosswalk/pa-2020-result-to-geometry-review.json",
+        "sha256": "300e0818664dcac9d380d787ae59ba01ebe5111ea4636b0184157ccda669d2c0",
+        "byteCount": 5524866,
+        "resultUnits": 6805,
+        "colorableResultUnits": 6805,
+        "matchedResultUnits": 6805,
+        "unmatchedResultUnits": 0,
+        "nonGeographicResultUnits": 0,
+        "sourceAliasResultUnits": 0,
+        "relationships": {
+          "oneToOne": 6805,
+          "oneToMany": 0,
+          "manyToOne": 0,
+          "unmatched": 0,
+          "nonGeographic": 0,
+          "sourceAlias": 0,
+          "pendingReview": 0
+        },
+        "reviewedRelationshipRecords": 6805,
+        "reviewedNoDataFeatures": 2345,
+        "methods": [
+          "official_crosswalk"
+        ]
+      },
+      "validation": {
+        "status": "reviewed",
+        "geometryValid": true,
+        "rowLevelRenderingSafe": true,
+        "parentTotalsReconciled": true,
+        "resultTotalsReconciled": true,
+        "errors": [],
+        "warnings": [
+          "Every displayed vote value comes only from the retained Pennsylvania Department of State precinct result export.",
+          "2360 official source units totaling 1,545,703 presidential candidate votes lack a reviewed polygon relationship and are never allocated.",
+          "The retained Redistricting Data Hub report could not fully reproduce VEST's joins and validation; CivicResultMaps accepts only exact county-qualified VTD and complete-candidate-vector matches.",
+          "All 6805 displayable precinct relationships are reviewed one-to-one across 66 mapped Pennsylvania county scopes.",
+          "Geometry delivery retains reviewed features for all 67 Pennsylvania counties, including explicit no-data shapes.",
+          "All official result units without reviewed geometry remain excluded from display and are never spatially allocated.",
+          "The 0 zero-presidential-vote precincts remain geographic reporting units.",
+          "All 2345 reviewed no-data polygons remain visible without an invented result row.",
+          "Pike County (GEOID 42103) has 18 reviewed geometry features and no accepted result relationship; all remain visible as no-data shapes.",
+          "Public presentation geometry is rounded to seven decimals and simplified at a 0.000005-degree tolerance; raw source geometry and exact join identities remain hash-pinned and unchanged."
+        ]
+      },
+      "delivery": {
+        "format": "parent_scoped_geojson",
+        "url": "/data/geography/pa/2020-11-03/precinct/pa-2020-11-03-reviewed-precinct-geometry-v1-830dd3cbccfc/index.json",
+        "sha256": "830dd3cbccfc1f0717dab5d8bfb73430a86c22809ff957da01258c30f58cc61a",
+        "byteCount": 13378,
+        "featureIdProperty": "geometryFeatureId",
+        "resultUnitProperty": "resultUnitCode",
+        "parentGeoidProperty": "parentGeoid",
+        "parentCount": 67,
+        "featureCount": 9150
+      },
+      "caveats": [
+        "No vote is estimated, spatially allocated, or copied from a geometry source.",
+        "Every displayed vote value comes only from the retained Pennsylvania Department of State precinct result export.",
+        "2360 official source units totaling 1,545,703 presidential candidate votes lack a reviewed polygon relationship and are never allocated.",
+        "The retained Redistricting Data Hub report could not fully reproduce VEST's joins and validation; CivicResultMaps accepts only exact county-qualified VTD and complete-candidate-vector matches.",
         "Immutable delivery and guarded production activation remain separate decisions."
       ]
     }

--- a/docs/developer/precinct-gis-implementation.md
+++ b/docs/developer/precinct-gis-implementation.md
@@ -8271,3 +8271,48 @@ evidence against its verified top-level package.
   publish immutable assets, merge the static activation, and execute the final
   database-gated cutover with exhaustive API/UI verification. Pennsylvania 2012
   and 2024 remain blocked throughout.
+
+### 2026-08-18 - Pennsylvania hidden load and immutable delivery completed
+
+- Release tooling merged as commit `ce0a70f7863f4986917ff3386ca12c201ef1b54b`.
+  The clean merged-commit rehearsal resealed release
+  `pa-precinct-gis-two-election-v1` at SHA-256
+  `1501aee622addd9908cef4fb53075ef0517211fc0a5f3f331e29beff214a462e`.
+  The candidate retains only the reviewed partial 2016 and 2020 universes;
+  2012 and 2024 remain absent from every release and activation path.
+- A read-only production preflight at public revision 25 found PostgreSQL 17,
+  migrations 0008 and 0009 complete, zero invalid constraints, and no existing
+  Pennsylvania precinct release rows. A subsequent full 31-table `public`
+  schema backup restored into the isolated PostgreSQL 17 clone with the exact
+  table set and every source row count matched before the guarded write.
+- The coupled hidden load committed at `2026-08-18T01:51:53.132Z` as
+  `COMMITTED_HIDDEN_NOT_PUBLIC`, incrementing the public revision once to 26.
+  Receipt SHA-256
+  `16ed15a6b18be8719d502fb4512f21a74429832b31d6b0746c09ba138e9fd8f9`
+  validates 8,014 reporting units, 24,042 candidate rows, and 9,167 features for
+  2016 plus 6,805 units, 20,415 rows, and 9,150 features for 2020. Both
+  geography versions remain blocked, `publicDeliveryAuthorized` remains false,
+  no canonical manifest changed, and no pending recovery marker remains.
+- Immediate live checks confirmed both gates stayed closed: the 2016 and 2020
+  PA manifest queries returned zero eligible rows, and sample Philadelphia 2016
+  and Pike 2020 precinct-result queries returned zero database rows.
+- All 136 immutable delivery objects were then created at the existing
+  credential-free Vercel Blob origin
+  `https://ehnlruzhgkm5byoi.public.blob.vercel-storage.com`. The publisher
+  uploaded 134 county objects before the two indexes, re-downloaded and
+  byte/hash verified all 65,578,988 bytes, and recorded evidence SHA-256
+  `8df1d6c859d7ee2f2b14c8dfb37f92f718a03ec6f9b7fee625ab8d102bcbcb8f`.
+  Blob publication did not change the registry or database eligibility.
+- Static activation candidate SHA-256
+  `989cee7550d934069dd34f86d31c38e2dc6e8f1b4e0da5b0c26a8e839d29ae66`
+  updates the canonical registry and the 2016/2020 coverage inventories while
+  retaining both rows as `partial`. The source-package regression now follows
+  the established activated-state contract: only the two reviewed years are
+  eligible, while the blocked 2012 and 2024 manifest identities remain absent.
+  The PA suite passes 39/39, shared parent delivery passes 7/7, and map,
+  provenance, source-package, typecheck, and production-build validation pass.
+- Public access is not yet enabled. The activation tree still requires a
+  protected Preview, review and merge, an exact READY/PROMOTED Production
+  deployment with the same Blob origin, and the separately hash-pinned atomic
+  database publication transaction. Excluded official units and their votes
+  remain unallocated throughout.

--- a/tests/api/pa-precinct-geometry.test.mjs
+++ b/tests/api/pa-precinct-geometry.test.mjs
@@ -266,7 +266,7 @@ test(
 );
 
 test(
-  "Pennsylvania packages preserve the official result universe and keep delivery closed",
+  "Pennsylvania packages preserve the official result universe while only reviewed partial years are active",
   () => {
     const registry = JSON.parse(
       readFileSync("data/precinct-geometry-manifests.json", "utf8"),
@@ -275,8 +275,14 @@ test(
       registry.manifests
         .filter((manifest) => manifest.state === "PA")
         .map((manifest) => manifest.id),
-      [],
-      "the source-package PR must not activate Pennsylvania manifests",
+      YEARS.filter((spec) => spec.safe).map((spec) => spec.manifestId),
+    );
+    assert.equal(
+      registry.manifests.some((manifest) =>
+        manifest.id === YEARS[0].manifestId
+        || manifest.id === YEARS[3].manifestId
+      ),
+      false,
     );
 
     for (const spec of YEARS) {
@@ -416,7 +422,7 @@ test(
 );
 
 test(
-  "Pennsylvania coverage ledgers expose no source package as publicly eligible",
+  "Pennsylvania coverage ledgers expose only reviewed partial years as publicly eligible",
   () => {
     const inventories = new Map([
       [2012, "data/precinct-geometry-coverage-inventory-2012.json"],
@@ -435,7 +441,10 @@ test(
       assert.equal(row.disposition, spec.disposition);
       assert.deepEqual(row.geometry.manifestIds, [spec.manifestId]);
       assert.equal(row.geometry.featureCount, spec.features);
-      assert.equal(row.geometry.publicEligibleManifestCount, 0);
+      assert.equal(
+        row.geometry.publicEligibleManifestCount,
+        spec.safe ? 1 : 0,
+      );
       assert.equal(
         row.crosswalk.resultUnits,
         spec.safe ? spec.mappedRows : spec.sourceUnits,


### PR DESCRIPTION
## Scope

Activates the guarded static Pennsylvania precinct-map registry entries for the reviewed, partial 2016 and 2020 packages only. This does **not** perform the final public database cutover.

## Sources and custody

- Vote authority: Pennsylvania Department of State retained precinct result exports.
- Geometry: election-specific VEST Pennsylvania reconstructions, pinned to the reviewed source revision and retained under CC BY 4.0.
- Immutable delivery origin: `https://ehnlruzhgkm5byoi.public.blob.vercel-storage.com`.
- No geometry source supplies displayed votes, and no vote is estimated or spatially allocated.

Production hidden-load receipt:
- authorization ID: `pa-precinct-hidden-load-ce0a70f7-20260818T015053Z`
- receipt SHA-256: `16ed15a6b18be8719d502fb4512f21a74429832b31d6b0746c09ba138e9fd8f9`
- decision: `COMMITTED_HIDDEN_NOT_PUBLIC`

Immutable Blob publication:
- authorization ID: `pa-precinct-blob-upload-ce0a70f7-20260818T0155Z`
- evidence SHA-256: `8df1d6c859d7ee2f2b14c8dfb37f92f718a03ec6f9b7fee625ab8d102bcbcb8f`
- 136 objects, 65,578,988 bytes, all re-downloaded and hash-verified
- decision: `ASSETS_PUBLISHED_MANIFESTS_STILL_BLOCKED`

## Changes

- Adds the reviewed 2016 and 2020 Pennsylvania entries to the public static manifest registry.
- Updates both year-specific coverage ledgers while retaining `partial` status and full caveats.
- Corrects the PA contract test that still assumed all PA manifests must remain ineligible.
- Adds the durable hidden-load, immutable-delivery, and guarded-activation record to the precinct GIS implementation ledger.
- Keeps 2012 and 2024 absent from the public manifest registry.
- Does not change result allocation logic or enable the production database gate.

## Reviewed coverage and caveats

- 2016: 8,014 displayable result units, 24,042 candidate rows, 9,167 geometry features.
- 2020: 6,805 displayable result units, 20,415 candidate rows, 9,150 geometry features.
- Across both elections, 3,518 official source units representing 2,328,386 presidential candidate votes lack reviewed polygon relationships; they remain excluded and are never allocated.
- 3,498 retained polygons are explicit no-data shapes.
- Pike County 2020 intentionally has 18 no-data shapes and zero displayable result rows.
- These packages remain partial, not statewide-complete.
- 2012 and 2024 remain blocked and ineligible.

## Preview verification

Exact commit: `1256dd29b066949c59d6113743af4fd36229bfde`  
Tree: `d65cec238acf7510a25e7c2c928cdcde6e736e3f`  
Vercel deployment: `dpl_HXr5eXM93AB52MLV2K6xZ8J8YPvu` (READY)

Protected Preview API checks:

- 2016 manifest: one eligible reviewed PA manifest (67 parents, 9,167 features).
- 2020 manifest: one eligible reviewed PA manifest (67 parents, 9,150 features).
- 2012 and 2024 manifests: zero rows.
- Philadelphia 2016 precinct results: zero rows.
- Pike 2020 precinct results: zero rows.
- Direct 2016 geography request: closed with `local geography publication is not active`.

This proves the static deployment is reviewable while result/geography publication remains fail-closed pending the separate post-merge public cutover.

## Validation

- PA precinct GIS suite: 39/39 passed.
- Shared precinct delivery suite: 7/7 passed.
- Source-package validation passed (existing legacy-bundle warnings only).
- Map validation passed (known equipment-boundary warnings only).
- Provenance validation passed.
- Typecheck passed.
- Production build passed.
- `git diff --check` passed.

## Display path

The Preview verifies the public manifest route plus the closed result and geography routes. After merge, the coordinator will verify the exact `main` Production deployment, generate the guarded publication plan/authorization, perform the atomic database cutover, and exhaustively verify live manifests, results, geometry, parent coverage, and rollback evidence.

## Independent review

Independent review found no blocker and no P0/P1/P2 issue. It confirmed the registry contains exactly the reviewed 2016/2020 PA entries, the ledgers remain partial, unsupported years remain absent, caveats are preserved, no allocation behavior changed, and application delivery remains database-gated.
