### PR TITLE
Fix Data Notes wrapping and ultrawide layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3977,6 +3977,8 @@ td {
 }
 
 .data-notes-panel {
+  container-name: data-notes;
+  container-type: inline-size;
   margin-bottom: 0;
 }
 
@@ -4019,12 +4021,18 @@ td {
   justify-content: space-between;
 }
 
+.data-note-head > strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .data-note-card p,
 .data-note-card span:not(.section-label):not(.quality-badge) {
   color: var(--muted);
   font-size: 13px;
   line-height: 1.45;
   margin: 0;
+  overflow-wrap: anywhere;
 }
 
 .review-summary-grid,
@@ -6359,6 +6367,11 @@ td {
   padding: 10px 12px;
 }
 
+.data-gap-banner > * {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .data-gap-banner.missing,
 .data-gap-banner.blocked {
   background: rgba(255, 143, 126, 0.08);
@@ -6465,6 +6478,12 @@ td {
   margin: 0;
 }
 
+@container data-notes (max-width: 720px) {
+  .data-gap-banner {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 @media (max-width: 900px) {
   .data-gap-banner,
   .source-drawer-panel dl,
@@ -6522,7 +6541,7 @@ td {
 
 .workspace-tabs[data-layout-content-width="wide"] {
   margin-inline: auto;
-  max-width: 1540px;
+  max-width: 1920px;
   width: 100%;
 }
 

--- a/tests/e2e/workspace-layout.spec.ts
+++ b/tests/e2e/workspace-layout.spec.ts
@@ -18,6 +18,7 @@ test.afterEach(async ({ page }) => {
 });
 test("public workspace uses the safe embedded layout and durable visitor cookie", async ({ page, context, baseURL }) => {
   test.setTimeout(90_000);
+  await page.setViewportSize({ height: 1080, width: 1920 });
   await context.addCookies([{ name: "crm_layout_visitor", value: "malformed", url: baseURL! }]);
   await page.goto("/?state=WA&year=2024&tab=map&mode=margin&fips=53033");
 
@@ -82,6 +83,15 @@ test("public workspace uses the safe embedded layout and durable visitor cookie"
   const dataNotes = page.getByRole("complementary", { name: "Washington data notes" });
   await workspace.getByRole("button", { name: /^Data Notes/ }).click();
   await expect(dataNotes.getByRole("heading", { name: "Data Notes", exact: true })).toBeVisible();
+  const dataNotesOverflow = await dataNotes.locator(".data-notes-panel").evaluate((panel) => ({
+    clientWidth: panel.clientWidth,
+    scrollWidth: panel.scrollWidth,
+  }));
+  expect(dataNotesOverflow.scrollWidth).toBeLessThanOrEqual(dataNotesOverflow.clientWidth + 1);
+
+  await page.setViewportSize({ height: 1440, width: 2560 });
+  await expect.poll(async () => workspace.evaluate((element) => element.getBoundingClientRect().width)).toBeGreaterThanOrEqual(1900);
+
   await dataNotes.getByRole("button", { name: "Collapse", exact: true }).press("Enter");
   await expect(dataNotes).toHaveClass(/is-collapsed/);
 


### PR DESCRIPTION
## What changed

- makes the Data Notes panel an inline-size query container and stacks status banners when the rail or drawer is too narrow for the three-column banner layout
- lets long Data Notes labels, evidence, and status text wrap instead of being clipped
- raises the intentional `wide` workspace ceiling from 1540px to 1920px while preserving the 1180px `standard` mode and uncapped `full` mode
- adds browser regressions for zero horizontal overflow at 1920px and approximately 1920px of workspace width on a 2560px viewport

## Why

Production reproduction showed the expanded Data Notes panel at 338px wide while its three-column banner list had a 565px scroll width. The panel's existing overflow boundary clipped that excess. The same inspection confirmed that `wide` mode stopped growing at 1540px, producing the reported page-width ceiling on ultrawide displays.

Fixes #304

## Validation

- `npx playwright test tests/e2e/workspace-layout.spec.ts --project=chromium --grep 'safe embedded' --workers=1` — passed
- `npx playwright test tests/e2e/workspace-layout.spec.ts --project=chromium --workers=1` — 7 passed
- `npm run test:layout` — passed
- `npm run typecheck` — passed
- `npm run build` — passed
- local browser verification — page rendered without an error overlay or console errors; expanded Data Notes measured `clientWidth: 338` and `scrollWidth: 338`
- `git diff --check` — passed
- `npm test` — layout/API and subsequent suites ran, but the broad suite ended on the pre-existing Rhode Island Data Hub raw-artifact SHA/byte drift in `normalize-ri-registration-datahub.mjs --check`; this PR does not touch that ETL path

## Review

An independent read-only diff review found no actionable implementation defects. Its only suggestion was to tighten the ultrawide regression; the assertion now requires at least 1900px rather than merely exceeding the old 1540px cap, and the focused test was rerun successfully.

## Operational notes

- no Layout Control draft or immutable revision was changed
- no layout was staged or published
- no production data promotion or database mutation was performed