### PR TITLE
Add adjustable comparison-safe chart scaling

### DIFF
--- a/docs/review-graph-calculations.md
+++ b/docs/review-graph-calculations.md
@@ -239,10 +239,15 @@ Center. They are not conclusions.
   marginal buckets. This is a marginal-density cue, not a two-dimensional heat
   map. Bucket width does not move or blur a point; its exact percentages remain
   the scatter coordinates.
-- The ordinary domain is 0-100 percent. Values above 100 percent expand an axis
-  through at most 200 percent. More extreme values are retained in the final
-  overflow bucket and drawn at the display boundary with their exact values in
-  the point tooltip.
+- The default comparison domain is fixed at 0-100 percent on both axes. Use that
+  mode for apples-to-apples comparisons between elections.
+- Fit-visible-data mode adds a padded, bucket-aligned zoom independently to the
+  turnout and vote-share axes so clustered points are easier to inspect. Because
+  the fitted domains vary with the selected data, their apparent shapes must not
+  be compared across elections unless the domains are identical.
+- Values outside the selected domain are retained in the final overflow bucket
+  and drawn at the display boundary with their exact values in the point tooltip.
+  Fitted domains are capped at 200 percent.
 - Missing identities, ambiguous or unmatched rows, missing weights, denominator
   warnings, mixed denominator notes, low point counts, and overflow values are
   disclosed by the chart-quality notice. A partial view remains behind an
@@ -267,11 +272,13 @@ Center. They are not conclusions.
   presidential votes when both are available; a stored share is used only when
   vote counts cannot calculate it. Vote-weighted mode still requires a positive
   total-vote weight.
-- Bucket widths are 1, 2, 5, or 10 percentage points. The nominal domain is
-  0-100 percent. Values above 100 percent remain visible; the domain expands to
-  200 percent, and more extreme values are retained in an explicit final
-  overflow bucket instead of being clamped or discarded. An exact endpoint is
-  included in the final ordinary bucket.
+- Bucket widths are 1, 2, 5, or 10 percentage points. The default comparison
+  domain is fixed at 0-100 percent so election-to-election views remain
+  apples-to-apples. Fit-visible-data mode removes empty tails with a padded,
+  bucket-aligned zoom, but fitted views must not be compared unless their domains
+  are identical. Values outside the selected domain remain in an explicit final
+  overflow bucket instead of being discarded. Fitted domains are capped at 200
+  percent, and an exact endpoint is included in the final ordinary bucket.
 - Jurisdiction scales are:
   - statewide distribution at county/county-equivalent scale;
   - statewide distribution at the loaded local-reporting-unit scale;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4392,6 +4392,37 @@ td {
   opacity: 0.42;
 }
 
