### PR TITLE
Add Vote Methods tab for every state

### DIFF
--- a/docs/developer/ui-layout-operations.md
+++ b/docs/developer/ui-layout-operations.md
@@ -25,7 +25,7 @@ Rows use a responsive 12-column grid. Desktop spans are 3, 4, 6, 8, 9, or 12; ta
 ## Safety boundaries
 
 - The registries in `src/lib/workspace-layout.ts` and `src/lib/workspace-layout-v2.ts` are the code-owned lists of allowed tabs and production components.
-- Map, Review Center, Data & Sources, and Review Guide are required tabs.
+- Map, Review Center, Vote Methods, Data & Sources, and Review Guide are required tabs. Vote Methods remains visible for every state and shows an explicit coverage gap when normalized method rows are unavailable.
 - Results Map and Source Provenance are required production sections.
 - Every visible tab must retain at least one visible production section.
 - Data Notes remains a fixed trust surface. Operators may change its initial open state and side, below, or drawer placement, but not its source-driven content or remove it.
@@ -35,6 +35,7 @@ Rows use a responsive 12-column grid. Desktop spans are 3, 4, 6, 8, 9, or 12; ta
 - Custom text is escaped. Links accept only safe internal paths, HTTPS URLs, and email links; protocol-relative links such as `//example.com` are rejected.
 - Verified labels, data queries, interactions, source caveats, and authorization remain code-owned.
 - Every manifest is validated against the exact registry and protected by a SHA-256 digest.
+- Newly introduced required tabs may be marked for additive backfill. Older valid manifests retain their digest and stored content, then receive the code-owned default tab during runtime/editor conversion.
 - Invalid editor state blocks saving.
 - Runtime precedence is authorized draft preview, enabled candidate, stable, then the embedded default.
 - Missing, malformed, stale, or tampered remote data fails closed to the next safe source.

--- a/src/app/guided-tour.tsx
+++ b/src/app/guided-tour.tsx
@@ -9,6 +9,7 @@ export type TourTabKey =
   | "map"
   | "review"
   | "history"
