### PR TITLE
Add histogram-context point styling to Klimek chart

### DIFF
--- a/docs/review-graph-calculations.md
+++ b/docs/review-graph-calculations.md
@@ -239,6 +239,23 @@ Center. They are not conclusions.
   marginal buckets. This is a marginal-density cue, not a two-dimensional heat
   map. Bucket width does not move or blur a point; its exact percentages remain
   the scatter coordinates.
+- The optional **Histogram peaks / valleys** point appearance compares each
+  marginal bin's observed height to the mean of its two immediate neighbors,
+  excluding the bin itself. The selected unit/vote accumulation and bin width
+  apply to both the bars and this comparison. Orange means a share-bin peak,
+  green a valley, and white a difference within 10% of the larger of the
+  observed/reference heights. Turnout-bin peaks and valleys use 95% fill opacity;
+  similar bins use 18%. These are fixed display settings, not significance
+  thresholds or individual-unit assessments. Endpoint/overflow comparisons and
+  comparisons bordering an overflow bin are unavailable (gray fill or 55%
+  opacity). Empty valleys do not create scatter points. Tooltips retain observed
+  values and adjacent-bin means, and exports name the selected appearance.
+- This local reference does **not** assume normally distributed election data,
+  apply skew/kurtosis amplification, or infer a fraud mechanism. Point positions,
+  sizes, source identities, counts, warning gates, and turnout semantics do not
+  change. Binning, geography, weighting, source coverage, and denominators can
+  change the descriptive pattern; a bin's appearance is not a conclusion about
+  any of its contributing units.
 - The default comparison domain is fixed at 0-100 percent on both axes. Use that
   mode for apples-to-apples comparisons between elections.
 - Fit-visible-data mode adds a padded, bucket-aligned zoom independently to the

--- a/src/app/chart-test-harness/page.tsx
+++ b/src/app/chart-test-harness/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from "next/navigation";
+import type { ReviewRowSummary, TurnoutRowSummary } from "@/lib/types";
+import { KlimekFingerprint } from "../klimek-fingerprint";
+
+export const dynamic = "force-dynamic";
+export const metadata = { robots: { follow: false, index: false }, title: "Synthetic chart test harness" };
+
+export default function ChartTestHarness() {
+  if (process.env.UI_LAYOUT_TEST_HARNESS !== "true" || process.env.VERCEL_ENV === "production") notFound();
+  const shares = [61, 61, 61, 62, 63, 64, 65, 65, 66, 68, 70, 70];
+  const reviewRows: ReviewRowSummary[] = shares.map((share, index) => ({
+    id: `fixture-review-${index}`, state: "EX", electionYear: 2024,
+    jurisdictionCode: "EX-COUNTY", jurisdictionName: "Synthetic County", jurisdictionTag: "county:01001",
+    localUnit: `Synthetic unit ${index + 1}`, level: "precinct", reportingUnitId: `fixture-unit-${index}`,
+    demCandidate: "Example A", repCandidate: "Example B", demVotes: share, repVotes: 100 - share,
+    harrisVotes: share, trumpVotes: 100 - share, totalVotes: 100, demShare: share, repShare: 100 - share,
+    harrisShare: share, trumpShare: 100 - share, demDropoff: null, repDropoff: null,
+    metrics: {}, sourceId: "synthetic-fixture-not-election-data",
+  }));
+  const turnoutRows: TurnoutRowSummary[] = shares.map((_, index) => ({
+    id: `fixture-turnout-${index}`, state: "EX", electionYear: 2024,
+    jurisdictionCode: "EX-COUNTY", jurisdictionName: "Synthetic County", jurisdictionTag: "county:01001",
+    level: "precinct", reportingUnitId: `fixture-unit-${index}`, ballotsCast: 110 + index,
+    registeredVoters: 200, turnoutPct: (110 + index) / 2,
+    denominatorNote: "Synthetic test denominator; not election data", warningRequired: index === 0,
+    sourceId: "synthetic-fixture-not-election-data",
+  }));
+  return (
+    <main style={{ margin: "24px auto", maxWidth: 1200, padding: 16 }}>
+      <h1>Synthetic chart test harness — not election data</h1>
+      <KlimekFingerprint countyLabel="County" electionYear={2024} reviewRows={reviewRows} stateCode="EX" stateName="Synthetic example" turnoutRows={turnoutRows} />
+    </main>
+  );
+}