+.chart-scale-guidance {
+  align-items: baseline;
+  background: rgba(53, 199, 163, 0.06);
+  border: 1px solid rgba(53, 199, 163, 0.24);
+  border-radius: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 10px;
+  padding: 9px 11px;
+}
+
+.chart-scale-guidance strong {
+  color: var(--accent);
+  font-size: 12px;
+}
+
+.chart-scale-guidance span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.chart-scale-guidance.is-fitted {
+  background: rgba(240, 195, 106, 0.06);
+  border-color: rgba(240, 195, 106, 0.28);
+}
+
+.chart-scale-guidance.is-fitted strong {
+  color: var(--gold);
+}
+
 .shpilkin-county-select {
   display: grid;
   gap: 6px;
@@ -4417,7 +4448,7 @@ td {
 .shpilkin-stats {
   display: grid;
   gap: 8px;
-  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   margin: 0;
 }
 

--- a/src/app/klimek-fingerprint.tsx
+++ b/src/app/klimek-fingerprint.tsx
@@ -13,6 +13,7 @@ import {
   type ShpilkinAccumulation,
   type ShpilkinScope,
 } from "@/lib/shpilkin-histogram";
+import { percentageTicks, type PercentageScaleMode } from "@/lib/percentage-scale";
 import type { ReviewRowSummary, TurnoutRowSummary } from "@/lib/types";
 import { Eli5 } from "./eli5";
 
@@ -37,6 +38,10 @@ const accumulationOptions: Array<{ key: ShpilkinAccumulation; label: string }> =
 const pointSizeOptions: Array<{ key: KlimekPointSize; label: string }> = [
   { key: "total_votes", label: "Total presidential votes" },
   { key: "winner_votes", label: "Votes for loaded winner" },
+];
+const scaleModeOptions: Array<{ key: PercentageScaleMode; label: string }> = [
+  { key: "comparison", label: "0%–100% (compare)" },
+  { key: "fit", label: "Fit visible data" },
 ];
 const integerFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
 const compactFormatter = new Intl.NumberFormat("en-US", {
@@ -134,6 +139,7 @@ export function KlimekFingerprint({
   const [accumulation, setAccumulation] = useState<ShpilkinAccumulation>("votes");
   const [pointSize, setPointSize] = useState<KlimekPointSize>("total_votes");
   const [bucketWidth, setBucketWidth] = useState<KlimekBucketWidth>(1);
+  const [scaleMode, setScaleMode] = useState<PercentageScaleMode>("comparison");
   const [requestedCountyTag, setRequestedCountyTag] = useState("");
   const [acknowledgedKeys, setAcknowledgedKeys] = useState<string[]>([]);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -154,10 +160,11 @@ export function KlimekFingerprint({
       countyTag: selectedCountyTag,
       pointSize,
       reviewRows,
+      scaleMode,
       scope,
       turnoutRows,
     }),
-    [accumulation, bucketWidth, pointSize, reviewRows, scope, selectedCountyTag, turnoutRows],
+    [accumulation, bucketWidth, pointSize, reviewRows, scaleMode, scope, selectedCountyTag, turnoutRows],
   );
   const issues = [
     fingerprint.referenceCandidate === null
@@ -191,7 +198,7 @@ export function KlimekFingerprint({
       ? `This selection combines ${formatCount(fingerprint.denominatorNotes.length)} turnout denominator notes; confirm that the definitions are comparable.`
       : "",
     fingerprint.xOverflowPointCount > 0 || fingerprint.yOverflowPointCount > 0
-      ? `${formatCount(fingerprint.xOverflowPointCount)} turnout and ${formatCount(fingerprint.yOverflowPointCount)} vote-share values exceed the 200% display domain; they remain in the final overflow bucket with exact values in their tooltips.`
+      ? `${formatCount(fingerprint.xOverflowPointCount)} turnout and ${formatCount(fingerprint.yOverflowPointCount)} vote-share values exceed the selected axis domains; they remain in the final overflow buckets and at the chart boundary with exact values in their tooltips.`
       : "",
     fingerprint.points.length > 0 && fingerprint.points.length < 10
       ? "Fewer than 10 exactly matched sub-jurisdictions are drawable, so the fingerprint shape is fragile."
@@ -206,6 +213,7 @@ export function KlimekFingerprint({
     accumulation,
     pointSize,
     bucketWidth,
+    scaleMode,
     fingerprint.referenceCandidate,
     fingerprint.points.length,
   ].join(":");
@@ -223,20 +231,24 @@ export function KlimekFingerprint({
       : "local reporting units";
   const pointSizeLabel = pointSize === "winner_votes" ? "winner votes" : "total presidential votes";
   const marginalLabel = accumulation === "units" ? "sub-jurisdiction count" : "accumulated votes";
-  const xTicks = [...new Set([0, 25, 50, 75, 100, fingerprint.xDomainMax])]
-    .filter((value) => value <= fingerprint.xDomainMax)
-    .sort((left, right) => left - right);
-  const yTicks = [...new Set([0, 25, 50, 75, 100, fingerprint.yDomainMax])]
-    .filter((value) => value <= fingerprint.yDomainMax)
-    .sort((left, right) => left - right);
+  const xTicks = percentageTicks({ max: fingerprint.xDomainMax, min: fingerprint.xDomainMin });
+  const yTicks = percentageTicks({ max: fingerprint.yDomainMax, min: fingerprint.yDomainMin });
   const plot = { bottom: 474, height: 420, left: 82, right: 714, top: 54, width: 632 };
   const side = { left: 734, right: 966, width: 232 };
   const bottom = { bottom: 644, height: 148, top: 496 };
-  const xPosition = (value: number) => plot.left + (Math.min(value, fingerprint.xDomainMax) / fingerprint.xDomainMax) * plot.width;
-  const yPosition = (value: number) => plot.bottom - (Math.min(value, fingerprint.yDomainMax) / fingerprint.yDomainMax) * plot.height;
+  const xDomainSpan = fingerprint.xDomainMax - fingerprint.xDomainMin;
+  const yDomainSpan = fingerprint.yDomainMax - fingerprint.yDomainMin;
+  const xPosition = (value: number) => plot.left + (
+    (Math.min(fingerprint.xDomainMax, Math.max(fingerprint.xDomainMin, value)) - fingerprint.xDomainMin)
+    / xDomainSpan
+  ) * plot.width;
+  const yPosition = (value: number) => plot.bottom - (
+    (Math.min(fingerprint.yDomainMax, Math.max(fingerprint.yDomainMin, value)) - fingerprint.yDomainMin)
+    / yDomainSpan
+  ) * plot.height;
   const bottomSlot = plot.width / fingerprint.bottomBuckets.length;
   const sideSlot = plot.height / fingerprint.sideBuckets.length;
-  const chartSummary = `${scopeLabel}: ${fingerprint.referenceCandidateLabel} vote share by turnout, with aligned ${bucketWidth}-point marginal histograms.`;
+  const chartSummary = `${scopeLabel}: ${fingerprint.referenceCandidateLabel} vote share by turnout, with aligned ${bucketWidth}-point marginal histograms on turnout ${fingerprint.xDomainMin}-${fingerprint.xDomainMax}% and vote-share ${fingerprint.yDomainMin}-${fingerprint.yDomainMax}% domains.`;
 
   return (
     <article className="history-chart-card wide klimek-workbench" data-tour="history-klimek">
@@ -253,7 +265,7 @@ export function KlimekFingerprint({
             disabled={gated || status === "blocked"}
             onClick={() => svgRef.current && downloadSvg(
               svgRef.current,
-              `${stateCode.toLowerCase()}-${electionYear}-klimek-${scope}-${bucketWidth}pct.svg`,
+              `${stateCode.toLowerCase()}-${electionYear}-klimek-${scope}-${scaleMode}-${bucketWidth}pct.svg`,
             )}
             type="button"
           >
@@ -306,6 +318,12 @@ export function KlimekFingerprint({
           </label>
         ) : null}
         <KlimekChoiceButtons
+          label="Axis scale"
+          onChange={setScaleMode}
+          options={scaleModeOptions}
+          value={scaleMode}
+        />
+        <KlimekChoiceButtons
           label="Point size"
           onChange={setPointSize}
           options={pointSizeOptions}
@@ -323,6 +341,15 @@ export function KlimekFingerprint({
           options={klimekBucketWidths.map((width) => ({ key: width, label: `${width}%` }))}
           value={bucketWidth}
         />
+      </div>
+
+      <div className={`chart-scale-guidance ${scaleMode === "fit" ? "is-fitted" : ""}`} role="note">
+        <strong>{scaleMode === "comparison" ? "Comparable 0%–100% scale" : "Zoomed, data-fitted scale"}</strong>
+        <span>
+          {scaleMode === "comparison"
+            ? "Use this fixed domain on both axes for apples-to-apples comparisons between elections."
+            : `This view fits turnout to ${fingerprint.xDomainMin}%–${fingerprint.xDomainMax}% and vote share to ${fingerprint.yDomainMin}%–${fingerprint.yDomainMax}% so clustered points spread out. Switch to 0%–100% before comparing elections.`}
+        </span>
       </div>
 
       <div className={`chart-quality-notice ${status === "partial" ? "acknowledgement_required" : status}`} role="status">
@@ -363,6 +390,10 @@ export function KlimekFingerprint({
         </div>
         <div><dt>Source datasets</dt><dd>{formatCount(fingerprint.sourceCount)}</dd></div>
         <div><dt>Marginal bucket width</dt><dd>{bucketWidth}%</dd></div>
+        <div>
+          <dt>Axis domains</dt>
+          <dd>X {fingerprint.xDomainMin}%–{fingerprint.xDomainMax}% · Y {fingerprint.yDomainMin}%–{fingerprint.yDomainMax}%</dd>
+        </div>
       </dl>
 
       <div className="klimek-legend" aria-label="Fingerprint encoding legend" role="note">
@@ -386,7 +417,7 @@ export function KlimekFingerprint({
             >
               <title id={titleId}>{chartSummary}</title>
               <desc id={descriptionId}>
-                {formatCount(fingerprint.points.length)} exactly matched {unitLabel}. Point placement uses exact turnout and winner vote-share percentages; marginal bars use {bucketWidth}-percentage-point buckets.
+                {formatCount(fingerprint.points.length)} exactly matched {unitLabel}. Point placement uses exact turnout and winner vote-share percentages on turnout {fingerprint.xDomainMin}%-to-{fingerprint.xDomainMax}% and vote-share {fingerprint.yDomainMin}%-to-{fingerprint.yDomainMax}% axes; marginal bars use {bucketWidth}-percentage-point buckets.
               </desc>
               <rect className="screening-svg-bg" height="700" width="1000" />
               <rect className="klimek-plot-bg" height={plot.height} width={plot.width} x={plot.left} y={plot.top} />
@@ -518,7 +549,7 @@ export function KlimekFingerprint({
           Counties pair only through canonical county tags. Local units pair only when the normalized vote-share and turnout rows carry the same reporting-unit identity; display-name similarity is never treated as an identity crosswalk. The two marginal histograms aggregate only the points visible in the scatterplot, so their buckets align exactly with its axes.
         </p>
         <p>
-          Bucket width affects the marginal bars and the point-opacity density cue, but it never moves or blurs a point. A two-dimensional heat-map transformation remains separate future work. Values above 100% expand the axis through 200%; more extreme values stay in a labeled overflow bucket and retain their exact tooltip values.
+          Bucket width affects the marginal bars and the point-opacity density cue, but it never moves or blurs a point. A two-dimensional heat-map transformation remains separate future work. The fixed 0%–100% domain is required for apples-to-apples comparisons between elections. Fit-visible-data mode adds padded, bucket-aligned zoom independently to each axis; it improves separation but must not be compared with a chart using different domains. Values outside the selected domain stay in the final overflow bucket, draw at the chart boundary, and retain their exact tooltip values.
         </p>
       </details>
     </article>

--- a/src/app/shpilkin-histogram.tsx
+++ b/src/app/shpilkin-histogram.tsx
@@ -12,6 +12,7 @@ import {
   type ShpilkinScope,
   type ShpilkinXAxis,
 } from "@/lib/shpilkin-histogram";
+import { percentageTicks, type PercentageScaleMode } from "@/lib/percentage-scale";
 import type { ReviewRowSummary, TurnoutRowSummary } from "@/lib/types";
 import { Eli5 } from "./eli5";
 
@@ -36,6 +37,10 @@ const xAxisOptions: Array<{ key: ShpilkinXAxis; label: string }> = [
 const accumulationOptions: Array<{ key: ShpilkinAccumulation; label: string }> = [
   { key: "votes", label: "Accumulated votes" },
   { key: "units", label: "Accumulated sub-jurisdictions" },
+];
+const scaleModeOptions: Array<{ key: PercentageScaleMode; label: string }> = [
+  { key: "comparison", label: "0%–100% (compare)" },
+  { key: "fit", label: "Fit visible data" },
 ];
 const yGridRatios = [0, 0.25, 0.5, 0.75, 1];
 const integerFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
@@ -127,6 +132,7 @@ export function ShpilkinHistogram({
   const [accumulation, setAccumulation] = useState<ShpilkinAccumulation>("votes");
   const [candidate, setCandidate] = useState<ShpilkinCandidate>("dem");
   const [bucketWidth, setBucketWidth] = useState<ShpilkinBucketWidth>(1);
+  const [scaleMode, setScaleMode] = useState<PercentageScaleMode>("comparison");
   const [requestedCountyTag, setRequestedCountyTag] = useState("");
   const [acknowledgedKeys, setAcknowledgedKeys] = useState<string[]>([]);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -147,11 +153,12 @@ export function ShpilkinHistogram({
       candidate,
       countyTag: selectedCountyTag,
       reviewRows,
+      scaleMode,
       scope,
       turnoutRows,
       xAxis,
     }),
-    [accumulation, bucketWidth, candidate, reviewRows, scope, selectedCountyTag, turnoutRows, xAxis],
+    [accumulation, bucketWidth, candidate, reviewRows, scaleMode, scope, selectedCountyTag, turnoutRows, xAxis],
   );
 
   const issues = [
@@ -168,7 +175,7 @@ export function ShpilkinHistogram({
       ? `This selection combines ${formatCount(histogram.denominatorNotes.length)} source denominator notes; confirm that the definitions are comparable.`
       : "",
     histogram.overflowObservationCount > 0
-      ? `${formatCount(histogram.overflowObservationCount)} observations exceed 200% and are grouped into the final overflow bucket.`
+      ? `${formatCount(histogram.overflowObservationCount)} observations exceed the selected ${histogram.domainMax}% domain and are grouped into the final overflow bucket.`
       : "",
     histogram.drawableObservationCount > 0 && histogram.drawableObservationCount < 10
       ? "Fewer than 10 drawable sub-jurisdictions are available, so the distribution shape is fragile."
@@ -184,6 +191,7 @@ export function ShpilkinHistogram({
     accumulation,
     candidate,
     bucketWidth,
+    scaleMode,
     histogram.drawableObservationCount,
   ].join(":");
   const acknowledged = acknowledgedKeys.includes(diagnosticKey);
@@ -203,12 +211,11 @@ export function ShpilkinHistogram({
     : histogram.levels.length === 1
       ? friendlyLevel(histogram.levels[0])
       : "local reporting units";
-  const xTicks = [...new Set([0, 25, 50, 75, 100, histogram.domainMax])]
-    .filter((value) => value <= histogram.domainMax)
-    .sort((left, right) => left - right);
+  const xTicks = percentageTicks({ max: histogram.domainMax, min: histogram.domainMin });
   const plot = { bottom: 300, height: 250, left: 76, right: 836, top: 50, width: 760 };
+  const domainSpan = histogram.domainMax - histogram.domainMin;
   const barSlot = plot.width / histogram.buckets.length;
-  const chartSummary = `${scopeLabel}: ${yAxisLabel.toLowerCase()} by ${xAxisLabel.toLowerCase()} in ${bucketWidth}-percentage-point buckets.`;
+  const chartSummary = `${scopeLabel}: ${yAxisLabel.toLowerCase()} by ${xAxisLabel.toLowerCase()} in ${bucketWidth}-percentage-point buckets on a ${histogram.domainMin}-${histogram.domainMax}% domain.`;
 
   return (
     <article className="history-chart-card wide shpilkin-workbench" data-tour="history-shpilkin">
@@ -225,7 +232,7 @@ export function ShpilkinHistogram({
             disabled={gated || status === "blocked"}
             onClick={() => svgRef.current && downloadSvg(
               svgRef.current,
-              `${stateCode.toLowerCase()}-${electionYear}-shpilkin-${xAxis}-${accumulation}-${bucketWidth}pct.svg`,
+              `${stateCode.toLowerCase()}-${electionYear}-shpilkin-${xAxis}-${accumulation}-${scaleMode}-${bucketWidth}pct.svg`,
             )}
             type="button"
           >
@@ -280,6 +287,12 @@ export function ShpilkinHistogram({
           </label>
         ) : null}
         <ChoiceButtons label="Horizontal axis" onChange={setXAxis} options={xAxisOptions} value={xAxis} />
+        <ChoiceButtons
+          label="Axis scale"
+          onChange={setScaleMode}
+          options={scaleModeOptions}
+          value={scaleMode}
+        />
         {xAxis === "candidate_share" ? (
           <ChoiceButtons
             label="Candidate"
@@ -303,6 +316,15 @@ export function ShpilkinHistogram({
           options={shpilkinBucketWidths.map((width) => ({ key: width, label: `${width}%` }))}
           value={bucketWidth}
         />
+      </div>
+
+      <div className={`chart-scale-guidance ${scaleMode === "fit" ? "is-fitted" : ""}`} role="note">
+        <strong>{scaleMode === "comparison" ? "Comparable 0%–100% scale" : "Zoomed, data-fitted scale"}</strong>
+        <span>
+          {scaleMode === "comparison"
+            ? "Use this fixed domain for apples-to-apples comparisons between elections."
+            : `This ${histogram.domainMin}%–${histogram.domainMax}% view spreads the selected observations across the chart. Switch to 0%–100% before comparing elections.`}
+        </span>
       </div>
 
       <div className={`chart-quality-notice ${status === "partial" ? "acknowledgement_required" : status}`} role="status">
@@ -340,6 +362,7 @@ export function ShpilkinHistogram({
         <div><dt>Accumulated total</dt><dd>{formatCount(histogram.totalValue)}</dd></div>
         <div><dt>Source datasets</dt><dd>{formatCount(histogram.sourceCount)}</dd></div>
         <div><dt>Bucket width</dt><dd>{bucketWidth}%</dd></div>
+        <div><dt>Axis domain</dt><dd>{histogram.domainMin}%–{histogram.domainMax}%</dd></div>
       </dl>
 
       <div className={`screening-chart-shell ${gated ? "is-gated" : ""}`}>
@@ -356,7 +379,7 @@ export function ShpilkinHistogram({
             >
               <title id={titleId}>{chartSummary}</title>
               <desc id={descriptionId}>
-                {formatCount(histogram.drawableObservationCount)} {unitLabel} grouped into {bucketWidth}-percentage-point buckets.
+                {formatCount(histogram.drawableObservationCount)} {unitLabel} grouped into {bucketWidth}-percentage-point buckets on a {histogram.domainMin}%-to-{histogram.domainMax}% axis.
               </desc>
               <rect className="screening-svg-bg" height="390" width="860" />
               {yGridRatios.map((ratio) => {
@@ -371,7 +394,7 @@ export function ShpilkinHistogram({
                 );
               })}
               {xTicks.map((tick) => {
-                const x = plot.left + (tick / histogram.domainMax) * plot.width;
+                const x = plot.left + ((tick - histogram.domainMin) / domainSpan) * plot.width;
                 return (
                   <g key={tick}>
                     <line className="shpilkin-x-gridline" x1={x} x2={x} y1={plot.top} y2={plot.bottom} />
@@ -452,6 +475,11 @@ export function ShpilkinHistogram({
           State-by-{pluralizeCountyLabel(countyLabel).toLowerCase()} mode rolls rows up only through canonical county tags.
           County-by-local-unit mode filters on that same tag; it does not infer parentage from a display name. Each bucket
           retains the contributing source-row IDs; the paired Klimek meta-chart uses the same deterministic bucket rules.
+        </p>
+        <p>
+          The fixed 0%–100% scale is required for apples-to-apples comparisons between elections. Fit-visible-data mode
+          adds padded, bucket-aligned zoom around the selected observations to make clustering easier to inspect, but its
+          apparent shape must not be compared with a chart using a different domain.
         </p>
       </details>
     </article>

--- a/src/lib/klimek-fingerprint.ts
+++ b/src/lib/klimek-fingerprint.ts
@@ -5,6 +5,10 @@ import {
   type ShpilkinHistogramObservation,
   type ShpilkinScope,
 } from "./shpilkin-histogram.ts";
+import {
+  resolvePercentageDomain,
+  type PercentageScaleMode,
+} from "./percentage-scale.ts";
 import type { ReviewRowSummary, TurnoutRowSummary } from "./types";
 
 export const klimekBucketWidths = [1, 2, 5] as const;
@@ -70,8 +74,10 @@ export type KlimekFingerprintResult = {
   untaggedSourceRowCount: number;
   warningPointCount: number;
   xDomainMax: number;
+  xDomainMin: number;
   xOverflowPointCount: number;
   yDomainMax: number;
+  yDomainMin: number;
   yOverflowPointCount: number;
 };
 
@@ -82,8 +88,6 @@ type ObservationIndex = {
 };
 
 type PointBeforeDensity = Omit<KlimekFingerprintPoint, "densityScore" | "xBucketLow" | "yBucketLow">;
-
-const maximumFingerprintDomain = 200;
 
 function distinct(values: string[]) {
   return [...new Set(values.filter(Boolean))];
@@ -119,17 +123,14 @@ function indexObservations(observations: ShpilkinHistogramObservation[]): Observ
   return { ambiguousKeys, missingIdentityCount, unique };
 }
 
-function domainMaximum(values: number[], bucketWidth: KlimekBucketWidth) {
-  const largest = values.reduce((maximum, value) => Math.max(maximum, value), 0);
-  return Math.min(
-    maximumFingerprintDomain,
-    Math.max(100, Math.ceil(largest / bucketWidth) * bucketWidth),
-  );
-}
-
-function bucketIndex(value: number, domainMax: number, bucketWidth: KlimekBucketWidth) {
-  const bucketCount = Math.max(1, Math.ceil(domainMax / bucketWidth));
-  return Math.min(bucketCount - 1, Math.max(0, Math.floor(value / bucketWidth)));
+function bucketIndex(
+  value: number,
+  domainMin: number,
+  domainMax: number,
+  bucketWidth: KlimekBucketWidth,
+) {
+  const bucketCount = Math.max(1, Math.ceil((domainMax - domainMin) / bucketWidth));
+  return Math.min(bucketCount - 1, Math.max(0, Math.floor((value - domainMin) / bucketWidth)));
 }
 
 function buildMarginalBuckets(input: {
@@ -137,14 +138,15 @@ function buildMarginalBuckets(input: {
   axis: "turnout" | "winner_share";
   bucketWidth: KlimekBucketWidth;
   domainMax: number;
+  domainMin: number;
   points: PointBeforeDensity[];
 }) {
-  const bucketCount = Math.max(1, Math.ceil(input.domainMax / input.bucketWidth));
+  const bucketCount = Math.max(1, Math.ceil((input.domainMax - input.domainMin) / input.bucketWidth));
   const hasOverflow = input.points.some((point) => (
     input.axis === "turnout" ? point.turnoutPct : point.winnerSharePct
   ) > input.domainMax);
   const buckets: KlimekMarginalBucket[] = Array.from({ length: bucketCount }, (_, index) => {
-    const low = index * input.bucketWidth;
+    const low = input.domainMin + index * input.bucketWidth;
     const high = Math.min(input.domainMax, low + input.bucketWidth);
     return {
       high,
@@ -159,7 +161,7 @@ function buildMarginalBuckets(input: {
 
   for (const point of input.points) {
     const percentage = input.axis === "turnout" ? point.turnoutPct : point.winnerSharePct;
-    const index = bucketIndex(percentage, input.domainMax, input.bucketWidth);
+    const index = bucketIndex(percentage, input.domainMin, input.domainMax, input.bucketWidth);
     const bucket = buckets[index];
     const voteWeight = input.axis === "turnout" ? point.ballotsCast : point.totalVotes;
     bucket.pointIds.push(point.id);
@@ -190,6 +192,7 @@ export function buildKlimekFingerprint(input: {
   countyTag?: string | null;
   pointSize: KlimekPointSize;
   reviewRows: ReviewRowSummary[];
+  scaleMode?: PercentageScaleMode;
   scope: ShpilkinScope;
   turnoutRows: TurnoutRowSummary[];
 }): KlimekFingerprintResult {
@@ -258,28 +261,38 @@ export function buildKlimekFingerprint(input: {
     });
   }
 
-  const xDomainMax = domainMaximum(pointsBeforeDensity.map((point) => point.turnoutPct), input.bucketWidth);
-  const yDomainMax = domainMaximum(pointsBeforeDensity.map((point) => point.winnerSharePct), input.bucketWidth);
+  const xDomain = resolvePercentageDomain(
+    pointsBeforeDensity.map((point) => point.turnoutPct),
+    input.bucketWidth,
+    input.scaleMode ?? "comparison",
+  );
+  const yDomain = resolvePercentageDomain(
+    pointsBeforeDensity.map((point) => point.winnerSharePct),
+    input.bucketWidth,
+    input.scaleMode ?? "comparison",
+  );
   const bottomBuckets = buildMarginalBuckets({
     accumulation: input.accumulation,
     axis: "turnout",
     bucketWidth: input.bucketWidth,
-    domainMax: xDomainMax,
+    domainMax: xDomain.max,
+    domainMin: xDomain.min,
     points: pointsBeforeDensity,
   });
   const sideBuckets = buildMarginalBuckets({
     accumulation: input.accumulation,
     axis: "winner_share",
     bucketWidth: input.bucketWidth,
-    domainMax: yDomainMax,
+    domainMax: yDomain.max,
+    domainMin: yDomain.min,
     points: pointsBeforeDensity,
   });
   const maxXUnits = Math.max(1, ...bottomBuckets.map((bucket) => bucket.unitCount));
   const maxYUnits = Math.max(1, ...sideBuckets.map((bucket) => bucket.unitCount));
   const points = pointsBeforeDensity
     .map((point) => {
-      const xIndex = bucketIndex(point.turnoutPct, xDomainMax, input.bucketWidth);
-      const yIndex = bucketIndex(point.winnerSharePct, yDomainMax, input.bucketWidth);
+      const xIndex = bucketIndex(point.turnoutPct, xDomain.min, xDomain.max, input.bucketWidth);
+      const yIndex = bucketIndex(point.winnerSharePct, yDomain.min, yDomain.max, input.bucketWidth);
       const xDensity = bottomBuckets[xIndex].unitCount / maxXUnits;
       const yDensity = sideBuckets[yIndex].unitCount / maxYUnits;
       return {
@@ -320,9 +333,11 @@ export function buildKlimekFingerprint(input: {
     turnoutUnmatchedObservationCount: turnout.observations.length - matchedUnitKeys.size,
     untaggedSourceRowCount: candidate.untaggedSourceRowCount + turnout.untaggedSourceRowCount,
     warningPointCount: points.filter((point) => point.warningRequired).length,
-    xDomainMax,
-    xOverflowPointCount: points.filter((point) => point.turnoutPct > xDomainMax).length,
-    yDomainMax,
-    yOverflowPointCount: points.filter((point) => point.winnerSharePct > yDomainMax).length,
+    xDomainMax: xDomain.max,
+    xDomainMin: xDomain.min,
+    xOverflowPointCount: points.filter((point) => point.turnoutPct > xDomain.max).length,
+    yDomainMax: yDomain.max,
+    yDomainMin: yDomain.min,
+    yOverflowPointCount: points.filter((point) => point.winnerSharePct > yDomain.max).length,
   };
 }

--- a/src/lib/percentage-scale.ts
+++ b/src/lib/percentage-scale.ts
@@ -1,0 +1,79 @@
+export const percentageScaleModes = ["comparison", "fit"] as const;
+
+export type PercentageScaleMode = (typeof percentageScaleModes)[number];
+
+export type PercentageDomain = {
+  max: number;
+  min: number;
+};
+
+export const comparisonPercentageDomain: PercentageDomain = { max: 100, min: 0 };
+export const maximumPercentageDomain = 200;
+
+function alignDown(value: number, interval: number) {
+  return Math.floor(value / interval) * interval;
+}
+
+function alignUp(value: number, interval: number) {
+  return Math.ceil(value / interval) * interval;
+}
+
+export function resolvePercentageDomain(
+  values: number[],
+  bucketWidth: number,
+  scaleMode: PercentageScaleMode,
+): PercentageDomain {
+  if (scaleMode === "comparison") return comparisonPercentageDomain;
+
+  const finiteValues = values.filter((value) => Number.isFinite(value) && value >= 0);
+  if (finiteValues.length === 0) return comparisonPercentageDomain;
+
+  const interval = Math.max(1, bucketWidth);
+  const boundedValues = finiteValues.map((value) => Math.min(value, maximumPercentageDomain));
+  const smallest = Math.min(...boundedValues);
+  const largest = Math.max(...boundedValues);
+  let min = Math.max(0, alignDown(smallest - interval, interval));
+  let max = Math.min(maximumPercentageDomain, alignUp(largest + interval, interval));
+
+  if (max - min < 10) {
+    if (min === 0) {
+      max = Math.min(maximumPercentageDomain, Math.max(max, 10));
+    } else if (max === maximumPercentageDomain) {
+      min = Math.max(0, maximumPercentageDomain - 10);
+    } else {
+      const midpoint = (min + max) / 2;
+      min = Math.max(0, alignDown(midpoint - 5, interval));
+      max = Math.min(maximumPercentageDomain, alignUp(midpoint + 5, interval));
+    }
+  }
+
+  if (max <= min) {
+    return comparisonPercentageDomain;
+  }
+
+  return { max, min };
+}
+
+export function percentageTicks(domain: PercentageDomain) {
+  if (domain.min === 0 && domain.max === 100) return [0, 25, 50, 75, 100];
+
+  const span = domain.max - domain.min;
+  const targetInterval = span / 5;
+  const intervals = [1, 2, 5, 10, 20, 25, 50, 100];
+  const interval = intervals.find((candidate) => candidate >= targetInterval) ?? 100;
+  const edgeBuffer = span * 0.06;
+  const ticks = [domain.min];
+
+  for (
+    let value = alignUp(domain.min, interval);
+    value < domain.max;
+    value += interval
+  ) {
+    if (value - domain.min >= edgeBuffer && domain.max - value >= edgeBuffer) {
+      ticks.push(value);
+    }
+  }
+
+  ticks.push(domain.max);
+  return [...new Set(ticks)].sort((left, right) => left - right);
+}

--- a/src/lib/shpilkin-histogram.ts
+++ b/src/lib/shpilkin-histogram.ts
@@ -1,4 +1,8 @@
 import type { ReviewRowSummary, TurnoutRowSummary } from "./types";
+import {
+  resolvePercentageDomain,
+  type PercentageScaleMode,
+} from "./percentage-scale.ts";
 
 export const shpilkinBucketWidths = [1, 2, 5, 10] as const;
 
@@ -42,6 +46,7 @@ export type ShpilkinHistogramResult = {
   candidateLabel: string;
   denominatorNotes: string[];
   domainMax: number;
+  domainMin: number;
   drawableObservationCount: number;
   inputObservationCount: number;
   levels: string[];
@@ -65,7 +70,6 @@ type ObservationBuildResult = {
 };
 
 const countyTagPattern = /^county:\d{5}$/u;
-const maximumHistogramDomain = 200;
 
 function finiteNumber(value: number | null | undefined) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
@@ -374,6 +378,7 @@ export function buildShpilkinHistogram(input: {
   candidate: ShpilkinCandidate;
   countyTag?: string | null;
   reviewRows: ReviewRowSummary[];
+  scaleMode?: PercentageScaleMode;
   scope: ShpilkinScope;
   turnoutRows: TurnoutRowSummary[];
   xAxis: ShpilkinXAxis;
@@ -394,14 +399,16 @@ export function buildShpilkinHistogram(input: {
     input.accumulation === "units" || observation.voteWeight !== null,
   );
   const weightOmissions = built.observations.length - observations.length;
-  const largestValue = observations.reduce((largest, observation) => Math.max(largest, observation.valuePct), 0);
-  const naturalDomainMax = Math.max(100, Math.ceil(largestValue / input.bucketWidth) * input.bucketWidth);
-  const domainMax = Math.min(maximumHistogramDomain, naturalDomainMax);
-  const bucketCount = Math.max(1, Math.ceil(domainMax / input.bucketWidth));
-  const hasOverflow = largestValue > domainMax;
+  const domain = resolvePercentageDomain(
+    observations.map((observation) => observation.valuePct),
+    input.bucketWidth,
+    input.scaleMode ?? "comparison",
+  );
+  const bucketCount = Math.max(1, Math.ceil((domain.max - domain.min) / input.bucketWidth));
+  const hasOverflow = observations.some((observation) => observation.valuePct > domain.max);
   const buckets: ShpilkinHistogramBucket[] = Array.from({ length: bucketCount }, (_, index) => {
-    const low = index * input.bucketWidth;
-    const high = Math.min(domainMax, low + input.bucketWidth);
+    const low = domain.min + index * input.bucketWidth;
+    const high = Math.min(domain.max, low + input.bucketWidth);
     return {
       high,
       label: hasOverflow && index === bucketCount - 1 ? `≥${low}%` : `${low}-${high}%`,
@@ -416,7 +423,7 @@ export function buildShpilkinHistogram(input: {
   for (const observation of observations) {
     const bucketIndex = Math.min(
       buckets.length - 1,
-      Math.max(0, Math.floor(observation.valuePct / input.bucketWidth)),
+      Math.max(0, Math.floor((observation.valuePct - domain.min) / input.bucketWidth)),
     );
     const bucket = buckets[bucketIndex];
     const voteCount = observation.voteWeight ?? 0;
@@ -431,14 +438,15 @@ export function buildShpilkinHistogram(input: {
     buckets,
     candidateLabel: built.candidateLabel,
     denominatorNotes: built.denominatorNotes,
-    domainMax,
+    domainMax: domain.max,
+    domainMin: domain.min,
     drawableObservationCount: observations.length,
     inputObservationCount: built.inputObservationCount,
     levels: distinct(observations.map((observation) => observation.level)).sort(),
     maxBucketValue: buckets.reduce((maximum, bucket) => Math.max(maximum, bucket.value), 0),
     observations,
     omittedObservationCount: built.omittedObservationCount + weightOmissions,
-    overflowObservationCount: observations.filter((observation) => observation.valuePct > domainMax).length,
+    overflowObservationCount: observations.filter((observation) => observation.valuePct > domain.max).length,
     sourceCount,
     totalValue: buckets.reduce((sum, bucket) => sum + bucket.value, 0),
     untaggedSourceRowCount: built.untaggedSourceRowCount,

--- a/tests/api/api-contract.test.mjs
+++ b/tests/api/api-contract.test.mjs
@@ -440,12 +440,16 @@ test("review indicators explain advisory meaning", () => {
   assert.match(tabs, /KlimekFingerprint/);
   assert.match(klimek, /Klimek-Style Vote Fingerprint \+ Aligned Marginals/);
   assert.match(klimek, /same reporting-unit identity/);
+  assert.match(klimek, /0%–100% \(compare\)/);
+  assert.match(klimek, /apples-to-apples comparisons between elections/);
   assert.match(klimekMath, /buildKlimekFingerprint/);
   assert.match(klimekMath, /klimekBucketWidths/);
   assert.match(tabs, /ShpilkinHistogram/);
   assert.match(shpilkin, /Shpilkin-Style Distribution Histograms/);
   assert.match(shpilkin, /Accumulated votes/);
   assert.match(shpilkin, /Accumulated sub-jurisdictions/);
+  assert.match(shpilkin, /0%–100% \(compare\)/);
+  assert.match(shpilkin, /Fit visible data/);
   assert.match(shpilkinMath, /buildShpilkinHistogram/);
   assert.match(shpilkinMath, /listShpilkinCountyOptions/);
   assert.match(tabs, /voteMethodDiagnostic/);

--- a/tests/api/klimek-fingerprint.test.mjs
+++ b/tests/api/klimek-fingerprint.test.mjs
@@ -110,6 +110,19 @@ test("plots turnout on x and the loaded scope winner share on y", () => {
   assert.equal(alpha.winnerSharePct, 60);
   assert.equal(alpha.sizeValue, 100);
   assert.deepEqual(alpha.sourceIds.sort(), ["official-review", "official-turnout"]);
+  assert.deepEqual([result.xDomainMin, result.xDomainMax], [0, 100]);
+  assert.deepEqual([result.yDomainMin, result.yDomainMax], [0, 100]);
+});
+
+test("fitted scaling spreads clustered points with bucket-aligned axis domains", () => {
+  const result = fingerprint({ scaleMode: "fit" });
+
+  assert.deepEqual([result.xDomainMin, result.xDomainMax], [70, 85]);
+  assert.deepEqual([result.yDomainMin, result.yDomainMax], [50, 65]);
+  assert.equal(result.bottomBuckets.length, 3);
+  assert.equal(result.sideBuckets.length, 3);
+  assert.equal(result.bottomBuckets.find((bucket) => bucket.low === 75).unitCount, 1);
+  assert.equal(result.sideBuckets.find((bucket) => bucket.low === 55).unitCount, 1);
 });
 
 test("supports both requested point-size encodings and aligned vote or unit marginals", () => {
@@ -208,22 +221,29 @@ test("state-by-county scope pairs canonical county rollups without display-name 
   assert.equal(result.untaggedSourceRowCount, 1);
 });
 
-test("preserves values above 100 percent and labels values beyond 200 as overflow", () => {
-  const result = fingerprint({
+test("uses 0-100 comparison axes and preserves extreme values in capped fitted axes", () => {
+  const input = {
     reviewRows: [reviewRow({ demVotes: 250, harrisVotes: 250, repVotes: 10, totalVotes: 100, trumpVotes: 10 })],
     turnoutRows: [turnoutRow({ ballotsCast: 300, registeredVoters: 100, turnoutPct: 300 })],
-  });
+  };
+  const comparison = fingerprint(input);
+  const fitted = fingerprint({ ...input, scaleMode: "fit" });
 
-  assert.equal(result.xDomainMax, 200);
-  assert.equal(result.yDomainMax, 200);
-  assert.equal(result.xOverflowPointCount, 1);
-  assert.equal(result.yOverflowPointCount, 1);
-  assert.equal(result.points[0].turnoutPct, 300);
-  assert.equal(result.points[0].winnerSharePct, 250);
-  assert.equal(result.bottomBuckets.at(-1).label, "≥195%");
-  assert.equal(result.sideBuckets.at(-1).label, "≥195%");
-  assert.ok(result.bottomBuckets.at(-1).sourceRowIds.includes("turnout-a"));
-  assert.ok(result.sideBuckets.at(-1).sourceRowIds.includes("review-a"));
+  assert.deepEqual([comparison.xDomainMin, comparison.xDomainMax], [0, 100]);
+  assert.deepEqual([comparison.yDomainMin, comparison.yDomainMax], [0, 100]);
+  assert.equal(comparison.bottomBuckets.at(-1).label, "≥95%");
+  assert.equal(comparison.sideBuckets.at(-1).label, "≥95%");
+
+  assert.deepEqual([fitted.xDomainMin, fitted.xDomainMax], [190, 200]);
+  assert.deepEqual([fitted.yDomainMin, fitted.yDomainMax], [190, 200]);
+  assert.equal(fitted.xOverflowPointCount, 1);
+  assert.equal(fitted.yOverflowPointCount, 1);
+  assert.equal(fitted.points[0].turnoutPct, 300);
+  assert.equal(fitted.points[0].winnerSharePct, 250);
+  assert.equal(fitted.bottomBuckets.at(-1).label, "≥195%");
+  assert.equal(fitted.sideBuckets.at(-1).label, "≥195%");
+  assert.ok(fitted.bottomBuckets.at(-1).sourceRowIds.includes("turnout-a"));
+  assert.ok(fitted.sideBuckets.at(-1).sourceRowIds.includes("review-a"));
 });
 
 test("uses marginal bucket density for opacity without changing exact coordinates", () => {

--- a/tests/api/shpilkin-histogram.test.mjs
+++ b/tests/api/shpilkin-histogram.test.mjs
@@ -115,7 +115,7 @@ test("supports 1, 2, 5, and 10 percentage-point buckets with an inclusive 100% e
   }
 });
 
-test("retains values above 100% and caps pathological values in an explicit overflow bucket", () => {
+test("uses a fixed 0-100 comparison domain and a capped fitted domain", () => {
   const overHundred = turnoutRow({ ballotsCast: 125, registeredVoters: 100, turnoutPct: 125 });
   const extreme = turnoutRow({
     ballotsCast: 300,
@@ -125,13 +125,38 @@ test("retains values above 100% and caps pathological values in an explicit over
     registeredVoters: 100,
     turnoutPct: 300,
   });
-  const result = histogram({ bucketWidth: 5, turnoutRows: [overHundred, extreme], xAxis: "turnout" });
+  const comparison = histogram({ bucketWidth: 5, turnoutRows: [overHundred, extreme], xAxis: "turnout" });
+  const fitted = histogram({
+    bucketWidth: 5,
+    scaleMode: "fit",
+    turnoutRows: [overHundred, extreme],
+    xAxis: "turnout",
+  });
 
-  assert.equal(result.domainMax, 200);
-  assert.equal(result.overflowObservationCount, 1);
-  assert.equal(result.buckets.at(-1).label, "≥195%");
-  assert.equal(result.buckets.at(-1).unitCount, 1);
-  assert.equal(result.buckets.find((bucket) => bucket.low === 125).unitCount, 1);
+  assert.equal(comparison.domainMin, 0);
+  assert.equal(comparison.domainMax, 100);
+  assert.equal(comparison.overflowObservationCount, 2);
+  assert.equal(comparison.buckets.at(-1).label, "≥95%");
+  assert.equal(comparison.buckets.at(-1).unitCount, 2);
+
+  assert.equal(fitted.domainMin, 120);
+  assert.equal(fitted.domainMax, 200);
+  assert.equal(fitted.overflowObservationCount, 1);
+  assert.equal(fitted.buckets.at(-1).label, "≥195%");
+  assert.equal(fitted.buckets.at(-1).unitCount, 1);
+  assert.equal(fitted.buckets.find((bucket) => bucket.low === 125).unitCount, 1);
+});
+
+test("fitted scaling removes empty tails while preserving bucket membership", () => {
+  const comparison = histogram();
+  const fitted = histogram({ scaleMode: "fit" });
+
+  assert.deepEqual([comparison.domainMin, comparison.domainMax], [0, 100]);
+  assert.equal(comparison.buckets.length, 10);
+  assert.deepEqual([fitted.domainMin, fitted.domainMax], [30, 70]);
+  assert.equal(fitted.buckets.length, 4);
+  assert.equal(fitted.buckets.find((bucket) => bucket.low === 40).unitCount, 1);
+  assert.equal(fitted.buckets.find((bucket) => bucket.low === 60).unitCount, 1);
 });
 
 test("statewide county rollups require canonical tags and retain contributing row ids", () => {


### PR DESCRIPTION
## Summary

- add an explicit `0%–100% (compare)` default to the Klimek fingerprint and Shpilkin histogram controls
- add `Fit visible data` scaling with padded, bucket-aligned domains so clustered points and bars are easier to inspect
- keep exact values, point membership, marginal alignment, source-row membership, and overflow handling intact
- show the active domain in chart stats, SVG descriptions, filenames, and visible guidance
- document that apples-to-apples election comparisons require the fixed 0%–100% domain

This is a follow-up to #310 and #311.

## Implementation

- `src/lib/percentage-scale.ts` owns the shared comparison/fitted domain and tick rules.
- Shpilkin buckets begin at the selected domain minimum and retain out-of-domain observations in the final overflow bucket.
- Klimek turnout and winner-share axes fit independently while their marginal buckets remain aligned with the scatterplot.
- Fitted domains are padded by at least one selected bucket and capped at 200%; the fixed comparison mode remains 0%–100%.

No election data, production database rows, source records, or ETL artifacts are changed.

## Validation

- `npm run typecheck` — passed
- `npm run build` — passed
- `node --experimental-strip-types --experimental-test-isolation=none --test tests/api/shpilkin-histogram.test.mjs tests/api/klimek-fingerprint.test.mjs` — 20 passed
- `node tests/api/api-contract.test.mjs` — passed
- `npm test` — all JavaScript/API, equipment, and affected chart suites passed; the full command later failed in an unrelated Rhode Island Python inventory test because `scripts/normalize-ri-registration-datahub.mjs --check` reports that the checked-in raw response does not match its pinned byte/SHA-256 identity. This PR does not touch Rhode Island files.

## Browser verification

Local production-data check at `/?state=MN&year=2024&tab=history`:

- default Klimek mode rendered X 0%–100% and Y 0%–100% with 64 exact matches
- fitted Klimek mode rendered X 70%–88% and Y 20%–68% while retaining the same plotted points
- default Shpilkin mode rendered 0%–100% with 87 drawable counties
- fitted Shpilkin mode rendered 20%–72% with the same 87 drawable counties
- no framework error overlay or captured browser console errors
- home route also rendered successfully

## Review and caveats

- React review passed: state is primitive and local, expensive chart calculations remain memoized, static options stay module-scoped, controls retain accessible `aria-pressed` semantics, and no new effects or client data fetches were added.
- Fitted charts are intentionally labeled as zoomed and not election-comparable unless domains match.
- Existing open PR #147 also touches `docs/review-graph-calculations.md`; it is currently marked dirty against `main`, while this branch is based on current `origin/main`.