+  | "methods"
   | "electronic"
   | "planner"
   | "data"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -179,7 +179,9 @@ export default async function Home({ searchParams }: HomeProps) {
   const needsIndicators = activeTab === "map" || needsReview;
   const needsTurnout = ["history", "data", "exports"].includes(activeTab);
   const needsHistory = ["history", "data", "exports"].includes(activeTab);
-  const needsMethods = (selectedYear === 2024 || activeTab === "exports")
+  const needsVoteMethods = (selectedYear === 2024 || activeTab === "exports")
+    && ["map", "electronic", "methods", "data", "exports"].includes(activeTab);
+  const needsEquipment = (selectedYear === 2024 || activeTab === "exports")
     && ["map", "electronic", "data", "exports"].includes(activeTab);
   const needsSecurity = (selectedYear === 2024 || activeTab === "exports")
     && ["map", "data", "exports"].includes(activeTab);
@@ -216,8 +218,8 @@ export default async function Home({ searchParams }: HomeProps) {
       : Promise.resolve([]),
     needsTurnout ? listTurnoutRows({ state: selectedState, year: selectedYear, limit: 20000 }) : Promise.resolve([]),
     needsHistory ? listHistoricalResultRows({ state: selectedState, limit: 5000 }) : Promise.resolve([]),
-    needsMethods ? listVoteMethodRows({ state: selectedState, year: selectedYear, limit: 20000 }) : Promise.resolve([]),
-    needsMethods ? listEquipmentRows({ state: selectedState, year: selectedYear, limit: 20000 }) : Promise.resolve([]),
+    needsVoteMethods ? listVoteMethodRows({ state: selectedState, year: selectedYear, limit: 20000 }) : Promise.resolve([]),
+    needsEquipment ? listEquipmentRows({ state: selectedState, year: selectedYear, limit: 20000 }) : Promise.resolve([]),
     needsSecurity ? listSecurityIncidents({ state: selectedState, year: selectedYear, limit: 5000 }) : Promise.resolve([]),
     listAdminSourceStatuses({ state: selectedState, year: workspaceSummaryYear }),
     listElectronicIntegrityArtifacts({ state: selectedState, year: workspaceSummaryYear }),

--- a/src/app/workspace-guided-links.tsx
+++ b/src/app/workspace-guided-links.tsx
@@ -24,6 +24,11 @@ const guidedDestinations: Partial<Record<WorkspaceTabId, GuidedDestination[]>> =
     { label: "Compare on the map", summary: "View the selected election year geographically.", tab: "map" },
     { label: "Check historical sources", summary: "Inspect the provenance behind the comparison rows.", tab: "data" },
   ],
+  methods: [
+    { label: "Map method patterns", summary: "Compare available participation methods geographically.", tab: "map" },
+    { label: "Verify the sources", summary: "Inspect method coverage, provenance, and source limitations.", tab: "data" },
+    { label: "Review responsibly", summary: "Read the evidence and interpretation guardrails.", tab: "methodology" },
+  ],
   electronic: [
     { label: "Check source records", summary: "Review the evidence inventory and official links.", tab: "data" },
     { label: "Review responsibly", summary: "Read the evidence and interpretation guardrails.", tab: "methodology" },
@@ -34,6 +39,7 @@ const guidedDestinations: Partial<Record<WorkspaceTabId, GuidedDestination[]>> =
   ],
   data: [
     { label: "View the results map", summary: "Return to the state's geographic result explorer.", tab: "map" },
+    { label: "Compare vote methods", summary: "Review mail, early in-person, and polling-place participation.", tab: "methods" },
     { label: "Open the Review Center", summary: "Use these sources to evaluate advisory findings.", tab: "review" },
     { label: "Download the data", summary: "Export normalized rows and source manifests.", tab: "exports" },
   ],

--- a/src/app/workspace-tabs.tsx
+++ b/src/app/workspace-tabs.tsx
@@ -271,6 +271,7 @@ const tabs: Array<{ icon: ComponentType<SVGProps<SVGSVGElement> & { size?: numbe
   { icon: MapIcon, key: "map", label: "Map" },
   { icon: BarChart3, key: "review", label: "Review Center" },
   { icon: History, key: "history", label: "History" },
+  { icon: Activity, key: "methods", label: "Vote Methods" },
   { icon: Server, key: "electronic", label: "Electronic Integrity" },
   { icon: ListChecks, key: "planner", label: "Source Planner" },
   { icon: FileCheck2, key: "data", label: "Data & Sources" },
@@ -281,7 +282,7 @@ const tabs: Array<{ icon: ComponentType<SVGProps<SVGSVGElement> & { size?: numbe
   { icon: Mail, key: "contact", label: "Contact" },
 ];
 
-const primaryWorkspaceTabOrder: TabKey[] = ["map", "review", "history", "data"];
+const primaryWorkspaceTabOrder: TabKey[] = ["map", "review", "history", "methods", "data"];
 const secondaryWorkspaceTabGroups: Array<{ label: string; tabKeys: TabKey[] }> = [
   {
     label: "Learn & investigate",
@@ -6179,9 +6180,13 @@ export function WorkspaceTabs({
         </div>
       ))}
 
-      {activeTab === "data" && (
+      {(activeTab === "data" || activeTab === "methods") && (
         <div className="tab-panel-content">
-          <section className="panel layout-section-container" data-tour="data-sources">
+          <section
+            className="panel layout-section-container"
+            data-tour={activeTab === "methods" ? "vote-methods" : "data-sources"}
+          >
+            {activeTab === "data" && (<>
             {captureProduction("source-provenance", (<div className="panel-header" {...layoutSectionProps(layoutManifest, "data", "source-provenance")}>
               <div>
                 <h2>Data & Sources</h2>
@@ -6210,13 +6215,14 @@ export function WorkspaceTabs({
                 variant={dataProvenanceConfig?.provenanceVariant ?? "expanded"}
               />
             </div>))}
-            {captureProduction("vote-methods", (<div className="vote-method-panel" data-tour="vote-method-summary" {...layoutSectionProps(layoutManifest, "data", "vote-methods")}>
+            </>)}
+            {captureProduction("vote-methods", (<div className="vote-method-panel" data-tour="vote-method-summary" {...layoutSectionProps(layoutManifest, activeTab, "vote-methods")}>
               <div className="vote-method-head">
                 <div>
                   <strong>Vote Methods</strong>
                   <span>
                     {voteMethodRows.length
-                      ? `${voteMethodJurisdictions.toLocaleString()} EAC jurisdictions, ${voteMethodRows.length.toLocaleString()} method rows`
+                      ? `${voteMethodJurisdictions.toLocaleString()} EAC jurisdictions, ${voteMethodRows.length.toLocaleString()} method rows. Compare mail, early in-person, and polling-place participation.`
                       : "No EAC vote-method rows loaded for this state."}
                   </span>
                 </div>
@@ -6301,7 +6307,7 @@ export function WorkspaceTabs({
                 </div>
               )}
             </div>))}
-            {captureProduction("vote-methods", (<div className="vote-method-caveat" data-tour="candidate-method-note" {...layoutSectionProps(layoutManifest, "data", "vote-methods")}>
+            {captureProduction("vote-methods", (<div className="vote-method-caveat" data-tour="candidate-method-note" {...layoutSectionProps(layoutManifest, activeTab, "vote-methods")}>
               <div>
                 <strong>Candidate by Method</strong>
                 <span>
@@ -6311,6 +6317,7 @@ export function WorkspaceTabs({
               </div>
               <span className="pending">Source required</span>
             </div>))}
+            {activeTab === "data" && (<>
             {captureProduction("equipment-context", (<div className="vote-method-panel" data-tour="equipment-context" {...layoutSectionProps(layoutManifest, "data", "equipment-context")}>
               <div className="vote-method-head">
                 <div>
@@ -6457,6 +6464,7 @@ export function WorkspaceTabs({
                 </div>
               )}
             </div>))}
+            </>)}
           </section>
         </div>
       )}

--- a/src/lib/ui-layout-v4-repository.ts
+++ b/src/lib/ui-layout-v4-repository.ts
@@ -15,6 +15,7 @@ import {
   embeddedWorkspaceLayoutManifestV3,
   flattenWorkspaceNodesV3,
   isWorkspaceGroupCustomOnlyV3,
+  toWorkspaceLayoutManifestV3,
   validateWorkspaceLayoutManifestV3,
   type WorkspaceLayoutGroupV3,
   type WorkspaceLayoutManifestV3,
@@ -39,12 +40,13 @@ export function isLayoutDraftDatabaseConfigured() {
 
 export async function listLayoutDrafts(limit = 40) {
   if (!hasDatabase()) return [];
-  return getDb()
+  const drafts = await getDb()
     .select()
     .from(uiLayoutDrafts)
     .where(isNull(uiLayoutDrafts.archivedAt))
     .orderBy(desc(uiLayoutDrafts.updatedAt))
     .limit(Math.min(Math.max(limit, 1), 100));
+  return drafts.map(normalizeStoredDraft);
 }
 
 export async function getLayoutDraft(draftId: string) {
@@ -54,7 +56,7 @@ export async function getLayoutDraft(draftId: string) {
     .from(uiLayoutDrafts)
     .where(eq(uiLayoutDrafts.id, draftId))
     .limit(1);
-  return draft ?? null;
+  return draft ? normalizeStoredDraft(draft) : null;
 }
 
 export async function createLayoutDraft(input: {
@@ -192,15 +194,23 @@ async function syncDraftAssets(draftId: string, manifest: WorkspaceLayoutManifes
 }
 
 function validateDraftPayload(manifest: WorkspaceLayoutManifestV3) {
-  const serialized = JSON.stringify(manifest);
+  const normalized = toWorkspaceLayoutManifestV3(manifest);
+  const serialized = JSON.stringify(normalized);
   if (new TextEncoder().encode(serialized).byteLength > MAX_DRAFT_BYTES) {
     throw new Error("Draft manifest is too large.");
   }
-  const validation = validateWorkspaceLayoutManifestV3(manifest);
+  const validation = validateWorkspaceLayoutManifestV3(normalized);
   if (!validation.ok) {
     throw new Error(validation.errors.join(" "));
   }
   return validation.value;
+}
+
+function normalizeStoredDraft(draft: typeof uiLayoutDrafts.$inferSelect) {
+  return {
+    ...draft,
+    manifest: toWorkspaceLayoutManifestV3(draft.manifest),
+  };
 }
 
 function validateGroupTemplate(group: WorkspaceLayoutGroupV3) {

--- a/src/lib/workspace-layout-v2.ts
+++ b/src/lib/workspace-layout-v2.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   defaultWorkspaceLayoutSettings,
+  shouldBackfillWorkspaceTab,
   workspaceLayoutRegistry,
   type WorkspaceCustomBlockKind,
   type WorkspaceLayoutEmphasis,
@@ -431,10 +432,11 @@ const manifestSchema = z.object({
       notesPosition: z.enum(["side", "below", "drawer"]).optional(),
     }).strict().optional(),
     visible: z.boolean(),
-  }).strict()).length(workspaceLayoutRegistry.length),
+  }).strict()).min(1).max(workspaceLayoutRegistry.length),
 }).strict();
 
 export const workspaceLayoutRegistryV2 = workspaceLayoutRegistry.map((tab) => ({
+  backfillIfMissing: shouldBackfillWorkspaceTab(tab),
   id: tab.id,
   label: tab.label,
   required: "required" in tab && tab.required === true,
@@ -504,7 +506,7 @@ export function validateWorkspaceLayoutManifestV2(value: unknown): WorkspaceLayo
 
 export function toWorkspaceLayoutManifestV2(manifest: WorkspaceLayoutManifest): WorkspaceLayoutManifestV2 {
   return manifest.schemaVersion === WORKSPACE_LAYOUT_SCHEMA_VERSION_V2
-    ? structuredClone(manifest)
+    ? backfillWorkspaceLayoutManifestV2(manifest)
     : upgradeWorkspaceLayoutManifestV1(manifest);
 }
 
@@ -583,7 +585,26 @@ export function upgradeWorkspaceLayoutManifestV1(manifest: WorkspaceLayoutManife
     }
     return defaultTab;
   });
-  return upgraded;
+  return backfillWorkspaceLayoutManifestV2(upgraded);
+}
+
+export function backfillWorkspaceLayoutManifestV2(manifest: WorkspaceLayoutManifestV2) {
+  const normalized = structuredClone(manifest);
+  const seenTabs = new Set(normalized.tabs.map((tab) => tab.id));
+
+  for (const [registryIndex, registryTab] of workspaceLayoutRegistryV2.entries()) {
+    if (!registryTab.backfillIfMissing || seenTabs.has(registryTab.id)) continue;
+    const previousTab = [...workspaceLayoutRegistryV2.slice(0, registryIndex)]
+      .reverse()
+      .find((candidate) => seenTabs.has(candidate.id));
+    const insertionIndex = previousTab
+      ? normalized.tabs.findIndex((tab) => tab.id === previousTab.id) + 1
+      : 0;
+    normalized.tabs.splice(insertionIndex, 0, defaultTabLayout(registryTab.id));
+    seenTabs.add(registryTab.id);
+  }
+
+  return normalized;
 }
 
 export function cloneWorkspaceLayoutManifestV2(
@@ -785,7 +806,9 @@ function inspectStructuralRules(manifest: WorkspaceLayoutManifestV2) {
     }
   }
   for (const registryTab of workspaceLayoutRegistryV2) {
-    if (!seenTabs.has(registryTab.id)) errors.push(`Tab ${registryTab.id} is missing.`);
+    if (!seenTabs.has(registryTab.id) && !registryTab.backfillIfMissing) {
+      errors.push(`Tab ${registryTab.id} is missing.`);
+    }
   }
   if (!manifest.tabs.find((tab) => tab.id === manifest.settings.defaultTab)?.visible) {
     errors.push("settings.defaultTab must reference a visible tab.");

--- a/src/lib/workspace-layout-v3.ts
+++ b/src/lib/workspace-layout-v3.ts
@@ -13,10 +13,11 @@ import {
   WORKSPACE_LAYOUT_MAX_CUSTOM_BLOCKS_PER_TAB,
   WORKSPACE_LAYOUT_MAX_ROWS_PER_TAB,
   WORKSPACE_LAYOUT_REGISTRY_VERSION_V2,
-  cloneWorkspaceLayoutManifestV2,
+  backfillWorkspaceLayoutManifestV2,
   embeddedWorkspaceLayoutManifestV2,
   toWorkspaceLayoutManifestV2,
   validateWorkspaceLayoutManifestV2,
+  workspaceLayoutRegistryV2,
   type WorkspaceCustomNodeV2,
   type WorkspaceLayoutColumnV2,
   type WorkspaceLayoutEnvelope,
@@ -206,19 +207,19 @@ export function validateWorkspaceLayoutManifestAnyV3(value: unknown) {
 
 export function toWorkspaceLayoutManifestV3(manifest: WorkspaceLayoutManifestAny): WorkspaceLayoutManifestV3 {
   if (manifest.schemaVersion === WORKSPACE_LAYOUT_SCHEMA_VERSION_V3) {
-    return cloneWorkspaceLayoutManifestV3(manifest);
+    return backfillWorkspaceLayoutManifestV3(manifest);
   }
   return upgradeWorkspaceLayoutManifestV2(toWorkspaceLayoutManifestV2(manifest));
 }
 
 export function workspaceLayoutManifestAnyToV2(manifest: WorkspaceLayoutManifestAny) {
   return manifest.schemaVersion === WORKSPACE_LAYOUT_SCHEMA_VERSION_V3
-    ? workspaceLayoutManifestV3ToV2(manifest)
+    ? toWorkspaceLayoutManifestV2(workspaceLayoutManifestV3ToV2(manifest))
     : toWorkspaceLayoutManifestV2(manifest);
 }
 
 export function upgradeWorkspaceLayoutManifestV2(manifest: WorkspaceLayoutManifestV2): WorkspaceLayoutManifestV3 {
-  const source = cloneWorkspaceLayoutManifestV2(manifest);
+  const source = backfillWorkspaceLayoutManifestV2(manifest);
   return {
     registryVersion: WORKSPACE_LAYOUT_REGISTRY_VERSION_V3,
     schemaVersion: WORKSPACE_LAYOUT_SCHEMA_VERSION_V3,
@@ -227,17 +228,7 @@ export function upgradeWorkspaceLayoutManifestV2(manifest: WorkspaceLayoutManife
       ...source.settings,
       accentColor: source.settings.accentColor ?? defaultWorkspaceLayoutSettingsV3.accentColor,
     },
-    tabs: source.tabs.map((tab) => ({
-      groups: [{
-        id: stableGroupId(tab.id),
-        name: "Primary layout",
-        presentation: { spacing: "comfortable", surface: "plain" },
-        rows: tab.rows,
-      }],
-      id: tab.id,
-      settings: tab.settings,
-      visible: tab.visible,
-    })),
+    tabs: source.tabs.map(workspaceLayoutTabV2ToV3),
   };
 }
 
@@ -274,6 +265,27 @@ export function cloneWorkspaceLayoutManifestV3(
   manifest: WorkspaceLayoutManifestV3 = embeddedWorkspaceLayoutManifestV3,
 ) {
   return structuredClone(manifest);
+}
+
+export function backfillWorkspaceLayoutManifestV3(manifest: WorkspaceLayoutManifestV3) {
+  const normalized = cloneWorkspaceLayoutManifestV3(manifest);
+  const seenTabs = new Set(normalized.tabs.map((tab) => tab.id));
+
+  for (const [registryIndex, registryTab] of workspaceLayoutRegistryV2.entries()) {
+    if (!registryTab.backfillIfMissing || seenTabs.has(registryTab.id)) continue;
+    const defaultTab = embeddedWorkspaceLayoutManifestV2.tabs.find((tab) => tab.id === registryTab.id);
+    if (!defaultTab) continue;
+    const previousTab = [...workspaceLayoutRegistryV2.slice(0, registryIndex)]
+      .reverse()
+      .find((candidate) => seenTabs.has(candidate.id));
+    const insertionIndex = previousTab
+      ? normalized.tabs.findIndex((tab) => tab.id === previousTab.id) + 1
+      : 0;
+    normalized.tabs.splice(insertionIndex, 0, workspaceLayoutTabV2ToV3(structuredClone(defaultTab)));
+    seenTabs.add(registryTab.id);
+  }
+
+  return normalized;
 }
 
 export function flattenWorkspaceGroupsV3(tab: WorkspaceLayoutTabV3) {
@@ -519,6 +531,20 @@ function customNode(component: WorkspaceCustomNodeV2["component"], title: string
   if (component === "link-list") return { ...base, items: [{ href: "/", label: "Workspace home" }] };
   if (component === "metric-strip") return { ...base, items: [{ label: "Metric one", value: "Value" }, { label: "Metric two", value: "Value" }] };
   return base;
+}
+
+function workspaceLayoutTabV2ToV3(tab: WorkspaceLayoutManifestV2["tabs"][number]): WorkspaceLayoutTabV3 {
+  return {
+    groups: [{
+      id: stableGroupId(tab.id),
+      name: "Primary layout",
+      presentation: { spacing: "comfortable", surface: "plain" },
+      rows: tab.rows,
+    }],
+    id: tab.id,
+    settings: tab.settings,
+    visible: tab.visible,
+  };
 }
 
 function stableGroupId(tabId: WorkspaceTabId) {

--- a/src/lib/workspace-layout.ts
+++ b/src/lib/workspace-layout.ts
@@ -5,6 +5,7 @@ export type WorkspaceTabId =
   | "map"
   | "review"
   | "history"
+  | "methods"
   | "electronic"
   | "planner"
   | "data"
@@ -133,6 +134,7 @@ export type WorkspaceSectionRegistryEntry = {
 };
 
 export type WorkspaceTabRegistryEntry = {
+  backfillIfMissing?: boolean;
   id: WorkspaceTabId;
   label: string;
   required?: boolean;
@@ -170,6 +172,13 @@ export const workspaceLayoutRegistry = [
       { id: "historical-summary", label: "Historical Summary" },
       { id: "historical-charts", label: "Historical Charts" },
     ],
+  },
+  {
+    backfillIfMissing: true,
+    id: "methods",
+    label: "Vote Methods",
+    required: true,
+    sections: [{ id: "vote-methods", label: "Vote Methods", required: true }],
   },
   {
     id: "electronic",
@@ -231,6 +240,10 @@ export const workspaceLayoutRegistry = [
     sections: [{ id: "contact-options", label: "Contact Options" }],
   },
 ] as const satisfies readonly WorkspaceTabRegistryEntry[];
+
+export function shouldBackfillWorkspaceTab(tab: WorkspaceTabRegistryEntry) {
+  return tab.backfillIfMissing === true;
+}
 
 const registryByTab = new Map<WorkspaceTabId, WorkspaceTabRegistryEntry>(
   workspaceLayoutRegistry.map((tab) => [tab.id, tab]),
@@ -416,12 +429,12 @@ export function validateWorkspaceLayoutManifest(value: unknown): WorkspaceLayout
   }
 
   for (const tab of workspaceLayoutRegistry) {
-    if (!seenTabs.has(tab.id)) {
+    if (!seenTabs.has(tab.id) && !shouldBackfillWorkspaceTab(tab)) {
       errors.push(`Tab ${tab.id} is missing.`);
     }
   }
-  if (value.tabs.length !== workspaceLayoutRegistry.length) {
-    errors.push(`Manifest must contain exactly ${workspaceLayoutRegistry.length} tabs.`);
+  if (value.tabs.length > workspaceLayoutRegistry.length) {
+    errors.push(`Manifest may contain at most ${workspaceLayoutRegistry.length} tabs.`);
   }
 
   return errors.length

--- a/src/lib/workspace-navigation.ts
+++ b/src/lib/workspace-navigation.ts
@@ -31,6 +31,7 @@ const workspaceTabs = new Set<WorkspaceTabId>([
   "map",
   "review",
   "history",
+  "methods",
   "electronic",
   "planner",
   "data",

--- a/tests/api/workspace-layout-v2.test.mjs
+++ b/tests/api/workspace-layout-v2.test.mjs
@@ -10,7 +10,10 @@ import {
   validateWorkspaceLayoutManifestV2,
   workspaceStarterTemplates,
 } from "../../src/lib/workspace-layout-v2.ts";
-import { embeddedWorkspaceLayoutManifest } from "../../src/lib/workspace-layout.ts";
+import {
+  embeddedWorkspaceLayoutManifest,
+  validateWorkspaceLayoutManifest,
+} from "../../src/lib/workspace-layout.ts";
 import {
   closeWorkspaceLayoutHistoryGroup,
   commitWorkspaceLayoutHistory,
@@ -66,6 +69,34 @@ test("the embedded v2 manifest and every starter template are structurally valid
     const validation = validateWorkspaceLayoutManifestV2(template.manifest);
     assert.equal(validation.ok, true, validation.ok ? "" : validation.errors.join("\n"));
   }
+});
+
+test("Vote Methods is global and older valid manifests receive it additively", () => {
+  const methods = embeddedWorkspaceLayoutManifestV2.tabs.find((tab) => tab.id === "methods");
+  assert.equal(methods?.visible, true);
+  assert.deepEqual(
+    methods?.rows.flatMap((row) => row.columns).flatMap((column) => column.items)
+      .filter((node) => node.kind === "production").map((node) => node.component),
+    ["vote-methods"],
+  );
+
+  const legacyV2 = cloneWorkspaceLayoutManifestV2(embeddedWorkspaceLayoutManifestV2);
+  legacyV2.tabs = legacyV2.tabs.filter((tab) => tab.id !== "methods");
+  const legacySnapshot = JSON.stringify(legacyV2);
+  assert.equal(validateWorkspaceLayoutManifestV2(legacyV2).ok, true);
+  assert.equal(validateWorkspaceLayoutEnvelope(createWorkspaceLayoutEnvelope({
+    manifest: legacyV2,
+    publishedAt: "2026-07-16T00:00:00.000Z",
+    revisionId: "pre-methods-v2",
+  })).ok, true);
+  const normalizedV2 = toWorkspaceLayoutManifestV2(legacyV2);
+  assert.equal(normalizedV2.tabs.find((tab) => tab.id === "methods")?.visible, true);
+  assert.equal(JSON.stringify(legacyV2), legacySnapshot);
+
+  const legacyV1 = structuredClone(embeddedWorkspaceLayoutManifest);
+  legacyV1.tabs = legacyV1.tabs.filter((tab) => tab.id !== "methods");
+  assert.equal(validateWorkspaceLayoutManifest(legacyV1).ok, true);
+  assert.equal(toWorkspaceLayoutManifestV2(legacyV1).tabs.some((tab) => tab.id === "methods"), true);
 });
 
 test("v1 revisions upgrade deterministically without mutating the original", () => {

--- a/tests/api/workspace-layout-v3.test.mjs
+++ b/tests/api/workspace-layout-v3.test.mjs
@@ -44,6 +44,28 @@ test("v2 upgrades are deterministic and retain compatibility structure", () => {
   assert.equal(JSON.stringify(workspaceLayoutManifestV3ToV2(first).tabs), JSON.stringify(embeddedWorkspaceLayoutManifestV2.tabs));
 });
 
+test("older v3 envelopes remain valid and gain the Vote Methods tab at conversion", () => {
+  const legacy = cloneWorkspaceLayoutManifestV3();
+  legacy.tabs = legacy.tabs.filter((tab) => tab.id !== "methods");
+  const snapshot = JSON.stringify(legacy);
+  const envelope = createWorkspaceLayoutEnvelope({
+    manifest: legacy,
+    publishedAt: "2026-07-16T00:00:00.000Z",
+    revisionId: "pre-methods-v3",
+  });
+  assert.equal(validateWorkspaceLayoutEnvelope(envelope).ok, true);
+
+  const normalized = toWorkspaceLayoutManifestV3(legacy);
+  const methods = normalized.tabs.find((tab) => tab.id === "methods");
+  assert.equal(methods?.visible, true);
+  assert.deepEqual(
+    methods?.groups.flatMap((group) => group.rows).flatMap((row) => row.columns)
+      .flatMap((column) => column.items).map((node) => node.component),
+    ["vote-methods"],
+  );
+  assert.equal(JSON.stringify(legacy), snapshot);
+});
+
 test("weak design-token contrast and unknown fields fail closed", () => {
   const weak = cloneWorkspaceLayoutManifestV3();
   weak.settings.textColor = weak.settings.backgroundColor;

--- a/tests/api/workspace-navigation.test.mjs
+++ b/tests/api/workspace-navigation.test.mjs
@@ -27,6 +27,10 @@ test("secondary workspace destinations retain their tab and canonical 2024 conte
     workspaceStateHref({ ...mapContext, tab: "review" }, "OR"),
     "/?state=OR&year=2024&tab=review",
   );
+  assert.equal(
+    workspaceStateHref({ ...mapContext, tab: "methods" }, "OR"),
+    "/?state=OR&year=2024&tab=methods",
+  );
 });
 
 test("exports preserve the selected historical election while removing map-only context", () => {


### PR DESCRIPTION
## Summary

- add an always-available **Vote Methods** workspace tab for every state
- show normalized EAC mail, early in-person, polling-place, provisional, and related participation-method totals when available
- show an explicit coverage-gap state when rows are unavailable, while preserving the candidate-by-method source limitation and CSV export
- backfill the tab additively into existing valid V1, V2, V3, and saved-draft layouts without changing stored manifests or digests

## Verification

- `npm run typecheck`
- `npm run test:layout`
- `npm run build`
- browser: Michigan shows 581 method rows with the Vote Methods tab selected
- browser: Washington shows the explicit no-data state, candidate-by-method caveat, and no Data Sources or Equipment panels

No ETL data was changed or promoted.