--- a/src/app/klimek-fingerprint.tsx
+++ b/src/app/klimek-fingerprint.tsx
@@ -14,6 +14,12 @@ import {
   type ShpilkinScope,
 } from "@/lib/shpilkin-histogram";
 import { percentageTicks, type PercentageScaleMode } from "@/lib/percentage-scale";
+import {
+  buildKlimekHistogramContext,
+  describeHistogramBin,
+  histogramContextColors,
+  type KlimekPointAppearance,
+} from "@/lib/klimek-histogram-context";
 import type { ReviewRowSummary, TurnoutRowSummary } from "@/lib/types";
 import { Eli5 } from "./eli5";
 
@@ -42,6 +48,10 @@ const pointSizeOptions: Array<{ key: KlimekPointSize; label: string }> = [
 const scaleModeOptions: Array<{ key: PercentageScaleMode; label: string }> = [
   { key: "comparison", label: "0%–100% (compare)" },
   { key: "fit", label: "Fit visible data" },
+];
+const pointAppearanceOptions: Array<{ key: KlimekPointAppearance; label: string }> = [
+  { key: "winner_density", label: "Winner color · density" },
+  { key: "histogram_context", label: "Histogram peaks / valleys" },
 ];
 const integerFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
 const compactFormatter = new Intl.NumberFormat("en-US", {
@@ -86,7 +96,20 @@ function friendlyLevel(level: string) {
 }
 
 function downloadSvg(svg: SVGSVGElement, filename: string) {
-  const content = new XMLSerializer().serializeToString(svg);
+  // The downloaded SVG has no page stylesheet. Preserve its paint and labels,
+  // including the selected appearance, without modifying the live chart.
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  const originalElements = [svg, ...svg.querySelectorAll<SVGElement>("*")];
+  const clonedElements = [clone, ...clone.querySelectorAll<SVGElement>("*")];
+  const properties = ["fill", "fill-opacity", "stroke", "stroke-width", "stroke-dasharray", "opacity", "font-family", "font-size", "font-weight", "text-anchor"];
+  originalElements.forEach((element, index) => {
+    const computed = window.getComputedStyle(element);
+    properties.forEach((property) => {
+      // Do not bake a transient hover-opacity override into the chosen encoding.
+      clonedElements[index].style.setProperty(property, element.style.getPropertyValue(property) || computed.getPropertyValue(property));
+    });
+  });
+  const content = new XMLSerializer().serializeToString(clone);
   const blob = new Blob([content], { type: "image/svg+xml;charset=utf-8" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
@@ -140,6 +163,7 @@ export function KlimekFingerprint({
   const [pointSize, setPointSize] = useState<KlimekPointSize>("total_votes");
   const [bucketWidth, setBucketWidth] = useState<KlimekBucketWidth>(1);
   const [scaleMode, setScaleMode] = useState<PercentageScaleMode>("comparison");
+  const [pointAppearance, setPointAppearance] = useState<KlimekPointAppearance>("winner_density");
   const [requestedCountyTag, setRequestedCountyTag] = useState("");
   const [acknowledgedKeys, setAcknowledgedKeys] = useState<string[]>([]);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -166,6 +190,8 @@ export function KlimekFingerprint({
     }),
     [accumulation, bucketWidth, pointSize, reviewRows, scaleMode, scope, selectedCountyTag, turnoutRows],
   );
+  const histogramContext = useMemo(() => buildKlimekHistogramContext(fingerprint), [fingerprint]);
+  const showHistogramContext = pointAppearance === "histogram_context";
   const issues = [
     fingerprint.referenceCandidate === null
       ? "The loaded Democratic and Republican comparison totals are tied or unavailable, so no winning candidate can be selected."
@@ -214,6 +240,7 @@ export function KlimekFingerprint({
     pointSize,
     bucketWidth,
     scaleMode,
+    pointAppearance,
     fingerprint.referenceCandidate,
     fingerprint.points.length,
   ].join(":");
@@ -248,10 +275,13 @@ export function KlimekFingerprint({
   ) * plot.height;
   const bottomSlot = plot.width / fingerprint.bottomBuckets.length;
   const sideSlot = plot.height / fingerprint.sideBuckets.length;
-  const chartSummary = `${scopeLabel}: ${fingerprint.referenceCandidateLabel} vote share by turnout, with aligned ${bucketWidth}-point marginal histograms on turnout ${fingerprint.xDomainMin}-${fingerprint.xDomainMax}% and vote-share ${fingerprint.yDomainMin}-${fingerprint.yDomainMax}% domains.`;
+  const encodingSummary = showHistogramContext
+    ? "Share bins: orange peak, white similar, green valley, gray unavailable. Turnout-bin peaks/valleys are opaque; similar bins are translucent."
+    : "Color: loaded winner. Opacity: shared marginal-bucket density.";
+  const chartSummary = `${scopeLabel}: ${fingerprint.referenceCandidateLabel} vote share by turnout, with aligned ${bucketWidth}-point marginal histograms on turnout ${fingerprint.xDomainMin}-${fingerprint.xDomainMax}% and vote-share ${fingerprint.yDomainMin}-${fingerprint.yDomainMax}% domains. ${encodingSummary}`;
 
   return (
-    <article className="history-chart-card wide klimek-workbench" data-tour="history-klimek">
+    <article className="history-chart-card wide klimek-workbench" data-appearance={pointAppearance} data-tour="history-klimek">
       <div className="shpilkin-heading">
         <div>
           <strong>Klimek-Style Vote Fingerprint + Aligned Marginals</strong>
@@ -265,7 +295,7 @@ export function KlimekFingerprint({
             disabled={gated || status === "blocked"}
             onClick={() => svgRef.current && downloadSvg(
               svgRef.current,
-              `${stateCode.toLowerCase()}-${electionYear}-klimek-${scope}-${scaleMode}-${bucketWidth}pct.svg`,
+              `${stateCode.toLowerCase()}-${electionYear}-klimek-${scope}-${scaleMode}-${pointAppearance}-${bucketWidth}pct.svg`,
             )}
             type="button"
           >
@@ -324,6 +354,12 @@ export function KlimekFingerprint({
           value={scaleMode}
         />
         <KlimekChoiceButtons
+          label="Point appearance"
+          onChange={setPointAppearance}
+          options={pointAppearanceOptions}
+          value={pointAppearance}
+        />
+        <KlimekChoiceButtons
           label="Point size"
           onChange={setPointSize}
           options={pointSizeOptions}
@@ -342,6 +378,15 @@ export function KlimekFingerprint({
           value={bucketWidth}
         />
       </div>
+
+      {showHistogramContext ? (
+        <div className="chart-scale-guidance" role="note">
+          <strong>Histogram context, not an assessment of a place</strong>
+          <span>
+            Each bin is compared with the mean height of its two immediate neighbors using the selected accumulation and bucket width. White/translucent means within 10% of that local reference, not agreement with a normal distribution. Endpoints and overflow have no two-sided comparison. All points in a bin share its context; this is not a probability, significance test, or evidence of misconduct. Empty valleys remain visible in the marginal gaps, not as invented points.
+          </span>
+        </div>
+      ) : null}
 
       <div className={`chart-scale-guidance ${scaleMode === "fit" ? "is-fitted" : ""}`} role="note">
         <strong>{scaleMode === "comparison" ? "Comparable 0%–100% scale" : "Zoomed, data-fitted scale"}</strong>
@@ -397,9 +442,16 @@ export function KlimekFingerprint({
       </dl>
 
       <div className="klimek-legend" aria-label="Fingerprint encoding legend" role="note">
-        <span><i aria-hidden className={`klimek-legend-dot ${fingerprint.referenceCandidate ?? "neutral"}`} /> Color: loaded winner</span>
+        {showHistogramContext ? (
+          <>
+            <span><i aria-hidden className="klimek-legend-dot" style={{ background: histogramContextColors.peak }} /> Share-bin peak</span>
+            <span><i aria-hidden className="klimek-legend-dot" style={{ background: histogramContextColors.similar }} /> Similar to neighbors</span>
+            <span><i aria-hidden className="klimek-legend-dot" style={{ background: histogramContextColors.valley }} /> Share-bin valley</span>
+            <span><i aria-hidden className="klimek-legend-dot" style={{ background: histogramContextColors.unavailable }} /> Comparison unavailable</span>
+          </>
+        ) : <span><i aria-hidden className={`klimek-legend-dot ${fingerprint.referenceCandidate ?? "neutral"}`} /> Color: loaded winner</span>}
         <span>Size: {pointSizeLabel}</span>
-        <span>Opacity: shared marginal-bucket density</span>
+        <span>{showHistogramContext ? "Opacity: turnout-bin peaks/valleys opaque; similar translucent; unavailable medium" : "Opacity: shared marginal-bucket density"}</span>
         <span>Bars: {marginalLabel}</span>
       </div>
 
@@ -412,14 +464,15 @@ export function KlimekFingerprint({
               aria-labelledby={titleId}
               ref={svgRef}
               role="img"
-              viewBox="0 0 1000 700"
+              viewBox="0 0 1000 758"
               xmlns="http://www.w3.org/2000/svg"
             >
               <title id={titleId}>{chartSummary}</title>
               <desc id={descriptionId}>
                 {formatCount(fingerprint.points.length)} exactly matched {unitLabel}. Point placement uses exact turnout and winner vote-share percentages on turnout {fingerprint.xDomainMin}%-to-{fingerprint.xDomainMax}% and vote-share {fingerprint.yDomainMin}%-to-{fingerprint.yDomainMax}% axes; marginal bars use {bucketWidth}-percentage-point buckets.
+                {encodingSummary} {showHistogramContext ? "Reference: immediate neighboring-bin mean, with a 10% visual tolerance. Not a normality or significance test; not an assessment of individual units or election conduct." : ""}
               </desc>
-              <rect className="screening-svg-bg" height="700" width="1000" />
+              <rect className="screening-svg-bg" height="758" width="1000" />
               <rect className="klimek-plot-bg" height={plot.height} width={plot.width} x={plot.left} y={plot.top} />
               {yTicks.map((tick) => (
                 <g key={`y-${tick}`}>
@@ -455,7 +508,7 @@ export function KlimekFingerprint({
                     x={x}
                     y={bottom.bottom - height}
                   >
-                    <title>{`${bucket.label}: ${formatCount(bucket.value)} ${accumulation === "votes" ? "ballots cast" : "sub-jurisdictions"}; ${formatCount(bucket.unitCount)} plotted units`}</title>
+                    <title>{`${bucket.label}: ${formatCount(bucket.value)} ${accumulation === "votes" ? "ballots cast" : "sub-jurisdictions"}; ${formatCount(bucket.unitCount)} plotted units${showHistogramContext ? `; ${describeHistogramBin(histogramContext.bottom[index])}` : ""}`}</title>
                   </rect>
                 );
               })}
@@ -470,11 +523,12 @@ export function KlimekFingerprint({
                     className={`klimek-marginal-bar ${fingerprint.referenceCandidate ?? "neutral"}`}
                     height={height}
                     key={`side-${bucket.low}`}
+                    style={showHistogramContext ? { fill: histogramContextColors[histogramContext.side[index].relation] } : undefined}
                     width={width}
                     x={side.left}
                     y={y}
                   >
-                    <title>{`${bucket.label}: ${formatCount(bucket.value)} ${accumulation === "votes" ? "presidential votes" : "sub-jurisdictions"}; ${formatCount(bucket.unitCount)} plotted units`}</title>
+                    <title>{`${bucket.label}: ${formatCount(bucket.value)} ${accumulation === "votes" ? "presidential votes" : "sub-jurisdictions"}; ${formatCount(bucket.unitCount)} plotted units${showHistogramContext ? `; ${describeHistogramBin(histogramContext.side[index])}` : ""}`}</title>
                   </rect>
                 );
               })}
@@ -483,6 +537,7 @@ export function KlimekFingerprint({
               <line className="fingerprint-axis" x1={plot.left} x2={plot.right} y1={bottom.top} y2={bottom.top} />
               <line className="fingerprint-axis" x1={side.left} x2={side.left} y1={plot.top} y2={plot.bottom} />
               {fingerprint.points.map((point) => {
+                const context = showHistogramContext ? histogramContext.byPoint.get(point.id) : undefined;
                 const radius = 3 + (fingerprint.maxPointSizeValue > 0
                   ? Math.sqrt(point.sizeValue / fingerprint.maxPointSizeValue) * 10
                   : 0);
@@ -495,16 +550,22 @@ export function KlimekFingerprint({
                     data-density-score={point.densityScore.toFixed(4)}
                     key={point.id}
                     r={radius.toFixed(2)}
-                    style={{ fillOpacity: 0.34 + point.densityScore * 0.58 }}
+                    style={context
+                      ? { fill: context.fill, fillOpacity: context.fillOpacity }
+                      : { fillOpacity: 0.34 + point.densityScore * 0.58 }}
                   >
                     <title>
-                      {`${point.label}: turnout ${point.turnoutPct.toFixed(2)}%; ${fingerprint.referenceCandidateLabel} ${point.winnerSharePct.toFixed(2)}%; total votes ${formatOptionalCount(point.totalVotes)}; winner votes ${formatOptionalCount(point.winnerVotes)}; point size ${formatCount(point.sizeValue)} ${pointSizeLabel}; marginal buckets ${bucketLabel(point.xBucketLow, point.turnoutPct, fingerprint.xDomainMax, bucketWidth)} turnout and ${bucketLabel(point.yBucketLow, point.winnerSharePct, fingerprint.yDomainMax, bucketWidth)} share`}
+                      {`${point.label}: turnout ${point.turnoutPct.toFixed(2)}%; ${fingerprint.referenceCandidateLabel} ${point.winnerSharePct.toFixed(2)}%; total votes ${formatOptionalCount(point.totalVotes)}; winner votes ${formatOptionalCount(point.winnerVotes)}; point size ${formatCount(point.sizeValue)} ${pointSizeLabel}; marginal buckets ${bucketLabel(point.xBucketLow, point.turnoutPct, fingerprint.xDomainMax, bucketWidth)} turnout and ${bucketLabel(point.yBucketLow, point.winnerSharePct, fingerprint.yDomainMax, bucketWidth)} share${context ? `; share bin: ${describeHistogramBin(context.share)}; turnout bin: ${describeHistogramBin(context.turnout)}` : ""}`}
                     </title>
                   </circle>
                 );
               })}
               <text className="klimek-marginal-max" textAnchor="end" x={side.right} y={plot.bottom + 17}>
                 side max {compactFormatter.format(fingerprint.maxSideBucketValue)}
+              </text>
+              <text fill="#b8c5be" fontSize="10" x={plot.left} y="722">{encodingSummary}</text>
+              <text fill="#b8c5be" fontSize="10" x={plot.left} y="742">
+                {showHistogramContext ? "Reference: neighboring-bin mean; 10% visual tolerance. Not a normality test or evidence of misconduct." : "Descriptive screening view; not evidence of misconduct."}
               </text>
             </svg>
           ) : (
@@ -550,6 +611,9 @@ export function KlimekFingerprint({
         </p>
         <p>
           Bucket width affects the marginal bars and the point-opacity density cue, but it never moves or blurs a point. A two-dimensional heat-map transformation remains separate future work. The fixed 0%–100% domain is required for apples-to-apples comparisons between elections. Fit-visible-data mode adds padded, bucket-aligned zoom independently to each axis; it improves separation but must not be compared with a chart using different domains. Values outside the selected domain stay in the final overflow bucket, draw at the chart boundary, and retain their exact tooltip values.
+        </p>
+        <p>
+          Histogram peaks / valleys is an optional local bar-height comparison. A bin is similar when its observed height differs from the mean of its immediate neighbors by at most 10% of the larger height. Otherwise it is a peak or valley relative to those neighbors. Share-bin context controls orange/white/green fill; turnout-bin context controls fixed opaque/translucent fill. Point positions, sizes, counts, and source identities never change. No normal-distribution assumption, skew/kurtosis amplification, fraud mechanism, or individual-unit inference is applied.
         </p>
       </details>
     </article>

--- a/src/lib/klimek-histogram-context.ts
+++ b/src/lib/klimek-histogram-context.ts
@@ -1,0 +1,73 @@
+import type { KlimekFingerprintResult, KlimekMarginalBucket } from "./klimek-fingerprint.ts";
+
+export type KlimekPointAppearance = "winner_density" | "histogram_context";
+export type HistogramBinRelation = "peak" | "valley" | "similar" | "unavailable";
+
+export type HistogramBinContext = {
+  observed: number;
+  reference: number | null;
+  relation: HistogramBinRelation;
+};
+
+export const histogramContextColors = {
+  peak: "#f4a340",
+  valley: "#42ba83",
+  similar: "#ffffff",
+  unavailable: "#9ca3af",
+} as const;
+
+/** A descriptive bar-height comparison, not a normality test or a unit assessment. */
+export function compareHistogramBin(observed: number, reference: number | null): HistogramBinContext {
+  if (!Number.isFinite(observed) || observed < 0 || reference === null || !Number.isFinite(reference) || reference < 0) {
+    return { observed, reference: null, relation: "unavailable" };
+  }
+  // This 10% visual tolerance is not a statistical significance threshold.
+  const tolerance = 0.1 * Math.max(observed, reference);
+  const relation = Math.abs(observed - reference) <= tolerance
+    ? "similar"
+    : observed > reference ? "peak" : "valley";
+  return { observed, reference, relation };
+}
+
+function marginalContext(buckets: KlimekMarginalBucket[]) {
+  return buckets.map((bucket, index) => {
+    const before = buckets[index - 1];
+    const after = buckets[index + 1];
+    // Keep endpoints/overflow neutral: they do not have two comparable neighbors.
+    const reference = before && after && ![before, bucket, after].some((row) => row.label.startsWith("≥"))
+      ? (before.value + after.value) / 2
+      : null;
+    return compareHistogramBin(bucket.value, reference);
+  });
+}
+
+export function buildKlimekHistogramContext(fingerprint: KlimekFingerprintResult) {
+  const bottom = marginalContext(fingerprint.bottomBuckets);
+  const side = marginalContext(fingerprint.sideBuckets);
+  const turnoutByPoint = new Map<string, HistogramBinContext>();
+  const shareByPoint = new Map<string, HistogramBinContext>();
+  fingerprint.bottomBuckets.forEach((bucket, index) => {
+    bucket.pointIds.forEach((id) => turnoutByPoint.set(id, bottom[index]));
+  });
+  fingerprint.sideBuckets.forEach((bucket, index) => {
+    bucket.pointIds.forEach((id) => shareByPoint.set(id, side[index]));
+  });
+  const byPoint = new Map(fingerprint.points.map((point) => {
+    const turnout = turnoutByPoint.get(point.id) ?? compareHistogramBin(0, null);
+    const share = shareByPoint.get(point.id) ?? compareHistogramBin(0, null);
+    return [point.id, {
+      share,
+      turnout,
+      fill: histogramContextColors[share.relation],
+      fillOpacity: turnout.relation === "similar" ? 0.18 : turnout.relation === "unavailable" ? 0.55 : 0.95,
+    }] as const;
+  }));
+  return { bottom, byPoint, side };
+}
+
+export function describeHistogramBin(context: HistogramBinContext | undefined) {
+  if (!context || context.reference === null) return "neighbor comparison unavailable (endpoint or overflow)";
+  const number = (value: number) => value.toLocaleString("en-US", { maximumFractionDigits: 1 });
+  const relation = context.relation === "similar" ? "similar to neighbors (within 10%)" : `${context.relation} relative to neighbors`;
+  return `${relation}; observed ${number(context.observed)}, adjacent-bin mean ${number(context.reference)}`;
+}

--- a/tests/api/klimek-fingerprint.test.mjs
+++ b/tests/api/klimek-fingerprint.test.mjs
@@ -4,6 +4,12 @@ import {
   buildKlimekFingerprint,
   klimekBucketWidths,
 } from "../../src/lib/klimek-fingerprint.ts";
+import {
+  buildKlimekHistogramContext,
+  compareHistogramBin,
+  describeHistogramBin,
+  histogramContextColors,
+} from "../../src/lib/klimek-histogram-context.ts";
 
 function reviewRow(overrides = {}) {
   return {
@@ -287,4 +293,84 @@ test("does not treat a missing loaded candidate vote count as zero when selectin
   assert.equal(result.loadedCandidateVotes.rep, 40);
   assert.equal(result.referenceCandidate, null);
   assert.equal(result.points.length, 0);
+});
+
+test("histogram context compares observed bar heights without a normality assumption", () => {
+  assert.equal(compareHistogramBin(10, 5).relation, "peak");
+  assert.equal(compareHistogramBin(5, 10).relation, "valley");
+  assert.equal(compareHistogramBin(90, 100).relation, "similar");
+  assert.equal(compareHistogramBin(89, 100).relation, "valley");
+  assert.equal(compareHistogramBin(0, 0).relation, "similar");
+  assert.equal(compareHistogramBin(1, 0).relation, "peak");
+  assert.equal(compareHistogramBin(0, 1).relation, "valley");
+  for (const [observed, reference] of [[1, null], [NaN, 1], [1, Infinity], [-1, 2], [2, -1]]) {
+    assert.equal(compareHistogramBin(observed, reference).relation, "unavailable");
+  }
+});
+
+test("histogram appearance uses shared bin membership and preserves all data", () => {
+  const result = fingerprint();
+  const before = structuredClone(result);
+  const context = buildKlimekHistogramContext(result);
+  const a = context.byPoint.get("reporting-unit:unit-a");
+  assert.equal(a.share.observed, 100);
+  assert.equal(a.share.reference, 100); // Adjacent 55-60% bin has 200; 65-70% has 0.
+  assert.equal(a.share.relation, "similar");
+  assert.equal(a.fill, histogramContextColors.similar);
+  assert.equal(a.turnout.reference, 75);
+  assert.equal(a.turnout.observed, 80);
+  assert.equal(a.fillOpacity, 0.18);
+  const b = context.byPoint.get("reporting-unit:unit-b");
+  assert.equal(b.fill, histogramContextColors.peak);
+  assert.equal(b.fillOpacity, 0.95);
+  assert.deepEqual(result, before);
+  assert.equal(context.byPoint.size, result.points.length);
+  assert.match(describeHistogramBin(a.share), /observed 100, adjacent-bin mean 100/);
+});
+
+test("context follows selected marginal weights, not point-size weights", () => {
+  const votes = buildKlimekHistogramContext(fingerprint());
+  const units = buildKlimekHistogramContext(fingerprint({ accumulation: "units" }));
+  const winnerSize = buildKlimekHistogramContext(fingerprint({ pointSize: "winner_votes" }));
+  assert.equal(votes.byPoint.get("reporting-unit:unit-a").share.relation, "similar");
+  assert.equal(units.byPoint.get("reporting-unit:unit-a").share.relation, "peak");
+  assert.deepEqual(votes, winnerSize);
+});
+
+test("valleys with observations are green while empty valleys never invent points", () => {
+  const result = fingerprint();
+  // Use a synthetic histogram independent of any real jurisdiction or candidate.
+  result.sideBuckets[10].value = 100;
+  result.sideBuckets[11].value = 10;
+  result.sideBuckets[12].value = 100;
+  const context = buildKlimekHistogramContext(result);
+  assert.equal(context.byPoint.get("reporting-unit:unit-b").fill, histogramContextColors.valley);
+  assert.ok(context.side.some((bucket) => bucket.observed === 0 && bucket.relation === "valley"));
+  assert.equal(context.byPoint.size, result.points.length);
+});
+
+test("endpoint and overflow bins do not acquire a fabricated two-sided comparison", () => {
+  const result = fingerprint({
+    reviewRows: [reviewRow({ demVotes: 100, repVotes: 0, harrisVotes: 100, trumpVotes: 0 })],
+    turnoutRows: [turnoutRow({ turnoutPct: 105, warningRequired: true })],
+  });
+  const context = buildKlimekHistogramContext(result);
+  const point = context.byPoint.values().next().value;
+  assert.equal(point.share.relation, "unavailable");
+  assert.equal(point.turnout.relation, "unavailable");
+  assert.equal(point.fill, histogramContextColors.unavailable);
+  assert.equal(point.fillOpacity, 0.55);
+  assert.equal(result.points[0].turnoutPct, 105);
+  assert.equal(result.points[0].warningRequired, true);
+  assert.equal(context.bottom.at(-2).relation, "unavailable");
+  assert.match(describeHistogramBin(point.turnout), /unavailable/);
+});
+
+test("interior bin comparisons survive fitted scaling and empty fingerprints", () => {
+  const fixed = buildKlimekHistogramContext(fingerprint());
+  const fit = buildKlimekHistogramContext(fingerprint({ scaleMode: "fit" }));
+  // 75% and 55% bins retain both neighbors in the fitted domains.
+  assert.deepEqual(fixed.byPoint.get("reporting-unit:unit-b"), fit.byPoint.get("reporting-unit:unit-b"));
+  const empty = fingerprint({ reviewRows: [], turnoutRows: [] });
+  assert.equal(buildKlimekHistogramContext(empty).byPoint.size, 0);
 });

--- a/tests/e2e/klimek-histogram-context.spec.ts
+++ b/tests/e2e/klimek-histogram-context.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+
+test("histogram appearance preserves points, warning gates, tooltips and standalone SVG", async ({ page }, testInfo) => {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("console", (message) => { if (message.type() === "error") errors.push(message.text()); });
+  await page.goto("/chart-test-harness");
+  const chart = page.locator('[data-tour="history-klimek"]');
+  await expect(chart).toHaveAttribute("data-appearance", "winner_density");
+  await chart.getByRole("button", { name: "State · local units", exact: true }).click();
+  await expect(chart.getByRole("button", { name: "Download SVG" })).toBeDisabled();
+  await chart.getByRole("button", { name: "I acknowledge these limits" }).click();
+  const pointGeometry = () => chart.locator("circle.klimek-point").evaluateAll((points) =>
+    points.map((point) => [point.getAttribute("cx"), point.getAttribute("cy"), point.getAttribute("r")]),
+  );
+  const original = await pointGeometry();
+  expect(original).toHaveLength(12);
+  await chart.getByRole("button", { name: "Histogram peaks / valleys", exact: true }).press("Enter");
+  await expect(chart).toHaveAttribute("data-appearance", "histogram_context");
+  await expect(chart.getByRole("button", { name: "Download SVG" })).toBeDisabled();
+  await chart.getByRole("button", { name: "I acknowledge these limits" }).click();
+  expect(await pointGeometry()).toEqual(original);
+  await expect(chart.locator("circle.klimek-point title").first()).toContainText("adjacent-bin mean");
+  const fills = await chart.locator("circle.klimek-point").evaluateAll((points) => points.map((point) => getComputedStyle(point).fill));
+  expect(fills.every((fill) => ["rgb(244, 163, 64)", "rgb(255, 255, 255)", "rgb(66, 186, 131)", "rgb(156, 163, 175)"].includes(fill))).toBe(true);
+  await chart.screenshot({ path: testInfo.outputPath("histogram-context.png") });
+  const downloadPromise = page.waitForEvent("download");
+  await chart.getByRole("button", { name: "Download SVG" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toContain("histogram_context");
+  const filename = await download.path();
+  expect(filename).not.toBeNull();
+  const svg = await readFile(filename!, "utf8");
+  expect(svg).toContain("adjacent-bin mean");
+  expect(svg).toContain("Not a normality test or evidence of misconduct");
+  expect(svg).toContain("fill-opacity:");
+  expect(svg).toContain("font-family:");
+  expect(svg.match(/class="klimek-point /g)).toHaveLength(12);
+  await chart.getByRole("button", { name: "Winner color · density", exact: true }).click();
+  expect(await pointGeometry()).toEqual(original);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(chart.getByRole("button", { name: "Histogram peaks / valleys", exact: true })).toBeVisible();
+  await expect(page.locator("[data-nextjs-dialog]")).toHaveCount(0);
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
Fixes #316

## Scope

Add an opt-in Histogram peaks / valleys appearance to the Klimek chart. Default winner/density appearance is unchanged.

- Share-bin peaks are orange, similar bins white, valleys green, unavailable endpoint/overflow comparisons gray.
- Turnout-bin peaks and valleys are opaque; bins near their local reference are translucent.
- Comparisons use the selected marginal accumulation and bin width, retaining exact point positions, sizes, identity joins, source membership and warning gates.
- Tooltips show observed bar heights and neighboring-bin means. SVG downloads retain their styles, encoding legend and caveats without depending on the page stylesheet.
- Add a synthetic, explicitly guarded chart fixture and browser regression test. The fixture is disabled unless UI_LAYOUT_TEST_HARNESS=true and always disabled on VERCEL_ENV=production.

## Method and limits

The reference is the mean height of the two immediate neighboring bins, not an assumed normal distribution of election data. A 10% visual tolerance is a display setting, not a significance threshold. This implements the requested descriptive peak/valley view without normality assumptions, skew/kurtosis amplification, inferred mechanisms, individual-unit assessments, or findings of misconduct. All points in one bin share its context. Empty valleys do not invent scatter points.

No ETL sources, result values, registration denominators, production data, or publication gates change. The source-pairing limitations in #314 and #317 remain independent; this does not make unavailable local units drawable.

## Validation

- Required crm_doctor: passed, no warnings or workflow drift.
- Klimek unit suite: 15/15 passed.
- Shpilkin regression suite: 11/11 passed.
- npm.cmd run typecheck: passed.
- npm.cmd run build: passed (normal-shell rerun after sandbox worker-spawn restriction).
- Playwright chart test: passed, including keyboard control, acknowledgement reset, 12 unchanged synthetic point geometries, palette, SVG download/content, mobile control visibility, and no browser console/page errors.
- Browser visual inspection: passed. It caught a multi-child SVG title hydration mismatch, corrected and regression-tested before publication.
- Independent Luna/high review: no remaining implementation blocker.
- git diff --check: passed.

## Integration

This branch is based on main commit 2d8e07b5. GitHub validation, Public API integration, Vercel deployment, and Vercel preview checks all passed for 5bc5f28d.

The open PA fix PR #318 also touches the chart component, chart calculation documentation, and Klimek tests. A non-checkout `git merge-tree --write-tree` simulation confirmed five conflict hunks in `src/app/klimek-fingerprint.tsx`; documentation and unit tests auto-merge. Both PRs currently merge independently against main, but must be reconciled with each other during integration.

Resolution must preserve both the new histogram-context encoding and #318's accurate participation-proxy terminology: keep both sets of memo/label declarations; combine the encoding suffix with the participation-aware chart summary and SVG description; retain context details while using `participationWeightLabel` for bottom-bar weights and `participationLabel` for point tooltips. Do not relabel a presidential-votes/registration proxy as ballots-cast turnout. Rerun the Klimek, Shpilkin, PA registration and chart browser tests after integration. Neither PR was merged and no production promotion was performed.
